### PR TITLE
Add Related Research: CSG paper + DLI citations

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,12 +397,25 @@ If you have expertise in MCP internals, A2A implementation, or any of the listed
 
 ---
 
+## Related Research
+
+This security testing framework is part of a broader research program on autonomous AI agent governance:
+
+| Publication | DOI | Description |
+|---|---|---|
+| **Constitutional Self-Governance for Autonomous AI Agents** | [10.5281/zenodo.19162104](https://doi.org/10.5281/zenodo.19162104) | Framework for governing agent *decisions*, not just permissions. 12 mechanisms observed in 77 days of production with 56 agents. Maps to EU AI Act, NIST AI Agent Standards Initiative, and Singapore's agentic AI framework. |
+| **Decision Load Index (DLI)** | [10.5281/zenodo.18217577](https://doi.org/10.5281/zenodo.18217577) | Measuring the cognitive burden of AI agent oversight on human operators. Connects agent governance architecture to measurable human outcomes. |
+
+**The WHO vs. HOW gap:** Current AI agent governance platforms govern *who* agents are (identity, access, audit). This repo tests for security failures at the WHO layer. The CSG paper addresses the complementary HOW layer - governing the *decisions* that access-controlled agents make.
+
+---
+
 ## Contributing
 
-Issues and PRs welcome. If you've adapted this framework for a different platform, open a discussion — I'll link notable forks here.
+Issues and PRs welcome. If you've adapted this framework for a different platform, open a discussion - I'll link notable forks here.
 
 ---
 
 ## License
 
-Apache License 2.0 — see [LICENSE](LICENSE).
+Apache License 2.0 - see [LICENSE](LICENSE).


### PR DESCRIPTION
Adds a Related Research section to README linking both DOI-citable publications:

- **Constitutional Self-Governance for Autonomous AI Agents** (DOI: 10.5281/zenodo.19162104) - 77 days production, 56 agents, 12 governance mechanisms
- **Decision Load Index** (DOI: 10.5281/zenodo.18217577) - Measuring cognitive burden of agent oversight

Also introduces the WHO vs. HOW framing that connects the security testing framework (WHO layer) to the governance paper (HOW layer).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README-only documentation update adding research citations and minor punctuation normalization; no runtime or security-impacting code changes.
> 
> **Overview**
> Adds a new **Related Research** section to `README.md` linking two DOI-citable publications (CSG and DLI) and introduces a brief *WHO vs. HOW* framing to position this repo’s security testing scope.
> 
> Also normalizes punctuation in the `Contributing` and `License` lines (replacing em dashes with hyphens).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a539bc0fa75e7d4cfba60d48d3a21a442d9ad367. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->