### PR TITLE
Add L402 payment flow security harness (14 tests, 6 categories)

### DIFF
--- a/protocol_tests/l402_harness.py
+++ b/protocol_tests/l402_harness.py
@@ -315,8 +315,8 @@ class L402SecurityTests:
         rejected = 0
         tested = 0
         for label, invoice in malformed_invoices:
-            # Construct an Authorization header with the malformed invoice as if we had a preimage
-            fake_preimage = _fake_preimage()
+            # Construct an Authorization header using the malformed invoice as the preimage component
+            fake_preimage = invoice  # Use the malformed invoice data as the presented "preimage"
             mac = challenge.macaroon if challenge else base64.b64encode(b"fake").decode()
             auth_header = f"L402 {mac}:{fake_preimage}"
             resp = self.transport.get(self.PATH_INDEX, headers={"Authorization": auth_header})
@@ -1162,6 +1162,7 @@ def _run_statistical(
     ]
     for category, method_names in L402SecurityTests.ALL_TESTS.items():
         if categories and category not in categories:
+            id_idx += len(method_names)  # Advance past excluded tests
             continue
         for method_name in method_names:
             all_tests_flat.append((category, method_name, test_id_order[id_idx]))


### PR DESCRIPTION
## What

New protocol-level security test harness for L402 (Lightning-gated HTTP) payment flows. 14 tests across 6 categories:

| Category | Tests | What it checks |
|---|---|---|
| invoice_validation | L4-001 - L4-003 | 402 challenge header, malformed invoices, expired/unpaid tokens |
| macaroon_integrity | L4-004 - L4-006 | Bit-flipped macaroons, injected caveats, stripped signatures |
| preimage_replay | L4-007 - L4-008 | Fake preimages, cross-session replay |
| caveat_escalation | L4-009 - L4-010 | Scope widening, admin=true escalation |
| payment_state_confusion | L4-011 - L4-012 | Incomplete auth headers, pre-settlement race |
| rate_dos | L4-013 - L4-014 | Rapid invoice generation, concurrent uniqueness |

## Why

L402 auth is becoming the standard for agent-to-agent service gating (MCP L402 Directory, Lightning-gated APIs). The attack surface is underexplored: invalid macaroons, replayed preimages, expired invoices, caveat tampering.

## Collaboration

Built in collaboration with @LeviEdwards (MCP L402 Directory). He provided 3 live test endpoints at dispatches.mystere.me. He gets systematic fuzzing of his endpoints; we get payment flow security coverage.

## Technical Details

- 1,242 lines, zero external dependencies (stdlib only)
- Follows same patterns as MCP and A2A harnesses
- Does NOT pay real invoices (all tests use crafted/tampered tokens)
- Supports --url, --categories, --trials N, --list flags
- JSON output format matches existing harnesses
- Wilson score CIs for multi-trial statistical evaluation

## Test Endpoints

```
GET  dispatches.mystere.me/api/dispatches      (10 sat)
GET  dispatches.mystere.me/api/dispatches/:id   (per-resource)
POST dispatches.mystere.me/api/ask              (100 sat)
```

Closes #14

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because it only adds a standalone test harness script; no production logic is modified, though it introduces a large new file that issues network requests and may affect CI/runtime if executed by default.
> 
> **Overview**
> Adds `protocol_tests/l402_harness.py`, a standalone CLI harness that exercises L402/LSAT endpoints at the HTTP level and validates servers reject tampered `Authorization` tokens (macaroon/preimage), caveat/scope escalation attempts, and replay/race scenarios across **14 tests in 6 categories**.
> 
> Includes result modeling, grouped test execution/filtering (`--categories`, `--list`), JSON report output (`--report`), and a multi-trial mode (`--trials`) that computes Wilson-score confidence intervals via `protocol_tests.statistical`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3f3e393107f95e9c84f5b61ded1b335450c901e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->