### PR TITLE
Fix test count: 189 -> 209 in pyproject.toml and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 [![PyPI version](https://badge.fury.io/py/agent-security-harness.svg)](https://pypi.org/project/agent-security-harness/)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![Apache 2.0 License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/security%20tests-189-green.svg)](#test-inventory)
+[![Tests](https://img.shields.io/badge/security%20tests-209-green.svg)](#test-inventory)
 
 **The first open-source security testing framework purpose-built for multi-agent AI deployments in critical infrastructure.**
 
 AI agents are being deployed into enterprise systems (SAP, SCADA, ServiceNow, financial platforms) with the ability to make decisions, invoke tools, and chain actions across systems. The attack surface is fundamentally different from traditional software: agent-to-agent escalation, context poisoning, prompt injection through operational data, and normalization of deviance in safety-critical environments.
 
-This framework provides **189 security tests** across application-layer scenarios, wire-protocol harnesses (MCP, A2A, L402), enterprise platform adapters (20 platforms), and APT simulations. Mapped to STRIDE, NIST AI RMF, NIST AI 800-2, OWASP Agentic Top 10, OWASP LLM Top 10, and ISA/IEC 62443.
+This framework provides **209 security tests** across application-layer scenarios, wire-protocol harnesses (MCP, A2A, L402), enterprise platform adapters (20 platforms), and APT simulations. Mapped to STRIDE, NIST AI RMF, NIST AI 800-2, OWASP Agentic Top 10, OWASP LLM Top 10, and ISA/IEC 62443.
 
 > Built from real InfraGard Houston AI-CSC guidance and 20+ years of enterprise integration experience in Oil & Gas.
 
@@ -73,7 +73,7 @@ Results: 8/10 passed (80% pass rate) - see report.json
 | **Advanced Attacks** | 10 | Multi-step | Polymorphic, stateful, multi-domain attack chains |
 | **Identity & Authorization** | 18 | NIST NCCoE | All 6 focus areas from NIST agent identity standards |
 
-**Total: 189 security tests**
+**Total: 209 security tests**
 
 ### Key Capabilities
 
@@ -101,7 +101,7 @@ Most AI security tools test **models** (prompt injection, jailbreaks, output fil
 | **APT simulation (GTG-1002)** | - | - | - | - | 17 tests (full campaign lifecycle) |
 | **NIST AI 800-2 evaluation protocol** | - | - | - | - | Statistical confidence intervals, qualified claims |
 | **Published research backing** | - | - | - | - | 2 DOI-citable papers + 3 NIST submissions |
-| **Executable tests** | Yes (model-layer) | Yes (policy-layer) | No (docs only) | Yes (static analysis) | Yes (189 tests, protocol + app layer) |
+| **Executable tests** | Yes (model-layer) | Yes (policy-layer) | No (docs only) | Yes (static analysis) | Yes (209 tests, protocol + app layer) |
 | **Governance layer** | WHO (model safety) | WHO (identity, access) | WHO (config) | WHO (code scanning) | **HOW (decision governance)** |
 
 ### The WHO vs. HOW Gap

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "agent-security-harness"
 version = "3.2.0"
-description = "189 security tests for AI agent systems - MCP, A2A, L402 wire-protocol testing, 20 enterprise platform adapters, GTG-1002 APT simulation"
+description = "209 security tests for AI agent systems - MCP, A2A, L402, x402 wire-protocol testing, 20 enterprise platform adapters, GTG-1002 APT simulation"
 readme = "README.md"
 license = {text = "Apache-2.0"}
 requires-python = ">=3.10"


### PR DESCRIPTION
Self-test suite caught 2 of 3 inconsistencies:
1. pyproject.toml description still said 189 - fixed to 209
2. README badge and body text still said 189 (4 occurrences) - fixed to 209
3. L4-004 'duplicate' is a false positive - same test method uses the ID in both error-return and success-return branches. Verified no cross-method ID duplicates exist.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/metadata-only change updating the advertised test count and project description; no runtime code paths are modified.
> 
> **Overview**
> Updates public-facing metadata to reflect the current **209 security tests** instead of 189, including the README badge/body totals and the `pyproject.toml` project description.
> 
> Also expands the `pyproject.toml` description text to mention `x402` alongside existing protocol coverage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 38cd6e77f3e1755d793ac4025291d2b109d11704. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->