### PR TITLE
Fix CI: per-method duplicate ID check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,16 +99,25 @@ jobs:
           python -c "
           import re, sys
           from pathlib import Path
-          # Only check protocol_tests/ source files (not testing/ which references IDs in assertions)
-          ids = []
+          # Check that each test ID is only defined in ONE test method across all harnesses.
+          # IDs can appear multiple times in the same method (error branch + success branch).
+          method_ids = {}  # {test_id: set of (file, method_name)}
           for f in Path('protocol_tests').glob('*.py'):
               content = f.read_text()
-              # Find IDs used as test_id assignments (the canonical definition)
-              found = re.findall(r'test_id=[\"\\']([A-Z][A-Z0-9]*-\d{3})[\"\\']', content)
-              ids.extend(found)
-          dupes = [x for x in set(ids) if ids.count(x) > 1]
+              # Split into methods and find test_id assignments per method
+              for match in re.finditer(r'def (test_\w+)\(self\)(.*?)(?=\n    def |\Z)', content, re.DOTALL):
+                  method_name = match.group(1)
+                  method_body = match.group(2)
+                  ids_in_method = set(re.findall(r'test_id=[\"\\']([A-Z][A-Z0-9]*-\d{3})[\"\\']', method_body))
+                  for tid in ids_in_method:
+                      if tid not in method_ids:
+                          method_ids[tid] = set()
+                      method_ids[tid].add((f.name, method_name))
+          dupes = {k: v for k, v in method_ids.items() if len(v) > 1}
           if dupes:
-              print(f'DUPLICATE TEST IDS: {dupes}')
+              print(f'DUPLICATE TEST IDS (used in multiple methods):')
+              for tid, locations in dupes.items():
+                  print(f'  {tid}: {locations}')
               sys.exit(1)
-          print(f'All {len(set(ids))} test IDs are unique')
+          print(f'All {len(method_ids)} test IDs are unique across methods')
           "


### PR DESCRIPTION
The unique test ID check was counting occurrences, not method-level definitions. IDs like L4-004 appear twice in the same method (error branch + success branch) which is correct. Now tracks which method each ID belongs to and only flags IDs used in multiple different methods.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that narrows duplicate detection to cross-method reuse of `test_id`s; potential risk is false negatives/positives if the regex-based method parsing misses unusual formatting.
> 
> **Overview**
> Updates the CI workflow’s unique `test_id` validation to detect duplicates *only when the same ID is assigned in multiple different test methods*, rather than counting repeated occurrences within a single method.
> 
> The check now groups IDs by `(file, method)` and prints clearer duplicate locations before failing the lint job.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a6e4724fe4b13ecdb7eb9053aa0e3ebfdcf9b27. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->