### PR TITLE
Refine AIUC-1 crosswalk: version pin, name gaps, clarify coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ agent-security test enterprise --platform salesforce --url https://your-org.sale
 
 ## AIUC-1 Crosswalk: Pre-Certification Testing
 
-[AIUC-1](https://www.aiuc-1.com) is the first AI agent certification standard, requiring **quarterly independent adversarial testing** to validate agent security, safety, and reliability. Built with MITRE, Cisco, Stanford, MIT, and Google Cloud. This framework provides the technical testing that AIUC-1 certification demands.
+[AIUC-1](https://www.aiuc-1.com) (v2026-Q1, last reviewed March 2026) is the first AI agent certification standard, requiring **quarterly independent adversarial testing** to validate agent security, safety, and reliability. Built with MITRE, Cisco, Stanford, MIT, and Google Cloud. This framework provides the technical testing that AIUC-1 certification demands.
 
 <details>
 <summary><strong>Full AIUC-1 Requirement Mapping (15 of 20 testable requirements covered)</strong></summary>
@@ -345,6 +345,10 @@ agent-security test enterprise --platform salesforce --url https://your-org.sale
 | A. Data & Privacy | 5 | 2 (40%) | Agent data access boundaries, IP leakage prevention |
 | E. Accountability | 7 | 3 (43%) | Vendor due diligence, audit evidence, CSG governance framework |
 | F. Society | 2 | 1 (50%) | GTG-1002 APT simulation |
+
+**Not yet covered (5 requirements):** A001 (input data policy - process requirement), A002 (output data policy - process requirement), A007 (prevent IP violations in outputs), E005 (cloud vs on-prem assessment - infrastructure decision), F002 (CBRN prevention - [tracked in #34](https://github.com/msaleme/red-team-blue-team-agent-fabric/issues/34)). See also: [#33](https://github.com/msaleme/red-team-blue-team-agent-fabric/issues/33) (C003/C004 harmful output testing) and [#35](https://github.com/msaleme/red-team-blue-team-agent-fabric/issues/35) (E001-E003 incident response validation).
+
+> **Note:** "100% coverage" on Security and Reliability means this framework maps to every requirement in those principles. It does not mean exhaustive depth validation of every possible attack vector within each requirement. Coverage indicates breadth of requirement mapping; depth depends on target system complexity and test configuration (use `--trials N` for statistical confidence).
 
 > **Use case:** Run this harness as your pre-certification adversarial testing tool. AIUC-1 requires quarterly third-party testing (B001, C010, D004). This framework satisfies those requirements with 209 executable tests, JSON audit reports, and statistical confidence intervals aligned to [NIST AI 800-2](https://doi.org/10.6028/NIST.AI.800-2).
 


### PR DESCRIPTION
Addresses 3 suggestions from the critical evaluation (68/68 passing, score 9/10):

1. **Pin to AIUC-1 version** - Added 'v2026-Q1, last reviewed March 2026' so the mapping doesn't go stale silently when the standard updates quarterly
2. **Name the 5 uncovered requirements** - Now explicitly lists A001, A002, A007, E005, F002 with links to tracking issues (#33, #34, #35)
3. **Clarify '100% coverage' scope** - Added note that coverage = breadth of requirement mapping, not exhaustive depth validation of every attack vector

No code changes. README only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README-only documentation update with no runtime or API changes; risk is limited to potential confusion if requirement IDs/links are incorrect.
> 
> **Overview**
> Updates the `README.md` AIUC-1 crosswalk to **pin the mapping to a specific AIUC-1 release** (`v2026-Q1`, last reviewed March 2026).
> 
> Adds an explicit list of the **five uncovered AIUC-1 requirements** with links to tracking issues, and clarifies that "100% coverage" refers to *breadth of requirement mapping* rather than exhaustive attack-depth validation (with guidance to use `--trials N` for confidence).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit abbc186e6b01caedaca16f64e969ea41479543d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->