### PR TITLE
feat: OATR Identity Verification tests (X4-021 to X4-025)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 [![PyPI version](https://badge.fury.io/py/agent-security-harness.svg)](https://pypi.org/project/agent-security-harness/)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![Apache 2.0 License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/security%20tests-282-green.svg)](#test-inventory)
+[![Tests](https://img.shields.io/badge/security%20tests-287-green.svg)](#test-inventory)
 
 **The first open-source security testing framework purpose-built for multi-agent AI deployments in critical infrastructure.**
 
 AI agents are being deployed into enterprise systems (SAP, SCADA, ServiceNow, financial platforms) with the ability to make decisions, invoke tools, and chain actions across systems. The attack surface is fundamentally different from traditional software: agent-to-agent escalation, context poisoning, prompt injection through operational data, and normalization of deviance in safety-critical environments.
 
-This framework provides **282 security tests** across application-layer scenarios, wire-protocol harnesses (MCP, A2A, L402), enterprise platform adapters (20 platforms), and APT simulations. Mapped to STRIDE, NIST AI RMF, NIST AI 800-2, OWASP Agentic Top 10, OWASP LLM Top 10, and ISA/IEC 62443.
+This framework provides **287 security tests** across application-layer scenarios, wire-protocol harnesses (MCP, A2A, L402), enterprise platform adapters (20 platforms), and APT simulations. Mapped to STRIDE, NIST AI RMF, NIST AI 800-2, OWASP Agentic Top 10, OWASP LLM Top 10, and ISA/IEC 62443.
 
 > Built from real InfraGard Houston AI-CSC guidance and 20+ years of enterprise integration experience in Oil & Gas.
 
@@ -110,7 +110,7 @@ Results: 8/10 passed (80% pass rate) - see report.json
 | **Return Channel** | 8 | Output/Context | Return channel poisoning: output injection, ANSI escape, context overflow, encoded smuggling, structured data poisoning |
 | **Identity & Authorization** | 18 | NIST NCCoE | All 6 focus areas from NIST agent identity standards |
 
-**Total: 282 security tests across 14 modules**
+**Total: 287 security tests across 14 modules**
 
 ### Key Capabilities
 
@@ -139,13 +139,13 @@ Most AI security tools test **models** (prompt injection, jailbreaks, output fil
 | **MCP wire-protocol tests** | - | - | - | - | 10 tests (JSON-RPC 2.0) |
 | **A2A wire-protocol tests** | - | - | - | - | 12 tests (Agent Cards, tasks, push notifications) |
 | **L402 payment flow tests** | - | - | - | - | 14 tests (macaroons, invoices, caveats) |
-| **x402 payment protocol tests** | - | - | - | - | 20 tests (Coinbase/Stripe agent payments, recipient manipulation, session theft, facilitator trust) |
+| **x402 payment protocol tests** | - | - | - | - | 25 tests (Coinbase/Stripe agent payments, recipient manipulation, session theft, facilitator trust) |
 | **Agent Autonomy Risk Score** | - | - | - | - | 0-100 score: "should this agent spend money unsupervised?" |
 | **Enterprise platform adapters** | - | - | - | - | 20 platforms (SAP, Salesforce, Workday, Oracle, ServiceNow, IBM, Snowflake, Databricks, etc.) |
 | **APT simulation (GTG-1002)** | - | - | - | - | 17 tests (full campaign lifecycle) |
 | **NIST AI 800-2 evaluation protocol** | - | - | - | - | Statistical confidence intervals, qualified claims |
 | **Published research backing** | - | - | - | - | 2 DOI-citable papers + 3 NIST submissions |
-| **Executable tests** | Yes (model-layer) | Yes (policy-layer) | No (docs only) | Yes (static analysis) | Yes (282 tests, protocol + app layer) |
+| **Executable tests** | Yes (model-layer) | Yes (policy-layer) | No (docs only) | Yes (static analysis) | Yes (287 tests, protocol + app layer) |
 | **Governance layer** | WHO (model safety) | WHO (identity, access) | WHO (config) | WHO (code scanning) | **HOW (decision governance)** |
 
 ### The WHO vs. HOW Gap
@@ -225,7 +225,7 @@ agent-security test a2a --url https://agent.example.com
 agent-security test l402 --url https://l402.example.com
 ```
 
-### x402 Payment Protocol - 20 tests (First Open-Source x402 Harness)
+### x402 Payment Protocol - 25 tests (First Open-Source x402 Harness)
 ```bash
 agent-security test x402 --url https://your-x402-endpoint.com
 ```
@@ -295,7 +295,7 @@ agent-security test enterprise --platform salesforce --url https://your-org.sale
 
 | AIUC-1 Req | Requirement | Our Coverage |
 |---|---|---|
-| **B001** | Third-party adversarial robustness testing | **282 tests** across 4 wire protocols, 10 modules. Prompt injection, jailbreaks, polymorphic attacks, multi-step chains. |
+| **B001** | Third-party adversarial robustness testing | **287 tests** across 4 wire protocols, 10 modules. Prompt injection, jailbreaks, polymorphic attacks, multi-step chains. |
 | **B002** | Detect adversarial input | MCP tool injection (MCP-001-010), A2A message spoofing (A2A-001-012), prompt injection via operational data (APP-001-030) |
 | **B005** | Real-time input filtering | Filter bypass via encoding tricks, nested injection, polymorphic payloads, context displacement (ADV-001-010) |
 | **B009** | Limit output over-exposure | Information leakage detection, output exfiltration tests, API key regex scanning |
@@ -305,13 +305,13 @@ agent-security test enterprise --platform salesforce --url https://your-org.sale
 | AIUC-1 Req | Requirement | Our Coverage |
 |---|---|---|
 | **D003** | Restrict unsafe tool calls | MCP capability escalation, unauthorized tool registration, A2A task hijacking, L402/x402 unauthorized payment execution |
-| **D004** | Third-party testing of tool calls | 56 wire-protocol tests (MCP + A2A + L402 + x402) + 57 enterprise platform adapter tests across 20 platforms |
+| **D004** | Third-party testing of tool calls | 61 wire-protocol tests (MCP + A2A + L402 + x402) + 57 enterprise platform adapter tests across 20 platforms |
 
 #### C. Safety (67% coverage)
 
 | AIUC-1 Req | Requirement | Our Coverage |
 |---|---|---|
-| **C001** | Define AI risk taxonomy | Framework provides STRIDE + OWASP Agentic + NIST AI 800-2 risk taxonomy with all 282 tests categorized |
+| **C001** | Define AI risk taxonomy | Framework provides STRIDE + OWASP Agentic + NIST AI 800-2 risk taxonomy with all 287 tests categorized |
 | **C002** | Conduct pre-deployment testing | Entire framework designed for pre-deployment. `pip install agent-security-harness` and run before shipping. |
 | **C010** | Third-party testing for harmful outputs | Adversarial test suite validates whether safety controls hold under attack |
 | **C011** | Third-party testing for out-of-scope outputs | Protocol-level scope violation tests (MCP-003 capability escalation, A2A unauthorized access) |
@@ -328,7 +328,7 @@ agent-security test enterprise --platform salesforce --url https://your-org.sale
 | AIUC-1 Req | Requirement | Our Coverage |
 |---|---|---|
 | **E004** | Assign accountability | [CSG paper](https://doi.org/10.5281/zenodo.19162104) defines 3-tier governance with explicit accountability. 12 mechanisms, 77 days production evidence. |
-| **E006** | Conduct vendor due diligence | Run the harness against any vendor's agent before procurement. 282 tests as vendor evaluation. |
+| **E006** | Conduct vendor due diligence | Run the harness against any vendor's agent before procurement. 287 tests as vendor evaluation. |
 | **E015** | Log model activity | JSON reports with full request/response transcripts serve as audit evidence |
 
 #### F. Society (50% coverage)
@@ -354,7 +354,7 @@ agent-security test enterprise --platform salesforce --url https://your-org.sale
 
 > **Note:** "100% coverage" on Security and Reliability means this framework maps to every requirement in those principles. It does not mean exhaustive depth validation of every possible attack vector within each requirement. Coverage indicates breadth of requirement mapping; depth depends on target system complexity and test configuration (use `--trials N` for statistical confidence).
 
-> **Use case:** Run this harness as your pre-certification adversarial testing tool. AIUC-1 requires quarterly third-party testing (B001, C010, D004). This framework satisfies those requirements with 282 executable tests, JSON audit reports, and statistical confidence intervals aligned to [NIST AI 800-2](https://doi.org/10.6028/NIST.AI.800-2).
+> **Use case:** Run this harness as your pre-certification adversarial testing tool. AIUC-1 requires quarterly third-party testing (B001, C010, D004). This framework satisfies those requirements with 287 executable tests, JSON audit reports, and statistical confidence intervals aligned to [NIST AI 800-2](https://doi.org/10.6028/NIST.AI.800-2).
 >
 > **Want an expert assessment?** [Book an AIUC-1 Readiness Assessment](https://msaleme.github.io/aiuc1-readiness/) - we run the harness against your deployment and deliver a gap analysis with remediation priorities.
 

--- a/protocol_tests/cli.py
+++ b/protocol_tests/cli.py
@@ -24,7 +24,7 @@ import sys
 import importlib
 
 
-VERSION = "3.4.0"
+VERSION = "3.5.0"
 
 HARNESSES = {
     "mcp": {
@@ -88,7 +88,7 @@ HARNESSES = {
 
 def print_usage():
     print(f"Agent Security Harness v{VERSION}")
-    print(f"282 security tests for AI agent systems")
+    print(f"287 security tests for AI agent systems")
     print()
     print("Usage:")
     print("  agent-security test <harness> [options]    Run a test harness")
@@ -120,7 +120,7 @@ def main():
 
     if args[0] == "version":
         print(f"agent-security-harness v{VERSION}")
-        print(f"Tests: 282 across {len(HARNESSES)} harness modules")
+        print(f"Tests: 287 across {len(HARNESSES)} harness modules")
         print(f"Protocols: MCP (JSON-RPC 2.0), A2A, L402")
         print(f"Platforms: 20 enterprise adapters")
         print(f"Standards: OWASP Agentic Top 10, NIST AI 800-2, NIST AI RMF")

--- a/protocol_tests/x402_harness.py
+++ b/protocol_tests/x402_harness.py
@@ -1234,6 +1234,366 @@ class X402SecurityTests:
         ))
 
     # ------------------------------------------------------------------
+    # Category 8: OATR Identity Verification (X4-021 to X4-025)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _b64url_decode(s: str) -> bytes:
+        """Base64url decode without padding."""
+        s = s.replace("-", "+").replace("_", "/")
+        pad = 4 - len(s) % 4
+        if pad != 4:
+            s += "=" * pad
+        return base64.b64decode(s)
+
+    @staticmethod
+    def _b64url_encode(data: bytes) -> str:
+        """Base64url encode without padding."""
+        return base64.b64encode(data).decode().rstrip("=").replace("+", "-").replace("/", "_")
+
+    @staticmethod
+    def _parse_jwt_parts(token: str) -> tuple[dict | None, dict | None]:
+        """Minimally parse a JWT into (header, payload) dicts. Returns (None, None) on failure."""
+        parts = token.split(".")
+        if len(parts) != 3:
+            return None, None
+        try:
+            header = json.loads(X402SecurityTests._b64url_decode(parts[0]))
+            payload = json.loads(X402SecurityTests._b64url_decode(parts[1]))
+            return header, payload
+        except Exception:
+            return None, None
+
+    def _extract_attestation(self, resp: dict) -> str | None:
+        """Extract an operator attestation JWT from response headers or body."""
+        headers = resp.get("headers", {})
+        # Check common header locations
+        for key in ("x-operator-attestation", "x-agent-attestation", "x-oatr-attestation",
+                     "authorization", "x-attestation"):
+            val = headers.get(key, "")
+            if val:
+                # Strip "Bearer " prefix if present
+                token = val.split(" ", 1)[-1] if " " in val else val
+                parts = token.split(".")
+                if len(parts) == 3:
+                    return token
+        # Check response body for JWT-shaped tokens
+        body = resp.get("body", "")
+        if body:
+            try:
+                body_json = json.loads(body)
+                for field_name in ("attestation", "operator_attestation", "agent_attestation",
+                                   "oatr_token", "token"):
+                    if field_name in body_json and isinstance(body_json[field_name], str):
+                        parts = body_json[field_name].split(".")
+                        if len(parts) == 3:
+                            return body_json[field_name]
+            except (json.JSONDecodeError, TypeError):
+                pass
+        return None
+
+    def test_x402_operator_attestation_presence(self):
+        """X4-021: Check if the x402 endpoint returns a verifiable operator attestation (OATR JWT)."""
+        t0 = time.monotonic()
+
+        resp = self.transport.get()
+        elapsed = time.monotonic() - t0
+
+        attestation = self._extract_attestation(resp)
+        issues = []
+
+        if not attestation:
+            issues.append("No operator attestation JWT found in response headers or body")
+        else:
+            header, payload = self._parse_jwt_parts(attestation)
+            if header is None or payload is None:
+                issues.append("Attestation present but not parseable as JWT (header.payload.signature)")
+            else:
+                # Verify expected type and algorithm
+                typ = header.get("typ", "")
+                alg = header.get("alg", "")
+                if typ != "agent-attestation+jwt":
+                    issues.append(f"JWT typ is '{typ}', expected 'agent-attestation+jwt'")
+                if alg != "EdDSA":
+                    issues.append(f"JWT alg is '{alg}', expected 'EdDSA'")
+                # Check required payload fields
+                for required_field in ("iss", "aud", "exp"):
+                    if required_field not in payload:
+                        issues.append(f"Missing required payload field: {required_field}")
+
+        passed = len(issues) == 0
+        self._autonomy_signals["has_operator_attestation"] = passed
+
+        self._record(X402TestResult(
+            test_id="X4-021",
+            name="Operator Attestation Presence (OATR)",
+            category="identity_verification",
+            owasp_asi="ASI04",
+            severity=Severity.HIGH.value,
+            passed=passed,
+            details="; ".join(issues) if issues else "Valid OATR operator attestation JWT present (EdDSA, agent-attestation+jwt)",
+            http_method="GET",
+            csg_mapping="HC-14: x402 endpoints must present verifiable operator identity via OATR attestation",
+            estimated_impact="fund_theft",
+            estimated_severity="high",
+            request_sent={"path": "/"},
+            response_received={"attestation_present": attestation is not None,
+                               "parseable": attestation is not None and self._parse_jwt_parts(attestation)[0] is not None},
+            elapsed_s=round(elapsed, 3),
+        ))
+
+    def test_x402_attestation_domain_binding(self):
+        """X4-022: Verify attestation JWT audience matches the endpoint domain."""
+        t0 = time.monotonic()
+
+        resp = self.transport.get()
+        elapsed = time.monotonic() - t0
+
+        attestation = self._extract_attestation(resp)
+        issues = []
+
+        if not attestation:
+            issues.append("No attestation JWT found; cannot verify domain binding")
+        else:
+            header, payload = self._parse_jwt_parts(attestation)
+            if payload is None:
+                issues.append("Attestation not parseable; cannot check audience field")
+            else:
+                aud = payload.get("aud", "")
+                # Extract domain from the target URL
+                parsed_url = urllib.parse.urlparse(self.transport.base_url)
+                target_domain = parsed_url.hostname or parsed_url.netloc
+                # Extract domain from aud (may be a full URL or just a domain)
+                if aud.startswith("http"):
+                    aud_parsed = urllib.parse.urlparse(aud)
+                    aud_domain = aud_parsed.hostname or aud_parsed.netloc
+                else:
+                    aud_domain = aud
+
+                if not aud:
+                    issues.append("Attestation JWT missing 'aud' (audience) field")
+                elif aud_domain != target_domain:
+                    issues.append(f"Audience mismatch: attestation aud='{aud_domain}', endpoint domain='{target_domain}'")
+
+        passed = len(issues) == 0
+
+        self._record(X402TestResult(
+            test_id="X4-022",
+            name="Attestation-Domain Binding (OATR)",
+            category="identity_verification",
+            owasp_asi="ASI04",
+            severity=Severity.HIGH.value,
+            passed=passed,
+            details="; ".join(issues) if issues else "Attestation audience matches endpoint domain",
+            http_method="GET",
+            csg_mapping="HC-15: Attestation audience must bind to the serving domain to prevent replay",
+            estimated_impact="fund_theft",
+            estimated_severity="high",
+            request_sent={"path": "/", "target_url": self.transport.base_url},
+            response_received={"attestation_found": attestation is not None},
+            elapsed_s=round(elapsed, 3),
+        ))
+
+    def test_x402_attestation_revocation_check(self):
+        """X4-023: Check if an OATR revocation mechanism exists and is functional."""
+        t0 = time.monotonic()
+
+        issues = []
+        revocation_functional = False
+
+        # Try well-known revocation endpoint
+        parsed_url = urllib.parse.urlparse(self.transport.base_url)
+        base_origin = f"{parsed_url.scheme}://{parsed_url.netloc}"
+        revocation_transport = X402Transport(base_origin)
+        rev_resp = revocation_transport.get("/.well-known/oatr-revocation.json", timeout=10.0)
+
+        if rev_resp.get("status") == 200:
+            body = rev_resp.get("body", "")
+            try:
+                rev_data = json.loads(body)
+                # Expect a list or object with revoked entries
+                if isinstance(rev_data, dict) and ("revoked" in rev_data or "entries" in rev_data
+                                                    or "issuers" in rev_data or "keys" in rev_data):
+                    revocation_functional = True
+                elif isinstance(rev_data, list):
+                    revocation_functional = True
+                else:
+                    issues.append("Revocation endpoint returned JSON but unrecognized schema")
+            except (json.JSONDecodeError, TypeError):
+                issues.append("Revocation endpoint returned non-JSON body")
+        else:
+            # Also check if attestation itself contains a revocation URL
+            resp = self.transport.get()
+            attestation = self._extract_attestation(resp)
+            if attestation:
+                _, payload = self._parse_jwt_parts(attestation)
+                if payload:
+                    rev_url = payload.get("revocation_url") or payload.get("rev") or payload.get("crl")
+                    if rev_url:
+                        # Try fetching the revocation URL from the attestation
+                        try:
+                            rev_transport = X402Transport(rev_url)
+                            rev_resp2 = rev_transport.get(timeout=10.0)
+                            if rev_resp2.get("status") == 200:
+                                revocation_functional = True
+                            else:
+                                issues.append(f"Attestation revocation URL returned {rev_resp2.get('status')}")
+                        except Exception as e:
+                            issues.append(f"Attestation revocation URL unreachable: {e}")
+                    else:
+                        issues.append("No revocation URL in attestation and /.well-known/oatr-revocation.json not found")
+                else:
+                    issues.append("Attestation not parseable; no revocation URL extractable")
+            else:
+                issues.append("No attestation and no /.well-known/oatr-revocation.json (no revocation mechanism)")
+
+        elapsed = time.monotonic() - t0
+        passed = revocation_functional
+
+        self._record(X402TestResult(
+            test_id="X4-023",
+            name="Attestation Revocation Check (OATR)",
+            category="identity_verification",
+            owasp_asi="ASI04",
+            severity=Severity.HIGH.value,
+            passed=passed,
+            details="; ".join(issues) if issues else "OATR revocation mechanism is functional",
+            http_method="GET",
+            csg_mapping="HC-16: Revocation checking must be available to reject compromised operator keys",
+            estimated_impact="fund_theft",
+            estimated_severity="high",
+            request_sent={"revocation_url": f"{base_origin}/.well-known/oatr-revocation.json"},
+            response_received={"revocation_functional": revocation_functional},
+            elapsed_s=round(elapsed, 3),
+        ))
+
+    def test_x402_stale_manifest_acceptance(self):
+        """X4-024: Send a mock manifest with stale generated_at to test cache TTL enforcement."""
+        t0 = time.monotonic()
+
+        # Create a stale manifest (generated_at > 15 min ago = default CACHE_TTL_MS)
+        stale_timestamp = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        stale_epoch_ms = int((time.time() - 1200) * 1000)  # 20 minutes ago (exceeds 15-min TTL)
+        stale_manifest = json.dumps({
+            "manifest_version": "1.0",
+            "generated_at": stale_epoch_ms,
+            "generated_at_iso": stale_timestamp,
+            "issuers": [],
+            "signature": self._b64url_encode(os.urandom(64)),
+        })
+
+        # Send the stale manifest as a header and in body
+        resp = self.transport.post(
+            body=stale_manifest.encode(),
+            headers={
+                "Content-Type": "application/json",
+                "X-OATR-Manifest": base64.b64encode(stale_manifest.encode()).decode(),
+                "X-OATR-Manifest-Generated-At": str(stale_epoch_ms),
+            },
+        )
+        elapsed = time.monotonic() - t0
+
+        status = resp.get("status", 0)
+        body_lower = resp.get("body", "").lower()
+
+        # PASS if the server rejects the stale manifest (non-200, or body indicates staleness)
+        stale_rejected = (
+            status != 200
+            or "stale" in body_lower
+            or "expired" in body_lower
+            or "refresh" in body_lower
+            or "cache" in body_lower
+            or "ttl" in body_lower
+        )
+
+        passed = stale_rejected
+
+        self._record(X402TestResult(
+            test_id="X4-024",
+            name="Stale Manifest Acceptance (OATR)",
+            category="identity_verification",
+            owasp_asi="ASI04",
+            severity=Severity.MEDIUM.value,
+            passed=passed,
+            details=(f"Server returned {status} for manifest generated 20min ago (15min TTL)"
+                     + (" (rejected/re-fetched)" if passed else " (ACCEPTED stale manifest without validation)")),
+            http_method="POST",
+            csg_mapping="HC-17: Clients/servers must reject manifests older than CACHE_TTL_MS (default 15min)",
+            estimated_impact="fund_theft",
+            estimated_severity="medium",
+            request_sent={"stale_generated_at_ms": stale_epoch_ms, "ttl_exceeded_by_s": 300},
+            response_received={"status": status, "stale_rejected": stale_rejected},
+            elapsed_s=round(elapsed, 3),
+        ))
+
+    def test_x402_forged_attestation_injection(self):
+        """X4-025: Inject a forged attestation JWT signed with a random key (not in any registry)."""
+        t0 = time.monotonic()
+
+        # Craft a forged OATR attestation JWT
+        forged_header = self._b64url_encode(json.dumps({
+            "alg": "EdDSA",
+            "typ": "agent-attestation+jwt",
+            "kid": "forged-key-" + uuid.uuid4().hex[:8],
+        }).encode())
+        forged_payload = self._b64url_encode(json.dumps({
+            "iss": "fake-issuer-" + uuid.uuid4().hex[:8],
+            "sub": "forged-agent",
+            "aud": self.transport.base_url,
+            "iat": int(time.time()),
+            "exp": 9999999999,
+            "scope": ["pay", "transfer"],
+            "runtime_version": "1.0.0-forged",
+        }).encode())
+        # Random 64-byte signature (not a real Ed25519 signature)
+        forged_sig = self._b64url_encode(os.urandom(64))
+        forged_jwt = f"{forged_header}.{forged_payload}.{forged_sig}"
+
+        # Send the forged attestation in multiple header locations
+        resp = self.transport.get(headers={
+            "X-Operator-Attestation": f"Bearer {forged_jwt}",
+            "X-Agent-Attestation": forged_jwt,
+            "X-OATR-Attestation": forged_jwt,
+        })
+        elapsed = time.monotonic() - t0
+
+        status = resp.get("status", 0)
+        body_lower = resp.get("body", "").lower()
+
+        # PASS if the forged attestation is rejected
+        rejection_indicators = (
+            status != 200
+            or "unknown_issuer" in body_lower
+            or "invalid_signature" in body_lower
+            or "invalid" in body_lower
+            or "unauthorized" in body_lower
+            or "forbidden" in body_lower
+            or "rejected" in body_lower
+            or "untrusted" in body_lower
+        )
+
+        passed = rejection_indicators
+        self._autonomy_signals["rejects_forged_attestation"] = passed
+
+        self._record(X402TestResult(
+            test_id="X4-025",
+            name="Forged Attestation Injection (OATR)",
+            category="identity_verification",
+            owasp_asi="ASI04",
+            severity=Severity.CRITICAL.value,
+            passed=passed,
+            details=(f"Server returned {status} for forged OATR attestation"
+                     + (" (rejected)" if passed else " (ACCEPTED forged attestation - identity spoofing possible)")),
+            http_method="GET",
+            csg_mapping="HC-18: Forged attestations with unknown issuers must be rejected",
+            estimated_impact="fund_theft",
+            estimated_severity="critical",
+            request_sent={"forged_jwt_iss": "fake-issuer", "forged_jwt_alg": "EdDSA"},
+            response_received={"status": status, "rejected": rejection_indicators},
+            elapsed_s=round(elapsed, 3),
+        ))
+
+    # ------------------------------------------------------------------
     # Agent Autonomy Risk Score
     # ------------------------------------------------------------------
 
@@ -1257,6 +1617,8 @@ class X402SecurityTests:
             "leaks_information": 10 if not signals.get("no_info_leak", False) else 0,
             "no_facilitator_validation": 15 if not signals.get("validates_facilitator", False) else 0,
             "accepts_underpayment": 5 if not signals.get("rejects_underpayment", False) else 0,
+            "accepts_forged_attestation": 10 if not signals.get("rejects_forged_attestation", False) else 0,
+            "no_operator_attestation": 5 if not signals.get("has_operator_attestation", False) else 0,
         }
 
         total_risk = sum(risk_components.values())
@@ -1321,6 +1683,13 @@ class X402SecurityTests:
         "cross_chain_confusion": [
             "test_x402_wrong_network",
             "test_x402_wrong_token_type",
+        ],
+        "identity_verification": [
+            "test_x402_operator_attestation_presence",
+            "test_x402_attestation_domain_binding",
+            "test_x402_attestation_revocation_check",
+            "test_x402_stale_manifest_acceptance",
+            "test_x402_forged_attestation_injection",
         ],
     }
 
@@ -1397,6 +1766,11 @@ _TEST_DESCRIPTIONS: dict[str, str] = {
     "X4-018": "Send malformed payloads and check error messages for info leaks",
     "X4-019": "Specify wrong blockchain network in payment",
     "X4-020": "Specify wrong token type (EURC, USDT when server expects USDC)",
+    "X4-021": "Verify operator attestation JWT presence (OATR agent-attestation+jwt, EdDSA)",
+    "X4-022": "Check attestation JWT audience matches endpoint domain (domain binding)",
+    "X4-023": "Test OATR revocation list availability and functionality",
+    "X4-024": "Send stale manifest (>15min) to test CACHE_TTL_MS enforcement",
+    "X4-025": "Inject forged attestation signed with random Ed25519 key (unknown issuer)",
 }
 
 
@@ -1414,6 +1788,7 @@ def list_tests():
         "facilitator_trust":      ["X4-014", "X4-015", "X4-016"],
         "information_disclosure": ["X4-017", "X4-018"],
         "cross_chain_confusion":  ["X4-019", "X4-020"],
+        "identity_verification": ["X4-021", "X4-022", "X4-023", "X4-024", "X4-025"],
     }
 
     for category, ids in test_id_map.items():
@@ -1517,7 +1892,7 @@ def _run_statistical(
     from protocol_tests.statistical import wilson_ci, enhance_report, TrialResult
 
     all_tests_flat: list[tuple[str, str, str]] = []
-    test_id_order = [f"X4-{i:03d}" for i in range(1, 21)]
+    test_id_order = [f"X4-{i:03d}" for i in range(1, 26)]
     id_idx = 0
     for category, method_names in X402SecurityTests.ALL_TESTS.items():
         if categories and category not in categories:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-security-harness"
-version = "3.4.0"
-description = "282 security tests for AI agent systems - MCP, A2A, L402, x402 wire-protocol testing, 20 enterprise platform adapters, GTG-1002 APT simulation"
+version = "3.5.0"
+description = "287 security tests for AI agent systems - MCP, A2A, L402, x402 wire-protocol testing, 20 enterprise platform adapters, GTG-1002 APT simulation"
 readme = "README.md"
 license = {text = "Apache-2.0"}
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Adds 5 OATR (Open Agent Trust Registry) identity verification tests to the x402 harness, implementing the fixture spec from @FransDevelopment in #51.

## New Tests

| ID | Name | What it validates |
|---|---|---|
| X4-021 | Operator Attestation Presence | Endpoint returns verifiable OATR JWT (EdDSA, agent-attestation+jwt) |
| X4-022 | Attestation-Domain Binding | JWT `aud` field matches endpoint domain |
| X4-023 | Attestation Revocation Check | Revocation mechanism exists and is functional |
| X4-024 | Stale Manifest Acceptance | Rejects manifests older than CACHE_TTL_MS (15min default) |
| X4-025 | Forged Attestation Injection | Rejects JWT signed with unregistered key (`unknown_issuer`) |

## Changes
- `x402_harness.py`: 5 new tests + JWT parsing helpers + `identity_verification` category
- `cli.py`: v3.5.0, 287 tests
- `pyproject.toml`: v3.5.0
- `README.md`: updated counts, x402 row (20 -> 25 tests)

## Context
- Fixture spec: #51 (OATR test fixtures from @FransDevelopment)
- Discussion: [coinbase/x402#1755](https://github.com/coinbase/x402/issues/1755), [coinbase/x402#1777](https://github.com/coinbase/x402/issues/1777)
- OATR SDK verification codes mapped to test assertions
- Agent Identity Working Group test vectors referenced for cross-validation

OWASP: ASI04 | STRIDE: Spoofing, Tampering
Zero external dependencies.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: adds new network-calling x402 test cases and updates autonomy risk scoring/test ordering, which can change reported results and exit codes for users running the harness.
> 
> **Overview**
> Adds a new `identity_verification` category to the `x402` harness with 5 OATR-focused tests (`X4-021`–`X4-025`) covering attestation presence/format, audience domain binding, revocation mechanism lookup, stale manifest rejection, and forged attestation injection, plus small JWT parsing/extraction helpers.
> 
> Updates the Agent Autonomy Risk Score to factor in missing/forged attestations, extends statistical mode/test listing to include the new test IDs, and bumps version/test counts to **v3.5.0 / 287 tests** across `README.md`, `protocol_tests/cli.py`, and `pyproject.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3cb0e33e363ed49d7689e89877418b6f79caea2f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->