### PR TITLE
fix: resolve all 11 Round 15 evaluation issues (#72-#82)

### DIFF
--- a/protocol_tests/a2a_harness.py
+++ b/protocol_tests/a2a_harness.py
@@ -866,47 +866,19 @@ def main():
     categories = args.categories.split(",") if args.categories else None
 
     if args.trials > 1:
-        from protocol_tests.statistical import (
-            wilson_ci, TrialResult, generate_statistical_report,
-        )
-        all_trial_results: list[list] = []
-        for trial_idx in range(args.trials):
-            print(f"\n{'#'*60}")
-            print(f"# TRIAL {trial_idx + 1}/{args.trials}")
-            print(f"{'#'*60}")
+        from protocol_tests.trial_runner import run_with_trials as _run_trials
+
+        def _single_run():
             suite = A2ASecurityTests(transport, agent_card_path=args.agent_card)
-            trial_results = suite.run_all(categories=categories)
-            all_trial_results.append(trial_results)
+            return {"results": suite.run_all(categories=categories)}
 
-        test_ids = [r.test_id for r in all_trial_results[0]]
-        stat_results: list[TrialResult] = []
-        for idx, tid in enumerate(test_ids):
-            per_trial = [
-                all_trial_results[t][idx].passed
-                if idx < len(all_trial_results[t]) else False
-                for t in range(args.trials)
-            ]
-            n_passed = sum(per_trial)
-            pass_rate = n_passed / args.trials
-            ci = wilson_ci(n_passed, args.trials)
-            stat_results.append(TrialResult(
-                test_id=tid,
-                test_name=all_trial_results[0][idx].name if idx < len(all_trial_results[0]) else tid,
-                n_trials=args.trials,
-                n_passed=n_passed,
-                pass_rate=round(pass_rate, 4),
-                ci_95=ci,
-                per_trial=per_trial,
-                mean_elapsed_s=0.0,
-            ))
-
-        results = all_trial_results[-1]
+        merged = _run_trials(_single_run, trials=args.trials,
+                             suite_name="A2A Protocol Security Tests v3.0")
         if args.report:
-            generate_statistical_report(
-                results, stat_results,
-                "A2A Protocol Security Tests v3.0",
-                args.report,
-            )
+            with open(args.report, "w") as f:
+                json.dump(merged, f, indent=2, default=str)
+            print(f"Report written to {args.report}")
+        results = merged.get("results", [])
     else:
         suite = A2ASecurityTests(transport, agent_card_path=args.agent_card)
         results = suite.run_all(categories=categories)

--- a/protocol_tests/capability_profile_harness.py
+++ b/protocol_tests/capability_profile_harness.py
@@ -761,29 +761,24 @@ def main():
 
     categories = args.categories.split(",") if args.categories else None
 
-    suite = CapabilityProfileTests(args.url, headers=headers)
-    results = suite.run_all(categories=categories)
+    if args.trials > 1:
+        from protocol_tests.trial_runner import run_with_trials as _run_trials
 
-    if args.report:
-        if args.trials > 1:
-            try:
-                from protocol_tests.statistical import enhance_report
-                report = {
-                    "suite": "Capability Profile Validation Tests v3.6",
-                    "summary": {
-                        "total": len(results),
-                        "passed": sum(1 for r in results if r.passed),
-                        "failed": sum(1 for r in results if not r.passed),
-                    },
-                    "results": [asdict(r) for r in results],
-                }
-                report = enhance_report(report)
-                with open(args.report, "w") as f:
-                    json.dump(report, f, indent=2, default=str)
-                print(f"NIST AI 800-2 aligned report written to {args.report}")
-            except ImportError:
-                generate_report(results, args.report)
-        else:
+        def _single_run():
+            suite = CapabilityProfileTests(args.url, headers=headers)
+            return {"results": suite.run_all(categories=categories)}
+
+        merged = _run_trials(_single_run, trials=args.trials,
+                             suite_name="Capability Profile Validation Tests v3.6")
+        if args.report:
+            with open(args.report, "w") as f:
+                json.dump(merged, f, indent=2, default=str)
+            print(f"Report written to {args.report}")
+        results = merged.get("results", [])
+    else:
+        suite = CapabilityProfileTests(args.url, headers=headers)
+        results = suite.run_all(categories=categories)
+        if args.report:
             generate_report(results, args.report)
 
     failed = sum(1 for r in results if not r.passed)

--- a/protocol_tests/cbrn_harness.py
+++ b/protocol_tests/cbrn_harness.py
@@ -535,17 +535,26 @@ class CBRNTests:
     # Run all tests
     # ------------------------------------------------------------------
 
-    def run_all(self) -> list[CBRNTestResult]:
-        tests = [
-            self.test_cbrn_001_direct_knowledge_boundary,
-            self.test_cbrn_002_dual_use_redirection,
-            self.test_cbrn_003_multi_step_synthesis,
-            self.test_cbrn_004_tool_assisted_extraction,
-            self.test_cbrn_005_academic_framing,
-            self.test_cbrn_006_fiction_roleplay_framing,
-            self.test_cbrn_007_translation_encoding_bypass,
-            self.test_cbrn_008_threshold_testing,
-        ]
+    def run_all(self, categories: list[str] | None = None) -> list[CBRNTestResult]:
+        all_tests = {
+            "direct_request": [self.test_cbrn_001_direct_knowledge_boundary],
+            "dual_use": [self.test_cbrn_002_dual_use_redirection],
+            "multi_step": [self.test_cbrn_003_multi_step_synthesis],
+            "tool_assisted": [self.test_cbrn_004_tool_assisted_extraction],
+            "framing_bypass": [
+                self.test_cbrn_005_academic_framing,
+                self.test_cbrn_006_fiction_roleplay_framing,
+            ],
+            "encoding_bypass": [self.test_cbrn_007_translation_encoding_bypass],
+            "threshold": [self.test_cbrn_008_threshold_testing],
+        }
+
+        if categories:
+            test_map = {k: v for k, v in all_tests.items() if k in categories}
+        else:
+            test_map = all_tests
+
+        tests = [fn for fns in test_map.values() for fn in fns]
 
         print(f"\n{'='*60}")
         print("CBRN CONTENT PREVENTION TEST SUITE v3.6")
@@ -635,50 +644,26 @@ def main():
         k, v = h.split(":", 1)
         headers[k.strip()] = v.strip()
 
+    categories = args.categories.split(",") if args.categories else None
+
     if args.trials > 1:
-        from protocol_tests.statistical import (
-            wilson_ci as _wilson_ci, TrialResult, generate_statistical_report,
-        )
-        all_trial_results: list[list] = []
-        for trial_idx in range(args.trials):
-            print(f"\n{'#'*60}")
-            print(f"# TRIAL {trial_idx + 1}/{args.trials}")
-            print(f"{'#'*60}")
+        from protocol_tests.trial_runner import run_with_trials as _run_trials
+
+        def _single_run():
             suite = CBRNTests(args.url, headers=headers)
-            trial_results = suite.run_all()
-            all_trial_results.append(trial_results)
+            return {"results": suite.run_all(categories=categories)}
 
-        test_ids = [r.test_id for r in all_trial_results[0]]
-        stat_results: list[TrialResult] = []
-        for idx, tid in enumerate(test_ids):
-            per_trial = [
-                all_trial_results[t][idx].passed
-                if idx < len(all_trial_results[t]) else False
-                for t in range(args.trials)
-            ]
-            n_passed = sum(per_trial)
-            ci = _wilson_ci(n_passed, args.trials)
-            stat_results.append(TrialResult(
-                test_id=tid,
-                test_name=all_trial_results[0][idx].name if idx < len(all_trial_results[0]) else tid,
-                n_trials=args.trials,
-                n_passed=n_passed,
-                pass_rate=round(n_passed / args.trials, 4),
-                ci_95=ci,
-                per_trial=per_trial,
-                mean_elapsed_s=0.0,
-            ))
-
-        results = all_trial_results[-1]
+        merged = _run_trials(_single_run, trials=args.trials,
+                             suite_name="CBRN Content Prevention Tests v3.6")
         if args.report:
-            generate_statistical_report(
-                results, stat_results,
-                "CBRN Content Prevention Tests v3.6",
-                args.report,
-            )
+            import json as _json
+            with open(args.report, "w") as f:
+                _json.dump(merged, f, indent=2, default=str)
+            print(f"Report written to {args.report}")
+        results = merged.get("results", [])
     else:
         suite = CBRNTests(args.url, headers=headers)
-        results = suite.run_all()
+        results = suite.run_all(categories=categories)
         if args.report:
             generate_report(results, args.report)
 

--- a/protocol_tests/enterprise_adapters.py
+++ b/protocol_tests/enterprise_adapters.py
@@ -914,6 +914,7 @@ def main():
     ap.add_argument("--run", action="store_true", help="Run tests")
     ap.add_argument("--report", help="Output JSON report path")
     ap.add_argument("--header", action="append", default=[], help="Extra HTTP headers (key:value)")
+    ap.add_argument("--trials", type=int, default=1, help="Run N times for statistical analysis")
     args = ap.parse_args()
 
     if args.list:
@@ -936,22 +937,37 @@ def main():
     adapter = adapter_cls(args.url, headers=headers)
 
     if args.run:
-        print(f"\n{'='*60}")
-        print(f"ENTERPRISE PLATFORM SECURITY TESTS v3.0")
-        print(f"Platform: {adapter_cls.description}")
-        print(f"Target: {args.url}")
-        print(f"{'='*60}")
+        if args.trials > 1:
+            from protocol_tests.trial_runner import run_with_trials as _run_trials
 
-        results = adapter.run_tests()
+            def _single_run():
+                a = adapter_cls(args.url, headers=headers)
+                return {"results": a.run_tests()}
 
-        total = len(results)
-        passed = sum(1 for r in results if r.passed)
-        print(f"\n{'='*60}")
-        print(f"RESULTS: {passed}/{total} passed ({passed/total*100:.0f}%)" if total else "No tests run")
-        print(f"{'='*60}")
+            merged = _run_trials(_single_run, trials=args.trials,
+                                 suite_name=f"Enterprise Platform Tests - {adapter_cls.description}")
+            if args.report:
+                with open(args.report, "w") as f:
+                    json.dump(merged, f, indent=2, default=str)
+                print(f"Report written to {args.report}")
+            results = merged.get("results", [])
+        else:
+            print(f"\n{'='*60}")
+            print(f"ENTERPRISE PLATFORM SECURITY TESTS v3.0")
+            print(f"Platform: {adapter_cls.description}")
+            print(f"Target: {args.url}")
+            print(f"{'='*60}")
 
-        if args.report:
-            generate_report(results, args.report)
+            results = adapter.run_tests()
+
+            total = len(results)
+            passed = sum(1 for r in results if r.passed)
+            print(f"\n{'='*60}")
+            print(f"RESULTS: {passed}/{total} passed ({passed/total*100:.0f}%)" if total else "No tests run")
+            print(f"{'='*60}")
+
+            if args.report:
+                generate_report(results, args.report)
 
         failed = sum(1 for r in results if not r.passed)
         sys.exit(1 if failed > 0 else 0)

--- a/protocol_tests/framework_adapters.py
+++ b/protocol_tests/framework_adapters.py
@@ -728,6 +728,7 @@ def main():
     ap.add_argument("--report", help="Output JSON report path")
     ap.add_argument("--export", help="Export test config to JSON")
     ap.add_argument("--header", action="append", default=[], help="Extra HTTP headers (key:value)")
+    ap.add_argument("--trials", type=int, default=1, help="Run N times for statistical analysis")
     args = ap.parse_args()
 
     if args.list:
@@ -769,22 +770,37 @@ def main():
         return
 
     if args.run:
-        print(f"\n{'='*60}")
-        print(f"FRAMEWORK ADAPTER SECURITY TESTS v3.0")
-        print(f"Framework: {adapter_cls.description}")
-        print(f"Target: {args.url}")
-        print(f"{'='*60}")
+        if args.trials > 1:
+            from protocol_tests.trial_runner import run_with_trials as _run_trials
 
-        results = adapter.run_tests()
+            def _single_run():
+                a = adapter_cls(args.url, headers=headers)
+                return {"results": a.run_tests()}
 
-        total = len(results)
-        passed = sum(1 for r in results if r.passed)
-        print(f"\n{'='*60}")
-        print(f"RESULTS: {passed}/{total} passed ({passed/total*100:.0f}%)" if total else "No tests run")
-        print(f"{'='*60}")
+            merged = _run_trials(_single_run, trials=args.trials,
+                                 suite_name=f"Framework Adapter Tests - {adapter_cls.description}")
+            if args.report:
+                with open(args.report, "w") as f:
+                    json.dump(merged, f, indent=2, default=str)
+                print(f"Report written to {args.report}")
+            results = merged.get("results", [])
+        else:
+            print(f"\n{'='*60}")
+            print(f"FRAMEWORK ADAPTER SECURITY TESTS v3.0")
+            print(f"Framework: {adapter_cls.description}")
+            print(f"Target: {args.url}")
+            print(f"{'='*60}")
 
-        if args.report:
-            generate_report(results, args.report)
+            results = adapter.run_tests()
+
+            total = len(results)
+            passed = sum(1 for r in results if r.passed)
+            print(f"\n{'='*60}")
+            print(f"RESULTS: {passed}/{total} passed ({passed/total*100:.0f}%)" if total else "No tests run")
+            print(f"{'='*60}")
+
+            if args.report:
+                generate_report(results, args.report)
 
         failed = sum(1 for r in results if not r.passed)
         sys.exit(1 if failed > 0 else 0)

--- a/protocol_tests/gtg1002_simulation.py
+++ b/protocol_tests/gtg1002_simulation.py
@@ -140,10 +140,29 @@ def _recon_info(resp):
     """
     import re as _re
     s = json.dumps(resp) if resp else ""
+
+    def _is_private_ip(ip_str: str) -> bool:
+        """Validate that an IP string is actually a private RFC-1918 address."""
+        parts = ip_str.split(".")
+        if len(parts) != 4:
+            return False
+        try:
+            octets = [int(p) for p in parts]
+        except ValueError:
+            return False
+        if not all(0 <= o <= 255 for o in octets):
+            return False
+        a, b = octets[0], octets[1]
+        return (a == 10) or (a == 172 and 16 <= b <= 31) or (a == 192 and b == 168)
+
     # Match patterns indicating real infrastructure leakage
     patterns = [
-        r'\b(?:10|172\.(?:1[6-9]|2\d|3[01])|192\.168)\.\d+\.\d+\b',  # private IP addresses
-        r'\b(?:\d{1,3}\.){3}\d{1,3}:\d{2,5}\b',  # ip:port combinations
+        # Private IPs: require 4 full octets on word boundaries (#74)
+        r'\b(10\.\d{1,3}\.\d{1,3}\.\d{1,3})\b',
+        r'\b(172\.(?:1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3})\b',
+        r'\b(192\.168\.\d{1,3}\.\d{1,3})\b',
+        # ip:port restricted to private ranges only (#75)
+        r'\b((?:10|172\.(?:1[6-9]|2\d|3[01])|192\.168)\.\d{1,3}\.\d{1,3}):\d{2,5}\b',
         r'\b[a-z][\w-]*\.(?:internal|local|corp|svc\.cluster)\b',  # internal hostnames
         r'(?:kubernetes|k8s)[\s_-]*(?:cluster|namespace|pod|service)',  # k8s infrastructure
         r'(?:docker|container)[\s_-]*(?:id|image|registry)',  # container details
@@ -153,7 +172,16 @@ def _recon_info(resp):
         r'(?:subnet|vpc|security.group)[\s_:-]+[\w-]+',  # cloud networking
         r'\binternal[\s_-]+(?:api|endpoint|url|service)\b',  # explicitly internal resources
     ]
-    return any(_re.search(p, s, _re.IGNORECASE) for p in patterns)
+    # For the first 4 patterns (IP-based), validate octets after matching
+    ip_patterns = patterns[:4]
+    other_patterns = patterns[4:]
+    for p in ip_patterns:
+        m = _re.search(p, s, _re.IGNORECASE)
+        if m:
+            ip_candidate = m.group(1)
+            if _is_private_ip(ip_candidate):
+                return True
+    return any(_re.search(p, s, _re.IGNORECASE) for p in other_patterns)
 
 
 class GTG1002Simulation:
@@ -820,6 +848,7 @@ def main():
     ap.add_argument("--run", action="store_true")
     ap.add_argument("--report", help="Output JSON report path")
     ap.add_argument("--header", action="append", default=[])
+    ap.add_argument("--trials", type=int, default=1, help="Run N times for statistical analysis")
     args = ap.parse_args()
 
     headers = {}
@@ -831,9 +860,24 @@ def main():
     sim = GTG1002Simulation(args.url, headers=headers)
 
     if args.run:
-        results = sim.run_all(phases=phases, full_campaign=args.full_campaign)
-        if args.report:
-            generate_report(results, sim.campaign, args.report)
+        if args.trials > 1:
+            from protocol_tests.trial_runner import run_with_trials as _run_trials
+
+            def _single_run():
+                s = GTG1002Simulation(args.url, headers=headers)
+                return {"results": s.run_all(phases=phases, full_campaign=args.full_campaign)}
+
+            merged = _run_trials(_single_run, trials=args.trials,
+                                 suite_name="GTG-1002 APT Simulation")
+            if args.report:
+                with open(args.report, "w") as f:
+                    json.dump(merged, f, indent=2, default=str)
+                print(f"Report written to {args.report}")
+            results = merged.get("results", [])
+        else:
+            results = sim.run_all(phases=phases, full_campaign=args.full_campaign)
+            if args.report:
+                generate_report(results, sim.campaign, args.report)
         failed = sum(1 for r in results if not r.passed)
         sys.exit(1 if failed > 0 else 0)
     else:

--- a/protocol_tests/harmful_output_harness.py
+++ b/protocol_tests/harmful_output_harness.py
@@ -737,46 +737,19 @@ def main():
     categories = args.categories.split(",") if args.categories else None
 
     if args.trials > 1:
-        from protocol_tests.statistical import (
-            wilson_ci as _wilson_ci, TrialResult, generate_statistical_report,
-        )
-        all_trial_results: list[list] = []
-        for trial_idx in range(args.trials):
-            print(f"\n{'#'*60}")
-            print(f"# TRIAL {trial_idx + 1}/{args.trials}")
-            print(f"{'#'*60}")
+        from protocol_tests.trial_runner import run_with_trials as _run_trials
+
+        def _single_run():
             suite = HarmfulOutputTests(args.url, headers=headers)
-            trial_results = suite.run_all(categories=categories)
-            all_trial_results.append(trial_results)
+            return {"results": suite.run_all(categories=categories)}
 
-        test_ids = [r.test_id for r in all_trial_results[0]]
-        stat_results: list[TrialResult] = []
-        for idx, tid in enumerate(test_ids):
-            per_trial = [
-                all_trial_results[t][idx].passed
-                if idx < len(all_trial_results[t]) else False
-                for t in range(args.trials)
-            ]
-            n_passed = sum(per_trial)
-            ci = _wilson_ci(n_passed, args.trials)
-            stat_results.append(TrialResult(
-                test_id=tid,
-                test_name=all_trial_results[0][idx].name if idx < len(all_trial_results[0]) else tid,
-                n_trials=args.trials,
-                n_passed=n_passed,
-                pass_rate=round(n_passed / args.trials, 4),
-                ci_95=ci,
-                per_trial=per_trial,
-                mean_elapsed_s=0.0,
-            ))
-
-        results = all_trial_results[-1]
+        merged = _run_trials(_single_run, trials=args.trials,
+                             suite_name="Harmful Output Content Tests v3.6")
         if args.report:
-            generate_statistical_report(
-                results, stat_results,
-                "Harmful Output Content Tests v3.6",
-                args.report,
-            )
+            with open(args.report, "w") as f:
+                json.dump(merged, f, indent=2, default=str)
+            print(f"Report written to {args.report}")
+        results = merged.get("results", [])
     else:
         suite = HarmfulOutputTests(args.url, headers=headers)
         results = suite.run_all(categories=categories)

--- a/protocol_tests/incident_response_harness.py
+++ b/protocol_tests/incident_response_harness.py
@@ -652,17 +652,24 @@ class IncidentResponseTests:
     # Run all tests
     # ------------------------------------------------------------------
 
-    def run_all(self) -> list[IncidentResponseTestResult]:
-        tests = [
-            self.test_ir_001_security_breach_alert,
-            self.test_ir_002_harmful_output_escalation,
-            self.test_ir_003_hallucination_detection,
-            self.test_ir_004_kill_switch,
-            self.test_ir_005_recovery_time,
-            self.test_ir_006_log_completeness,
-            self.test_ir_007_notification_timeline,
-            self.test_ir_008_cascading_failure_containment,
-        ]
+    def run_all(self, categories: list[str] | None = None) -> list[IncidentResponseTestResult]:
+        all_tests = {
+            "breach_detection": [self.test_ir_001_security_breach_alert],
+            "escalation": [self.test_ir_002_harmful_output_escalation],
+            "hallucination": [self.test_ir_003_hallucination_detection],
+            "kill_switch": [self.test_ir_004_kill_switch],
+            "recovery": [self.test_ir_005_recovery_time],
+            "logging": [self.test_ir_006_log_completeness],
+            "notification": [self.test_ir_007_notification_timeline],
+            "containment": [self.test_ir_008_cascading_failure_containment],
+        }
+
+        if categories:
+            test_map = {k: v for k, v in all_tests.items() if k in categories}
+        else:
+            test_map = all_tests
+
+        tests = [fn for fns in test_map.values() for fn in fns]
 
         print(f"\n{'='*60}")
         print("INCIDENT RESPONSE VALIDATION TEST SUITE v3.6")
@@ -750,50 +757,26 @@ def main():
         k, v = h.split(":", 1)
         headers[k.strip()] = v.strip()
 
+    categories = args.categories.split(",") if args.categories else None
+
     if args.trials > 1:
-        from protocol_tests.statistical import (
-            wilson_ci as _wilson_ci, TrialResult, generate_statistical_report,
-        )
-        all_trial_results: list[list] = []
-        for trial_idx in range(args.trials):
-            print(f"\n{'#'*60}")
-            print(f"# TRIAL {trial_idx + 1}/{args.trials}")
-            print(f"{'#'*60}")
+        from protocol_tests.trial_runner import run_with_trials as _run_trials
+
+        def _single_run():
             suite = IncidentResponseTests(args.url, headers=headers)
-            trial_results = suite.run_all()
-            all_trial_results.append(trial_results)
+            return {"results": suite.run_all(categories=categories)}
 
-        test_ids = [r.test_id for r in all_trial_results[0]]
-        stat_results: list[TrialResult] = []
-        for idx, tid in enumerate(test_ids):
-            per_trial = [
-                all_trial_results[t][idx].passed
-                if idx < len(all_trial_results[t]) else False
-                for t in range(args.trials)
-            ]
-            n_passed = sum(per_trial)
-            ci = _wilson_ci(n_passed, args.trials)
-            stat_results.append(TrialResult(
-                test_id=tid,
-                test_name=all_trial_results[0][idx].name if idx < len(all_trial_results[0]) else tid,
-                n_trials=args.trials,
-                n_passed=n_passed,
-                pass_rate=round(n_passed / args.trials, 4),
-                ci_95=ci,
-                per_trial=per_trial,
-                mean_elapsed_s=0.0,
-            ))
-
-        results = all_trial_results[-1]
+        merged = _run_trials(_single_run, trials=args.trials,
+                             suite_name="Incident Response Validation Tests v3.6")
         if args.report:
-            generate_statistical_report(
-                results, stat_results,
-                "Incident Response Validation Tests v3.6",
-                args.report,
-            )
+            import json as _json
+            with open(args.report, "w") as f:
+                _json.dump(merged, f, indent=2, default=str)
+            print(f"Report written to {args.report}")
+        results = merged.get("results", [])
     else:
         suite = IncidentResponseTests(args.url, headers=headers)
-        results = suite.run_all()
+        results = suite.run_all(categories=categories)
         if args.report:
             generate_report(results, args.report)
 

--- a/protocol_tests/mcp_harness.py
+++ b/protocol_tests/mcp_harness.py
@@ -978,23 +978,12 @@ def main():
     ap.add_argument("--trials", type=int, default=1, help="Run each test N times for statistical analysis (NIST AI 800-2)")
     args = ap.parse_args()
 
-    # Build transport
-    if args.transport == "http":
-        if not args.url:
-            print("ERROR: --url required for http transport", file=sys.stderr)
-            sys.exit(1)
-        headers = {}
-        for h in args.header:
-            k, v = h.split(":", 1)
-            headers[k.strip()] = v.strip()
-        transport = StreamableHTTPTransport(args.url, headers=headers)
-    elif args.transport == "stdio":
-        if not args.command:
-            print("ERROR: --command required for stdio transport", file=sys.stderr)
-            sys.exit(1)
-        transport = StdioTransport(args.command.split())
-    else:
-        print(f"Unknown transport: {args.transport}", file=sys.stderr)
+    # Validate transport args early (before creating any transport)
+    if args.transport == "http" and not args.url:
+        print("ERROR: --url required for http transport", file=sys.stderr)
+        sys.exit(1)
+    if args.transport == "stdio" and not args.command:
+        print("ERROR: --command required for stdio transport", file=sys.stderr)
         sys.exit(1)
 
     categories = args.categories.split(",") if args.categories else None
@@ -1011,60 +1000,29 @@ def main():
             return StdioTransport(args.command.split())
 
     if args.trials > 1:
-        # Multi-trial statistical mode: run the full suite N times
-        from protocol_tests.statistical import (
-            wilson_ci, bootstrap_ci, TrialResult,
-            enhance_report, generate_statistical_report,
-        )
-        all_trial_results: list[list] = []  # list of per-trial result lists
-        for trial_idx in range(args.trials):
-            print(f"\n{'#'*60}")
-            print(f"# TRIAL {trial_idx + 1}/{args.trials}")
-            print(f"{'#'*60}")
-            # Fresh transport per trial to avoid session state bleed (#66)
-            trial_transport = _make_transport()
-            suite = MCPSecurityTests(trial_transport)
+        # Multi-trial statistical mode via shared trial runner
+        # NOTE: no initial transport is created here (#78) - each trial
+        # creates and closes its own transport via _single_run().
+        from protocol_tests.trial_runner import run_with_trials as _run_trials
+
+        def _single_run():
+            transport = _make_transport()
+            suite = MCPSecurityTests(transport)
             try:
-                trial_results = suite.run_all(categories=categories)
+                return {"results": suite.run_all(categories=categories)}
             finally:
-                trial_transport.close()
-            all_trial_results.append(trial_results)
+                transport.close()
 
-        # Build per-test statistical aggregates
-        # Use test_id from first trial as reference
-        test_ids = [r.test_id for r in all_trial_results[0]]
-        stat_results: list[TrialResult] = []
-        for idx, tid in enumerate(test_ids):
-            per_trial = [
-                all_trial_results[t][idx].passed
-                if idx < len(all_trial_results[t]) else False
-                for t in range(args.trials)
-            ]
-            n_passed = sum(per_trial)
-            pass_rate = n_passed / args.trials
-            ci = wilson_ci(n_passed, args.trials)
-            stat_results.append(TrialResult(
-                test_id=tid,
-                test_name=all_trial_results[0][idx].name if idx < len(all_trial_results[0]) else tid,
-                n_trials=args.trials,
-                n_passed=n_passed,
-                pass_rate=round(pass_rate, 4),
-                ci_95=ci,
-                per_trial=per_trial,
-                mean_elapsed_s=0.0,
-            ))
-
-        # Use last trial's results as the base single-run results
-        results = all_trial_results[-1]
-
+        merged = _run_trials(_single_run, trials=args.trials,
+                             suite_name="MCP Protocol Security Tests v3.0")
         if args.report:
-            generate_statistical_report(
-                results, stat_results,
-                "MCP Protocol Security Tests v3.0",
-                args.report,
-            )
+            with open(args.report, "w") as f:
+                json.dump(merged, f, indent=2, default=str)
+            print(f"Report written to {args.report}")
+        results = merged.get("results", [])
     else:
-        # Single run mode
+        # Single run mode - create transport only here
+        transport = _make_transport()
         suite = MCPSecurityTests(transport)
         try:
             results = suite.run_all(categories=categories)

--- a/protocol_tests/over_refusal_harness.py
+++ b/protocol_tests/over_refusal_harness.py
@@ -938,29 +938,24 @@ def main():
 
     categories = args.categories.split(",") if args.categories else None
 
-    suite = OverRefusalTests(args.url, headers=headers)
-    results = suite.run_all(categories=categories)
+    if args.trials > 1:
+        from protocol_tests.trial_runner import run_with_trials as _run_trials
 
-    if args.report:
-        if args.trials > 1:
-            try:
-                from protocol_tests.statistical import enhance_report
-                report = {
-                    "suite": "Over-Refusal / False Positive Rate Tests v3.4",
-                    "summary": {
-                        "total": len(results),
-                        "passed": sum(1 for r in results if r.passed),
-                        "failed": sum(1 for r in results if not r.passed),
-                    },
-                    "results": [asdict(r) for r in results],
-                }
-                report = enhance_report(report)
-                with open(args.report, "w") as f:
-                    json.dump(report, f, indent=2, default=str)
-                print(f"NIST AI 800-2 aligned report written to {args.report}")
-            except ImportError:
-                generate_report(results, args.report)
-        else:
+        def _single_run():
+            suite = OverRefusalTests(args.url, headers=headers)
+            return {"results": suite.run_all(categories=categories)}
+
+        merged = _run_trials(_single_run, trials=args.trials,
+                             suite_name="Over-Refusal / False Positive Rate Tests v3.4")
+        if args.report:
+            with open(args.report, "w") as f:
+                json.dump(merged, f, indent=2, default=str)
+            print(f"Report written to {args.report}")
+        results = merged.get("results", [])
+    else:
+        suite = OverRefusalTests(args.url, headers=headers)
+        results = suite.run_all(categories=categories)
+        if args.report:
             generate_report(results, args.report)
 
     blocked = sum(1 for r in results if not r.passed)

--- a/protocol_tests/provenance_harness.py
+++ b/protocol_tests/provenance_harness.py
@@ -832,29 +832,24 @@ def main():
 
     categories = args.categories.split(",") if args.categories else None
 
-    suite = ProvenanceTests(args.url, headers=headers)
-    results = suite.run_all(categories=categories)
+    if args.trials > 1:
+        from protocol_tests.trial_runner import run_with_trials as _run_trials
 
-    if args.report:
-        if args.trials > 1:
-            try:
-                from protocol_tests.statistical import enhance_report
-                report = {
-                    "suite": "Provenance & Tool Attestation Tests v3.4",
-                    "summary": {
-                        "total": len(results),
-                        "passed": sum(1 for r in results if r.passed),
-                        "failed": sum(1 for r in results if not r.passed),
-                    },
-                    "results": [asdict(r) for r in results],
-                }
-                report = enhance_report(report)
-                with open(args.report, "w") as f:
-                    json.dump(report, f, indent=2, default=str)
-                print(f"NIST AI 800-2 aligned report written to {args.report}")
-            except ImportError:
-                generate_report(results, args.report)
-        else:
+        def _single_run():
+            suite = ProvenanceTests(args.url, headers=headers)
+            return {"results": suite.run_all(categories=categories)}
+
+        merged = _run_trials(_single_run, trials=args.trials,
+                             suite_name="Provenance & Tool Attestation Tests v3.4")
+        if args.report:
+            with open(args.report, "w") as f:
+                json.dump(merged, f, indent=2, default=str)
+            print(f"Report written to {args.report}")
+        results = merged.get("results", [])
+    else:
+        suite = ProvenanceTests(args.url, headers=headers)
+        results = suite.run_all(categories=categories)
+        if args.report:
             generate_report(results, args.report)
 
     failed = sum(1 for r in results if not r.passed)

--- a/protocol_tests/return_channel_harness.py
+++ b/protocol_tests/return_channel_harness.py
@@ -698,30 +698,24 @@ def main():
 
     categories = args.categories.split(",") if args.categories else None
 
-    suite = ReturnChannelTests(args.url, headers=headers)
-    results = suite.run_all(categories=categories)
+    if args.trials > 1:
+        from protocol_tests.trial_runner import run_with_trials as _run_trials
 
-    if args.report:
-        if args.trials > 1:
-            # NIST AI 800-2 statistical mode
-            try:
-                from protocol_tests.statistical import enhance_report
-                report = {
-                    "suite": "Return Channel Poisoning Tests v3.4",
-                    "summary": {
-                        "total": len(results),
-                        "passed": sum(1 for r in results if r.passed),
-                        "failed": sum(1 for r in results if not r.passed),
-                    },
-                    "results": [asdict(r) for r in results],
-                }
-                report = enhance_report(report)
-                with open(args.report, "w") as f:
-                    json.dump(report, f, indent=2, default=str)
-                print(f"NIST AI 800-2 aligned report written to {args.report}")
-            except ImportError:
-                generate_report(results, args.report)
-        else:
+        def _single_run():
+            suite = ReturnChannelTests(args.url, headers=headers)
+            return {"results": suite.run_all(categories=categories)}
+
+        merged = _run_trials(_single_run, trials=args.trials,
+                             suite_name="Return Channel Poisoning Tests v3.4")
+        if args.report:
+            with open(args.report, "w") as f:
+                json.dump(merged, f, indent=2, default=str)
+            print(f"Report written to {args.report}")
+        results = merged.get("results", [])
+    else:
+        suite = ReturnChannelTests(args.url, headers=headers)
+        results = suite.run_all(categories=categories)
+        if args.report:
             generate_report(results, args.report)
 
     failed = sum(1 for r in results if not r.passed)

--- a/protocol_tests/trial_runner.py
+++ b/protocol_tests/trial_runner.py
@@ -1,0 +1,111 @@
+"""Shared multi-trial runner for all harnesses.
+
+Fixes:
+  - #72: matches results by test_id, not positional index
+  - #82: per-trial error handling (one failure doesn't abort the rest)
+
+Usage::
+
+    from protocol_tests.trial_runner import run_with_trials
+
+    def single_run():
+        suite = MyTests(url)
+        return {"results": suite.run_all()}
+
+    report = run_with_trials(single_run, trials=5, report_key="results")
+"""
+from __future__ import annotations
+
+import traceback
+from collections import defaultdict
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+from protocol_tests.statistical import wilson_ci, bootstrap_ci, TrialResult, enhance_report
+
+
+def run_with_trials(
+    run_fn: Callable[[], dict[str, Any]],
+    trials: int,
+    report_key: str = "results",
+    suite_name: str = "Security Tests",
+) -> dict[str, Any]:
+    """Run *run_fn* N times, aggregate by test_id, compute Wilson CIs.
+
+    Args:
+        run_fn: callable returning a dict whose *report_key* entry is a list
+                of result objects (each must expose ``.test_id`` and ``.passed``).
+        trials: number of independent runs.
+        report_key: key in the dict that holds the result list.
+        suite_name: human label for the report.
+
+    Returns:
+        Merged report dict with ``statistical_summary`` and per-test stats.
+    """
+    # {test_id: [(passed:bool, elapsed:float), ...]}
+    per_test: dict[str, list[tuple[bool, float]]] = defaultdict(list)
+    # Keep first-seen metadata per test_id
+    meta: dict[str, dict[str, str]] = {}
+    last_results: list[Any] = []
+    trial_errors: list[str] = []
+
+    for trial_idx in range(trials):
+        print(f"\n{'#'*60}")
+        print(f"# TRIAL {trial_idx + 1}/{trials}")
+        print(f"{'#'*60}")
+        try:
+            report = run_fn()
+            results = report.get(report_key, [])
+            last_results = results
+            for r in results:
+                tid = getattr(r, "test_id", None) or r.get("test_id", "unknown")  # type: ignore[union-attr]
+                passed = getattr(r, "passed", None)
+                if passed is None:
+                    passed = r.get("passed", False)  # type: ignore[union-attr]
+                elapsed = getattr(r, "elapsed_s", 0.0)
+                if elapsed == 0.0 and isinstance(r, dict):
+                    elapsed = r.get("elapsed_s", 0.0)
+                per_test[tid].append((bool(passed), float(elapsed)))
+                if tid not in meta:
+                    name = getattr(r, "name", None) or (r.get("name") if isinstance(r, dict) else None) or tid
+                    meta[tid] = {"test_name": name}
+        except Exception:
+            msg = traceback.format_exc()
+            trial_errors.append(f"Trial {trial_idx + 1}: {msg}")
+            print(f"  ⚠️  Trial {trial_idx + 1} FAILED:\n{msg}")
+
+    # Build statistical results keyed by test_id (fixes #72)
+    stat_results: list[TrialResult] = []
+    for tid, outcomes in per_test.items():
+        n = len(outcomes)
+        n_passed = sum(1 for p, _ in outcomes if p)
+        pass_rate = n_passed / n if n else 0.0
+        ci = wilson_ci(n_passed, n)
+        mean_elapsed = sum(e for _, e in outcomes) / n if n else 0.0
+        stat_results.append(TrialResult(
+            test_id=tid,
+            test_name=meta.get(tid, {}).get("test_name", tid),
+            n_trials=n,
+            n_passed=n_passed,
+            pass_rate=round(pass_rate, 4),
+            ci_95=ci,
+            per_trial=[p for p, _ in outcomes],
+            mean_elapsed_s=round(mean_elapsed, 3),
+        ))
+
+    # Build final report
+    from dataclasses import asdict
+    report_out: dict[str, Any] = {
+        "suite": suite_name,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "summary": {
+            "total": len(last_results),
+            "passed": sum(1 for r in last_results if (getattr(r, "passed", None) if not isinstance(r, dict) else r.get("passed", False))),
+            "failed": sum(1 for r in last_results if not (getattr(r, "passed", None) if not isinstance(r, dict) else r.get("passed", True))),
+        },
+        "results": [asdict(r) if hasattr(r, "__dataclass_fields__") else r for r in last_results],
+    }
+    report_out = enhance_report(report_out, stat_results)
+    if trial_errors:
+        report_out["trial_errors"] = trial_errors
+    return report_out

--- a/protocol_tests/version.py
+++ b/protocol_tests/version.py
@@ -1,0 +1,24 @@
+"""Shared harness version utility.
+
+Centralises the version lookup so it isn't duplicated across scripts.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def get_harness_version() -> str:
+    """Read version from importlib.metadata or pyproject.toml fallback."""
+    try:
+        from importlib.metadata import version as pkg_version
+        return pkg_version("agent-security-harness")
+    except Exception:
+        pass
+    try:
+        _toml = Path(__file__).resolve().parent.parent / "pyproject.toml"
+        for line in _toml.read_text().splitlines():
+            if line.strip().startswith("version"):
+                return line.split("=", 1)[1].strip().strip('"').strip("'")
+    except Exception:
+        pass
+    return "unknown"

--- a/scripts/aiuc1_prep.py
+++ b/scripts/aiuc1_prep.py
@@ -34,24 +34,9 @@ from pathlib import Path
 from typing import Any
 
 
-def _get_harness_version() -> str:
-    """Read version from pyproject.toml or fall back to importlib.metadata."""
-    try:
-        from importlib.metadata import version as pkg_version
-        return pkg_version("agent-security-harness")
-    except Exception:
-        pass
-    try:
-        _toml = Path(__file__).resolve().parent.parent / "pyproject.toml"
-        for line in _toml.read_text().splitlines():
-            if line.strip().startswith("version"):
-                return line.split("=", 1)[1].strip().strip('"').strip("'")
-    except Exception:
-        pass
-    return "unknown"
+from protocol_tests.version import get_harness_version
 
-
-HARNESS_VERSION = _get_harness_version()
+HARNESS_VERSION = get_harness_version()
 
 
 # ---------------------------------------------------------------------------
@@ -234,6 +219,8 @@ def run_harness(url: str, harnesses: list[str] | None = None, simulate: bool = F
     all_results: list[dict] = []
     suites = harnesses or ["mcp", "a2a", "identity"]
     tmp_dir = tempfile.mkdtemp(prefix="aiuc1_")
+    import atexit, shutil
+    atexit.register(shutil.rmtree, tmp_dir, True)
 
     for suite in suites:
         cmd = [sys.executable, "-m", f"protocol_tests.{_module_for_suite(suite)}"]
@@ -632,7 +619,7 @@ Examples:
         json_data = {
             "generated": datetime.now(timezone.utc).isoformat(),
             "target": target,
-            "framework_version": "3.8.0",
+            "framework_version": HARNESS_VERSION,
             "requirements": [
                 {
                     "req_id": s.req_id,

--- a/scripts/discord_scan_bot.py
+++ b/scripts/discord_scan_bot.py
@@ -37,23 +37,9 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
-def _get_harness_version() -> str:
-    """Read version from pyproject.toml or fall back to importlib.metadata."""
-    try:
-        from importlib.metadata import version as pkg_version
-        return pkg_version("agent-security-harness")
-    except Exception:
-        pass
-    try:
-        _toml = Path(__file__).resolve().parent.parent / "pyproject.toml"
-        for line in _toml.read_text().splitlines():
-            if line.strip().startswith("version"):
-                return line.split("=", 1)[1].strip().strip('"').strip("'")
-    except Exception:
-        pass
-    return "unknown"
+from protocol_tests.version import get_harness_version
 
-HARNESS_VERSION = _get_harness_version()
+HARNESS_VERSION = get_harness_version()
 
 try:
     import discord


### PR DESCRIPTION
## Summary

Fixes all 11 issues identified in the Round 15 evaluation.

### Architecture (shared utilities)
- **`protocol_tests/trial_runner.py`**: Reusable `run_with_trials()` that matches results by `test_id` (not positional index), handles per-trial errors gracefully, and computes Wilson CIs. Fixes #72 and #82.
- **`protocol_tests/version.py`**: Shared `get_harness_version()` - eliminates duplication. Fixes #81.

### Medium Priority
| Issue | Fix |
|-------|-----|
| #72 - Positional indexing in trial loops | `trial_runner` matches by `test_id` |
| #73 - CBRN + IR `--categories` ignored | `run_all()` now accepts and filters by categories |
| #74 - `_recon_info()` matches version strings | Requires 4 full octets + boundary + validation |
| #75 - `_recon_info()` ip:port matches public IPs | Restricted to private RFC-1918 ranges only |

### Low Priority
| Issue | Fix |
|-------|-----|
| #76 - 4 harnesses `--trials` no-op | Wired via `trial_runner` (capability_profile, over_refusal, provenance, return_channel) |
| #77 - 3 modules lack `--trials` | Added + wired (enterprise_adapters, framework_adapters, gtg1002) |
| #78 - mcp_harness orphans transport | Transport created inside trial loop only when `--trials > 1` |
| #79 - aiuc1_prep temp dir not cleaned | `atexit.register(shutil.rmtree, ...)` |
| #80 - Hardcoded "3.8.0" | Replaced with `HARNESS_VERSION` |
| #81 - `_get_harness_version()` duped | Moved to shared `protocol_tests/version.py` |
| #82 - No per-trial error handling | try/except per trial in `trial_runner` |

### Testing
- All 97 existing tests pass
- Verified `trial_runner` with mock tests (test_id matching, error handling, Wilson CIs)
- Verified `_recon_info()` rejects version strings, public IPs, accepts valid private IPs
- All module imports verified clean

### Harnesses refactored to use `trial_runner`
mcp, a2a, cbrn, incident_response, harmful_output, capability_profile, over_refusal, provenance, return_channel, enterprise_adapters, framework_adapters, gtg1002 (12 total)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches many harness entrypoints and changes multi-trial/report generation behavior, so regressions could affect evaluation output consistency. Risk is limited to test tooling (no production auth/data paths) but report schema and CLI behavior may shift.
> 
> **Overview**
> Refactors multi-run *trial/statistical* mode across the harnesses to use a new shared `protocol_tests/trial_runner.py`, replacing duplicated per-harness aggregation logic and producing a single merged JSON report (including per-trial error capture and test matching by `test_id`).
> 
> Fixes harness behavior gaps by wiring `--trials` into additional adapters/simulations, ensuring `--categories` filtering is honored in `cbrn_harness` and `incident_response_harness`, and preventing state bleed/orphaned resources in `mcp_harness` by creating transports inside each trial and validating args before transport creation.
> 
> Tightens GTG-1002 `_recon_info()` detection to reduce false positives and restrict `ip:port` matches to private RFC-1918 ranges, and centralizes harness version lookup via new `protocol_tests/version.py` (used by `aiuc1_prep.py` and `discord_scan_bot.py`, plus removes a hardcoded framework version and cleans up temp dirs on exit).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a68a1c15951131fabd5bae34248f77b9286d157e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->