### PR TITLE
fix: resolve 7 Round 16 evaluation issues (#83-#89)

### DIFF
--- a/protocol_tests/advanced_attacks.py
+++ b/protocol_tests/advanced_attacks.py
@@ -690,46 +690,19 @@ def main():
 
     if args.run:
         if args.trials > 1:
-            from protocol_tests.statistical import (
-                wilson_ci, TrialResult, generate_statistical_report,
-            )
-            all_trial_results: list[list] = []
-            for trial_idx in range(args.trials):
-                print(f"\n{'#'*60}")
-                print(f"# TRIAL {trial_idx + 1}/{args.trials}")
-                print(f"{'#'*60}")
+            from protocol_tests.trial_runner import run_with_trials as _run_trials
+
+            def _single_run():
                 suite = AdvancedAttackTests(args.url, headers=headers)
-                trial_results = suite.run_all(categories=categories)
-                all_trial_results.append(trial_results)
+                return {"results": suite.run_all(categories=categories)}
 
-            test_ids = [r.test_id for r in all_trial_results[0]]
-            stat_results: list[TrialResult] = []
-            for idx, tid in enumerate(test_ids):
-                per_trial = [
-                    all_trial_results[t][idx].passed
-                    if idx < len(all_trial_results[t]) else False
-                    for t in range(args.trials)
-                ]
-                n_passed = sum(per_trial)
-                ci = wilson_ci(n_passed, args.trials)
-                stat_results.append(TrialResult(
-                    test_id=tid,
-                    test_name=all_trial_results[0][idx].name if idx < len(all_trial_results[0]) else tid,
-                    n_trials=args.trials,
-                    n_passed=n_passed,
-                    pass_rate=round(n_passed / args.trials, 4),
-                    ci_95=ci,
-                    per_trial=per_trial,
-                    mean_elapsed_s=0.0,
-                ))
-
-            results = all_trial_results[-1]
+            merged = _run_trials(_single_run, trials=args.trials,
+                                 suite_name="Advanced Attack Pattern Tests v3.0")
             if args.report:
-                generate_statistical_report(
-                    results, stat_results,
-                    "Advanced Attack Pattern Tests v3.0",
-                    args.report,
-                )
+                with open(args.report, "w") as f:
+                    json.dump(merged, f, indent=2, default=str)
+                print(f"Report written to {args.report}")
+            results = merged.get("results", [])
         else:
             suite = AdvancedAttackTests(args.url, headers=headers)
             results = suite.run_all(categories=categories)

--- a/protocol_tests/cloud_agent_harness.py
+++ b/protocol_tests/cloud_agent_harness.py
@@ -977,45 +977,18 @@ def main():
         return run_results
 
     if args.trials > 1:
-        from protocol_tests.statistical import (
-            wilson_ci, TrialResult, generate_statistical_report,
-        )
-        all_trial_results: list[list[CloudAgentTestResult]] = []
-        for trial_idx in range(args.trials):
-            print(f"\n{'#'*60}")
-            print(f"# TRIAL {trial_idx + 1}/{args.trials}")
-            print(f"{'#'*60}")
-            trial_results = _run_once()
-            all_trial_results.append(trial_results)
+        from protocol_tests.trial_runner import run_with_trials as _run_trials
 
-        test_ids = [r.test_id for r in all_trial_results[0]]
-        stat_results: list[TrialResult] = []
-        for idx, tid in enumerate(test_ids):
-            per_trial = [
-                all_trial_results[t][idx].passed
-                if idx < len(all_trial_results[t]) else False
-                for t in range(args.trials)
-            ]
-            n_passed = sum(per_trial)
-            ci = wilson_ci(n_passed, args.trials)
-            stat_results.append(TrialResult(
-                test_id=tid,
-                test_name=all_trial_results[0][idx].name if idx < len(all_trial_results[0]) else tid,
-                n_trials=args.trials,
-                n_passed=n_passed,
-                pass_rate=round(n_passed / args.trials, 4),
-                ci_95=ci,
-                per_trial=per_trial,
-                mean_elapsed_s=0.0,
-            ))
+        def _single_run():
+            return {"results": _run_once()}
 
-        all_results = all_trial_results[-1]
+        merged = _run_trials(_single_run, trials=args.trials,
+                             suite_name="Cloud Agent Platform Security Tests v1.0")
         if args.report:
-            generate_statistical_report(
-                all_results, stat_results,
-                "Cloud Agent Platform Security Tests v1.0",
-                args.report,
-            )
+            with open(args.report, "w") as f:
+                json.dump(merged, f, indent=2, default=str)
+            print(f"Report saved to {args.report}")
+        all_results = merged.get("results", [])
     else:
         all_results = _run_once()
         if args.report:

--- a/protocol_tests/extended_enterprise_adapters.py
+++ b/protocol_tests/extended_enterprise_adapters.py
@@ -791,46 +791,20 @@ def main():
         print(f"{'='*60}")
 
         if args.trials > 1:
-            from protocol_tests.statistical import (
-                wilson_ci, TrialResult, generate_statistical_report,
-            )
-            all_trial_results: list[list] = []
-            for trial_idx in range(args.trials):
-                print(f"\n{'#'*60}")
-                print(f"# TRIAL {trial_idx + 1}/{args.trials}")
-                print(f"{'#'*60}")
+            from protocol_tests.trial_runner import run_with_trials as _run_trials
+
+            def _single_run():
                 adapter = cls(args.url, headers=headers)
-                trial_results = adapter.run_tests()
-                all_trial_results.append(trial_results)
+                return {"results": adapter.run_tests()}
 
-            test_ids = [r.test_id for r in all_trial_results[0]]
-            stat_results: list[TrialResult] = []
-            for idx, tid in enumerate(test_ids):
-                per_trial = [
-                    all_trial_results[t][idx].passed
-                    if idx < len(all_trial_results[t]) else False
-                    for t in range(args.trials)
-                ]
-                n_passed = sum(per_trial)
-                ci = wilson_ci(n_passed, args.trials)
-                stat_results.append(TrialResult(
-                    test_id=tid,
-                    test_name=all_trial_results[0][idx].name if idx < len(all_trial_results[0]) else tid,
-                    n_trials=args.trials,
-                    n_passed=n_passed,
-                    pass_rate=round(n_passed / args.trials, 4),
-                    ci_95=ci,
-                    per_trial=per_trial,
-                    mean_elapsed_s=0.0,
-                ))
-
-            results = all_trial_results[-1]
+            merged = _run_trials(_single_run, trials=args.trials,
+                                 suite_name=f"Extended Enterprise Security Tests - {cls.description}")
             if args.report:
-                generate_statistical_report(
-                    results, stat_results,
-                    f"Extended Enterprise Security Tests - {cls.description}",
-                    args.report,
-                )
+                import json as _json
+                with open(args.report, "w") as f:
+                    _json.dump(merged, f, indent=2, default=str)
+                print(f"Report written to {args.report}")
+            results = merged.get("results", [])
         else:
             adapter = cls(args.url, headers=headers)
             results = adapter.run_tests()

--- a/protocol_tests/gtg1002_simulation.py
+++ b/protocol_tests/gtg1002_simulation.py
@@ -161,8 +161,10 @@ def _recon_info(resp):
         r'\b(10\.\d{1,3}\.\d{1,3}\.\d{1,3})\b',
         r'\b(172\.(?:1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3})\b',
         r'\b(192\.168\.\d{1,3}\.\d{1,3})\b',
-        # ip:port restricted to private ranges only (#75)
-        r'\b((?:10|172\.(?:1[6-9]|2\d|3[01])|192\.168)\.\d{1,3}\.\d{1,3}):\d{2,5}\b',
+        # ip:port restricted to private ranges only (#75, #89 — require 4 octets for all ranges)
+        r'\b(10\.\d{1,3}\.\d{1,3}\.\d{1,3}):\d{2,5}\b',
+        r'\b(172\.(?:1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3}):\d{2,5}\b',
+        r'\b(192\.168\.\d{1,3}\.\d{1,3}):\d{2,5}\b',
         r'\b[a-z][\w-]*\.(?:internal|local|corp|svc\.cluster)\b',  # internal hostnames
         r'(?:kubernetes|k8s)[\s_-]*(?:cluster|namespace|pod|service)',  # k8s infrastructure
         r'(?:docker|container)[\s_-]*(?:id|image|registry)',  # container details
@@ -172,9 +174,9 @@ def _recon_info(resp):
         r'(?:subnet|vpc|security.group)[\s_:-]+[\w-]+',  # cloud networking
         r'\binternal[\s_-]+(?:api|endpoint|url|service)\b',  # explicitly internal resources
     ]
-    # For the first 4 patterns (IP-based), validate octets after matching
-    ip_patterns = patterns[:4]
-    other_patterns = patterns[4:]
+    # For the first 6 patterns (IP-based), validate octets after matching
+    ip_patterns = patterns[:6]
+    other_patterns = patterns[6:]
     for p in ip_patterns:
         m = _re.search(p, s, _re.IGNORECASE)
         if m:

--- a/protocol_tests/identity_harness.py
+++ b/protocol_tests/identity_harness.py
@@ -898,46 +898,19 @@ def main():
 
     if args.run:
         if args.trials > 1:
-            from protocol_tests.statistical import (
-                wilson_ci, TrialResult, generate_statistical_report,
-            )
-            all_trial_results: list[list] = []
-            for trial_idx in range(args.trials):
-                print(f"\n{'#'*60}")
-                print(f"# TRIAL {trial_idx + 1}/{args.trials}")
-                print(f"{'#'*60}")
+            from protocol_tests.trial_runner import run_with_trials as _run_trials
+
+            def _single_run():
                 suite = IdentitySecurityTests(args.url, headers=headers)
-                trial_results = suite.run_all(categories=categories)
-                all_trial_results.append(trial_results)
+                return {"results": suite.run_all(categories=categories)}
 
-            test_ids = [r.test_id for r in all_trial_results[0]]
-            stat_results: list[TrialResult] = []
-            for idx, tid in enumerate(test_ids):
-                per_trial = [
-                    all_trial_results[t][idx].passed
-                    if idx < len(all_trial_results[t]) else False
-                    for t in range(args.trials)
-                ]
-                n_passed = sum(per_trial)
-                ci = wilson_ci(n_passed, args.trials)
-                stat_results.append(TrialResult(
-                    test_id=tid,
-                    test_name=all_trial_results[0][idx].name if idx < len(all_trial_results[0]) else tid,
-                    n_trials=args.trials,
-                    n_passed=n_passed,
-                    pass_rate=round(n_passed / args.trials, 4),
-                    ci_95=ci,
-                    per_trial=per_trial,
-                    mean_elapsed_s=0.0,
-                ))
-
-            results = all_trial_results[-1]
+            merged = _run_trials(_single_run, trials=args.trials,
+                                 suite_name="Agent Identity & Authorization Security Tests v3.0")
             if args.report:
-                generate_statistical_report(
-                    results, stat_results,
-                    "Agent Identity & Authorization Security Tests v3.0",
-                    args.report,
-                )
+                with open(args.report, "w") as f:
+                    json.dump(merged, f, indent=2, default=str)
+                print(f"Report written to {args.report}")
+            results = merged.get("results", [])
         else:
             suite = IdentitySecurityTests(args.url, headers=headers)
             results = suite.run_all(categories=categories)

--- a/protocol_tests/jailbreak_harness.py
+++ b/protocol_tests/jailbreak_harness.py
@@ -1047,46 +1047,19 @@ def main():
     categories = args.categories.split(",") if args.categories else None
 
     if args.trials > 1:
-        from protocol_tests.statistical import (
-            wilson_ci as _wilson_ci, TrialResult, generate_statistical_report,
-        )
-        all_trial_results: list[list] = []
-        for trial_idx in range(args.trials):
-            print(f"\n{'#'*60}")
-            print(f"# TRIAL {trial_idx + 1}/{args.trials}")
-            print(f"{'#'*60}")
+        from protocol_tests.trial_runner import run_with_trials as _run_trials
+
+        def _single_run():
             suite = JailbreakTests(args.url, headers=headers)
-            trial_results = suite.run_all(categories=categories)
-            all_trial_results.append(trial_results)
+            return {"results": suite.run_all(categories=categories)}
 
-        test_ids = [r.test_id for r in all_trial_results[0]]
-        stat_results: list[TrialResult] = []
-        for idx, tid in enumerate(test_ids):
-            per_trial = [
-                all_trial_results[t][idx].passed
-                if idx < len(all_trial_results[t]) else False
-                for t in range(args.trials)
-            ]
-            n_passed = sum(per_trial)
-            ci = _wilson_ci(n_passed, args.trials)
-            stat_results.append(TrialResult(
-                test_id=tid,
-                test_name=all_trial_results[0][idx].name if idx < len(all_trial_results[0]) else tid,
-                n_trials=args.trials,
-                n_passed=n_passed,
-                pass_rate=round(n_passed / args.trials, 4),
-                ci_95=ci,
-                per_trial=per_trial,
-                mean_elapsed_s=0.0,
-            ))
-
-        results = all_trial_results[-1]
+        merged = _run_trials(_single_run, trials=args.trials,
+                             suite_name="Expanded Jailbreak Corpus Tests v3.4")
         if args.report:
-            generate_statistical_report(
-                results, stat_results,
-                "Expanded Jailbreak Corpus Tests v3.4",
-                args.report,
-            )
+            with open(args.report, "w") as f:
+                json.dump(merged, f, indent=2, default=str)
+            print(f"Report written to {args.report}")
+        results = merged.get("results", [])
     else:
         suite = JailbreakTests(args.url, headers=headers)
         results = suite.run_all(categories=categories)

--- a/protocol_tests/trial_runner.py
+++ b/protocol_tests/trial_runner.py
@@ -21,7 +21,7 @@ from collections import defaultdict
 from datetime import datetime, timezone
 from typing import Any, Callable
 
-from protocol_tests.statistical import wilson_ci, bootstrap_ci, TrialResult, enhance_report
+from protocol_tests.statistical import wilson_ci, TrialResult, enhance_report
 
 
 def run_with_trials(
@@ -93,17 +93,21 @@ def run_with_trials(
             mean_elapsed_s=round(mean_elapsed, 3),
         ))
 
-    # Build final report
-    from dataclasses import asdict
+    # Build final report — summary aggregated across ALL trials (#85)
+    total_tests = len(stat_results)
+    passed_tests = sum(1 for sr in stat_results if sr.pass_rate >= 0.5)
+    failed_tests = total_tests - passed_tests
+
     report_out: dict[str, Any] = {
         "suite": suite_name,
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "summary": {
-            "total": len(last_results),
-            "passed": sum(1 for r in last_results if (getattr(r, "passed", None) if not isinstance(r, dict) else r.get("passed", False))),
-            "failed": sum(1 for r in last_results if not (getattr(r, "passed", None) if not isinstance(r, dict) else r.get("passed", True))),
+            "total": total_tests,
+            "passed": passed_tests,
+            "failed": failed_tests,
         },
-        "results": [asdict(r) if hasattr(r, "__dataclass_fields__") else r for r in last_results],
+        # Return the original result objects so callers can use attribute access (#83)
+        "results": last_results,
     }
     report_out = enhance_report(report_out, stat_results)
     if trial_errors:

--- a/protocol_tests/version.py
+++ b/protocol_tests/version.py
@@ -8,17 +8,18 @@ from pathlib import Path
 
 
 def get_harness_version() -> str:
-    """Read version from importlib.metadata or pyproject.toml fallback."""
-    try:
-        from importlib.metadata import version as pkg_version
-        return pkg_version("agent-security-harness")
-    except Exception:
-        pass
+    """Read version from pyproject.toml first, fall back to importlib.metadata."""
+    # Prefer local pyproject.toml so dev builds always show the source version (#86)
     try:
         _toml = Path(__file__).resolve().parent.parent / "pyproject.toml"
         for line in _toml.read_text().splitlines():
             if line.strip().startswith("version"):
                 return line.split("=", 1)[1].strip().strip('"').strip("'")
+    except Exception:
+        pass
+    try:
+        from importlib.metadata import version as pkg_version
+        return pkg_version("agent-security-harness")
     except Exception:
         pass
     return "unknown"

--- a/testing/test_trial_runner.py
+++ b/testing/test_trial_runner.py
@@ -1,0 +1,182 @@
+"""Tests for protocol_tests.trial_runner (#88)."""
+from __future__ import annotations
+
+import pytest
+from dataclasses import dataclass
+
+
+@dataclass
+class _MockResult:
+    test_id: str
+    name: str
+    passed: bool
+    elapsed_s: float = 0.1
+
+
+def _make_run_fn(results: list[_MockResult]):
+    """Return a callable that returns a report dict with the given results."""
+    def run_fn():
+        return {"results": list(results)}
+    return run_fn
+
+
+class TestRunWithTrials:
+    """Unit tests for run_with_trials."""
+
+    def test_single_trial_all_pass(self):
+        from protocol_tests.trial_runner import run_with_trials
+
+        results = [
+            _MockResult("T-001", "Test One", True),
+            _MockResult("T-002", "Test Two", True),
+        ]
+        report = run_with_trials(_make_run_fn(results), trials=1)
+
+        assert report["summary"]["total"] == 2
+        assert report["summary"]["passed"] == 2
+        assert report["summary"]["failed"] == 0
+        assert "statistical_summary" in report
+
+    def test_single_trial_mixed(self):
+        from protocol_tests.trial_runner import run_with_trials
+
+        results = [
+            _MockResult("T-001", "Test One", True),
+            _MockResult("T-002", "Test Two", False),
+        ]
+        report = run_with_trials(_make_run_fn(results), trials=1)
+
+        assert report["summary"]["total"] == 2
+        assert report["summary"]["passed"] == 1
+        assert report["summary"]["failed"] == 1
+
+    def test_multi_trial_aggregation(self):
+        from protocol_tests.trial_runner import run_with_trials
+
+        call_count = 0
+
+        def alternating_run():
+            nonlocal call_count
+            call_count += 1
+            # First trial: T-001 passes, T-002 fails
+            # Second trial: T-001 passes, T-002 passes
+            if call_count % 2 == 1:
+                return {"results": [
+                    _MockResult("T-001", "Test One", True),
+                    _MockResult("T-002", "Test Two", False),
+                ]}
+            else:
+                return {"results": [
+                    _MockResult("T-001", "Test One", True),
+                    _MockResult("T-002", "Test Two", True),
+                ]}
+
+        report = run_with_trials(alternating_run, trials=2)
+
+        # T-001 passed 2/2 (pass_rate=1.0 >= 0.5 -> counted as passed)
+        # T-002 passed 1/2 (pass_rate=0.5 >= 0.5 -> counted as passed)
+        assert report["summary"]["total"] == 2
+        assert report["summary"]["passed"] == 2
+
+        # Check statistical summary exists
+        stat_summary = report.get("statistical_summary", {})
+        per_test = stat_summary.get("per_test", [])
+        assert len(per_test) == 2
+        t001 = [s for s in per_test if s["test_id"] == "T-001"][0]
+        assert t001["n_passed"] == 2
+        assert t001["pass_rate"] == 1.0
+
+    def test_test_id_matching(self):
+        """Results are matched by test_id, not positional index (#72)."""
+        from protocol_tests.trial_runner import run_with_trials
+
+        call_count = 0
+
+        def reordered_run():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return {"results": [
+                    _MockResult("T-001", "Test One", True),
+                    _MockResult("T-002", "Test Two", False),
+                ]}
+            else:
+                # Different order
+                return {"results": [
+                    _MockResult("T-002", "Test Two", True),
+                    _MockResult("T-001", "Test One", True),
+                ]}
+
+        report = run_with_trials(reordered_run, trials=2)
+
+        per_test = report.get("statistical_summary", {}).get("per_test", [])
+        t001 = [s for s in per_test if s["test_id"] == "T-001"][0]
+        t002 = [s for s in per_test if s["test_id"] == "T-002"][0]
+        assert t001["n_passed"] == 2
+        assert t002["n_passed"] == 1  # Failed first trial, passed second
+
+    def test_error_handling_one_trial_fails(self):
+        """One trial raising an exception shouldn't abort everything (#82)."""
+        from protocol_tests.trial_runner import run_with_trials
+
+        call_count = 0
+
+        def flaky_run():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 2:
+                raise RuntimeError("Simulated network failure")
+            return {"results": [_MockResult("T-001", "Test One", True)]}
+
+        report = run_with_trials(flaky_run, trials=3)
+
+        assert "trial_errors" in report
+        assert len(report["trial_errors"]) == 1
+        assert "Trial 2" in report["trial_errors"][0]
+        # Should still have stats from the 2 successful trials
+        per_test = report.get("statistical_summary", {}).get("per_test", [])
+        assert len(per_test) == 1
+        assert per_test[0]["n_trials"] == 2
+
+    def test_results_support_attribute_access(self):
+        """Results in the report should support attribute access (#83)."""
+        from protocol_tests.trial_runner import run_with_trials
+
+        results = [_MockResult("T-001", "Test One", True)]
+        report = run_with_trials(_make_run_fn(results), trials=1)
+
+        for r in report["results"]:
+            # Must support attribute access (not just dict)
+            assert hasattr(r, "passed")
+            assert r.passed is True
+            assert r.test_id == "T-001"
+
+
+class TestVersion:
+    """Unit tests for protocol_tests.version (#88)."""
+
+    def test_returns_version_string(self):
+        from protocol_tests.version import get_harness_version
+
+        version = get_harness_version()
+        assert isinstance(version, str)
+        assert version != "unknown"
+        # Should look like a version number
+        parts = version.split(".")
+        assert len(parts) >= 2, f"Expected semver-like version, got: {version}"
+
+    def test_prefers_pyproject_toml(self):
+        """version.py should read from pyproject.toml first (#86)."""
+        from protocol_tests.version import get_harness_version
+
+        version = get_harness_version()
+        # Read pyproject.toml directly to compare
+        from pathlib import Path
+        toml_path = Path(__file__).resolve().parent.parent / "pyproject.toml"
+        toml_version = None
+        for line in toml_path.read_text().splitlines():
+            if line.strip().startswith("version"):
+                toml_version = line.split("=", 1)[1].strip().strip('"').strip("'")
+                break
+        assert toml_version is not None
+        assert version == toml_version


### PR DESCRIPTION
## Round 16 Fixes

### MEDIUM priority (3)
- **#83** - **CRITICAL**: Remove `asdict()` in trial_runner.py so callers can use attribute access (`r.passed`) on result objects without crashing in multi-trial mode
- **#84** - Migrate 5 remaining harnesses to shared `trial_runner.run_with_trials()`: advanced_attacks, cloud_agent_harness, extended_enterprise_adapters, identity_harness, jailbreak_harness
- **#85** - Fix trial_runner summary to aggregate across all trials using statistical pass rates instead of last-trial-only counts

### LOW priority (4)
- **#86** - version.py now prefers pyproject.toml over importlib.metadata so dev builds show the correct source version
- **#87** - Remove unused `bootstrap_ci` import from trial_runner
- **#88** - Add 8 unit tests: 6 for trial_runner.py (single/multi-trial, aggregation, test_id matching, error handling, attribute access) and 2 for version.py
- **#89** - Fix ip:port regex in gtg1002_simulation.py: `10.x.x.x` now correctly requires 4 octets (was matching only 3, causing false negatives)

### Tests
All 105 tests pass (including 8 new tests).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how multi-trial execution aggregates and serializes results across several harness CLIs, which could affect reporting/exit behavior and downstream consumers despite being test-covered.
> 
> **Overview**
> Multi-trial mode in five harness CLIs now delegates to shared `trial_runner.run_with_trials()` and writes the merged JSON report directly (replacing per-harness statistical aggregation/report generation).
> 
> `trial_runner` now (1) drops the unused `bootstrap_ci` import, (2) returns raw result objects instead of `asdict()`-converted dicts to preserve attribute access, and (3) computes `summary` counts from aggregated per-test pass rates across all trials (rather than last-trial-only).
> 
> Also updates `version.get_harness_version()` to prefer `pyproject.toml` for source builds, fixes GTG-1002 recon `ip:port` regexes to require full 4-octet private IPs, and adds new unit tests covering `trial_runner` behaviors and version resolution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b5d7bfad31a212f5e8eb77cf5c64554d7a55336. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->