### PR TITLE
feat: x402 --method/--body flags + MCP context displacement tests

### DIFF
--- a/protocol_tests/mcp_harness.py
+++ b/protocol_tests/mcp_harness.py
@@ -861,6 +861,114 @@ class MCPSecurityTests:
             elapsed_s=round(elapsed, 3),
         ))
 
+    def test_mcp_tool_description_oversized(self):
+        """MCP-012: Check tools/list for oversized descriptions that could displace LLM context."""
+        t0 = time.monotonic()
+
+        SIZE_THRESHOLD = 10_240  # 10 KB — descriptions beyond this are suspicious
+
+        msg = jsonrpc_request("tools/list", {})
+        resp = self.transport.send(msg)
+        elapsed = time.monotonic() - t0
+
+        tools = []
+        if resp and "result" in resp:
+            tools = resp["result"].get("tools", [])
+
+        oversized = []
+        for tool in tools:
+            desc = tool.get("description") or ""
+            if len(desc) > SIZE_THRESHOLD:
+                oversized.append({
+                    "name": tool.get("name", "?"),
+                    "desc_len": len(desc),
+                })
+
+        passed = len(oversized) == 0
+
+        self._record(MCPTestResult(
+            test_id="MCP-012",
+            name="Tool Description Oversized Check",
+            category="context_displacement",
+            owasp_asi="ASI08",
+            severity=Severity.HIGH.value,
+            passed=passed,
+            details=(
+                f"{len(oversized)} tool(s) exceed {SIZE_THRESHOLD} byte description threshold: "
+                f"{[o['name'] + ' (' + str(o['desc_len']) + 'B)' for o in oversized]}"
+                if oversized
+                else f"All {len(tools)} tool descriptions are within {SIZE_THRESHOLD}B threshold"
+            ),
+            mcp_method="tools/list",
+            request_sent=msg,
+            response_received={"n_tools": len(tools),
+                               "oversized": oversized},
+            elapsed_s=round(elapsed, 3),
+        ))
+
+    def test_mcp_tool_description_padding_detection(self):
+        """MCP-013: Detect repeated/padding text in tool descriptions designed to consume context tokens."""
+        t0 = time.monotonic()
+
+        msg = jsonrpc_request("tools/list", {})
+        resp = self.transport.send(msg)
+        elapsed = time.monotonic() - t0
+
+        tools = []
+        if resp and "result" in resp:
+            tools = resp["result"].get("tools", [])
+
+        # Heuristics for padding detection:
+        #  1. High ratio of repeated n-grams (sliding window)
+        #  2. Long runs of the same sentence/phrase repeated
+        REPEAT_PATTERN = re.compile(r"(.{20,}?)\1{3,}", re.DOTALL)  # same 20+ char chunk repeated 4+ times
+        WHITESPACE_PADDING = re.compile(r"[\s]{500,}")  # 500+ contiguous whitespace chars
+
+        padded_tools = []
+        for tool in tools:
+            desc = tool.get("description") or ""
+            if len(desc) < 200:
+                continue  # too short to be padding
+            issues = []
+            if REPEAT_PATTERN.search(desc):
+                issues.append("repeated_phrase")
+            if WHITESPACE_PADDING.search(desc):
+                issues.append("whitespace_padding")
+            # Check character-level entropy: if a long description has very few
+            # unique characters relative to its length, it's likely padding
+            if len(desc) > 1000:
+                unique_ratio = len(set(desc)) / len(desc)
+                if unique_ratio < 0.01:  # <1% unique chars in 1000+ char desc
+                    issues.append("low_entropy")
+            if issues:
+                padded_tools.append({
+                    "name": tool.get("name", "?"),
+                    "desc_len": len(desc),
+                    "issues": issues,
+                })
+
+        passed = len(padded_tools) == 0
+
+        self._record(MCPTestResult(
+            test_id="MCP-013",
+            name="Tool Description Padding / Repetition Detection",
+            category="context_displacement",
+            owasp_asi="ASI08",
+            severity=Severity.HIGH.value,
+            passed=passed,
+            details=(
+                f"{len(padded_tools)} tool(s) contain suspicious padding/repetition: "
+                f"{[t['name'] + ' (' + ','.join(t['issues']) + ')' for t in padded_tools]}"
+                if padded_tools
+                else f"No padding or repetition detected in {len(tools)} tool descriptions"
+            ),
+            mcp_method="tools/list",
+            request_sent=msg,
+            response_received={"n_tools": len(tools),
+                               "padded_tools": padded_tools},
+            elapsed_s=round(elapsed, 3),
+        ))
+
     # ------------------------------------------------------------------
     # Run all tests
     # ------------------------------------------------------------------
@@ -895,6 +1003,8 @@ class MCPSecurityTests:
             ],
             "context_displacement": [
                 self.test_mcp_tool_description_context_displacement,
+                self.test_mcp_tool_description_oversized,
+                self.test_mcp_tool_description_padding_detection,
             ],
         }
 

--- a/protocol_tests/x402_harness.py
+++ b/protocol_tests/x402_harness.py
@@ -127,10 +127,13 @@ class X402Transport:
     """HTTP transport for x402-gated APIs."""
 
     def __init__(self, base_url: str, headers: dict | None = None,
-                 paid_path: str = ""):
+                 paid_path: str = "", default_method: str = "GET",
+                 default_body: str | None = None):
         self.base_url = base_url.rstrip("/")
         self.headers = headers or {}
         self.paid_path = paid_path  # Path that returns 402 (e.g., /api/v1/tools/weather/call)
+        self.default_method = default_method.upper()
+        self.default_body = default_body  # Optional JSON body for POST endpoints
 
     def request(
         self,
@@ -181,7 +184,18 @@ class X402Transport:
             return {"status": 0, "headers": {}, "body": "", "_error": True, "_exception": str(e)}
 
     def get(self, path: str = "", headers: dict | None = None, timeout: float = 15.0) -> dict:
-        return self.request("GET", path, headers=headers, timeout=timeout)
+        """Send a request using the transport's default method and body.
+
+        Despite the name, this respects ``default_method`` so that callers
+        (all existing tests) automatically use POST when ``--method POST``
+        is passed without requiring per-call changes.
+        """
+        body = self.default_body.encode("utf-8") if self.default_body else None
+        extra_headers = dict(headers or {})
+        if body and "Content-Type" not in extra_headers:
+            extra_headers["Content-Type"] = "application/json"
+        return self.request(self.default_method, path, body=body,
+                            headers=extra_headers, timeout=timeout)
 
     def post(self, path: str = "", body: bytes | None = None, headers: dict | None = None, timeout: float = 15.0) -> dict:
         return self.request("POST", path, body=body, headers=headers, timeout=timeout)
@@ -1861,6 +1875,12 @@ def main():
     ap.add_argument("--paid-path", default="",
                     help="Path that returns 402 (e.g., /api/v1/tools/weather/call). "
                          "If omitted, tests hit the root URL.")
+    ap.add_argument("--method", default="GET", choices=["GET", "POST"],
+                    help="HTTP method for the paid endpoint (default: GET). "
+                         "Use POST for x402 endpoints that only accept POST.")
+    ap.add_argument("--body", default=None,
+                    help="Optional JSON request body for POST endpoints "
+                         "(e.g., '{\"prompt\": \"hello\"}')")
     ap.add_argument("--categories", help="Comma-separated test categories to run")
     ap.add_argument("--report", help="Output JSON report path")
     ap.add_argument("--header", action="append", default=[], help="Extra HTTP headers (key:value)")
@@ -1881,7 +1901,12 @@ def main():
         k, v = h.split(":", 1)
         headers[k.strip()] = v.strip()
 
-    transport = X402Transport(args.url, headers=headers, paid_path=args.paid_path)
+    # Validate --body requires --method POST
+    if args.body and args.method != "POST":
+        ap.error("--body requires --method POST")
+
+    transport = X402Transport(args.url, headers=headers, paid_path=args.paid_path,
+                              default_method=args.method, default_body=args.body)
     categories = args.categories.split(",") if args.categories else None
 
     if args.trials > 1:


### PR DESCRIPTION
## Summary

Fixes two quick-win issues:

### #58 - x402: Add --method and --body flags for POST-only payment endpoints
- Added `--method` flag (GET/POST, default GET) to x402 harness CLI
- Added `--body` flag (optional JSON string) for POST request body
- Wired through `X402Transport` so all 25 existing tests automatically use the configured method
- Validates that `--body` requires `--method POST`

**Usage:**
```bash
python -m protocol_tests.x402_harness --url https://x402.example.com --method POST --body '{"prompt": "hello"}'
```

### #16 - MCP tool description DoS via context displacement
- **MCP-012**: Checks tools/list for oversized descriptions (>10KB threshold) that could displace useful context in an LLM's context window
- **MCP-013**: Detects repeated/padding text in tool descriptions (repeated phrases, whitespace padding, low-entropy content) designed to consume context tokens

Total test count: 332 (was 330).

All 105 existing tests pass.

Closes #58
Closes #16

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because `X402Transport.get()` semantics change to use a configurable default method/body, which affects all existing x402 tests and could alter request behavior against servers. MCP changes only add additional security test cases and test selection wiring.
> 
> **Overview**
> Adds two new MCP *context displacement* security tests: `MCP-012` flags tool descriptions over a 10KB threshold, and `MCP-013` detects padded/repetitive/low-entropy descriptions returned by `tools/list`, and wires both into `run_all` under `context_displacement`.
> 
> Extends the x402 harness CLI/transport to support POST-only paid endpoints by adding `--method` (GET/POST) and optional `--body` flags, validating that `--body` requires POST, and updating `X402Transport.get()` to send requests using the configured default method/body (including auto `Content-Type: application/json`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9374269601c4beb82fcfe46c43dec2f610436d1c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->