### PR TITLE
fix: Round 18 evaluation - test counts, pypi-publish pin, L402/CHANGELOG corrections

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -47,6 +47,6 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1 # Docker-based action requires tag ref
+        uses: pypa/gh-action-pypi-publish@v1.13.0 # Docker-based action requires tag ref, not SHA
         # Uses trusted publishing (OIDC) - no API token needed
         # Configure at: https://pypi.org/manage/project/agent-security-harness/settings/publishing/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Agent identity metadata** per entry: `agent_card_url`, `operator_id`, `trust_score` for OATR integration
 - **Attestation report validation** utility (`protocol_tests/attestation.py`) with schema validation and v3.7-to-v3.8 migration
 - **v3.8 roadmap** (`docs/v3.8-roadmap.md`) with MoltBridge/TrustAgentAI mapping documentation
+- x402 `--method` and `--body` flags for POST-only payment endpoints (#58)
+- **MCP-012** Tool Description Oversized Check - detects descriptions exceeding 10KB threshold for context displacement
+- **MCP-013** Tool Description Padding / Repetition Detection - detects repeated phrases, whitespace padding, and low-entropy descriptions
 
 ### Fixed
 - `count_tests.py` now catches test IDs passed as function arguments (AIUC-F002a/b/c), adds 3 missing IDs
 - `count_tests.py` excludes synthetic `CVE-ERR` error-handler ID from count
-- Definitive test count corrected to **330** across 21 modules
+- Definitive test count corrected to **332** across 21 modules
 - `action.yml` parse-report step converted from shell-interpolated Python to heredoc+env pattern (no more `${REPORT}` injection)
 - `a2a_harness.py` `--trials` flag now wired into statistical report enhancement
 - `harmful_output_harness.py` `--categories` flag now filters tests by category
@@ -29,13 +32,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Planned
 - OATR test fixtures for x402 identity verification (#51)
-- x402 `--method` and `--body` flags for POST-only payment endpoints (#58)
 - Subliminal bias propagation tests (#60)
 
 ## [3.7.0] - 2026-03-25
 
 ### Added
-- 330 security tests across 21 modules
+- 332 security tests across 21 modules
 - OATR fixture loader (`protocol_tests/oatr_fixtures.py`)
 - x402 payment flow harness with L402 interop
 - CVE-2026-25253 supply chain provenance tests

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![PyPI version](https://badge.fury.io/py/agent-security-harness.svg)](https://pypi.org/project/agent-security-harness/)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![Apache 2.0 License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/security%20tests-330-green.svg)](#test-inventory)
+[![Tests](https://img.shields.io/badge/security%20tests-332-green.svg)](#test-inventory)
 
 The first open-source security testing framework purpose-built for multi-agent AI deployments in critical infrastructure and other high-impact enterprise environments.
 
@@ -29,7 +29,7 @@ A fast-emerging example is **agentic payments and stablecoin settlement**, where
 
 ## What This Repo Provides
 
-This framework provides **330 executable security tests across 21 modules**, including:
+This framework provides **332 executable security tests across 21 modules**, including:
 
 - application-layer attack scenarios
 - MCP and A2A wire-protocol harnesses
@@ -151,7 +151,7 @@ Results: 8/10 passed (80% pass rate) - see report.json
 
 | Module | Tests | Layer | Description |
 |---|---|---|---|
-| **MCP Protocol** | 11 | JSON-RPC 2.0 | Anthropic MCP wire-protocol testing |
+| **MCP Protocol** | 13 | JSON-RPC 2.0 | Anthropic MCP wire-protocol testing |
 | **A2A Protocol** | 12 | JSON-RPC/HTTP | Google Agent-to-Agent communication |
 | **L402 Payment** | 14 | HTTP/Lightning | Bitcoin/Lightning payment flow security (macaroons, preimages, caveats) |
 | **x402 Payment** | 25 | HTTP/USDC | Coinbase/Stripe agent payment protocol (recipient manipulation, session theft, facilitator trust, cross-chain confusion) |
@@ -172,7 +172,7 @@ Results: 8/10 passed (80% pass rate) - see report.json
 | **AIUC-1 Compliance** | 12 | Agent Safety | Incident response, CBRN prevention, harmful content, scope creep, authority impersonation |
 | **Cloud Agent Platforms** | 25 | Platform APIs | AWS Bedrock, Azure AI Agent Service, Google Vertex, Salesforce Agentforce, IBM watsonx |
 
-**Total: 330 security tests across 21 modules** (verified by `scripts/count_tests.py`)
+**Total: 332 security tests across 21 modules** (verified by `scripts/count_tests.py`)
 
 ### Key Capabilities
 
@@ -207,7 +207,7 @@ Most AI security tools test **models** (prompt injection, jailbreaks, output fil
 | **APT simulation (GTG-1002)** | - | - | - | - | 17 tests (full campaign lifecycle) |
 | **NIST AI 800-2 evaluation protocol** | - | - | - | - | Statistical confidence intervals, qualified claims |
 | **Published research backing** | - | - | - | - | 2 DOI-citable papers + 3 NIST submissions |
-| **Executable tests** | Yes (model-layer) | Yes (policy-layer) | No (docs only) | Yes (static analysis) | Yes (330 tests, protocol + app layer) |
+| **Executable tests** | Yes (model-layer) | Yes (policy-layer) | No (docs only) | Yes (static analysis) | Yes (332 tests, protocol + app layer) |
 | **Governance layer** | WHO (model safety) | WHO (identity, access) | WHO (config) | WHO (code scanning) | **HOW (decision governance)** |
 
 ### The WHO vs. HOW Gap
@@ -259,7 +259,7 @@ This framework provides **complete mapping** to all 10 categories of the OWASP A
 <details>
 <summary><strong>Protocol-Level Test Harnesses</strong></summary>
 
-### MCP (Model Context Protocol) - 11 tests
+### MCP (Model Context Protocol) - 13 tests
 ```bash
 agent-security test mcp --url http://localhost:8080/mcp
 ```
@@ -277,13 +277,15 @@ agent-security test mcp --url http://localhost:8080/mcp
 | MCP-009 | Batch Request DoS | ASI08 | Batch request flood testing |
 | MCP-010 | Tool Call Argument Injection | ASI02 | Malicious tool parameter injection |
 | MCP-011 | Tool Description Context Displacement | ASI08 | 50K+ char description DoS with hidden injection payload |
+| MCP-012 | Tool Description Oversized Check | ASI08 | Detects tool descriptions exceeding 10KB threshold for context displacement |
+| MCP-013 | Tool Description Padding / Repetition Detection | ASI08 | Detects repeated phrases, whitespace padding, and low-entropy descriptions |
 
 ### A2A (Agent-to-Agent) - 12 tests  
 ```bash
 agent-security test a2a --url https://agent.example.com
 ```
 
-### L402 Payment Protocol - 15 tests
+### L402 Payment Protocol - 14 tests
 ```bash
 agent-security test l402 --url https://l402.example.com
 ```
@@ -358,7 +360,7 @@ agent-security test enterprise --platform salesforce --url https://your-org.sale
 
 | AIUC-1 Req | Requirement | Our Coverage |
 |---|---|---|
-| **B001** | Third-party adversarial robustness testing | **330 tests** across 4 wire protocols, 21 modules. Prompt injection, jailbreaks, polymorphic attacks, multi-step chains, CVE reproduction. |
+| **B001** | Third-party adversarial robustness testing | **332 tests** across 4 wire protocols, 21 modules. Prompt injection, jailbreaks, polymorphic attacks, multi-step chains, CVE reproduction. |
 | **B002** | Detect adversarial input | MCP tool injection (MCP-001-010), A2A message spoofing (A2A-001-012), prompt injection via operational data (APP-001-030) |
 | **B005** | Real-time input filtering | Filter bypass via encoding tricks, nested injection, polymorphic payloads, context displacement (ADV-001-010) |
 | **B009** | Limit output over-exposure | Information leakage detection, output exfiltration tests, API key regex scanning |
@@ -374,7 +376,7 @@ agent-security test enterprise --platform salesforce --url https://your-org.sale
 
 | AIUC-1 Req | Requirement | Our Coverage |
 |---|---|---|
-| **C001** | Define AI risk taxonomy | Framework provides STRIDE + OWASP Agentic + NIST AI 800-2 risk taxonomy with all 330 tests categorized |
+| **C001** | Define AI risk taxonomy | Framework provides STRIDE + OWASP Agentic + NIST AI 800-2 risk taxonomy with all 332 tests categorized |
 | **C002** | Conduct pre-deployment testing | Entire framework designed for pre-deployment. `pip install agent-security-harness` and run before shipping. |
 | **C010** | Third-party testing for harmful outputs | Adversarial test suite validates whether safety controls hold under attack |
 | **C011** | Third-party testing for out-of-scope outputs | Protocol-level scope violation tests (MCP-003 capability escalation, A2A unauthorized access) |
@@ -391,7 +393,7 @@ agent-security test enterprise --platform salesforce --url https://your-org.sale
 | AIUC-1 Req | Requirement | Our Coverage |
 |---|---|---|
 | **E004** | Assign accountability | [CSG paper](https://doi.org/10.5281/zenodo.19162104) defines 3-tier governance with explicit accountability. 12 mechanisms, 77 days production evidence. |
-| **E006** | Conduct vendor due diligence | Run the harness against any vendor's agent before procurement. 330 tests as vendor evaluation. |
+| **E006** | Conduct vendor due diligence | Run the harness against any vendor's agent before procurement. 332 tests as vendor evaluation. |
 | **E015** | Log model activity | JSON reports with full request/response transcripts serve as audit evidence |
 
 #### F. Society (50% coverage)
@@ -417,7 +419,7 @@ agent-security test enterprise --platform salesforce --url https://your-org.sale
 
 > **Note:** "100% coverage" on Security and Reliability means this framework maps to every requirement in those principles. It does not mean exhaustive depth validation of every possible attack vector within each requirement. Coverage indicates breadth of requirement mapping; depth depends on target system complexity and test configuration (use `--trials N` for statistical confidence).
 
-> **Use case:** Run this harness as your pre-certification adversarial testing tool. AIUC-1 requires quarterly third-party testing (B001, C010, D004). This framework satisfies those requirements with 330 executable tests, JSON audit reports, and statistical confidence intervals aligned to [NIST AI 800-2](https://doi.org/10.6028/NIST.AI.800-2).
+> **Use case:** Run this harness as your pre-certification adversarial testing tool. AIUC-1 requires quarterly third-party testing (B001, C010, D004). This framework satisfies those requirements with 332 executable tests, JSON audit reports, and statistical confidence intervals aligned to [NIST AI 800-2](https://doi.org/10.6028/NIST.AI.800-2).
 >
 > **Want an expert assessment?** [Book an AIUC-1 Readiness Assessment](https://msaleme.github.io/aiuc1-readiness/) - we run the harness against your deployment and deliver a gap analysis with remediation priorities.
 

--- a/protocol_tests/cli.py
+++ b/protocol_tests/cli.py
@@ -29,7 +29,7 @@ VERSION = "3.8.0"
 HARNESSES = {
     "mcp": {
         "module": "protocol_tests.mcp_harness",
-        "description": "MCP wire-protocol security tests (11 tests, JSON-RPC 2.0)",
+        "description": "MCP wire-protocol security tests (13 tests, JSON-RPC 2.0)",
     },
     "a2a": {
         "module": "protocol_tests.a2a_harness",
@@ -116,7 +116,7 @@ HARNESSES = {
 
 def print_usage():
     print(f"Agent Security Harness v{VERSION}")
-    print(f"330 security tests for AI agent systems")
+    print(f"332 security tests for AI agent systems")
     print()
     print("Usage:")
     print("  agent-security test <harness> [options]    Run a test harness")
@@ -148,7 +148,7 @@ def main():
 
     if args[0] == "version":
         print(f"agent-security-harness v{VERSION}")
-        print(f"Tests: 330 across {len(HARNESSES)} harness modules")
+        print(f"Tests: 332 across {len(HARNESSES)} harness modules")
         print(f"Protocols: MCP (JSON-RPC 2.0), A2A, L402, x402")
         print(f"Platforms: 25 cloud + 20 enterprise adapters")
         print(f"Standards: OWASP Agentic Top 10, NIST AI 800-2, NIST AI RMF, AIUC-1")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "agent-security-harness"
 version = "3.8.0"
-description = "330 security tests for AI agent systems - MCP, A2A, L402, x402 wire-protocol testing, CVE-2026-25253 reproduction, AIUC-1 compliance, 25 cloud platform + 20 enterprise adapters, GTG-1002 APT simulation"
+description = "332 security tests for AI agent systems - MCP, A2A, L402, x402 wire-protocol testing, CVE-2026-25253 reproduction, AIUC-1 compliance, 25 cloud platform + 20 enterprise adapters, GTG-1002 APT simulation"
 readme = "README.md"
 license = {text = "Apache-2.0"}
 requires-python = ">=3.10"


### PR DESCRIPTION
## Round 18 Evaluation Fixes

### #93 HIGH - Test count 330→332
- Updated all references from 330 to 332 across `cli.py`, `pyproject.toml`, `README.md`, `CHANGELOG.md`
- Updated MCP module count from 11 to 13 (MCP-012, MCP-013 added in prior commit)
- Verified via `scripts/count_tests.py`: **332 unique test IDs confirmed**

### #94 MEDIUM - pypa/gh-action-pypi-publish mutable ref
- Pinned from `@release/v1` (mutable branch) to `@v1.13.0` (immutable tag)
- Uses tag ref (not SHA) because this is a Docker-based action where SHA refs break image pull

### #95 LOW - README L402 says 15 tests
- Corrected L402 section header from 15 to 14 tests

### #96 LOW - CHANGELOG x402 --method/--body listed as Planned
- Moved to Added section in v3.8.0 (feature is implemented)

### #97 LOW - CHANGELOG missing MCP-012/MCP-013
- Added both new test entries to v3.8.0 Added section
- Added to README test inventory table with descriptions

### Verification
- `count_tests.py`: 332 total
- `pytest`: 105 passed, 27 subtests passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI action pinning and documentation/metadata count corrections; no runtime harness logic or security-sensitive behavior is modified.
> 
> **Overview**
> Updates release workflow to publish with `pypa/gh-action-pypi-publish@v1.13.0` instead of the mutable `release/v1` ref.
> 
> Corrects reported inventory numbers from **330→332** across CLI output, package metadata (`pyproject.toml`), README, and CHANGELOG, including MCP being **11→13** tests and L402 being **15→14** in docs, and moves the x402 `--method`/`--body` flags entry from *Planned* to *Added* in `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8cdd51638c668fa62317864f78616591485cc0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->