### PR TITLE
fix: Final cleanup for 10/10 eval - R27 + Cursor findings

### DIFF
--- a/protocol_tests/community_runner.py
+++ b/protocol_tests/community_runner.py
@@ -266,7 +266,7 @@ def verify_pattern_integrity(
         if strict:
             return TRUST_UNREVIEWED, (
                 f"Pattern not in MANIFEST.yaml: {rel_path}. "
-                f"Run with --update-manifest to add it, or --no-strict to skip verification."
+                f"Add an entry to MANIFEST.yaml manually, or use --no-strict to skip verification."
             )
         return TRUST_UNREVIEWED, None  # Allow in non-strict mode
 
@@ -312,7 +312,7 @@ def update_manifest(community_dir: str):
 
     if updated > 0:
         with open(manifest_path, "w") as f:
-            yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+            yaml.safe_dump(data, f, default_flow_style=False, sort_keys=False)
         print(f"\nManifest updated: {updated} hash(es) written to {manifest_path}")
     else:
         print("All hashes are current. No updates needed.")
@@ -919,9 +919,9 @@ def run_community_tests(
             continue
         seen_ids.add(pattern.id)
 
-        # Block unreviewed patterns from execution
-        if trust_tier == TRUST_UNREVIEWED and not validate_only and not list_only:
-            print(f"  SKIP {pattern.id}: trust tier is 'unreviewed' (validate-only)")
+        # Block patterns outside executable trust tiers
+        if trust_tier not in EXECUTABLE_TRUST_TIERS and not validate_only and not list_only:
+            print(f"  SKIP {pattern.id}: trust tier '{trust_tier}' is not executable (requires: {', '.join(sorted(EXECUTABLE_TRUST_TIERS))})")
             continue
 
         pattern_trust[pattern.id] = trust_tier
@@ -1052,8 +1052,13 @@ Examples:
 
     args = parser.parse_args()
 
-    # Handle --hash (standalone utility)
+    # Handle --hash (standalone utility, restricted to project directory)
     if args.hash:
+        hash_path = Path(args.hash).resolve()
+        cwd = Path.cwd().resolve()
+        if not hash_path.is_relative_to(cwd):
+            print(f"ERROR: --hash path must be within the project directory", file=sys.stderr)
+            sys.exit(1)
         h = compute_file_hash(args.hash)
         print(f"{h}  {args.hash}")
         sys.exit(0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "agent-security-harness"
 version = "3.8.1"
-description = "332 security tests for AI agent systems - MCP, A2A, L402, x402 wire-protocol testing, CVE-2026-25253 reproduction, AIUC-1 compliance, 25 cloud platform + 20 enterprise adapters, GTG-1002 APT simulation"
+description = "342 security tests for AI agent systems - MCP, A2A, L402, x402 wire-protocol testing, CVE-2026-25253 reproduction, AIUC-1 compliance, 25 cloud platform + 20 enterprise adapters, GTG-1002 APT simulation"
 readme = "README.md"
 license = {text = "Apache-2.0"}
 requires-python = ">=3.10"


### PR DESCRIPTION
All 4 R27 issues + all 3 Cursor Bugbot findings addressed.

| Issue | Fix |
|-------|-----|
| #147 pyproject.toml 332 | Changed to 342 |
| #148 --hash reads arbitrary files | Added is_relative_to check |
| #149 yaml.dump unsafe | Changed to yaml.safe_dump |
| Cursor: EXECUTABLE_TRUST_TIERS unused | Now used in execution gate |
| Cursor: --hash no path check | Added (same as #148) |
| Cursor: misleading error message | Fixed remediation text |

Only remaining item is #150 (TOCTOU, LOW) which is inherent to filesystem operations and mitigated by the trust tier system.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are small and mostly security-hardening, but they may alter CLI behavior by refusing `--hash` paths outside the repo and skipping non-executable trust tiers.
> 
> **Overview**
> **Security hardening for community pattern execution and tooling.** The runner now blocks execution for any pattern whose trust tier is not in `EXECUTABLE_TRUST_TIERS` (instead of only special-casing `unreviewed`) and improves the skip message to reflect the required tiers.
> 
> The `--hash` utility is restricted to files within the project directory to prevent arbitrary file reads, `update_manifest` now writes with `yaml.safe_dump` instead of `yaml.dump`, and the strict-mode manifest error text is updated to remove the `--update-manifest` remediation.
> 
> Also updates `pyproject.toml` description metadata from 332 to 342 tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf2159fc2889b4f29489d04c64fe069e97e752d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->