### PR TITLE
feat: --json CLI output and improved connection errors (v3.9)

### DIFF
--- a/protocol_tests/cli.py
+++ b/protocol_tests/cli.py
@@ -25,7 +25,7 @@ import sys
 import importlib
 
 
-VERSION = "3.8.1"
+VERSION = "3.9.0"
 
 HARNESSES = {
     "mcp": {
@@ -143,6 +143,7 @@ def print_usage():
     print("  agent-security test mcp --transport stdio --command 'node server.js'")
     print("  agent-security test mcp --url http://localhost:8080 --trials 5")
     print("  agent-security test mcp --url http://localhost:8080 --delay 1000")
+    print("  agent-security test mcp --url http://localhost:8080 --json")
     print()
     print("Attestation & Configuration:")
     print("  agent-security publish --attestation <file> --server-name <name>")
@@ -291,10 +292,11 @@ def main():
             sys.exit(1)
 
         info = HARNESSES[harness_name]
-        # Extract --delay/--delay-ms and --no-telemetry before passing to harness
+        # Extract --delay/--delay-ms, --no-telemetry, and --json before passing to harness
         harness_args = args[2:]
         delay_ms = 0
         no_telemetry = False
+        json_output = False
         filtered_args = []
         i = 0
         while i < len(harness_args):
@@ -307,6 +309,9 @@ def main():
             elif harness_args[i] == "--no-telemetry":
                 no_telemetry = True
                 i += 1
+            elif harness_args[i] == "--json":
+                json_output = True
+                i += 1
             else:
                 filtered_args.append(harness_args[i])
                 i += 1
@@ -315,9 +320,16 @@ def main():
         if no_telemetry:
             os.environ["AGENT_SECURITY_TELEMETRY"] = "off"
 
+        # --json flag: tell harnesses to output JSON to stdout (#103)
+        if json_output:
+            os.environ["AGENT_SECURITY_JSON_OUTPUT"] = "1"
+            # Also pass --json through to harness modules that support it
+            filtered_args.append("--json")
+
         if delay_ms > 0:
             os.environ["AGENT_SECURITY_DELAY_MS"] = str(delay_ms)
-            print(f"[Delay: {delay_ms}ms between tests]")
+            if not json_output:
+                print(f"[Delay: {delay_ms}ms between tests]")
 
         sys.argv = [info["module"]] + filtered_args
 

--- a/protocol_tests/mcp_harness.py
+++ b/protocol_tests/mcp_harness.py
@@ -42,6 +42,7 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Optional
 import http.client
+import socket
 import urllib.request
 
 
@@ -248,16 +249,18 @@ class MCPTestResult:
 class MCPSecurityTests:
     """Protocol-level security tests for MCP servers."""
 
-    def __init__(self, transport: MCPTransport):
+    def __init__(self, transport: MCPTransport, json_output: bool = False):
         self.transport = transport
         self.results: list[MCPTestResult] = []
         self.server_info: dict = {}
         self.server_capabilities: dict = {}
+        self.json_output = json_output or os.environ.get("AGENT_SECURITY_JSON_OUTPUT") == "1"
 
     def _record(self, result: MCPTestResult):
         self.results.append(result)
-        status = "PASS ✅" if result.passed else "FAIL ❌"
-        print(f"  {status} {result.test_id}: {result.name} ({result.elapsed_s:.2f}s)")
+        if not self.json_output:
+            status = "PASS ✅" if result.passed else "FAIL ❌"
+            print(f"  {status} {result.test_id}: {result.name} ({result.elapsed_s:.2f}s)")
 
     # ------------------------------------------------------------------
     # Setup: Initialize connection (required before testing)
@@ -265,7 +268,8 @@ class MCPSecurityTests:
 
     def initialize(self) -> bool:
         """Perform MCP initialize handshake."""
-        print("\n[Initializing MCP connection]")
+        if not self.json_output:
+            print("\n[Initializing MCP connection]")
         msg = jsonrpc_request("initialize", {
             "protocolVersion": "2025-03-26",
             "capabilities": {},
@@ -274,19 +278,61 @@ class MCPSecurityTests:
                 "version": "3.0.0"
             }
         })
-        resp = self.transport.send(msg)
+        try:
+            resp = self.transport.send(msg)
+        except ConnectionRefusedError:
+            url = getattr(self.transport, "url", "unknown")
+            err_msg = f"Could not connect to {url} — is the server running? (connection refused)"
+            if not self.json_output:
+                print(f"  {err_msg}", file=sys.stderr)
+            self._connection_error = err_msg
+            return False
+        except socket.timeout:
+            url = getattr(self.transport, "url", "unknown")
+            err_msg = f"Could not connect to {url} — is the server running? (connection timed out)"
+            if not self.json_output:
+                print(f"  {err_msg}", file=sys.stderr)
+            self._connection_error = err_msg
+            return False
+        except urllib.error.URLError as e:
+            url = getattr(self.transport, "url", "unknown")
+            reason = str(e.reason) if hasattr(e, "reason") else str(e)
+            if "Name or service not known" in reason or "getaddrinfo" in reason:
+                err_msg = f"Could not connect to {url} — DNS resolution failed. Check the hostname."
+            elif "Connection refused" in reason:
+                err_msg = f"Could not connect to {url} — is the server running? (connection refused)"
+            elif "timed out" in reason:
+                err_msg = f"Could not connect to {url} — is the server running? (connection timed out)"
+            else:
+                err_msg = f"Could not connect to {url} — {reason}"
+            if not self.json_output:
+                print(f"  {err_msg}", file=sys.stderr)
+            self._connection_error = err_msg
+            return False
+        except OSError as e:
+            url = getattr(self.transport, "url", "unknown")
+            err_msg = f"Could not connect to {url} — {e}"
+            if not self.json_output:
+                print(f"  {err_msg}", file=sys.stderr)
+            self._connection_error = err_msg
+            return False
+
         if resp and "result" in resp:
             self.server_info = resp["result"].get("serverInfo", {})
             self.server_capabilities = resp["result"].get("capabilities", {})
-            print(f"  Server: {self.server_info.get('name', 'unknown')} "
-                  f"v{self.server_info.get('version', '?')}")
-            print(f"  Capabilities: {list(self.server_capabilities.keys())}")
+            if not self.json_output:
+                print(f"  Server: {self.server_info.get('name', 'unknown')} "
+                      f"v{self.server_info.get('version', '?')}")
+                print(f"  Capabilities: {list(self.server_capabilities.keys())}")
 
             # Send initialized notification
             self.transport.send(jsonrpc_notification("notifications/initialized"))
             return True
         else:
-            print(f"  ⚠️  Initialize failed: {resp}")
+            err_msg = f"Initialize failed: {resp}"
+            if not self.json_output:
+                print(f"  ⚠️  {err_msg}")
+            self._connection_error = err_msg
             return False
 
     # ------------------------------------------------------------------
@@ -1014,23 +1060,28 @@ class MCPSecurityTests:
         else:
             test_map = all_tests
 
-        print(f"\n{'='*60}")
-        print("MCP PROTOCOL SECURITY TEST SUITE v3.0")
-        print(f"{'='*60}")
+        if not self.json_output:
+            print(f"\n{'='*60}")
+            print("MCP PROTOCOL SECURITY TEST SUITE v3.0")
+            print(f"{'='*60}")
 
         # Initialize connection
         if not self.initialize():
-            print("\n❌ Failed to initialize MCP connection. Aborting.")
+            err = getattr(self, "_connection_error", "Failed to initialize MCP connection")
+            if not self.json_output:
+                print(f"\n❌ {err}. Aborting.")
             return self.results
 
         for category, tests in test_map.items():
-            print(f"\n[{category.upper().replace('_', ' ')}]")
+            if not self.json_output:
+                print(f"\n[{category.upper().replace('_', ' ')}]")
             for test_fn in tests:
                 try:
                     test_fn()
                 except Exception as e:
                     _eid = re.search(r"([A-Z]{2,}-\d{3})", test_fn.__doc__ or "") ; _eid = _eid.group(1) if _eid else test_fn.__name__
-                    print(f"  ERROR ⚠️  {_eid}: {e}")
+                    if not self.json_output:
+                        print(f"  ERROR ⚠️  {_eid}: {e}")
                     self.results.append(MCPTestResult(
                         test_id=_eid,
                         name=f"ERROR: {_eid}",
@@ -1045,9 +1096,10 @@ class MCPSecurityTests:
         # Summary
         total = len(self.results)
         passed = sum(1 for r in self.results if r.passed)
-        print(f"\n{'='*60}")
-        print(f"RESULTS: {passed}/{total} passed ({passed/total*100:.0f}%)" if total else "No tests run")
-        print(f"{'='*60}\n")
+        if not self.json_output:
+            print(f"\n{'='*60}")
+            print(f"RESULTS: {passed}/{total} passed ({passed/total*100:.0f}%)" if total else "No tests run")
+            print(f"{'='*60}\n")
 
         return self.results
 
@@ -1056,8 +1108,8 @@ class MCPSecurityTests:
 # Report generation
 # ---------------------------------------------------------------------------
 
-def generate_report(results: list[MCPTestResult], output_path: str):
-    """Write JSON report."""
+def build_report(results: list[MCPTestResult], error: str | None = None) -> dict:
+    """Build report dict from results."""
     report = {
         "suite": "MCP Protocol Security Tests v3.0",
         "timestamp": datetime.now(timezone.utc).isoformat(),
@@ -1068,6 +1120,14 @@ def generate_report(results: list[MCPTestResult], output_path: str):
         },
         "results": [asdict(r) for r in results],
     }
+    if error:
+        report["error"] = error
+    return report
+
+
+def generate_report(results: list[MCPTestResult], output_path: str):
+    """Write JSON report."""
+    report = build_report(results)
     with open(output_path, "w") as f:
         json.dump(report, f, indent=2, default=str)
     print(f"Report written to {output_path}")
@@ -1084,16 +1144,27 @@ def main():
     ap.add_argument("--command", help="Server command (for stdio transport), space-separated")
     ap.add_argument("--categories", help="Comma-separated test categories to run")
     ap.add_argument("--report", help="Output JSON report path")
+    ap.add_argument("--json", action="store_true", dest="json_output",
+                    help="Output results as JSON to stdout (no human-readable text)")
     ap.add_argument("--header", action="append", default=[], help="Extra HTTP headers (key:value)")
     ap.add_argument("--trials", type=int, default=1, help="Run each test N times for statistical analysis (NIST AI 800-2)")
     args = ap.parse_args()
 
+    # Also check env var for JSON output (set by CLI --json flag)
+    json_output = args.json_output or os.environ.get("AGENT_SECURITY_JSON_OUTPUT") == "1"
+
     # Validate transport args early (before creating any transport)
     if args.transport == "http" and not args.url:
-        print("ERROR: --url required for http transport", file=sys.stderr)
+        if json_output:
+            print(json.dumps({"error": "--url required for http transport"}))
+        else:
+            print("ERROR: --url required for http transport", file=sys.stderr)
         sys.exit(1)
     if args.transport == "stdio" and not args.command:
-        print("ERROR: --command required for stdio transport", file=sys.stderr)
+        if json_output:
+            print(json.dumps({"error": "--command required for stdio transport"}))
+        else:
+            print("ERROR: --command required for stdio transport", file=sys.stderr)
         sys.exit(1)
 
     categories = args.categories.split(",") if args.categories else None
@@ -1117,7 +1188,7 @@ def main():
 
         def _single_run():
             transport = _make_transport()
-            suite = MCPSecurityTests(transport)
+            suite = MCPSecurityTests(transport, json_output=json_output)
             try:
                 return {"results": suite.run_all(categories=categories)}
             finally:
@@ -1128,19 +1199,28 @@ def main():
         if args.report:
             with open(args.report, "w") as f:
                 json.dump(merged, f, indent=2, default=str)
-            print(f"Report written to {args.report}")
+            if not json_output:
+                print(f"Report written to {args.report}")
+        if json_output:
+            print(json.dumps(merged, indent=2, default=str))
         results = merged.get("results", [])
     else:
         # Single run mode - create transport only here
         transport = _make_transport()
-        suite = MCPSecurityTests(transport)
+        suite = MCPSecurityTests(transport, json_output=json_output)
+        conn_error = None
         try:
             results = suite.run_all(categories=categories)
+            conn_error = getattr(suite, "_connection_error", None)
         finally:
             transport.close()
 
         if args.report:
             generate_report(results, args.report)
+
+        if json_output:
+            report = build_report(results, error=conn_error)
+            print(json.dumps(report, indent=2, default=str))
 
     # Exit code
     failed = sum(1 for r in results if not r.passed)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-security-harness"
-version = "3.8.1"
+version = "3.9.0"
 description = "342 security tests for AI agent systems - MCP, A2A, L402, x402 wire-protocol testing, CVE-2026-25253 reproduction, AIUC-1 compliance, 25 cloud platform + 20 enterprise adapters, GTG-1002 APT simulation"
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary

Implements two v3.9 milestone items:

- **`--json` output flag (#103)** — `agent-security test mcp --url ... --json` outputs structured JSON to stdout with no human-readable text. Uses the same report structure as `--report` file output. Works in both single-run and multi-trial modes.
- **Improved connection error messages (#90)** — Distinguishes DNS failure, connection refused, and timeout with actionable messages like "Could not connect to http://... — is the server running? (connection refused)". Errors appear in JSON output when `--json` is set.

### Implementation details

**`protocol_tests/cli.py`**
- Parses `--json` flag alongside `--delay` and `--no-telemetry`
- Sets `AGENT_SECURITY_JSON_OUTPUT=1` env var and passes `--json` through to harness
- Suppresses CLI's own status messages in JSON mode

**`protocol_tests/mcp_harness.py`**
- `MCPSecurityTests.__init__` accepts `json_output` param (also checks env var)
- `_record()` suppresses emoji output in JSON mode
- `run_all()` suppresses banners, category headers, and summary in JSON mode
- `initialize()` catches `ConnectionRefusedError`, `socket.timeout`, `urllib.error.URLError`, `OSError` separately with descriptive messages
- New `build_report()` factored out of `generate_report()` for stdout JSON output
- Connection errors stored in `_connection_error` attr for inclusion in JSON output

**`pyproject.toml`** — Version bump to 3.9.0

### Example usage

```bash
# JSON to stdout (pipe to jq, CI tools, etc.)
agent-security test mcp --url http://localhost:8080/mcp --json

# Connection error in JSON mode
agent-security test mcp --url http://unreachable:9999/mcp --json
# {"suite": "MCP Protocol Security Tests v3.0", ..., "error": "Could not connect to http://unreachable:9999/mcp — is the server running? (connection refused)"}
```

## Test plan

- [x] All 140 existing tests pass (1 pre-existing unrelated failure in test_21_harnesses)
- [ ] Manual test: `--json` flag produces valid JSON to stdout
- [ ] Manual test: unreachable server shows descriptive error
- [ ] Manual test: `--json` + unreachable server includes error in JSON output

Closes #103, closes #90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new machine-readable JSON output path and changes when/how the MCP harness prints or emits errors, which may affect existing scripts that parse stdout/stderr or expect banners/delay messages.
> 
> **Overview**
> Adds a `--json` flag to `agent-security test` (and the `mcp` harness) to emit **structured JSON results to stdout** and suppress human-readable banners/status lines; the top-level CLI also forwards the flag via `AGENT_SECURITY_JSON_OUTPUT` and avoids printing the delay banner in JSON mode.
> 
> Improves MCP initialization failure handling by catching DNS/timeout/refused cases and returning **actionable connection errors**, with those errors included in JSON output; report generation is refactored via `build_report()` to share structure between `--report` file output and stdout JSON. Also bumps version to `3.9.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 790f372d64d7f3a97133d8fdd7c57e7a84fd3aac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->