### PR TITLE
Add engagement infrastructure: comparison, launch posts, templates

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/compliance-experience.yml
+++ b/.github/DISCUSSION_TEMPLATE/compliance-experience.yml
@@ -1,0 +1,30 @@
+title: "[Compliance] "
+labels: ["compliance", "community"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Share your experience with AI agent compliance — EU AI Act, AIUC-1, NIST, OWASP Agentic Top 10, or other frameworks.
+
+        We're building compliance-grade evidence tooling and want to understand what auditors actually accept, what enterprises need, and where the gaps are.
+  - type: textarea
+    id: context
+    attributes:
+      label: What compliance framework or regulation are you working with?
+      placeholder: "e.g., EU AI Act high-risk, AIUC-1 pre-certification, NIST AI RMF, internal governance..."
+    validations:
+      required: true
+  - type: textarea
+    id: experience
+    attributes:
+      label: What's working? What's missing?
+      placeholder: "What evidence do auditors actually accept? What tools are you using? Where are the gaps?"
+    validations:
+      required: true
+  - type: textarea
+    id: interest
+    attributes:
+      label: Would you be interested in testing the evidence pack generator?
+      placeholder: "We have a new tool that produces signed evidence packages for AIUC-1 and OWASP mapping. Happy to share early access."
+    validations:
+      required: false

--- a/.github/DISCUSSION_TEMPLATE/payment-protocol-security.yml
+++ b/.github/DISCUSSION_TEMPLATE/payment-protocol-security.yml
@@ -1,0 +1,23 @@
+title: "[Payments] "
+labels: ["x402", "l402", "payments"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This project has the only dedicated security testing suite for agent payment protocols (x402/L402 — 39 tests).
+
+        If you're building on x402, L402, or other agent payment rails, we want to hear about your security concerns and what testing you need.
+  - type: textarea
+    id: context
+    attributes:
+      label: What payment protocol and use case are you working with?
+      placeholder: "e.g., x402/USDC settlement, L402/Lightning micropayments, agent-to-agent payments..."
+    validations:
+      required: true
+  - type: textarea
+    id: concerns
+    attributes:
+      label: What security concerns keep you up at night?
+      placeholder: "e.g., unauthorized execution, budget overflow, replay attacks, facilitator trust..."
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/security-test-request.yml
+++ b/.github/ISSUE_TEMPLATE/security-test-request.yml
@@ -1,0 +1,51 @@
+name: Security Test Request
+description: Request a new security test scenario for the harness
+title: "[Test Request] "
+labels: ["enhancement", "test-request"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Request a new adversarial test scenario. We prioritize tests that cover real-world attack surfaces not addressed by static scanners.
+  - type: dropdown
+    id: protocol
+    attributes:
+      label: Protocol / Layer
+      options:
+        - MCP (Model Context Protocol)
+        - A2A (Agent-to-Agent)
+        - L402 (Lightning payments)
+        - x402 (USDC/stablecoin payments)
+        - Enterprise platform (SAP, Salesforce, etc.)
+        - Cloud agent platform (Bedrock, Azure, Vertex)
+        - Decision governance
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: scenario
+    attributes:
+      label: Attack scenario
+      placeholder: "Describe the adversarial scenario. What does the attacker do? What should the agent do? What would a failure look like?"
+    validations:
+      required: true
+  - type: textarea
+    id: real-world
+    attributes:
+      label: Real-world context
+      placeholder: "Have you seen this in production? Is this based on a published CVE, research paper, or incident?"
+    validations:
+      required: false
+  - type: dropdown
+    id: compliance
+    attributes:
+      label: Compliance mapping (if known)
+      options:
+        - AIUC-1
+        - OWASP Agentic Top 10
+        - NIST AI RMF
+        - EU AI Act
+        - Not sure
+        - Other
+    validations:
+      required: false

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -1,0 +1,58 @@
+# Agent Security Tool Comparison (April 2026)
+
+How does the Agent Security Harness compare to other tools in the AI agent security space?
+
+**Short answer:** We test what static scanners can't see — whether authorized agents make safe decisions under adversarial pressure.
+
+## Comparison Matrix
+
+| Capability | [Cisco MCP Scanner](https://github.com/cisco-ai-defense/mcp-scanner) | [Snyk Agent Scan](https://github.com/snyk/agent-scan) | [NVIDIA Garak](https://github.com/NVIDIA/garak) | **Agent Security Harness** |
+|---|---|---|---|---|
+| **Approach** | Static + LLM-as-judge | Config scanning + toxic flow | Model-layer probing | **Wire-protocol adversarial testing** |
+| **MCP coverage** | Tool descriptions, YARA rules | Config files | — | **13 tests: real JSON-RPC 2.0 attacks** |
+| **A2A coverage** | — | — | — | **12 tests** |
+| **L402/x402 payment coverage** | — | — | — | **39 tests** |
+| **Enterprise platform adapters** | — | — | — | **25 cloud + 20 enterprise** |
+| **Behavioral profiling / drift** | — | — | — | **Planned (v3.10)** |
+| **Compliance evidence packs** | — | — | — | **Yes (AIUC-1, OWASP, NIST)** |
+| **AIUC-1 requirement mapping** | — | — | — | **19/20 requirements (95%)** |
+| **OWASP Agentic Top 10** | — | — | — | **Complete ASI01-ASI10** |
+| **Statistical multi-trial** | — | — | — | **Wilson CIs (NIST AI 800-2)** |
+| **CI/CD integration** | — | Snyk platform | — | **GitHub Action + CLI** |
+| **License** | Apache 2.0 | Proprietary | Apache 2.0 | **Apache 2.0** |
+
+## When to Use What
+
+**Use static scanners (Cisco, Snyk) for:**
+- Pre-deployment config review
+- Tool description analysis
+- Known pattern matching
+- MCP server metadata scanning
+
+**Use this framework for:**
+- Active adversarial testing against live endpoints
+- Decision-governance validation (does the agent behave safely when authorized?)
+- Multi-protocol coverage (MCP + A2A + L402 + x402)
+- Compliance evidence generation (AIUC-1, EU AI Act)
+- Payment protocol security testing
+
+**Use both.** They're complementary layers. Scan for known issues, then test for behavioral failures under adversarial conditions.
+
+## The Gap This Fills
+
+Most tools answer: *"Is the agent properly configured?"*
+
+This framework answers: *"Even if properly configured, can the agent still be manipulated into unsafe behavior?"*
+
+That's the decision-governance layer. Identity tells you the agent is allowed. Decision governance tells you the agent is right.
+
+## Learn More
+
+- [Repository](https://github.com/msaleme/red-team-blue-team-agent-fabric)
+- [Research (5 peer-reviewed preprints)](https://github.com/msaleme/red-team-blue-team-agent-fabric#research)
+- [AIUC-1 Compliance Mapping](https://github.com/msaleme/red-team-blue-team-agent-fabric/blob/main/configs/aiuc1_mapping.yaml)
+- [Roadmap](https://github.com/msaleme/red-team-blue-team-agent-fabric/blob/main/ROADMAP.md)
+
+---
+
+> This comparison reflects publicly available information as of April 2026. We welcome corrections — open an issue or PR.

--- a/docs/engagement/LAUNCH_POSTS.md
+++ b/docs/engagement/LAUNCH_POSTS.md
@@ -1,0 +1,151 @@
+# Engagement Posts — Ready to Publish
+
+These are ready-to-post discussion starters for GitHub Discussions, LinkedIn, and relevant communities. Each is designed to attract a specific type of person into the project's orbit.
+
+---
+
+## Post 1: GitHub Discussion — "What evidence do AIUC-1 auditors actually accept?"
+
+**Target:** Compliance leads, auditors, GRC teams
+**Where:** GitHub Discussions (Compliance category), LinkedIn, r/cybersecurity
+
+**Title:** What evidence do AIUC-1 auditors actually accept?
+
+**Body:**
+
+UiPath just became the first platform to achieve AIUC-1 certification (audited by Schellman, March 2026). As more organizations pursue certification, a practical question emerges:
+
+**What does "testable evidence" actually look like for each AIUC-1 requirement?**
+
+We're building open-source tooling that produces audit-ready evidence packages for AIUC-1 compliance — mapping 19 of 20 requirements to executable tests with signed JSON artifacts. But we want to hear from people on the audit side:
+
+- What format do auditors prefer? (JSON, PDF, structured markdown?)
+- Which requirements are hardest to demonstrate evidence for?
+- What's the difference between "we tested this" and "an auditor accepted this as evidence"?
+
+If you're working on AIUC-1, EU AI Act compliance, or agent security governance, we'd love your input.
+
+Context: https://github.com/msaleme/red-team-blue-team-agent-fabric
+
+---
+
+## Post 2: GitHub Discussion — "Who's testing x402/L402 payment security?"
+
+**Target:** Fintech builders, x402 integrators, payment protocol developers
+**Where:** GitHub Discussions (Payments category), x402 Discord, relevant Telegram groups
+
+**Title:** Who's testing x402/L402 agent payment security?
+
+**Body:**
+
+x402 is processing 1B+ HTTP 402 responses/day through Cloudflare. L402 is growing on Lightning. Agent-to-agent payments are becoming real.
+
+But who's actually testing the security of these flows?
+
+We built 39 dedicated tests for agent payment protocols — unauthorized execution, budget overflow, replay attacks, facilitator trust, cross-chain confusion, autonomy risk scoring. As far as we can tell, no other tool covers this.
+
+Questions for the community:
+
+- Are you integrating x402 or L402 into agent workflows? What's your security testing look like today?
+- What payment-specific attack scenarios worry you most?
+- Would a CI gate that scores "should this agent spend money unsupervised?" be useful?
+
+We're especially interested in hearing from teams at fintechs, neobanks, or payment platforms who are building on these rails.
+
+Context: https://github.com/msaleme/red-team-blue-team-agent-fabric
+
+---
+
+## Post 3: LinkedIn — "Static scanners vs. behavioral testing"
+
+**Target:** Security architects, CISOs, DevSecOps leads
+**Where:** LinkedIn
+
+**Body:**
+
+The AI agent security market is splitting into three layers:
+
+**Layer 1: Static scanners** — Cisco MCP Scanner, Snyk Agent Scan. Analyze configs, tool descriptions, metadata.
+
+**Layer 2: Enterprise platforms** — CrowdStrike, Microsoft Agent 365, Okta. Broad agent governance from identity to runtime.
+
+**Layer 3: Behavioral assurance** — Test whether authorized agents make safe decisions under adversarial pressure. This is the layer nobody owns yet.
+
+We're building in Layer 3. Our open-source harness sends real adversarial payloads across MCP, A2A, L402, and x402 protocols and measures whether agents behave safely.
+
+The question we test: "Even if an agent is properly authenticated and authorized, can it still be manipulated into unsafe behavior?"
+
+Static scanners can't answer that. Enterprise platforms don't test for it. We do.
+
+342 tests. 24 modules. 5 peer-reviewed preprints. Apache 2.0.
+
+https://github.com/msaleme/red-team-blue-team-agent-fabric
+
+---
+
+## Post 4: GitHub Discussion — "Attestation registry: should evidence be shared across orgs?"
+
+**Target:** Standards body participants, compliance consultants, enterprise security teams
+**Where:** GitHub Discussions
+
+**Title:** Should agent security evidence be shared across organizations?
+
+**Body:**
+
+We have an attestation registry that stores security test evidence. Right now it's per-organization.
+
+But what if it were shared?
+
+Imagine: Organization A runs decision-governance tests on their MCP deployment and publishes the evidence. Organization B, evaluating the same MCP server for procurement, can see that evidence instead of re-running from scratch.
+
+Over time, the registry accumulates longitudinal comparative data — behavioral drift scores across deployments, failure patterns by protocol version, risk trends.
+
+That's a very different value proposition from a local scanner.
+
+Questions:
+- Would your organization publish security evidence to a shared registry?
+- What would need to be true for you to trust evidence someone else produced?
+- Is there a model between "fully public" and "fully private" that works? (e.g., anonymized aggregate data, trusted auditor attestation)
+
+This is relevant to AIUC-1, EU AI Act, and any framework that requires ongoing evidence of agent safety.
+
+---
+
+## Post 5: Hacker News — Show HN
+
+**Target:** Technical practitioners, early adopters, security researchers
+**Where:** Hacker News (Show HN)
+
+**Title:** Show HN: 342-test adversarial harness for AI agents (MCP, A2A, x402/L402)
+
+**Body:**
+
+We built an open-source security testing framework for autonomous AI agents. Unlike static scanners (Cisco MCP Scanner, Snyk Agent Scan), it sends real adversarial payloads across live protocols and measures whether agents make safe decisions.
+
+- 342 executable tests across 24 modules
+- 4 wire protocols: MCP, A2A, L402, x402
+- AIUC-1 compliance mapping (19/20 requirements)
+- OWASP Agentic Top 10 complete coverage
+- Signed evidence packages for auditors
+- GitHub Action for CI/CD gating
+- 5 peer-reviewed preprints, NIST alignment
+
+The key insight: identity and authorization are solved. The hard problem is whether an authorized agent behaves safely under adversarial conditions.
+
+pip install agent-security-harness
+
+https://github.com/msaleme/red-team-blue-team-agent-fabric
+
+---
+
+## Posting Sequence
+
+| Week | Post | Platform | Goal |
+|------|------|----------|------|
+| 1 | Post 5 (Show HN) | Hacker News | Technical awareness, stars, early adopters |
+| 1 | Post 3 (Static vs behavioral) | LinkedIn | CISO/architect awareness |
+| 2 | Post 1 (AIUC-1 evidence) | GitHub Discussions + LinkedIn | Compliance community engagement |
+| 2 | Post 2 (Payment security) | GitHub Discussions + x402 community | Fintech/payment builder engagement |
+| 3 | Post 4 (Shared registry) | GitHub Discussions | Standards/compliance thought leadership |
+
+**Rule:** One post per platform per week. Don't spam. Each post should generate conversation, not just views.


### PR DESCRIPTION
## Summary

Boardy-model engagement infrastructure — discoverable artifacts that bring the right people into the project's orbit.

### What's included

- **`docs/COMPARISON.md`** — SEO-visible comparison matrix vs Cisco MCP Scanner, Snyk Agent Scan, NVIDIA Garak. Positioned as complementary ("use both"), not combative. Makes the behavioral-assurance gap obvious.

- **`docs/engagement/LAUNCH_POSTS.md`** — 5 ready-to-post discussion starters, sequenced over 3 weeks:
  1. Show HN (technical awareness)
  2. LinkedIn: static vs behavioral testing (CISO/architect awareness)
  3. AIUC-1 evidence question (compliance community)
  4. x402/L402 payment security (fintech builders)
  5. Shared attestation registry (standards thought leadership)

- **`.github/DISCUSSION_TEMPLATE/`** — Structured templates for compliance experience sharing and payment protocol security discussions

- **`.github/ISSUE_TEMPLATE/security-test-request.yml`** — Structured test request form with protocol selection, compliance mapping, and real-world context fields

### Discussions already created

- [#129: What evidence do AIUC-1 auditors actually accept?](https://github.com/msaleme/red-team-blue-team-agent-fabric/discussions/129)
- [#130: Who's testing x402/L402 agent payment security?](https://github.com/msaleme/red-team-blue-team-agent-fabric/discussions/130)

### Strategy

Each artifact targets a specific buyer/collaborator persona and creates a reason for them to engage with the project. The comparison matrix is the "static scanner vs behavioral testing" story that makes discovery organic. The discussion posts are conversation starters, not announcements.

## Test plan

- [ ] Verify COMPARISON.md links resolve
- [ ] Review launch post tone (collegial, not salesy)
- [ ] Review issue template renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to GitHub Discussion/Issue templates and documentation/engagement copy, with no runtime code or security-sensitive logic impacted.
> 
> **Overview**
> Adds community/engagement infrastructure: new GitHub Discussion templates for *compliance experience* and *payment protocol security*, plus a new Issue template to request additional security test scenarios with protocol/compliance fields.
> 
> Introduces new docs content to support outreach and positioning, including a `docs/COMPARISON.md` matrix against other agent security tools and `docs/engagement/LAUNCH_POSTS.md` with prewritten launch/engagement posts and a suggested posting sequence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9d1ac761b05f2daf96059a5ecb5bae87ef5e937. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->