### PR TITLE
fix: address 5 Cursor Bugbot findings from PRs #127 and #128

### DIFF
--- a/protocol_tests/aiuc1_compliance_harness.py
+++ b/protocol_tests/aiuc1_compliance_harness.py
@@ -93,12 +93,12 @@ class AIUCTestResult:
     def __post_init__(self):
         if not self.timestamp:
             self.timestamp = datetime.now(timezone.utc).isoformat()
-        if not self.aiuc1_req and self.aiuc_control:
+        if not self.aiuc1_req and self.aiuc_control and self.aiuc_control != "ERR":
             # Derive AIUC-1 requirement ID from control (e.g., "E001" from "AIUC-E001")
-            self.aiuc1_req = self.aiuc_control.replace("AIUC-", "").split("-")[0]
+            candidate = self.aiuc_control.replace("AIUC-", "").split("-")[0]
             # Normalize: "C003a" -> "C003", "F002b" -> "F002"
             import re
-            m = re.match(r"([A-Z]\d{3})", self.aiuc1_req)
+            m = re.match(r"([A-Z]\d{3})", candidate)
             if m:
                 self.aiuc1_req = m.group(1)
 
@@ -1053,7 +1053,7 @@ def main():
 
     if args.report:
         with open(args.report, "w") as f:
-            json.dump(report, f, indent=2)
+            json.dump(report, f, indent=2, default=str)
         if not json_output:
             print(f"Report saved to {args.report}")
 

--- a/scripts/evidence_pack.py
+++ b/scripts/evidence_pack.py
@@ -68,7 +68,7 @@ def _build_requirement_index(mapping: dict[str, Any]) -> dict[str, dict]:
                 "owasp_asi": req_def.get("owasp_asi", ""),
                 "nist_rmf": req_def.get("nist_rmf", ""),
                 "status": req_def.get("status", "UNKNOWN"),
-                "gap_notes": req_def.get("gap_notes", ""),
+                "gap_notes": req_def.get("gap_notes") or "",
             }
     return index
 
@@ -120,7 +120,7 @@ def compute_aiuc1_coverage(
                 "passed": 0,
                 "failed": 0,
                 "total": 0,
-                "notes": req_def.get("gap_notes", "Not yet covered"),
+                "notes": req_def.get("gap_notes") or "Not yet covered",
             }
             gap_count += 1
             continue
@@ -191,7 +191,9 @@ def compute_owasp_coverage(
     for _req_id, req_def in req_index.items():
         asi = req_def.get("owasp_asi", "")
         if asi:
-            asi_tests.setdefault(asi, []).extend(req_def["test_ids"])
+            for tid in req_def["test_ids"]:
+                if tid not in asi_tests.get(asi, []):
+                    asi_tests.setdefault(asi, []).append(tid)
 
     # Index results
     result_by_id: dict[str, dict] = {}
@@ -202,7 +204,7 @@ def compute_owasp_coverage(
 
     owasp: dict[str, Any] = {}
     for asi_id, asi_name in OWASP_AGENTIC_CATEGORIES.items():
-        test_ids = asi_tests.get(asi_id, [])
+        test_ids = list(dict.fromkeys(asi_tests.get(asi_id, [])))  # deduplicate preserving order
         matched = [tid for tid in test_ids if tid in result_by_id]
         passed = sum(1 for tid in matched if result_by_id[tid].get("passed", False))
         failed = len(matched) - passed
@@ -429,8 +431,8 @@ def build_evidence_pack(
         sign_key = os.environ.get("AGENT_SECURITY_SIGN_KEY", "")
         if not sign_key:
             sign_key = secrets.token_hex(32)
-            print(f"No AGENT_SECURITY_SIGN_KEY set. Auto-generated key: {sign_key}")
-            print("Store this key to verify the signature later.")
+            print(f"No AGENT_SECURITY_SIGN_KEY set. Auto-generated key: {sign_key}", file=sys.stderr)
+            print("Store this key to verify the signature later.", file=sys.stderr)
         attestation = sign_evidence(evidence_hash, sign_key)
 
     # Build evidence-summary.json


### PR DESCRIPTION
## Summary

Fixes all 5 issues reported by Cursor Bugbot on the evidence pack (#127) and AIUC-1 suite (#128) PRs.

| # | File | Severity | Issue | Fix |
|---|------|----------|-------|-----|
| 1 | evidence_pack.py | Medium | Duplicate test IDs inflate OWASP coverage stats | Deduplicate per-ASI test ID lists |
| 2 | evidence_pack.py | Medium | HMAC signing key leaked to stdout in CI | Print to stderr |
| 3 | evidence_pack.py | Low | "Not yet covered" default unreachable | Use `or` instead of dict `.get()` default |
| 4 | aiuc1_compliance_harness.py | Low | Missing `default=str` in file JSON dump | Added to match stdout output and all other harnesses |
| 5 | aiuc1_compliance_harness.py | Low | Phantom "ERR" requirement in coverage | Skip derivation when `aiuc_control="ERR"` |

## Test plan

- [x] 140 tests pass (1 pre-existing harness count mismatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit b0cb12d10fcc91e88049694eadf0e5da3d3a8375. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->