### PR TITLE
Add FRIA evidence collection and compliance report generation

### DIFF
--- a/scripts/compliance_report.py
+++ b/scripts/compliance_report.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Compliance Report Auto-Generation (HTML/PDF)
+
+Generates auditor-ready compliance reports with framework-specific language,
+evidence summaries, and gap analysis. Combines AUROC metrics, framework
+crosswalks, and FRIA evidence into a single document.
+
+Tracks GitHub issue #160.
+
+Usage:
+    python scripts/compliance_report.py --report results.json --output report.html
+    python scripts/compliance_report.py --report results.json --output report.html --framework eu-ai-act
+    python scripts/compliance_report.py --report results.json --output report.html --framework all --fria
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from typing import Any
+
+# Ensure repo root is importable
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, REPO_ROOT)
+
+
+def _esc(text: Any) -> str:
+    return html.escape(str(text))
+
+
+def _load_json(path: str) -> dict:
+    with open(path) as f:
+        return json.load(f)
+
+
+def _status_badge(status: str) -> str:
+    s = status.upper()
+    colors = {
+        "PASS": ("#dcfce7", "#166534"), "COVERED": ("#dcfce7", "#166534"),
+        "FAIL": ("#fee2e2", "#991b1b"), "FLAGGED": ("#fee2e2", "#991b1b"),
+        "NON_COMPLIANT": ("#fee2e2", "#991b1b"),
+        "GAP": ("#fef3c7", "#92400e"), "INCOMPLETE": ("#fef3c7", "#92400e"),
+        "COMPLIANT": ("#dcfce7", "#166534"),
+    }
+    bg, fg = colors.get(s, ("#f3f4f6", "#6b7280"))
+    return (f'<span style="display:inline-block;padding:2px 10px;border-radius:12px;'
+            f'font-size:12px;font-weight:600;background:{bg};color:{fg}">{_esc(s)}</span>')
+
+
+_CSS = """\
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+ color:#1a1a2e;background:#fff;line-height:1.6;font-size:13px}
+.container{max-width:900px;margin:0 auto;padding:32px 24px}
+h1{font-size:22px;font-weight:700;margin-bottom:4px}
+h2{font-size:17px;font-weight:600;margin:28px 0 10px;padding-bottom:6px;border-bottom:2px solid #e0e0e0}
+h3{font-size:14px;font-weight:600;margin:16px 0 6px}
+.meta{color:#666;font-size:12px;margin-bottom:20px}
+.meta span{margin-right:16px}
+.card-row{display:flex;gap:14px;flex-wrap:wrap;margin:14px 0}
+.card{flex:1;min-width:140px;background:#f8f9fa;border:1px solid #e0e0e0;border-radius:8px;
+ padding:14px 16px;text-align:center}
+.card .label{font-size:11px;text-transform:uppercase;letter-spacing:.5px;color:#888;margin-bottom:2px}
+.card .value{font-size:24px;font-weight:700}
+table{width:100%;border-collapse:collapse;margin:10px 0;border:1px solid #e0e0e0;font-size:12px}
+th{background:#f1f5f9;font-weight:600;text-align:left;padding:8px 12px;border-bottom:2px solid #e0e0e0}
+td{padding:8px 12px;border-bottom:1px solid #f0f0f0}
+tr:hover{background:#f8fafc}
+.footer{margin-top:32px;padding-top:12px;border-top:1px solid #e0e0e0;color:#888;font-size:11px;text-align:center}
+.narrative{background:#f8f9fa;border-left:3px solid #2563eb;padding:10px 14px;margin:8px 0;font-size:12px}
+@media print{body{font-size:11px}.container{max-width:100%;padding:0}}
+"""
+
+
+def generate_compliance_html(
+    report_data: dict[str, Any],
+    frameworks: list[str] | None = None,
+    include_fria: bool = False,
+) -> str:
+    """Generate a compliance-focused HTML report.
+
+    Args:
+        report_data: Harness JSON output.
+        frameworks: List of framework IDs to include (eu-ai-act, iso-42001, aiuc-1).
+        include_fria: Whether to include FRIA evidence section.
+
+    Returns:
+        HTML string.
+    """
+    results = report_data.get("results", [])
+    total = len(results)
+    passed = sum(1 for r in results if r.get("passed", False))
+    timestamp = report_data.get("timestamp", datetime.now(timezone.utc).isoformat())
+
+    parts: list[str] = []
+    parts.append("<!DOCTYPE html><html lang='en'><head>")
+    parts.append("<meta charset='UTF-8'><meta name='viewport' content='width=device-width,initial-scale=1'>")
+    parts.append(f"<title>Compliance Report - {_esc(timestamp[:10])}</title>")
+    parts.append(f"<style>{_CSS}</style></head><body><div class='container'>")
+
+    # Header
+    parts.append("<h1>Agent Security Compliance Report</h1>")
+    parts.append(f'<div class="meta"><span>Generated: {_esc(timestamp)}</span>'
+                 f'<span>Tests: {total}</span></div>')
+
+    # Executive Summary
+    parts.append("<h2>1. Executive Summary</h2>")
+    parts.append('<div class="card-row">')
+    parts.append(f'<div class="card"><div class="label">Total Tests</div><div class="value" style="color:#2563eb">{total}</div></div>')
+    parts.append(f'<div class="card"><div class="label">Passed</div><div class="value" style="color:#16a34a">{passed}</div></div>')
+    parts.append(f'<div class="card"><div class="label">Failed</div><div class="value" style="color:{"#dc2626" if total-passed else "#16a34a"}">{total-passed}</div></div>')
+    rate = (passed / total * 100) if total else 0
+    parts.append(f'<div class="card"><div class="label">Pass Rate</div><div class="value" style="color:{"#16a34a" if rate >= 90 else "#d97706" if rate >= 70 else "#dc2626"}">{rate:.1f}%</div></div>')
+    parts.append("</div>")
+
+    # AUROC section
+    try:
+        from scripts.auroc import compute_all_auroc, auroc_label
+        auroc = compute_all_auroc(report_data)
+        if auroc.get("modules"):
+            parts.append("<h2>2. Detection Effectiveness (AUROC)</h2>")
+            parts.append("<table><tr><th>Module</th><th>AUROC</th><th>Rating</th></tr>")
+            for mod, score in sorted(auroc["modules"].items()):
+                parts.append(f"<tr><td>{_esc(mod)}</td><td><strong>{score:.4f}</strong></td>"
+                             f"<td>{_esc(auroc_label(score))}</td></tr>")
+            parts.append("</table>")
+            parts.append(f'<p style="color:#888;font-size:11px">{_esc(auroc.get("methodology", ""))}</p>')
+    except Exception:
+        pass
+
+    # Framework compliance sections
+    if frameworks:
+        try:
+            from scripts.compliance_crosswalk import load_crosswalk, apply_crosswalk
+        except ImportError:
+            frameworks = []
+
+    section_num = 3
+    for fw in (frameworks or []):
+        try:
+            crosswalk = load_crosswalk(fw)
+            compliance = apply_crosswalk(crosswalk, results)
+
+            parts.append(f"<h2>{section_num}. {_esc(compliance['framework'])} Compliance</h2>")
+            parts.append(f"<p>Controls: {compliance['covered']}/{compliance['total_controls']} covered | "
+                         f"Gaps: {compliance['gaps']} | Failing: {compliance['failing']} | "
+                         f"Rate: {compliance['compliance_rate']*100:.0f}%</p>")
+
+            parts.append("<table><tr><th>Control</th><th>Description</th><th>Section</th>"
+                         "<th>Mapped</th><th>Run</th><th>Pass</th><th>Fail</th><th>Status</th></tr>")
+            for ctrl in compliance["controls"]:
+                parts.append(
+                    f"<tr><td><strong>{_esc(ctrl['control_id'])}</strong></td>"
+                    f"<td>{_esc(ctrl['description'])}</td>"
+                    f"<td>{_esc(ctrl.get('section', ''))}</td>"
+                    f"<td>{ctrl.get('tests_mapped', 0)}</td>"
+                    f"<td>{ctrl.get('tests_run', 0)}</td>"
+                    f"<td>{ctrl.get('passed', 0)}</td>"
+                    f"<td>{ctrl.get('failed', 0)}</td>"
+                    f"<td>{_status_badge(ctrl['status'])}</td></tr>"
+                )
+            parts.append("</table>")
+
+            # Gap analysis
+            gap_controls = [c for c in compliance["controls"] if c["status"] in ("GAP", "FAIL", "NO_RESULTS")]
+            if gap_controls:
+                parts.append(f"<h3>Gap Analysis — {_esc(compliance['framework'])}</h3>")
+                parts.append("<table><tr><th>Control</th><th>Issue</th><th>Notes</th></tr>")
+                for gc in gap_controls:
+                    issue = "No tests mapped" if gc["status"] == "GAP" else (
+                        "No results" if gc["status"] == "NO_RESULTS" else
+                        f"{gc.get('failed', 0)} tests failing"
+                    )
+                    parts.append(f"<tr><td><strong>{_esc(gc['control_id'])}</strong></td>"
+                                 f"<td>{_esc(issue)}</td>"
+                                 f"<td>{_esc(gc.get('gap_notes', ''))}</td></tr>")
+                parts.append("</table>")
+
+            section_num += 1
+        except Exception as e:
+            parts.append(f"<p style='color:red'>Error loading {fw}: {_esc(str(e))}</p>")
+
+    # FRIA section
+    if include_fria:
+        try:
+            from scripts.fria_evidence import generate_fria_evidence
+            fria = generate_fria_evidence(results)
+
+            parts.append(f"<h2>{section_num}. Fundamental Rights Impact Assessment (FRIA)</h2>")
+            parts.append(f"<p>EU AI Act Article 27 | Status: {_status_badge(fria['overall_status'])}</p>")
+
+            summary = fria["summary"]
+            parts.append('<div class="card-row">')
+            parts.append(f'<div class="card"><div class="label">Covered</div><div class="value" style="color:#16a34a">{summary["covered"]}</div></div>')
+            parts.append(f'<div class="card"><div class="label">Flagged</div><div class="value" style="color:#dc2626">{summary["flagged"]}</div></div>')
+            parts.append(f'<div class="card"><div class="label">Gaps</div><div class="value" style="color:#d97706">{summary["gaps"]}</div></div>')
+            parts.append("</div>")
+
+            for cat_id, cat_data in fria["categories"].items():
+                parts.append(f"<h3>{_status_badge(cat_data['status'])} {_esc(cat_data['title'])}</h3>")
+                parts.append(f'<div class="narrative">{_esc(cat_data["narrative"])}</div>')
+                parts.append(f"<p style='font-size:11px;color:#888'>Tests: {cat_data['passed']}/{cat_data['tests_run']} passing "
+                             f"({cat_data['tests_mapped']} mapped)</p>")
+
+            section_num += 1
+        except Exception as e:
+            parts.append(f"<p style='color:red'>FRIA error: {_esc(str(e))}</p>")
+
+    # Methodology
+    parts.append(f"<h2>{section_num}. Methodology</h2>")
+    parts.append("<ul>")
+    parts.append("<li>Tests are adversarial simulations against the target agent endpoint</li>")
+    parts.append("<li>Pass/fail determined by agent response to attack payloads</li>")
+    parts.append("<li>Statistical confidence via Wilson score intervals</li>")
+    parts.append("<li>AUROC computed from attack detection rate vs. false positive rate</li>")
+    parts.append("<li>Framework mappings derived from crosswalk YAML configurations</li>")
+    parts.append("</ul>")
+
+    # Footer
+    parts.append('<div class="footer">')
+    parts.append(f"Generated by Agent Security Harness | {_esc(timestamp)} | "
+                 '<a href="https://github.com/msaleme/red-team-blue-team-agent-fabric">'
+                 "github.com/msaleme/red-team-blue-team-agent-fabric</a>")
+    parts.append("</div></div></body></html>")
+
+    return "\n".join(parts)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate auditor-ready compliance report (HTML)",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+    python scripts/compliance_report.py --report results.json --output compliance.html
+    python scripts/compliance_report.py --report results.json --output compliance.html --framework eu-ai-act --fria
+    python scripts/compliance_report.py --report results.json --output compliance.html --framework all --fria
+        """,
+    )
+    parser.add_argument("--report", required=True, help="Harness JSON report path")
+    parser.add_argument("--output", "-o", required=True, help="Output HTML file path")
+    parser.add_argument("--framework", action="append", default=[],
+                        help="Framework(s) to include (eu-ai-act, iso-42001, aiuc-1, all)")
+    parser.add_argument("--fria", action="store_true", help="Include FRIA evidence section")
+
+    args = parser.parse_args()
+
+    report_data = _load_json(args.report)
+
+    # Resolve frameworks
+    frameworks = []
+    for fw in args.framework:
+        if fw == "all":
+            frameworks = ["eu-ai-act", "iso-42001"]
+            break
+        frameworks.append(fw)
+
+    html_content = generate_compliance_html(
+        report_data,
+        frameworks=frameworks or None,
+        include_fria=args.fria,
+    )
+
+    with open(args.output, "w") as f:
+        f.write(html_content)
+    print(f"Compliance report written to {args.output}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fria_evidence.py
+++ b/scripts/fria_evidence.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""FRIA Evidence Collection Module
+
+Maps harness test results to EU AI Act Article 27 FRIA (Fundamental Rights
+Impact Assessment) categories, generating structured evidence for compliance.
+
+Consumes harness JSON output and produces FRIA-categorized evidence with
+gap identification.
+
+Tracks GitHub issue #158.
+
+Usage:
+    python scripts/fria_evidence.py --report results.json
+    python scripts/fria_evidence.py --report results.json --output fria.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from typing import Any
+
+
+# FRIA categories per EU AI Act Article 27
+FRIA_CATEGORIES = {
+    "safety": {
+        "title": "Safety and Physical Integrity",
+        "description": "Impact on safety and physical integrity of natural persons",
+        "test_patterns": {
+            "IR-": "Incident response and cascade containment",
+            "CBRN-": "CBRN content prevention",
+            "MCP-": "MCP protocol security",
+        },
+        "test_ids": [
+            "IR-001", "IR-002", "IR-005", "IR-006", "IR-008",
+            "IR-009", "IR-010", "IR-011", "IR-012",
+            "CBRN-001", "CBRN-002", "CBRN-003",
+            "MCP-001", "MCP-002", "MCP-003", "MCP-006",
+        ],
+    },
+    "non_discrimination": {
+        "title": "Non-Discrimination and Equality",
+        "description": "Impact on non-discrimination, equality, and bias",
+        "test_patterns": {
+            "FPR-": "Over-refusal / false positive rate (proxy for bias)",
+            "HO-": "Harmful output detection",
+        },
+        "test_ids": [
+            "HO-001", "HO-002",
+        ],
+        "gap_note": "No dedicated bias/fairness harness. FPR tests provide partial proxy coverage.",
+    },
+    "privacy": {
+        "title": "Privacy and Data Protection",
+        "description": "Impact on privacy and protection of personal data",
+        "test_patterns": {
+            "MEM-": "Memory poisoning and data exfiltration",
+            "DATA-": "Data classification and provenance",
+        },
+        "test_ids": [
+            "MEM-002", "MEM-005", "MEM-010",
+            "DATA-001", "DATA-002", "DATA-003",
+        ],
+    },
+    "human_oversight": {
+        "title": "Human Oversight",
+        "description": "Impact on effective human oversight and agency",
+        "test_patterns": {
+            "AUDIT-": "Audit trail and non-repudiation",
+            "CP-": "Capability profile and logging",
+            "AIUC-E": "AIUC-1 safety requirements",
+        },
+        "test_ids": [
+            "AUDIT-001", "AUDIT-002",
+            "CP-001", "CP-009",
+            "AIUC-E001", "AIUC-E002", "AIUC-E003",
+        ],
+    },
+    "transparency": {
+        "title": "Transparency and Explainability",
+        "description": "Impact on transparency, explainability, and information provision",
+        "test_patterns": {
+            "PRV-": "Provenance and attestation",
+            "WM-": "Watermark compliance (Article 50)",
+            "ATT-": "Attestation reports",
+        },
+        "test_ids": [
+            "PRV-010", "PRV-011", "PRV-012",
+            "WM-001", "WM-002", "WM-003", "WM-004", "WM-005",
+            "ATT-001", "ATT-002", "ATT-003", "ATT-004",
+        ],
+    },
+    "accountability": {
+        "title": "Accountability and Redress",
+        "description": "Impact on accountability, redress, and governance",
+        "test_patterns": {
+            "AUDIT-": "Audit trail completeness",
+            "IR-006": "Log completeness for incident response",
+            "AUTHZ-": "Authorization and delegation",
+        },
+        "test_ids": [
+            "AUDIT-001", "AUDIT-002",
+            "IR-006", "IR-007",
+            "AUTHZ-001", "AUTHZ-002", "AUTHZ-003",
+        ],
+    },
+}
+
+
+def generate_fria_evidence(results: list[dict[str, Any]]) -> dict[str, Any]:
+    """Map harness test results to FRIA categories.
+
+    Args:
+        results: List of test result dicts from harness JSON output.
+
+    Returns:
+        FRIA evidence dict with per-category status and gap analysis.
+    """
+    result_by_id = {r.get("test_id", ""): r for r in results if r.get("test_id")}
+
+    categories: dict[str, dict] = {}
+    total_covered = 0
+    total_flagged = 0
+    total_gaps = 0
+
+    for cat_id, cat_def in FRIA_CATEGORIES.items():
+        mapped_ids = cat_def["test_ids"]
+        matched = [tid for tid in mapped_ids if tid in result_by_id]
+        passed = sum(1 for tid in matched if result_by_id[tid].get("passed", False))
+        failed = len(matched) - passed
+
+        if not matched:
+            if cat_def.get("gap_note"):
+                status = "gap"
+                total_gaps += 1
+            else:
+                status = "no_results"
+                total_gaps += 1
+        elif failed > 0:
+            status = "flagged"
+            total_flagged += 1
+        else:
+            status = "covered"
+            total_covered += 1
+
+        # Build evidence narrative
+        if status == "covered":
+            narrative = (
+                f"All {len(matched)} mapped tests pass. Evidence supports that "
+                f"the system adequately addresses {cat_def['description'].lower()}."
+            )
+        elif status == "flagged":
+            failing_ids = [tid for tid in matched if not result_by_id[tid].get("passed", False)]
+            narrative = (
+                f"{failed} of {len(matched)} tests failing ({', '.join(failing_ids)}). "
+                f"Deployment may pose risks to {cat_def['description'].lower()}. "
+                "Remediation required before FRIA approval."
+            )
+        elif status == "gap":
+            narrative = (
+                f"Insufficient test coverage for {cat_def['description'].lower()}. "
+                f"{cat_def.get('gap_note', 'Additional tests needed.')} "
+                f"Expected tests: {', '.join(mapped_ids[:5])}{'...' if len(mapped_ids) > 5 else ''}."
+            )
+        else:
+            narrative = (
+                f"No test results available for {cat_def['description'].lower()}. "
+                f"Run the harness with relevant modules to generate evidence."
+            )
+
+        categories[cat_id] = {
+            "title": cat_def["title"],
+            "description": cat_def["description"],
+            "status": status,
+            "tests_mapped": len(mapped_ids),
+            "tests_run": len(matched),
+            "passed": passed,
+            "failed": failed,
+            "narrative": narrative,
+            "test_coverage": {
+                pattern: desc for pattern, desc in cat_def["test_patterns"].items()
+            },
+            "gap_note": cat_def.get("gap_note", ""),
+        }
+
+    total = len(FRIA_CATEGORIES)
+    overall = "compliant" if total_flagged == 0 and total_gaps == 0 else (
+        "non_compliant" if total_flagged > 0 else "incomplete"
+    )
+
+    return {
+        "framework": "EU AI Act Article 27 — Fundamental Rights Impact Assessment",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "overall_status": overall,
+        "summary": {
+            "total_categories": total,
+            "covered": total_covered,
+            "flagged": total_flagged,
+            "gaps": total_gaps,
+        },
+        "categories": categories,
+    }
+
+
+def fria_narrative_report(evidence: dict[str, Any]) -> str:
+    """Generate human-readable FRIA narrative from evidence.
+
+    Args:
+        evidence: Output from generate_fria_evidence().
+
+    Returns:
+        Markdown-formatted FRIA report.
+    """
+    lines: list[str] = []
+    lines.append("# Fundamental Rights Impact Assessment (FRIA)")
+    lines.append("## EU AI Act Article 27 — Compliance Evidence Report\n")
+    lines.append(f"Generated: {evidence.get('generated_at', 'unknown')}\n")
+
+    summary = evidence["summary"]
+    lines.append(f"**Overall Status: {evidence['overall_status'].upper()}**")
+    lines.append(f"- Categories covered: {summary['covered']}/{summary['total_categories']}")
+    lines.append(f"- Categories flagged: {summary['flagged']}")
+    lines.append(f"- Coverage gaps: {summary['gaps']}\n")
+
+    status_icons = {
+        "covered": "PASS",
+        "flagged": "FAIL",
+        "gap": "GAP",
+        "no_results": "N/A",
+    }
+
+    for cat_id, cat_data in evidence["categories"].items():
+        icon = status_icons.get(cat_data["status"], "?")
+        lines.append(f"### [{icon}] {cat_data['title']}")
+        lines.append(f"*{cat_data['description']}*\n")
+        lines.append(cat_data["narrative"])
+        lines.append(f"\nTests: {cat_data['passed']}/{cat_data['tests_run']} passing "
+                     f"({cat_data['tests_mapped']} mapped)\n")
+
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="FRIA Evidence Collection")
+    parser.add_argument("--report", required=True, help="Harness JSON report path")
+    parser.add_argument("--output", "-o", help="Output FRIA JSON path")
+    parser.add_argument("--narrative", action="store_true", help="Print narrative report")
+    args = parser.parse_args()
+
+    with open(args.report) as f:
+        data = json.load(f)
+
+    results = data.get("results", [])
+    evidence = generate_fria_evidence(results)
+
+    if args.narrative:
+        print(fria_narrative_report(evidence))
+    elif args.output:
+        with open(args.output, "w") as f:
+            json.dump(evidence, f, indent=2)
+        print(f"FRIA evidence written to {args.output}", file=sys.stderr)
+    else:
+        print(json.dumps(evidence, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_fria_evidence.py
+++ b/tests/test_fria_evidence.py
@@ -1,0 +1,102 @@
+"""Tests for FRIA evidence collection module.
+
+Tracks GitHub issue #158.
+"""
+
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from scripts.fria_evidence import generate_fria_evidence, fria_narrative_report, FRIA_CATEGORIES
+
+
+def test_all_categories_present():
+    """Output always has all 6 FRIA categories."""
+    evidence = generate_fria_evidence([])
+    assert len(evidence["categories"]) == 6
+    for cat_id in FRIA_CATEGORIES:
+        assert cat_id in evidence["categories"]
+
+
+def test_passing_tests_produce_covered():
+    """Tests that pass produce 'covered' status."""
+    results = [
+        {"test_id": "IR-001", "passed": True},
+        {"test_id": "IR-002", "passed": True},
+        {"test_id": "IR-005", "passed": True},
+    ]
+    evidence = generate_fria_evidence(results)
+    safety = evidence["categories"]["safety"]
+    assert safety["status"] == "covered"
+    assert safety["passed"] >= 3
+
+
+def test_failing_tests_produce_flagged():
+    """Failing tests produce 'flagged' status."""
+    results = [
+        {"test_id": "IR-001", "passed": True},
+        {"test_id": "IR-002", "passed": False},
+    ]
+    evidence = generate_fria_evidence(results)
+    safety = evidence["categories"]["safety"]
+    assert safety["status"] == "flagged"
+    assert safety["failed"] >= 1
+
+
+def test_no_results_produce_gap():
+    """No matching results produce 'gap' or 'no_results'."""
+    evidence = generate_fria_evidence([])
+    for cat_data in evidence["categories"].values():
+        assert cat_data["status"] in ("gap", "no_results")
+
+
+def test_overall_status_compliant():
+    """All passing → compliant."""
+    results = []
+    for cat_def in FRIA_CATEGORIES.values():
+        for tid in cat_def["test_ids"]:
+            results.append({"test_id": tid, "passed": True})
+    evidence = generate_fria_evidence(results)
+    assert evidence["overall_status"] == "compliant"
+
+
+def test_overall_status_non_compliant():
+    """Any flagged → non_compliant."""
+    results = [{"test_id": "IR-001", "passed": False}]
+    evidence = generate_fria_evidence(results)
+    assert evidence["overall_status"] == "non_compliant"
+
+
+def test_summary_structure():
+    """Summary has expected keys."""
+    evidence = generate_fria_evidence([])
+    assert "framework" in evidence
+    assert "overall_status" in evidence
+    assert "summary" in evidence
+    assert evidence["summary"]["total_categories"] == 6
+
+
+def test_narrative_nonempty():
+    """Narrative report produces readable output."""
+    results = [
+        {"test_id": "IR-001", "passed": True},
+        {"test_id": "MEM-002", "passed": False},
+    ]
+    evidence = generate_fria_evidence(results)
+    text = fria_narrative_report(evidence)
+    assert len(text) > 200
+    assert "FRIA" in text
+    assert "Article 27" in text
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    passed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+            passed += 1
+        except Exception as e:
+            print(f"  FAIL  {t.__name__}: {e}")
+    print(f"\n{passed}/{len(tests)} tests passed.")


### PR DESCRIPTION
## Summary
- FRIA evidence module mapping harness results to 6 EU AI Act Article 27 categories (#158)
- Compliance report generator: auditor-ready HTML with AUROC, crosswalks, FRIA, gap analysis (#160)
- 8/8 tests passing

## Test plan
- [x] `python3 tests/test_fria_evidence.py` — 8/8 passing
- [ ] Generate compliance report with `--framework all --fria` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new compliance reporting/evidence-generation logic that could influence audit/compliance interpretation; although it’s tooling-only and additive, incorrect mappings/status calculations could misstate coverage or gaps.
> 
> **Overview**
> Introduces a new `scripts/fria_evidence.py` module that maps harness `test_id` results into six EU AI Act Article 27 FRIA categories, producing per-category status (*covered/flagged/gap/no_results*), narratives, and an overall FRIA status summary.
> 
> Adds `scripts/compliance_report.py` to generate an auditor-oriented HTML report with an executive summary, optional AUROC section, optional per-framework crosswalk compliance tables with gap analysis, and an optional embedded FRIA evidence section.
> 
> Adds `tests/test_fria_evidence.py` to validate FRIA category presence, status transitions, overall status calculation, and narrative output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05069d26ad6a4d079039f0c9cf1ab0fdd868a182. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->