### PR TITLE
fix: PraisonAI adapter cleanup — simulate flag, base signature, docs

### DIFF
--- a/protocol_tests/cli.py
+++ b/protocol_tests/cli.py
@@ -193,7 +193,7 @@ HARNESSES = {
     },
     "framework": {
         "module": "protocol_tests.framework_adapters",
-        "description": "Framework adapters (11 tests, 5 frameworks)",
+        "description": "Framework adapters (15 tests, 6 frameworks)",
     },
     "identity": {
         "module": "protocol_tests.identity_harness",

--- a/protocol_tests/framework_adapters.py
+++ b/protocol_tests/framework_adapters.py
@@ -138,7 +138,7 @@ class FrameworkAdapter(ABC):
         print(f"  {status} {result.test_id}: {result.name} ({result.elapsed_s:.2f}s)")
 
     @abstractmethod
-    def run_tests(self) -> list[AdapterTestResult]:
+    def run_tests(self, simulate: bool = False) -> list[AdapterTestResult]:
         pass
 
     def _test_prompt_injection(self, endpoint: str, payload: dict, test_id: str, name: str):
@@ -1022,6 +1022,11 @@ class PraisonAIAdapter(FrameworkAdapter):
     # ------------------------------------------------------------------
 
     def run_tests(self, simulate: bool = False) -> list[AdapterTestResult]:
+        # PA-001 through PA-004 are CVE-specific tests that replace the generic
+        # _test_prompt_injection and _test_tool_overreach inherited from FrameworkAdapter.
+        # The inherited tests are intentionally excluded because the PraisonAI attack
+        # surface requires framework-specific payloads (YAML job execution, browser bridge,
+        # event streams, template injection).
         mode = "SIMULATE" if simulate else f"LIVE ({self.base_url})"
         print(f"\n[PRAISONAI — {mode}]")
 
@@ -1081,6 +1086,9 @@ def main():
     ap.add_argument("--export", help="Export test config to JSON")
     ap.add_argument("--header", action="append", default=[], help="Extra HTTP headers (key:value)")
     ap.add_argument("--trials", type=int, default=1, help="Run N times for statistical analysis")
+    ap.add_argument("--simulate", action="store_true",
+                    help="Run in simulate mode (validate payloads without a live target; "
+                         "supported by PraisonAIAdapter, graceful fallback for others)")
     args = ap.parse_args()
 
     if args.list:
@@ -1128,7 +1136,11 @@ def main():
 
             def _single_run():
                 a = adapter_cls(args.url, headers=headers)
-                return {"results": a.run_tests()}
+                try:
+                    return {"results": a.run_tests(simulate=args.simulate)}
+                except TypeError:
+                    # Adapter does not support simulate yet — run normally
+                    return {"results": a.run_tests()}
 
             merged = _run_trials(_single_run, trials=args.trials,
                                  suite_name=f"Framework Adapter Tests - {adapter_cls.description}")
@@ -1144,7 +1156,11 @@ def main():
             print(f"Target: {args.url}")
             print(f"{'='*60}")
 
-            results = adapter.run_tests()
+            try:
+                results = adapter.run_tests(simulate=args.simulate)
+            except TypeError:
+                # Adapter does not support simulate yet — run normally
+                results = adapter.run_tests()
 
             total = len(results)
             passed = sum(1 for r in results if r.passed)


### PR DESCRIPTION
## Summary

- **Fix 1 (cli.py):** Update framework adapter suite description from `11 tests, 5 frameworks` to `15 tests, 6 frameworks` to reflect the PraisonAI addition.
- **Fix 2 (framework_adapters.py):** Add `--simulate` flag to the `framework_adapters` CLI. Wires through to `adapter.run_tests(simulate=True)`; catches `TypeError` as a graceful fallback for adapters that don't accept the kwarg yet.
- **Fix 3 (framework_adapters.py):** Promote `simulate: bool = False` to the `FrameworkAdapter.run_tests()` abstract method signature. Backward-compatible — all existing subclasses still work without changes; `PraisonAIAdapter` already uses it.
- **Fix 4 (framework_adapters.py):** Add inline comment at the top of `PraisonAIAdapter.run_tests()` explaining why the inherited `_test_prompt_injection` and `_test_tool_overreach` tests are intentionally excluded in favour of PA-001 through PA-004.

## Test plan

- [x] `python3 -c "from protocol_tests import framework_adapters; print('OK')"` — passes
- [x] `python3 -c "from protocol_tests import cli; print('OK')"` — passes
- [ ] Manual: `python -m protocol_tests.framework_adapters praisonai --url http://localhost:9000 --simulate --run` — should print `[PRAISONAI — SIMULATE]` and exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly CLI/plumbing and signature alignment changes; runtime behavior is unchanged unless `--simulate` is used, and a fallback preserves compatibility with older adapters.
> 
> **Overview**
> Updates the main CLI’s `framework` harness description to reflect the expanded framework adapter suite (now 15 tests across 6 frameworks).
> 
> Standardizes `FrameworkAdapter.run_tests()` to accept `simulate: bool = False` and adds a `--simulate` flag to `protocol_tests.framework_adapters` that forwards this option when running adapters, with a `TypeError` fallback for adapters that haven’t adopted the new signature yet. Also documents in `PraisonAIAdapter.run_tests()` why its CVE-specific tests replace the inherited generic injection/overreach checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b37c304695053f4c216884c6539716000c18c115. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->