### PR TITLE
fix(mcp-harness): dead import cleanup, GCP/Azure SSRF targets, canary finally block

### DIFF
--- a/protocol_tests/mcp_harness.py
+++ b/protocol_tests/mcp_harness.py
@@ -41,11 +41,9 @@ import subprocess
 import sys
 import time
 import uuid
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Optional
-import http.client
 import socket
 import urllib.parse
 import urllib.request
@@ -1319,6 +1317,8 @@ class MCPSecurityTests:
             "http://127.0.0.1",
             "http://10.0.0.1",
             "file:///etc/passwd",
+            "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token",
+            "http://169.254.169.254/metadata/instance?api-version=2021-02-01",
         ]
 
         # Build one representative request up front so simulate validates it compiles
@@ -1376,6 +1376,8 @@ class MCPSecurityTests:
             "iam", "security-credentials", "ami-id", "instance-id",  # AWS metadata
             "root:", "daemon:", "nobody:",  # /etc/passwd content
             "169.254", "10.0.0", "127.0.0.1",  # internal IP echoed back
+            "access_token", "token_type", "expires_in",  # GCP service account token
+            "azEnvironment", "location", "osType", "subscriptionId",  # Azure instance metadata
         ]
 
         vulnerable_tools = []
@@ -1413,6 +1415,9 @@ class MCPSecurityTests:
 
     # ------------------------------------------------------------------
     # Category 10: SSRF via Resource URI (ASI02)
+    # P1-High (not P0-Critical like MCP-015) because resource URIs are server-defined,
+    # not user-controlled. Tool call arguments (MCP-015) are more commonly
+    # attacker-influenced.
     # ------------------------------------------------------------------
 
     def test_mcp_ssrf_via_resource_uri(self):
@@ -1424,6 +1429,8 @@ class MCPSecurityTests:
             "http://127.0.0.1:80/",
             "http://10.0.0.1/",
             "http://[::1]/",
+            "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token",
+            "http://169.254.169.254/metadata/instance?api-version=2021-02-01",
         ]
 
         # Build request up front so simulate validates it compiles
@@ -1444,6 +1451,8 @@ class MCPSecurityTests:
         aws_creds_indicators = [
             "accesskeyid", "secretaccesskey", "token", "expiration",  # AWS creds JSON keys
             "iam", "security-credentials",
+            "access_token", "token_type", "expires_in",  # GCP service account token
+            "azEnvironment", "location", "osType", "subscriptionId",  # Azure instance metadata
         ]
         internal_content_indicators = [
             "169.254", "localhost", "internal", "intranet",
@@ -1475,7 +1484,7 @@ class MCPSecurityTests:
             severity=Severity.HIGH.value,
             passed=passed,
             details=(
-                f"SSRF: {len(ssrf_hits)} URI(s) returned AWS credentials or internal content: {ssrf_hits}"
+                f"SSRF: {len(ssrf_hits)} URI(s) returned cloud credentials or internal content (AWS/GCP/Azure): {ssrf_hits}"
                 if ssrf_hits
                 else f"{blocked_count}/{len(ssrf_uris)} SSRF resource URIs blocked"
             ),
@@ -1549,32 +1558,31 @@ class MCPSecurityTests:
         canary_exists = os.path.exists(canary_path)
         elapsed = time.monotonic() - t0
 
-        # Clean up canary if it was created
-        try:
-            os.remove(canary_path)
-        except FileNotFoundError:
-            pass
-
         passed = not canary_exists
 
-        self._record(MCPTestResult(
-            test_id="MCP-017",
-            name="STDIO Pre-Handshake Command Execution",
-            category="stdio_security",
-            owasp_asi="ASI04",
-            severity=Severity.CRITICAL.value,
-            passed=passed,
-            details=(
-                f"CRITICAL: canary file '{canary_path}' was created — server executed a command "
-                "from clientInfo before completing MCP handshake validation"
-                if canary_exists
-                else "Canary file was not created; no pre-handshake command execution detected"
-            ),
-            mcp_method="initialize",
-            request_sent=test_msg,
-            response_received=resp,
-            elapsed_s=round(elapsed, 3),
-        ))
+        try:
+            self._record(MCPTestResult(
+                test_id="MCP-017",
+                name="STDIO Pre-Handshake Command Execution",
+                category="stdio_security",
+                owasp_asi="ASI04",
+                severity=Severity.CRITICAL.value,
+                passed=passed,
+                details=(
+                    f"CRITICAL: canary file '{canary_path}' was created — server executed a command "
+                    "from clientInfo before completing MCP handshake validation"
+                    if canary_exists
+                    else "Canary file was not created; no pre-handshake command execution detected"
+                ),
+                mcp_method="initialize",
+                request_sent=test_msg,
+                response_received=resp,
+                elapsed_s=round(elapsed, 3),
+            ))
+        finally:
+            # Guarantee canary removal even if _record raises
+            if os.path.exists(canary_path):
+                os.unlink(canary_path)
 
     # ------------------------------------------------------------------
     # Run all tests


### PR DESCRIPTION
## Summary

- **Dead import removal** — drops unused `field` (dataclasses), `Optional`/`Any` (typing), and `http.client`; no functional change, eliminates linter noise.
- **GCP/Azure SSRF coverage (MCP-015 and MCP-016)** — adds GCP service-account token URL and Azure IMDS URL to both SSRF payload lists; extends indicator sets to catch `access_token`/`token_type`/`expires_in` (GCP) and `azEnvironment`/`subscriptionId` (Azure). Previous coverage was AWS-only.
- **MCP-017 canary cleanup** — wraps `_record()` call in `try/finally` with `os.unlink`; canary file is now guaranteed to be removed even if recording raises.
- **MCP-016 severity rationale** — adds a comment above the test explaining why it is P1-High rather than P0-Critical: resource URIs are server-defined and not directly attacker-controlled, unlike tool call arguments (MCP-015).

## Test plan

- [x] `python3 -c "from protocol_tests import mcp_harness; print('OK')"` — import clean
- [x] `python3 -m protocol_tests.mcp_harness --simulate` — 17/17 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the security test harness (payload lists, string matching, and local temp-file cleanup) with no production logic impact.
> 
> **Overview**
> **Expands SSRF coverage** in `MCP-015` and `MCP-016` by adding GCP service-account token and Azure IMDS endpoints to the payload lists, and by extending response indicator strings to detect GCP/Azure credential/metadata leakage (not just AWS).
> 
> **Hardens `MCP-017` cleanup** by wrapping result recording in a `try/finally` and always removing the canary file even if `_record()` raises, and removes several unused imports plus adds a brief comment clarifying `MCP-016`’s severity rationale.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7c5742d45c5b0fee889d4dd5210b35258f2fda3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->