### PR TITLE
refactor: SOLID/DRY cleanup — shared _utils.py, P0 bug fixes, CLI registration

### DIFF
--- a/protocol_tests/_utils.py
+++ b/protocol_tests/_utils.py
@@ -1,0 +1,119 @@
+"""Shared utilities for the Agent Security Harness protocol_tests package.
+
+This module provides zero-dependency helpers that are used across multiple
+harness files.  Import from here instead of copy-pasting implementations.
+
+    from protocol_tests._utils import Severity, wilson_ci, jsonrpc_request, http_post_json
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import uuid
+import urllib.error
+import urllib.request
+from enum import Enum
+
+
+class Severity(Enum):
+    """Test severity classification (P0 = most critical)."""
+
+    CRITICAL = "P0-Critical"
+    HIGH = "P1-High"
+    MEDIUM = "P2-Medium"
+    LOW = "P3-Low"
+
+
+def wilson_ci(passed: int, total: int, z: float = 1.96) -> tuple[float, float]:
+    """Compute a Wilson score confidence interval for a binomial proportion.
+
+    Args:
+        passed: Number of successes.
+        total:  Total number of trials.
+        z:      Z-score for the desired confidence level (default 1.96 → 95%).
+
+    Returns:
+        A (lower, upper) tuple, both rounded to 4 decimal places.
+        Returns (0.0, 0.0) when *total* is zero to avoid division by zero.
+    """
+    if total == 0:
+        return (0.0, 0.0)
+    p_hat = passed / total
+    z2 = z * z
+    n = total
+    denominator = 1 + z2 / n
+    center = (p_hat + z2 / (2 * n)) / denominator
+    spread = z * math.sqrt((p_hat * (1 - p_hat) / n + z2 / (4 * n * n))) / denominator
+    return (round(max(0.0, center - spread), 4), round(min(1.0, center + spread), 4))
+
+
+def jsonrpc_request(
+    method: str,
+    params: dict | None = None,
+    id: str | None = None,
+) -> dict:
+    """Build a JSON-RPC 2.0 request message.
+
+    Args:
+        method: The RPC method name (e.g. ``"tools/list"``).
+        params: Optional parameters dict to include in the request.
+        id:     Optional request ID.  A random 8-character UUID fragment is
+                used when not supplied.
+
+    Returns:
+        A dict representing a complete JSON-RPC 2.0 request.
+    """
+    msg: dict = {"jsonrpc": "2.0", "method": method}
+    if params is not None:
+        msg["params"] = params
+    msg["id"] = id or str(uuid.uuid4())[:8]
+    return msg
+
+
+def http_post_json(
+    url: str,
+    payload: dict,
+    headers: dict | None = None,
+    timeout: int = 15,
+) -> dict:
+    """POST a JSON payload and return the parsed response dict.
+
+    Always returns a plain ``dict``; on any error the dict contains an
+    ``_error`` key so callers can check ``resp.get("_error")`` without
+    catching exceptions.
+
+    Args:
+        url:     Target URL.
+        payload: Request body (will be JSON-serialised).
+        headers: Additional HTTP headers to merge with the default
+                 ``Content-Type``/``Accept`` pair.
+        timeout: Socket timeout in seconds (default 15).
+
+    Returns:
+        Parsed JSON response dict, with ``_status`` injected on success.
+        On HTTP errors: ``{"_error": True, "_status": <code>, "_body": ...}``.
+        On network/other errors: ``{"_error": True, "_exception": ..., "_message": ...}``.
+    """
+    data = json.dumps(payload).encode("utf-8")
+    hdrs: dict = {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        **(headers or {}),
+    }
+    req = urllib.request.Request(url, data=data, headers=hdrs, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode("utf-8")
+            result = json.loads(raw) if raw else {}
+            result["_status"] = resp.status
+            return result
+    except urllib.error.HTTPError as e:
+        body_text = ""
+        try:
+            body_text = e.read().decode("utf-8")[:500]
+        except Exception:
+            pass
+        return {"_error": True, "_status": e.code, "_body": body_text}
+    except Exception as e:
+        return {"_error": True, "_exception": type(e).__name__, "_message": str(e)[:300]}

--- a/protocol_tests/benchmark_integrity_harness.py
+++ b/protocol_tests/benchmark_integrity_harness.py
@@ -33,66 +33,20 @@ from __future__ import annotations
 
 import argparse
 import json
-import math
 import os
 import re
-import subprocess
 import sys
 import time
 import uuid
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
-from enum import Enum
 
-
-# ---------------------------------------------------------------------------
-# Wilson score CI (inlined for zero-dep)
-# ---------------------------------------------------------------------------
-
-def wilson_ci(successes: int, trials: int, z: float = 1.96) -> tuple[float, float]:
-    """Wilson score confidence interval for binomial proportion."""
-    if trials == 0:
-        return (0.0, 0.0)
-    p_hat = successes / trials
-    z2 = z * z
-    n = trials
-    denominator = 1 + z2 / n
-    center = (p_hat + z2 / (2 * n)) / denominator
-    spread = z * math.sqrt((p_hat * (1 - p_hat) / n + z2 / (4 * n * n))) / denominator
-    lower = max(0.0, center - spread)
-    upper = min(1.0, center + spread)
-    return (round(lower, 4), round(upper, 4))
-
-
-# ---------------------------------------------------------------------------
-# HTTP helper (zero-dep)
-# ---------------------------------------------------------------------------
-
-def _http_post_json(url: str, payload: dict, headers: dict | None = None) -> dict:
-    """POST JSON payload and return parsed response dict."""
-    import urllib.request
-    data = json.dumps(payload).encode()
-    req_headers = {"Content-Type": "application/json", "Accept": "application/json"}
-    if headers:
-        req_headers.update(headers)
-    req = urllib.request.Request(url, data=data, headers=req_headers, method="POST")
-    try:
-        with urllib.request.urlopen(req, timeout=10) as resp:
-            body = resp.read().decode()
-            return json.loads(body)
-    except Exception as exc:
-        return {"_error": str(exc)}
+from protocol_tests._utils import Severity, wilson_ci, http_post_json
 
 
 # ---------------------------------------------------------------------------
 # Test result model
 # ---------------------------------------------------------------------------
-
-class Severity(Enum):
-    CRITICAL = "P0-Critical"
-    HIGH = "P1-High"
-    MEDIUM = "P2-Medium"
-    LOW = "P3-Low"
 
 
 @dataclass
@@ -144,7 +98,7 @@ class BenchmarkIntegrityTests:
         """Submit an agent output payload to the evaluation endpoint."""
         if not self.url:
             return {"_error": "No evaluation URL configured"}
-        return _http_post_json(self.url + "/evaluate", payload, self.headers)
+        return http_post_json(self.url + "/evaluate", payload, self.headers)
 
     # ------------------------------------------------------------------
     # BI-001: Agent-Evaluator Isolation Check (CRITICAL)
@@ -199,7 +153,7 @@ class BenchmarkIntegrityTests:
         # Detect grader internals in response
         resp_str = json.dumps(resp).lower()
         leaked = [p for p in grader_paths if p.lower().replace(".py", "") in resp_str]
-        passed = len(leaked) == 0 and not resp.get("_error") is False
+        passed = len(leaked) == 0 and not resp.get("_error")
 
         self._record(BenchmarkIntegrityResult(
             test_id="BI-001", name="Agent-Evaluator Isolation Check",
@@ -565,13 +519,7 @@ class BenchmarkIntegrityTests:
         }
 
         if self.simulate:
-            assert all(
-                v == {} or any(
-                    not v or v.get("agent_output") in (None, "", "N/A", "   ", "{{ANSWER}}")
-                    for k, v in ([("x", v)] if isinstance(v, dict) else [])
-                ) or v == {}
-                for v in empty_payloads
-            ) or True, "Payload list is well-formed"
+            assert len(empty_payloads) > 0, "Payload list must be non-empty"
 
             self._record(BenchmarkIntegrityResult(
                 test_id="BI-006", name="Validator Bypass",

--- a/protocol_tests/cli.py
+++ b/protocol_tests/cli.py
@@ -283,12 +283,20 @@ HARNESSES = {
         "module": "protocol_tests.watermark_harness",
         "description": "Watermark adversarial tests (5 tests, forgery + stripping + extraction resistance)",
     },
+    "benchmark-integrity": {
+        "module": "protocol_tests.benchmark_integrity_harness",
+        "description": "Benchmark integrity tests (7 tests, UC Berkeley RDI eval pipeline vulnerabilities)",
+    },
+    "governance-modification": {
+        "module": "protocol_tests.governance_modification_harness",
+        "description": "Governance self-modification tests (6 tests, agent gate/threshold/permission tampering)",
+    },
 }
 
 
 def print_usage():
     print(f"Agent Security Harness v{VERSION}")
-    print(f"439 security tests for AI agent systems")
+    print(f"461 security tests for AI agent systems")
     print()
     print("Usage:")
     print("  agent-security test <harness> [options]    Run a test harness")
@@ -328,7 +336,7 @@ def main():
 
     if args[0] == "version":
         print(f"agent-security-harness v{VERSION}")
-        print(f"Tests: 439 across {len(HARNESSES)} harness modules")
+        print(f"Tests: 461 across {len(HARNESSES)} harness modules")
         print(f"Protocols: MCP (JSON-RPC 2.0), A2A, L402, x402")
         print(f"Platforms: 25 cloud + 20 enterprise adapters")
         print(f"Standards: OWASP Agentic Top 10, NIST AI 800-2, NIST AI RMF, AIUC-1")

--- a/protocol_tests/cve_2026_25253_harness.py
+++ b/protocol_tests/cve_2026_25253_harness.py
@@ -73,7 +73,7 @@ import uuid
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any
+import urllib.error
 import urllib.request
 
 
@@ -326,7 +326,33 @@ OPENCLAW_SSRF_PAYLOADS = [
         "path": "etc/passwd",
         "description": "0.0.0.0 bind-address bypass",
     },
+    {
+        "channel": "file-fetch",
+        "base_url": "file:///etc/passwd",
+        "path": "",
+        "description": "Local file read via file:// scheme",
+    },
+    {
+        "channel": "http-fetch",
+        "base_url": "http://metadata.google.internal/computeMetadata/v1/",
+        "path": "instance/service-accounts/default/token",
+        "description": "GCP instance metadata endpoint",
+    },
 ]
+
+# Private/loopback address prefixes used by the CVE-010 SSRF validator.
+# Promoted to module level so external validators can import and reuse this list.
+OPENCLAW_SSRF_PRIVATE_PREFIXES = (
+    "http://169.254.",      # Link-local / AWS metadata
+    "http://10.",           # RFC-1918 class A
+    "http://192.168.",      # RFC-1918 class C
+    "http://172.16.",       # RFC-1918 class B start
+    "http://localhost",
+    "http://[::1]",
+    "http://0.0.0.0",
+    "file://",              # Local filesystem reads
+    "http://metadata.google.internal",  # GCP metadata
+)
 
 # Patterns that indicate a channel extension leaked internal resource content
 OPENCLAW_SSRF_LEAK_PATTERNS = re.compile(
@@ -1186,8 +1212,8 @@ class CVE202625253Tests:
                 )
                 with urllib.request.urlopen(req, timeout=15) as r:
                     resp = json.loads(r.read().decode())
-            except Exception:
-                pass
+            except Exception as e:
+                resp = {"_error": str(e)}
 
             resp_text = json.dumps(resp) if resp else ""
             # Check if response contains evidence of granted elevated scope
@@ -1244,26 +1270,18 @@ class CVE202625253Tests:
         t0 = time.monotonic()
 
         if self.simulate:
-            # Simulate: evaluate each SSRF payload against a reference
-            # allowlist validator.  A secure implementation must reject
-            # any base_url that resolves to a private/loopback/link-local
-            # address space.
-            _PRIVATE_PREFIXES = (
-                "http://169.254.",    # Link-local / AWS metadata
-                "http://10.",         # RFC-1918 class A
-                "http://192.168.",    # RFC-1918 class C
-                "http://172.16.",     # RFC-1918 class B start
-                "http://localhost",
-                "http://[::1]",
-                "http://0.0.0.0",
-            )
-
+            # Simulate: evaluate each SSRF payload against the module-level
+            # OPENCLAW_SSRF_PRIVATE_PREFIXES allowlist validator.  A secure
+            # implementation must reject any base_url that resolves to a
+            # private/loopback/link-local address space.
             blocked_sim = []
             unblocked_sim = []
 
             for p in OPENCLAW_SSRF_PAYLOADS:
                 base = p["base_url"]
-                would_block = any(base.startswith(pfx) for pfx in _PRIVATE_PREFIXES)
+                would_block = any(
+                    base.startswith(pfx) for pfx in OPENCLAW_SSRF_PRIVATE_PREFIXES
+                )
                 entry = {
                     "channel": p["channel"],
                     "base_url": base,

--- a/protocol_tests/governance_modification_harness.py
+++ b/protocol_tests/governance_modification_harness.py
@@ -31,42 +31,14 @@ from __future__ import annotations
 
 import argparse
 import json
-import math
 import re
 import sys
 import time
 import uuid
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
-from enum import Enum
-import urllib.request
 
-
-# ---------------------------------------------------------------------------
-# Statistics helpers
-# ---------------------------------------------------------------------------
-
-def wilson_ci(successes: int, trials: int, z: float = 1.96) -> tuple[float, float]:
-    if trials == 0:
-        return (0.0, 0.0)
-    p_hat = successes / trials
-    z2 = z * z
-    n = trials
-    denominator = 1 + z2 / n
-    center = (p_hat + z2 / (2 * n)) / denominator
-    spread = z * math.sqrt((p_hat * (1 - p_hat) / n + z2 / (4 * n * n))) / denominator
-    return (round(max(0.0, center - spread), 4), round(min(1.0, center + spread), 4))
-
-
-# ---------------------------------------------------------------------------
-# Severity enum and result dataclass
-# ---------------------------------------------------------------------------
-
-class Severity(Enum):
-    CRITICAL = "P0-Critical"
-    HIGH = "P1-High"
-    MEDIUM = "P2-Medium"
-    LOW = "P3-Low"
+from protocol_tests._utils import Severity, wilson_ci, jsonrpc_request, http_post_json
 
 
 @dataclass
@@ -84,42 +56,6 @@ class GovernanceModTestResult:
     request_sent: dict | None = None
     response_received: dict | None = None
     elapsed_s: float = 0.0
-
-
-# ---------------------------------------------------------------------------
-# HTTP / JSON-RPC helpers
-# ---------------------------------------------------------------------------
-
-def jsonrpc_request(method: str, params: dict | None = None, id: str | None = None) -> dict:
-    """Build a JSON-RPC 2.0 request message."""
-    msg: dict = {"jsonrpc": "2.0", "method": method}
-    if params is not None:
-        msg["params"] = params
-    msg["id"] = id or str(uuid.uuid4())[:8]
-    return msg
-
-
-def http_post_json(url: str, body: dict, headers: dict | None = None,
-                   timeout: int = 30) -> dict:
-    data = json.dumps(body).encode("utf-8")
-    hdrs = {"Content-Type": "application/json", "Accept": "application/json",
-            **(headers or {})}
-    req = urllib.request.Request(url, data=data, headers=hdrs, method="POST")
-    try:
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
-            raw = resp.read().decode("utf-8")
-            result = json.loads(raw) if raw else {}
-            result["_status"] = resp.status
-            return result
-    except urllib.error.HTTPError as e:
-        body_text = ""
-        try:
-            body_text = e.read().decode("utf-8")[:500]
-        except Exception:
-            pass
-        return {"_error": True, "_status": e.code, "_body": body_text}
-    except Exception as e:
-        return {"_error": True, "_exception": type(e).__name__, "_message": str(e)[:300]}
 
 
 def _response_allows_change(resp: dict) -> bool:


### PR DESCRIPTION
## Summary
- Extract shared utilities to `protocol_tests/_utils.py` (Severity, wilson_ci, jsonrpc_request, http_post_json)
- Fix 3 P0 bugs: BI-001 pass logic, BI-006 no-op assertion, CVE-009 bare except
- Register benchmark-integrity and governance-modification in CLI
- Update test count to 461
- Remove dead imports, add missing imports, extend CVE-010 SSRF coverage

## Motivation
New harness modules (benchmark_integrity, governance_modification) duplicated ~100 lines of utility code each. Applying DRY principle by extracting to shared module. Fixing bugs found during independent testing.

## Test plan
- [x] `python3 -m protocol_tests.benchmark_integrity_harness --simulate` — 7/7 pass
- [x] `python3 -m protocol_tests.governance_modification_harness --simulate` — 6/6 pass
- [x] `python3 -m protocol_tests.cve_2026_25253_harness --simulate` — 3 pass, 7 fail (intentional)
- [x] `python3 -m protocol_tests.mcp_harness --simulate` — 17/17 pass (no regression)
- [x] All 40 protocol_tests modules import cleanly
- [x] `agent-security list` shows benchmark-integrity and governance-modification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to test harness/CLI code and primarily deduplicate helpers and correct pass/fail/error handling; main risk is unintended behavior changes in how some tests interpret responses.
> 
> **Overview**
> Adds a shared `protocol_tests/_utils.py` module and refactors the new `benchmark_integrity` and `governance_modification` harnesses to reuse common helpers (`Severity`, `wilson_ci`, JSON-RPC message building, and robust JSON POST handling) instead of duplicating code.
> 
> Fixes several harness correctness issues: adjusts BI-001 pass/fail logic to properly treat error responses as failures, replaces a broken BI-006 simulate assertion with a simple non-empty check, and tightens `cve_2026_25253_harness` exception handling while expanding CVE-010 SSRF coverage (adds `file://` + GCP metadata payloads and promotes the private-prefix blocklist to an importable constant).
> 
> Updates the unified CLI to register the `benchmark-integrity` and `governance-modification` harnesses and bumps the reported total test count to 461.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1aead46558f133c632639b920519667b1822f854. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->