### PR TITLE
fix: align roadmap version numbers, test counts, and timeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 [![PyPI version](https://badge.fury.io/py/agent-security-harness.svg)](https://pypi.org/project/agent-security-harness/)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![Apache 2.0 License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/security%20tests-439-green.svg)](#three-layers-of-agent-decision-security)
+[![Tests](https://img.shields.io/badge/security%20tests-461-green.svg)](#three-layers-of-agent-decision-security)
 
 **Even if an agent is properly authenticated and authorized, can it still be manipulated into unsafe or policy-violating behavior?**
 
-439 executable security tests across 29 modules. MCP + A2A + L402 + x402 wire-protocol testing. Decision-layer attack scenarios. One `pip install` away.
+461 executable security tests across 31 modules. MCP + A2A + L402 + x402 wire-protocol testing. Decision-layer attack scenarios. One `pip install` away.
 
 ```
 $ agent-security test mcp --url http://localhost:8080/mcp
@@ -70,7 +70,7 @@ See [docs/QUICKSTART.md](docs/QUICKSTART.md) for mock server setup, rate limitin
 | **Research backing** | - | Cisco blog | - | Papers | **5 DOIs + 3 NIST submissions** |
 | **MCP server mode** | - | - | - | - | **Yes - invoke from any AI agent** |
 | **Statistical testing** | - | - | - | - | **Wilson CIs, multi-trial** |
-| **Total tests** | Pattern matching | YARA rules | Config checks | Model probes | **439 active tests** |
+| **Total tests** | Pattern matching | YARA rules | Config checks | Model probes | **461 active tests** |
 
 **Use both.** Scan with [Invariant MCP-Scan](https://github.com/invariantlabs-ai/mcp-scan) or [Cisco MCP Scanner](https://github.com/cisco-ai-defense/mcp-scanner) for static analysis. Test with this framework for active exploitation. They're complementary layers.
 
@@ -95,7 +95,7 @@ Five peer-reviewed preprints and three NIST submissions underpin the methodology
 | Resource | Link |
 |---|---|
 | Expanded Quick Start | [docs/QUICKSTART.md](docs/QUICKSTART.md) |
-| Full Test Inventory (439 tests) | [docs/TEST-INVENTORY.md](docs/TEST-INVENTORY.md) |
+| Full Test Inventory (461 tests) | [docs/TEST-INVENTORY.md](docs/TEST-INVENTORY.md) |
 | AIUC-1 Crosswalk | [docs/AIUC1-CROSSWALK.md](docs/AIUC1-CROSSWALK.md) |
 | Advanced Capabilities | [docs/ADVANCED.md](docs/ADVANCED.md) |
 | MCP Server | [docs/mcp-server.md](docs/mcp-server.md) |
@@ -108,7 +108,7 @@ Five peer-reviewed preprints and three NIST submissions underpin the methodology
 
 ## Roadmap
 
-**v3.10 -- Prove It to Auditors** ✅ Shipped. **v4.1 -- Compliance Evidence** ✅ Shipped. 439 tests, 29 modules, AUROC metrics, EU AI Act + ISO 42001 crosswalks, FRIA evidence, kill-switch compliance, watermark adversarial tests, HTML compliance report generator. **v4.0 -- Lock the Category** (H2 2026): benchmark corpus, schema standardization, longitudinal registry. Full details in [ROADMAP.md](ROADMAP.md).
+**v3.10 -- Prove It to Auditors** ✅ Shipped. **v4.1 -- Compliance Evidence** ✅ Shipped. 461 tests, 31 modules, AUROC metrics, EU AI Act + ISO 42001 crosswalks, FRIA evidence, kill-switch compliance, watermark adversarial tests, HTML compliance report generator. **v4.2 -- Incident-Tested** (next). 22 new tests mapped to OX Security, UC Berkeley, PraisonAI CVEs, lightningzero, OpenClaw April CVEs. **v5.0 -- Lock the Category** (H2 2026): benchmark corpus, schema standardization, longitudinal registry. Full details in [ROADMAP.md](ROADMAP.md).
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,7 +24,7 @@ Our harness is positioned around that fourth layer while pressure-testing the ot
 | Wire-protocol adversarial testing | Temporary | 6-12 months before major vendors add this |
 | Multi-protocol coverage | Temporary | 6-12 months |
 | AIUC-1 mapping | Temporary | One release cycle after competitors notice |
-| Test corpus depth (439 tests) | Temporary | Must maintain velocity lead |
+| Test corpus depth (461 tests) | Temporary | Must maintain velocity lead |
 
 The strategy sequences investment toward **sustained advantages** while defending temporary ones through speed.
 
@@ -52,8 +52,9 @@ Identity and authorization controls answer *who* an agent is and *what* it can a
 |---------|-------|------------------|--------|
 | **v3.9 - Adopt in 15 Minutes** | CI integration and developer experience | `--json` output, error messages, scope docs, GitHub Action | **Shipped** (v3.9.0) |
 | **v3.10 - Prove It to Auditors** | Evidence format adoption + payment depth + drift scoring | Evidence packs, payment tests doubled, behavioral profiling, HTML dashboards, 2 independent security audits | **Shipped** (v3.10.0) |
-| **v4.1 - Compliance Evidence** | EU AI Act + ISO 42001 mapping, AUROC, FRIA, kill-switch, watermark tests | 439 tests, 29 modules, compliance report generator, 31 framework controls mapped | **Shipped** (v4.1.0) |
-| **v4.0 - Lock the Category** | Standard-setting: benchmark + schema standardization + registry | Named benchmark corpus, attestation schema to IETF/OASIS, longitudinal registry | H2 2026 |
+| **v4.1 - Compliance Evidence** | EU AI Act + ISO 42001 mapping, AUROC, FRIA, kill-switch, watermark tests | 461 tests, 31 modules, compliance report generator, 31 framework controls mapped | **Shipped** (v4.1.0) |
+| **v4.2 - Incident-Tested** | Tests mapped to named April 2026 security incidents | NEXT — 22 new tests mapped to OX Security MCP disclosure, UC Berkeley benchmark hacking, PraisonAI CVEs, lightningzero governance finding, OpenClaw April CVEs. 3 new modules (benchmark integrity, governance modification, PraisonAI adapter). Shared `_utils.py`. |
+| **v5.0 - Lock the Category** | Standard-setting: benchmark + schema standardization + registry | H2 2026 — Benchmark corpus (#120), methodology paper (#138), IETF attestation schema (#137), longitudinal registry API, drift comparison. |
 
 ## v3.9 - Adopt in 15 Minutes ✅ SHIPPED
 
@@ -121,17 +122,40 @@ Released as v4.1.0. Transforms the harness from a security testing tool into a c
 | HTML compliance report generator | #160 | `--framework all --fria` one-command report |
 | Simulate mode expansion | F7 (R33) | MCP, A2A, Identity (39 new simulate tests) |
 
-**Total: 439 tests, 29 modules, 31 framework controls mapped.**
+**Total: 461 tests, 31 modules, 31 framework controls mapped.**
 
 ### Independent review
 
-Audit R33 (`docs/AUDIT-R33-INDEPENDENT-REVIEW.md`): 7 findings, all resolved. 19/19 pytest passing. Zero import/compile errors across 29 modules.
+Audit R33 (`docs/AUDIT-R33-INDEPENDENT-REVIEW.md`): 7 findings, all resolved. 19/19 pytest passing. Zero import/compile errors across 31 modules.
 
-## v4.0 - Lock the Category
+### v4.2 — Incident-Tested
+
+Every new module maps to a named security incident from April 2026:
+
+| Module | Tests | Incident Source |
+|--------|-------|----------------|
+| `benchmark_integrity_harness.py` | BI-001 — BI-007 | UC Berkeley: all 8 AI benchmarks hackable for perfect scores |
+| `governance_modification_harness.py` | GM-001 — GM-006 | lightningzero: 9/12 agents disabled own gates within 48h |
+| PraisonAI adapter | PA-001 — PA-004 | CVE-2026-40288 (9.8), CVE-2026-40289 (9.1), CVE-2026-39889, CVE-2026-39891 (8.8) |
+| MCP SSRF + STDIO | MCP-015 — MCP-017 | OX Security MCP STDIO disclosure, BlueRock 36.7% SSRF finding |
+| OpenClaw CVE tests | CVE-009, CVE-010 | CVE-2026-35625 (privilege escalation), CVE-2026-35629 (SSRF) |
+
+Also: shared `_utils.py` (SOLID/DRY), CLI registration, P0 bug fixes.
+
+**Total: 461 tests, 31 modules.**
+
+### v4.3 — Supply Chain + Research
+
+- Skill Security Protocol implementation (`skill_security_harness.py`) from RFC #99 — 341 malicious ClawHub skills
+- Publish DOIs #6-7 from #116 (intent contracts), #117 (multi-agent), #119 (memory security) research
+- Migrate all remaining harnesses to `_utils.py`
+- Dynamic test count in CLI
+
+## v5.0 — Lock the Category
 
 **Goal:** Become the standard others reference, not just a tool others use.
 
-v4.0 is reframed around **standard-setting**, not feature shipping. The three moves that convert temporary advantages into sustained ones:
+v5.0 is reframed around **standard-setting**, not feature shipping. The three moves that convert temporary advantages into sustained ones:
 
 ### Move 1: Publish the benchmark (the thing others cite)
 
@@ -182,10 +206,7 @@ We are authoring a public corpus that highlights the gaps between metadata scann
 ## Sequencing
 
 ```text
-v3.9  ✅ SHIPPED        -> "Find dangerous stuff in 15 minutes"
-v3.10 ✅ SHIPPED        -> "The evidence auditors accept"
-v4.0  (H2 2026)         -> "The standard others reference"
-v4.x  (2027)            -> Network effects from registry + standard citations
+v3.9  → v3.10 → v4.1 (shipped) → v4.2 (next) → v4.3 → v5.0 (H2 2026)
 ```
 
 ## Sustained Advantage Trajectory
@@ -194,9 +215,9 @@ v4.x  (2027)            -> Network effects from registry + standard citations
 Now:     Research (5 DOIs)
 v3.10:   + Evidence format adoption
          + Payment protocol depth
-v4.0:    + Benchmark others cite
+v5.0:    + Benchmark others cite
          + Schema in standards body
-v4.x:    + Registry network effect
+v5.x:    + Registry network effect
 ```
 
 Each step converts a temporary advantage into a more durable one. Miss any step and the corresponding moat does not form.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-security-harness"
-version = "4.1.1"
-description = "439 security tests for AI agent systems - MCP, A2A, L402, x402 wire-protocol testing, decision governance, AIUC-1 compliance, NIST AI 800-2 aligned"
+version = "4.2.0"
+description = "461 security tests for AI agent systems - MCP, A2A, L402, x402 wire-protocol testing, decision governance, AIUC-1 compliance, NIST AI 800-2 aligned"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {text = "Apache-2.0"}
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Rename v4.0 → v5.0 (standards/category play, H2 2026)
- Add v4.2 "Incident-Tested" to roadmap (maps 22 tests to named incidents)
- Add v4.3 "Supply Chain + Research" to roadmap
- Update test counts 439 → 461 everywhere (README, ROADMAP, pyproject.toml)
- Update module counts 29 → 31
- Bump version to 4.2.0
- Issue #114 renamed to v5.0

## Test plan
- [ ] No "439" remains in README, ROADMAP, pyproject.toml, or cli.py
- [ ] No "v4.0" remains (all changed to v5.0)
- [ ] pyproject.toml version is 4.2.0
- [ ] All imports still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and package-metadata-only changes; no runtime code paths or security logic are modified.
> 
> **Overview**
> Updates published metadata to reflect the new release baseline: bumps `pyproject.toml` from `4.1.1` to `4.2.0` and updates the project description to **461 tests across 31 modules**.
> 
> Aligns `README.md` and `ROADMAP.md` with the new counts and revises roadmap versioning/timeline by introducing **`v4.2` ("Incident-Tested")** and **`v4.3`**, and renaming the longer-term standards effort from **`v4.0` to `v5.0`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3084e5fb02b904fa9fed0d608e7595c318c6490. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->