### PR TITLE
feat(vs-r02): synthetic x402 merchant scaffold for settlement testing

### DIFF
--- a/protocol_tests/x402_merchant.py
+++ b/protocol_tests/x402_merchant.py
@@ -1,0 +1,340 @@
+"""Synthetic x402 merchant — settlement-test infrastructure for VS-R02 Tier B.
+
+The protocol/harness modules test x402 *clients* (agents constructing payment
+payloads). VS-R02's settlement tests (ACP-012 receipt-nonce-reuse, ACP-016
+settled-spend aggregation) need the *server* side: a merchant we control that
+takes the agent's signed `X-PAYMENT`, relays it to the x402 facilitator's
+verify/settle, and records what settled. This module is that merchant.
+
+Design — two halves so the scaffold is build-and-test-able with NO live money:
+
+  • `SyntheticMerchant`  — pure request logic (`handle()`), unit-testable in
+    process, no socket. Records settled payments and seen nonces.
+  • `FacilitatorClient` — abstract verify()/settle(). `MockFacilitator` (default)
+    returns deterministic synthetic receipts and enforces nonce-uniqueness in
+    memory, so ACP-012/016 can be exercised with zero gas. `CoinbaseFacilitator`
+    (live) POSTs to the real x402 facilitator — used ONLY in Mike's live-stack
+    session via `--live`, never in CI.
+
+The on-chain settlement (EIP-3009 `transferWithAuthorization`) is the
+facilitator's job; the merchant only relays and records. Run standalone with
+`python -m protocol_tests.x402_merchant --pay-to 0x... [--live]`.
+
+x402 reference: https://www.x402.org/  | EIP-3009 (transferWithAuthorization).
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import sys
+import urllib.request
+from dataclasses import dataclass, field, asdict
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+# Base Sepolia USDC (testnet) — the asset VS-R02 settles in.
+BASE_SEPOLIA_USDC = "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+DEFAULT_FACILITATOR = "https://x402.org/facilitator"
+X402_VERSION = 1
+
+
+# ---------------------------------------------------------------------------
+# Payment requirements (what the 402 advertises)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class PaymentRequirements:
+    """The `accepts` entry an x402 402 response advertises (exact scheme)."""
+    pay_to: str
+    max_amount_required: str = "10000"          # 0.01 USDC (6 decimals)
+    network: str = "base-sepolia"
+    asset: str = BASE_SEPOLIA_USDC
+    resource: str = "/paid"
+    description: str = "VS-R02 synthetic merchant resource"
+    max_timeout_seconds: int = 120
+    scheme: str = "exact"
+
+    def to_accepts(self) -> dict:
+        return {
+            "scheme": self.scheme,
+            "network": self.network,
+            "maxAmountRequired": self.max_amount_required,
+            "resource": self.resource,
+            "description": self.description,
+            "mimeType": "application/json",
+            "payTo": self.pay_to,
+            "asset": self.asset,
+            "maxTimeoutSeconds": self.max_timeout_seconds,
+        }
+
+    def challenge_body(self) -> dict:
+        return {"x402Version": X402_VERSION, "accepts": [self.to_accepts()],
+                "error": "X-PAYMENT header required"}
+
+
+# ---------------------------------------------------------------------------
+# Payment payload parsing (the agent's X-PAYMENT header)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ParsedPayment:
+    raw: str
+    scheme: str = ""
+    network: str = ""
+    nonce: str = ""
+    value: str = ""
+    pay_from: str = ""
+    pay_to: str = ""
+    valid_before: str = ""
+    valid_after: str = ""
+    decode_error: str = ""
+
+
+def parse_x_payment(header: str) -> ParsedPayment:
+    """Decode a base64(JSON) X-PAYMENT header into the fields tests assert on.
+
+    Tolerant: an opaque/garbage header yields a ParsedPayment with decode_error
+    set rather than raising, so the merchant can return a clean 402/400.
+    """
+    p = ParsedPayment(raw=header)
+    try:
+        decoded = base64.b64decode(header, validate=True)
+        obj = json.loads(decoded)
+    except Exception as e:
+        p.decode_error = f"{type(e).__name__}: {e}"
+        return p
+    p.scheme = obj.get("scheme", "")
+    p.network = obj.get("network", "")
+    payload = obj.get("payload", obj)
+    auth = payload.get("authorization", payload) if isinstance(payload, dict) else {}
+    p.nonce = str(auth.get("nonce", "")) or ""
+    p.value = str(auth.get("value", "")) or ""
+    p.pay_from = auth.get("from", "")
+    p.pay_to = auth.get("to", "")
+    p.valid_before = str(auth.get("validBefore", "")) or ""
+    p.valid_after = str(auth.get("validAfter", "")) or ""
+    return p
+
+
+def encode_x_payment(authorization: dict, scheme: str = "exact",
+                     network: str = "base-sepolia") -> str:
+    """Helper for tests: build a base64 X-PAYMENT header from an authorization."""
+    obj = {"x402Version": X402_VERSION, "scheme": scheme, "network": network,
+           "payload": {"authorization": authorization, "signature": "0xtest"}}
+    return base64.b64encode(json.dumps(obj).encode()).decode()
+
+
+# ---------------------------------------------------------------------------
+# Facilitator clients (verify + settle)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SettleResult:
+    success: bool
+    tx_hash: str = ""
+    reason: str = ""
+    network: str = ""
+
+
+class FacilitatorClient:
+    """Interface: verify a payment, then settle it on-chain."""
+
+    def verify(self, payment: ParsedPayment, req: PaymentRequirements) -> SettleResult:
+        raise NotImplementedError
+
+    def settle(self, payment: ParsedPayment, req: PaymentRequirements) -> SettleResult:
+        raise NotImplementedError
+
+
+class MockFacilitator(FacilitatorClient):
+    """In-memory facilitator: deterministic receipts, no gas, no network.
+
+    Enforces EIP-3009-style nonce uniqueness (a settled nonce cannot settle
+    again) so ACP-012 replay behavior is exercisable. `fail_verify` lets a test
+    force a verify failure.
+    """
+
+    def __init__(self, fail_verify: bool = False):
+        self.fail_verify = fail_verify
+        self._spent_nonces: set[str] = set()
+        self.calls: list[tuple[str, str]] = []  # (op, nonce)
+
+    def verify(self, payment, req):
+        self.calls.append(("verify", payment.nonce))
+        if payment.decode_error:
+            return SettleResult(False, reason=f"undecodable payment: {payment.decode_error}")
+        if self.fail_verify:
+            return SettleResult(False, reason="verify forced-fail")
+        if payment.value and req.max_amount_required and \
+                int(payment.value) > int(req.max_amount_required):
+            return SettleResult(False, reason="amount exceeds maxAmountRequired")
+        return SettleResult(True, network=req.network)
+
+    def settle(self, payment, req):
+        self.calls.append(("settle", payment.nonce))
+        if payment.nonce in self._spent_nonces:
+            # EIP-3009: an authorization nonce is single-use on-chain.
+            return SettleResult(False, reason="nonce already used (replay)", network=req.network)
+        self._spent_nonces.add(payment.nonce)
+        tx = "0x" + hashlib.sha256(
+            f"{payment.nonce}:{payment.value}:{req.pay_to}".encode()).hexdigest()
+        return SettleResult(True, tx_hash=tx, network=req.network)
+
+
+class CoinbaseFacilitator(FacilitatorClient):
+    """Live facilitator — POSTs to the real x402 facilitator. Used only in the
+    live-stack session (`--live`); never exercised in CI."""
+
+    def __init__(self, base_url: str = DEFAULT_FACILITATOR, timeout: float = 20.0):
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+
+    def _post(self, path: str, body: dict) -> dict:
+        req = urllib.request.Request(
+            self.base_url + path, data=json.dumps(body).encode(),
+            headers={"Content-Type": "application/json"}, method="POST")
+        with urllib.request.urlopen(req, timeout=self.timeout) as r:
+            return json.loads(r.read())
+
+    def verify(self, payment, req):
+        try:
+            r = self._post("/verify", {"x402Version": X402_VERSION,
+                                       "paymentPayload": payment.raw,
+                                       "paymentRequirements": req.to_accepts()})
+            return SettleResult(bool(r.get("isValid")), reason=r.get("invalidReason", ""))
+        except Exception as e:
+            return SettleResult(False, reason=f"facilitator verify error: {e}")
+
+    def settle(self, payment, req):
+        try:
+            r = self._post("/settle", {"x402Version": X402_VERSION,
+                                       "paymentPayload": payment.raw,
+                                       "paymentRequirements": req.to_accepts()})
+            return SettleResult(bool(r.get("success")), tx_hash=r.get("transaction", ""),
+                                reason=r.get("errorReason", ""), network=r.get("network", ""))
+        except Exception as e:
+            return SettleResult(False, reason=f"facilitator settle error: {e}")
+
+
+# ---------------------------------------------------------------------------
+# The merchant (pure logic + HTTP wrapper)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SettlementRecord:
+    nonce: str
+    value: str
+    pay_from: str
+    tx_hash: str
+    success: bool
+    reason: str = ""
+
+
+class SyntheticMerchant:
+    """x402 merchant logic. `handle()` is socket-free and unit-testable.
+
+    Records every settlement attempt so settlement-layer tests can assert on
+    them: ACP-016 sums `value` across sessions; ACP-012 checks the second
+    same-nonce attempt is refused.
+    """
+
+    def __init__(self, requirements: PaymentRequirements,
+                 facilitator: FacilitatorClient | None = None):
+        self.req = requirements
+        self.facilitator = facilitator or MockFacilitator()
+        self.settlements: list[SettlementRecord] = []
+
+    @property
+    def total_settled(self) -> int:
+        return sum(int(s.value or 0) for s in self.settlements if s.success)
+
+    def handle(self, path: str, x_payment: str | None) -> tuple[int, dict]:
+        """Return (http_status, body_dict) for a request to the paid resource."""
+        if path.rstrip("/") != self.req.resource.rstrip("/"):
+            return 404, {"error": "not found"}
+        if not x_payment:
+            return 402, self.req.challenge_body()
+
+        payment = parse_x_payment(x_payment)
+        verify = self.facilitator.verify(payment, self.req)
+        if not verify.success:
+            self.settlements.append(SettlementRecord(
+                payment.nonce, payment.value, payment.pay_from, "", False,
+                f"verify failed: {verify.reason}"))
+            return 402, {"x402Version": X402_VERSION, "error": verify.reason,
+                         "accepts": [self.req.to_accepts()]}
+
+        settle = self.facilitator.settle(payment, self.req)
+        self.settlements.append(SettlementRecord(
+            payment.nonce, payment.value, payment.pay_from, settle.tx_hash,
+            settle.success, settle.reason))
+        if not settle.success:
+            # 402 again — settlement refused (e.g. replay). The agent sees it failed.
+            return 402, {"x402Version": X402_VERSION, "error": settle.reason,
+                         "accepts": [self.req.to_accepts()]}
+        return 200, {"resource": self.req.description, "paid": True,
+                     "settlement": {"txHash": settle.tx_hash, "network": settle.network,
+                                    "amount": payment.value, "nonce": payment.nonce}}
+
+
+def _make_handler(merchant: SyntheticMerchant):
+    class _Handler(BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802
+            status, body = merchant.handle(self.path, self.headers.get("X-PAYMENT"))
+            payload = json.dumps(body).encode()
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        do_POST = do_GET  # paid resources may be POSTed against too
+
+        def log_message(self, *a):  # silence default stderr logging
+            pass
+    return _Handler
+
+
+def serve(merchant: SyntheticMerchant, port: int = 8402) -> ThreadingHTTPServer:
+    """Start the merchant on `port`. Returns the server (caller controls lifetime)."""
+    httpd = ThreadingHTTPServer(("127.0.0.1", port), _make_handler(merchant))
+    return httpd
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Synthetic x402 merchant (VS-R02 settlement infra)")
+    ap.add_argument("--pay-to", required=True, help="Merchant receiving address (you control it)")
+    ap.add_argument("--amount", default="10000", help="maxAmountRequired in smallest unit (default 0.01 USDC)")
+    ap.add_argument("--network", default="base-sepolia")
+    ap.add_argument("--resource", default="/paid")
+    ap.add_argument("--port", type=int, default=8402)
+    ap.add_argument("--live", action="store_true",
+                    help="Use the real Coinbase x402 facilitator (settles on-chain). Default: mock, no gas.")
+    ap.add_argument("--facilitator", default=DEFAULT_FACILITATOR)
+    args = ap.parse_args()
+
+    req = PaymentRequirements(pay_to=args.pay_to, max_amount_required=args.amount,
+                              network=args.network, resource=args.resource)
+    facilitator = CoinbaseFacilitator(args.facilitator) if args.live else MockFacilitator()
+    merchant = SyntheticMerchant(req, facilitator)
+    httpd = serve(merchant, args.port)
+    mode = "LIVE (on-chain settlement)" if args.live else "MOCK (no gas)"
+    print(f"x402 synthetic merchant on http://127.0.0.1:{args.port}{args.resource} "
+          f"| payTo={args.pay_to} amount={args.amount} {args.network} | facilitator: {mode}",
+          file=sys.stderr)
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        httpd.shutdown()
+        print(f"\nsettlements: {[asdict(s) for s in merchant.settlements]}", file=sys.stderr)
+        print(f"total settled: {merchant.total_settled}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/testing/test_x402_merchant.py
+++ b/testing/test_x402_merchant.py
@@ -1,0 +1,135 @@
+"""Unit tests for the synthetic x402 merchant (VS-R02 Tier B infra).
+
+All tests use the MockFacilitator — no network, no gas. They exercise the same
+flows the live ACP-012 (replay) and ACP-016 (aggregate spend) tests will use.
+"""
+
+import json
+import threading
+import urllib.request
+
+from protocol_tests.x402_merchant import (
+    PaymentRequirements,
+    SyntheticMerchant,
+    MockFacilitator,
+    parse_x_payment,
+    encode_x_payment,
+    serve,
+)
+
+PAY_TO = "0x7889454DF1EB44B2fA0878179A1845F5b4649286"
+
+
+def _req():
+    return PaymentRequirements(pay_to=PAY_TO, max_amount_required="10000", resource="/paid")
+
+
+def _payment(nonce="0x01", value="10000", to=PAY_TO):
+    return encode_x_payment({"from": "0xAgent", "to": to, "value": value,
+                             "nonce": nonce, "validAfter": "0", "validBefore": "9999999999"})
+
+
+# --- 402 challenge ----------------------------------------------------------
+
+def test_402_challenge_shape():
+    m = SyntheticMerchant(_req())
+    status, body = m.handle("/paid", None)
+    assert status == 402
+    assert body["x402Version"] == 1
+    accepts = body["accepts"][0]
+    assert accepts["payTo"] == PAY_TO
+    assert accepts["network"] == "base-sepolia"
+    assert accepts["scheme"] == "exact"
+    assert accepts["asset"].startswith("0x")
+
+
+def test_wrong_path_404():
+    m = SyntheticMerchant(_req())
+    assert m.handle("/other", _payment())[0] == 404
+
+
+# --- successful settle ------------------------------------------------------
+
+def test_successful_settlement():
+    m = SyntheticMerchant(_req())
+    status, body = m.handle("/paid", _payment(nonce="0xAA"))
+    assert status == 200
+    assert body["paid"] is True
+    assert body["settlement"]["txHash"].startswith("0x")
+    assert len(m.settlements) == 1 and m.settlements[0].success
+
+
+# --- ACP-012 shape: receipt nonce reuse / replay ----------------------------
+
+def test_replay_same_nonce_refused():
+    m = SyntheticMerchant(_req())
+    first = m.handle("/paid", _payment(nonce="0xBEEF"))
+    second = m.handle("/paid", _payment(nonce="0xBEEF"))  # same nonce again
+    assert first[0] == 200
+    assert second[0] == 402
+    assert "replay" in second[1]["error"].lower() or "nonce" in second[1]["error"].lower()
+    # one successful settlement, one refused
+    assert sum(1 for s in m.settlements if s.success) == 1
+
+
+# --- ACP-016 shape: settled-spend aggregation -------------------------------
+
+def test_aggregate_settled_spend():
+    m = SyntheticMerchant(_req())
+    for i in range(5):
+        status, _ = m.handle("/paid", _payment(nonce=f"0x{i:02x}", value="10000"))
+        assert status == 200
+    # 5 distinct-nonce settlements of 0.01 USDC each = 0.05 USDC
+    assert m.total_settled == 50000
+    assert sum(1 for s in m.settlements if s.success) == 5
+
+
+# --- verify-layer rejections ------------------------------------------------
+
+def test_amount_over_max_rejected():
+    m = SyntheticMerchant(_req())
+    status, body = m.handle("/paid", _payment(nonce="0x10", value="999999"))
+    assert status == 402
+    assert "amount" in body["error"].lower()
+    assert not m.settlements[0].success
+
+
+def test_undecodable_payment_rejected():
+    m = SyntheticMerchant(_req())
+    status, _ = m.handle("/paid", "!!!not-base64-json!!!")
+    assert status == 402
+
+
+def test_forced_verify_failure():
+    m = SyntheticMerchant(_req(), MockFacilitator(fail_verify=True))
+    assert m.handle("/paid", _payment())[0] == 402
+
+
+# --- payload codec ----------------------------------------------------------
+
+def test_encode_parse_roundtrip():
+    p = parse_x_payment(_payment(nonce="0x2a", value="500"))
+    assert p.decode_error == ""
+    assert p.nonce == "0x2a"
+    assert p.value == "500"
+    assert p.pay_to == PAY_TO
+
+
+# --- HTTP wrapper smoke -----------------------------------------------------
+
+def test_http_server_serves_402():
+    m = SyntheticMerchant(_req())
+    httpd = serve(m, 0)  # ephemeral port
+    port = httpd.server_address[1]
+    t = threading.Thread(target=httpd.serve_forever, daemon=True)
+    t.start()
+    try:
+        with urllib.request.urlopen(f"http://127.0.0.1:{port}/paid", timeout=5) as r:
+            # 402 is raised as HTTPError by urllib; reaching here would be a 200.
+            raise AssertionError("expected 402")
+    except urllib.error.HTTPError as e:
+        assert e.code == 402
+        body = json.loads(e.read())
+        assert body["accepts"][0]["payTo"] == PAY_TO
+    finally:
+        httpd.shutdown()


### PR DESCRIPTION
Pre-builds the gating infrastructure for **VS-R02 Tier B** (the settlement tests). The harness had x402 *client* primitives only; this adds the *server* — a merchant we control that relays the agent's signed `X-PAYMENT` to the x402 facilitator's verify/settle and records what settled.

## Design — build/test now with zero live money
- **`SyntheticMerchant.handle()`** — socket-free, unit-testable; records every settlement (value, nonce, txHash).
- **`MockFacilitator`** (default) — deterministic receipts, in-memory EIP-3009 nonce-uniqueness, no gas/network. Exercises the ACP-012/016 flows in CI.
- **`CoinbaseFacilitator`** (live) — POSTs the real `/verify` + `/settle`; used **only** in the live-stack session via `--live`, never in CI.
- `serve()` + CLI: `python -m protocol_tests.x402_merchant --pay-to 0x... [--live]`.

## Maps directly to the two Tier B tests
- **ACP-012** (replay): `test_replay_same_nonce_refused` — second same-nonce settle returns 402.
- **ACP-016** (aggregate): `test_aggregate_settled_spend` — 5 distinct-nonce settles of 0.01 USDC → `total_settled == 50000`.

## Verification
- 10 unit tests, full suite **194 passed, 0 failures**
- Count unchanged at **474** — this is infrastructure, not a test family (deliberately not padding the number)
- CLI boots a valid 402 challenge with the VS-R02 granted wallet (`0x7889454…`)

For Mike's VS-R02 session: run with `--live` + the real facilitator, point AgentCore ProcessPayment at it, then the ACP-012/016 stubs assert against `merchant.settlements`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New test infrastructure only; default path uses in-memory mock facilitator and is not wired into production payment flows unless `--live` is used manually.
> 
> **Overview**
> Adds **VS-R02 Tier B settlement infrastructure**: a controllable x402 *merchant* that accepts `X-PAYMENT`, relays verify/settle to a facilitator, and records outcomes—complementing existing x402 *client* harness work.
> 
> **`SyntheticMerchant`** exposes socket-free `handle()` (402 challenge → verify → settle → 200 or 402), keeps **`SettlementRecord`**s, and exposes **`total_settled`** for spend aggregation. **`MockFacilitator`** is the default in CI (deterministic tx hashes, in-memory nonce replay rejection, amount caps, optional forced verify failure). **`CoinbaseFacilitator`** hits real `/verify` and `/settle` when the CLI runs with **`--live`**. Also adds **`parse_x_payment` / `encode_x_payment`**, a small HTTP **`serve()`** wrapper, and **`python -m protocol_tests.x402_merchant --pay-to …`**.
> 
> **`testing/test_x402_merchant.py`** (10 tests, all mock) covers 402 shape, successful settle, replay refusal (ACP-012-style), aggregate spend (ACP-016-style), verify failures, and HTTP smoke—no live money in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cf979760b75d698a2121a41b713fc5b6aeed8b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->