### PR TITLE
fix(vs-r02): guard MockFacilitator nonce dedup against threaded races

### DIFF
--- a/protocol_tests/x402_merchant.py
+++ b/protocol_tests/x402_merchant.py
@@ -30,6 +30,7 @@ import base64
 import hashlib
 import json
 import sys
+import threading
 import urllib.request
 from dataclasses import dataclass, field, asdict
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -160,9 +161,14 @@ class MockFacilitator(FacilitatorClient):
         self.fail_verify = fail_verify
         self._spent_nonces: set[str] = set()
         self.calls: list[tuple[str, str]] = []  # (op, nonce)
+        # serve() runs a ThreadingHTTPServer, so concurrent same-nonce requests
+        # can hit settle() at once. Guard the check-then-add nonce dedup (and the
+        # shared call log) so the EIP-3009 single-use guarantee holds under load.
+        self._lock = threading.Lock()
 
     def verify(self, payment, req):
-        self.calls.append(("verify", payment.nonce))
+        with self._lock:
+            self.calls.append(("verify", payment.nonce))
         if payment.decode_error:
             return SettleResult(False, reason=f"undecodable payment: {payment.decode_error}")
         if self.fail_verify:
@@ -173,11 +179,13 @@ class MockFacilitator(FacilitatorClient):
         return SettleResult(True, network=req.network)
 
     def settle(self, payment, req):
-        self.calls.append(("settle", payment.nonce))
-        if payment.nonce in self._spent_nonces:
-            # EIP-3009: an authorization nonce is single-use on-chain.
-            return SettleResult(False, reason="nonce already used (replay)", network=req.network)
-        self._spent_nonces.add(payment.nonce)
+        with self._lock:
+            self.calls.append(("settle", payment.nonce))
+            if payment.nonce in self._spent_nonces:
+                # EIP-3009: an authorization nonce is single-use on-chain.
+                return SettleResult(False, reason="nonce already used (replay)",
+                                    network=req.network)
+            self._spent_nonces.add(payment.nonce)  # atomic with the check above
         tx = "0x" + hashlib.sha256(
             f"{payment.nonce}:{payment.value}:{req.pay_to}".encode()).hexdigest()
         return SettleResult(True, tx_hash=tx, network=req.network)

--- a/testing/test_x402_merchant.py
+++ b/testing/test_x402_merchant.py
@@ -133,3 +133,33 @@ def test_http_server_serves_402():
         assert body["accepts"][0]["payTo"] == PAY_TO
     finally:
         httpd.shutdown()
+
+
+# --- concurrency: replay guarantee holds under threads (Bugbot #217) --------
+
+def test_concurrent_same_nonce_settles_once():
+    # serve() is threaded; without a lock the check-then-add nonce dedup races
+    # and the same nonce can settle twice. Fire many threads at one nonce,
+    # gated by a barrier to maximize contention, and assert exactly one wins.
+    m = SyntheticMerchant(_req())
+    n = 50
+    barrier = threading.Barrier(n)
+    results = []
+    lock = threading.Lock()
+
+    def hit():
+        barrier.wait()
+        status, _ = m.handle("/paid", _payment(nonce="0xRACE", value="10000"))
+        with lock:
+            results.append(status)
+
+    threads = [threading.Thread(target=hit) for _ in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert results.count(200) == 1, f"exactly one settle expected, got {results.count(200)}"
+    assert results.count(402) == n - 1
+    assert sum(1 for s in m.settlements if s.success) == 1
+    assert m.total_settled == 10000


### PR DESCRIPTION
Follow-up to #217. Cursor Bugbot flagged a HIGH: `MockFacilitator.settle` checks-then-adds `_spent_nonces` without synchronization, while `serve()` runs a `ThreadingHTTPServer` — concurrent same-nonce requests could both settle, breaking the EIP-3009 single-use (ACP-012 replay) guarantee.

## Fix
`threading.Lock` around the nonce check-add (and the shared call log) in `MockFacilitator`.

## Honest scope note
The flag is correct by inspection — it's an unsynchronized check-then-act. **In practice CPython's GIL masks it**: the check+add has no yield point, so it doesn't interleave (I could not reproduce a double-settle across 20× 50-thread barrier runs). But the fix is still right:
- Free-threaded Python (3.13+, already in this repo's CI matrix) removes the GIL's accidental protection.
- Any future I/O in that critical section would open the window.
- A "settlement single-use" component in a security harness shouldn't rely on an interpreter accident for a correctness invariant.

## Verification
- +1 concurrency regression test (50 threads, one nonce, barrier-gated → exactly one settle)
- 11 merchant tests; full suite **195 passed, 0 failures**; stable across repeated runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-harness mock facilitator only; change tightens correctness for settlement replay tests with no production payment-path impact.
> 
> **Overview**
> **`MockFacilitator`** now uses a **`threading.Lock`** so nonce check-and-mark-as-spent (and the shared **`calls`** log) are atomic when **`serve()`** handles concurrent requests on the same EIP-3009 nonce. That preserves the single-use / ACP-012 replay invariant under threaded load (not only under CPython’s GIL).
> 
> Adds **`test_concurrent_same_nonce_settles_once`**: 50 barrier-synchronized threads hit one nonce and assert exactly one **200** settle, the rest **402**, and **`total_settled`** matches a single payment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 082ce572292685d79d49e54e1c0019870e9ad950. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->