### PR TITLE
ci: add ruff F821 undefined-name gate (+ fix 2 bugs it found)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,14 @@ jobs:
           python -m py_compile scripts/compliance_report.py
           echo "All modules pass syntax check"
 
+      - name: Undefined-name check (ruff F821)
+        # py_compile only checks syntax; it does not catch a name used but never bound
+        # (e.g. an undefined variable in a verdict's non-simulate path). F821 does, and
+        # such a bug is a NameError at runtime on exactly the live paths CI cannot exercise.
+        run: |
+          pip install ruff
+          ruff check --select F821 protocol_tests/ testing/ scripts/ mcp_server/
+
       - name: Check for unique test IDs
         run: |
           python -c "

--- a/protocol_tests/framework_adapters.py
+++ b/protocol_tests/framework_adapters.py
@@ -916,6 +916,8 @@ class PraisonAIAdapter(FrameworkAdapter):
         # "rejected" signal).  We use urllib directly to inspect Content-Type and body.
         rejected = False
         leaked = False
+        raw_status = 0
+        body_preview = ""
         try:
             raw_req = urllib.request.Request(endpoint, method="GET")
             with urllib.request.urlopen(raw_req, timeout=10) as raw_resp:
@@ -944,7 +946,8 @@ class PraisonAIAdapter(FrameworkAdapter):
                 if rejected and not leaked
                 else "Event stream accessible without auth — agent activity leaked (CVE-2026-39889)"
             ),
-            endpoint=endpoint, request_sent=stream_request, response_received=resp,
+            endpoint=endpoint, request_sent=stream_request,
+            response_received={"status": raw_status, "rejected": rejected, "leaked": leaked},
             elapsed_s=round(elapsed, 3),
         )
 

--- a/scripts/evidence_pack.py
+++ b/scripts/evidence_pack.py
@@ -425,6 +425,11 @@ def build_evidence_pack(
     # Compute evidence hash over the two JSON payloads
     evidence_hash = compute_evidence_hash(test_results_json, aiuc1_mapping_json)
 
+    # Output dir must exist before signing — an auto-generated signing key is written
+    # into it.
+    pack_dir = Path(output_dir)
+    pack_dir.mkdir(parents=True, exist_ok=True)
+
     # Signing
     attestation: dict[str, Any] = {"signed": False}
     if do_sign:
@@ -473,9 +478,7 @@ def build_evidence_pack(
         timestamp=timestamp,
     )
 
-    # Write output
-    pack_dir = Path(output_dir)
-    pack_dir.mkdir(parents=True, exist_ok=True)
+    # Write output (pack_dir already created above, before signing)
 
     files = {
         "evidence-summary.json": evidence_summary_json,


### PR DESCRIPTION
## Why

`py_compile` (the current Lint job) checks syntax but **cannot catch a name used yet never bound** — a `NameError` that only fires at runtime on the live/non-simulate paths CI doesn't exercise. The VS-R03 round shipped exactly one such bug (L4-008's `status`) through all four Python test matrices *and* the Lint job; it was caught only by an external reviewer.

This adds a fast `ruff check --select F821` step to the `lint` job over `protocol_tests/`, `testing/`, `scripts/`, `mcp_server/`.

## The gate paid for itself immediately

Enabling it surfaced **two pre-existing NameErrors** nothing else caught — both fixed in this PR:

- **`framework_adapters.py`** (PA-003 event-stream auth test, CVE-2026-39889): `response_received=resp` on the live path referenced an undefined `resp` → NameError whenever the test ran against a real endpoint. Now built from the collected `status`/`rejected`/`leaked`; `raw_status`/`body_preview` initialized so the `except` path is safe too.
- **`scripts/evidence_pack.py`** (`build_evidence_pack`): used `pack_dir` to write an auto-generated `signing.key` ~40 lines *before* `pack_dir` was defined → NameError when signing without `AGENT_SECURITY_SIGN_KEY` set. The output dir is now created before the signing block.

## Verification

- `ruff check --select F821` clean across the repo.
- Full suite **220 passed**, zero regressions.
- Both fixes are on live/CLI paths the test suite doesn't drive — consistent with the under-tested evidence-producing-code gap this gate is meant to backstop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-only CI addition plus small bugfixes on under-tested live/CLI paths; no auth or data-model changes.
> 
> **Overview**
> Adds **`ruff check --select F821`** to the CI lint job over `protocol_tests/`, `testing/`, `scripts/`, and `mcp_server/` so undefined names are caught before runtime—something `py_compile` alone cannot do on live/non-simulate paths.
> 
> Enabling that gate exposed and fixes **two pre-existing `NameError`s**: in **`framework_adapters.py`** (PA-003 live event-stream test), `response_received` no longer references undefined `resp` and instead reports `status`/`rejected`/`leaked`, with `raw_status`/`body_preview` initialized for safe error paths; in **`scripts/evidence_pack.py`**, the output directory is created **before** signing so auto-generated `signing.key` can be written when `AGENT_SECURITY_SIGN_KEY` is unset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5ac5b25d16ccd6cf9f9dcad3d0ab9177c68a84c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->