### PR TITLE
fix(vs-r03): address 3 follow-up bugbot findings (all true positives)

### DIFF
--- a/protocol_tests/framework_adapters.py
+++ b/protocol_tests/framework_adapters.py
@@ -930,6 +930,7 @@ class PraisonAIAdapter(FrameworkAdapter):
                 "execution_log",
             ])
         except urllib.error.HTTPError as e:
+            raw_status = e.code
             rejected = e.code in (401, 403)
             leaked = False
         except Exception:

--- a/protocol_tests/mcp_harness.py
+++ b/protocol_tests/mcp_harness.py
@@ -226,7 +226,9 @@ class StdioTransport(MCPTransport):
         if ready:
             resp_line = self.proc.stdout.readline().decode("utf-8").strip()
             if resp_line:
-                return json.loads(resp_line)
+                # Same trust boundary as the HTTP transport: a stdio server must not be
+                # able to inject the harness's internal control sentinels (VS-R03 A1).
+                return _strip_server_sentinels(json.loads(resp_line))
         return None
 
     def send_raw(self, raw_bytes: bytes) -> bytes | None:
@@ -1501,7 +1503,12 @@ class MCPSecurityTests:
                 "accesskeyid", "secretaccesskey", "access_token", "token_type",
                 "expires_in", "expiration", "azenvironment", "subscriptionid", "ostype",
             ]
-            has_creds = any(ind in resp_str for ind in cred_value_indicators)
+            # Require >=2 distinct credential-field names to co-occur. A real metadata
+            # response carries several (AccessKeyId + SecretAccessKey + Token + Expiration,
+            # or access_token + token_type + expires_in); a benign error message that merely
+            # mentions one generic term (e.g. "expiration") is not a leak (VS-R03 A2, refined
+            # after review to avoid a single-word false positive).
+            has_creds = sum(1 for ind in cred_value_indicators if ind in resp_str) >= 2
             has_sensitive = any(ind in resp_str for ind in aws_creds_indicators + internal_content_indicators)
 
             if has_creds:

--- a/testing/test_vsr03_verdict_correctness.py
+++ b/testing/test_vsr03_verdict_correctness.py
@@ -86,6 +86,16 @@ class TestMCP016CredentialLeak(unittest.TestCase):
             "credential leak under an error envelope must be flagged as SSRF, not blocked",
         )
 
+    def test_single_credential_word_in_error_is_not_a_leak(self):
+        # A JSON-RPC error that merely mentions one generic credential term (e.g.
+        # "expiration") is not a leak — a real metadata response carries several fields,
+        # so >=2 must co-occur (A2 refined after review to drop the single-word FP).
+        benign = {"error": {"code": -32602, "message": "invalid token expiration format"}}
+        suite = MCPSecurityTests(_FixedTransport(benign))
+        suite.test_mcp_ssrf_via_resource_uri()
+        result = next(r for r in suite.results if r.test_id == "MCP-016")
+        self.assertTrue(result.passed, "one credential word in an error is not an SSRF leak")
+
     def test_benign_host_echo_under_error_still_blocked(self):
         # A genuine rejection that merely echoes the target host (no credential
         # material) must still count as blocked — guards against over-correction.


### PR DESCRIPTION
Three valid Cursor bugbot findings on the merged VS-R03 (#220) and F821 (#221) PRs. All confirmed against the source and fixed; one regression test added.

### 1. `StdioTransport.send` skipped sentinel stripping (Medium) — A1 gap
Cluster A1 added `_strip_server_sentinels` to `StreamableHTTPTransport` only. A **stdio** MCP server could still inject `_error`/`_status` into a successful JSON body to forge a "blocked" verdict. Applied the same trust boundary to `StdioTransport.send`. Good catch — I missed a transport.

### 2. MCP-016 single-word false positive (Medium) — A2 refinement
A leak was flagged on **any one** `cred_value_indicator` substring, so a benign JSON-RPC error merely mentioning `expiration` scored as an SSRF hit. Now requires **≥2 distinct** indicators to co-occur — a real metadata response carries several (`AccessKeyId` + `SecretAccessKey` + `Token` + `Expiration`; or `access_token` + `token_type` + `expires_in`); a one-word error does not. The genuine multi-field leak is still caught (existing test unchanged, passes). Added `test_single_credential_word_in_error_is_not_a_leak`.

### 3. `framework_adapters` PA-003 evidence accuracy (Low)
The `HTTPError` branch set `rejected` from `e.code` but left `raw_status` at its initial `0`, so a 401/403 was recorded as `status: 0` in `response_received`. Bound `raw_status = e.code`.

### Verification
- `ruff check --select F821` clean.
- Full suite **221 passed**, zero regressions.

Note on the earlier "version suffix" bugbot finding (#220): that one was a false positive (already handled by `package_name`; bot reviewed the pre-fix commit). These three are real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to security test harness verdict logic and test evidence; no production auth or runtime behavior is modified.
> 
> **Overview**
> Follow-up fixes for **VS-R03** verdict correctness in protocol test harnesses: closes a stdio transport gap, tightens MCP-016 SSRF leak detection, and corrects PA-003 HTTP error evidence.
> 
> **Stdio MCP transport** now runs parsed JSON through `_strip_server_sentinels`, matching Streamable HTTP so a malicious stdio server cannot forge harness control keys (`_error`, `_status`, etc.) to fake a “blocked” result.
> 
> **MCP-016** (`test_mcp_ssrf_via_resource_uri`) treats credential exfiltration as a hit only when **at least two** distinct metadata field indicators appear in the response, reducing single-word false positives (e.g. “expiration” in a benign error) while keeping multi-field leaks covered; a regression test was added.
> 
> **PraisonAI PA-003** sets `raw_status` from `HTTPError.code` so 401/403 rejections are recorded with the real status instead of `0` in `response_received`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c82d2e6f2b2b648000e74b5e5857eaabb44765f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->