### PR TITLE
fix(cli): derive VERSION from pyproject via version.py (issue #5)

### DIFF
--- a/protocol_tests/cli.py
+++ b/protocol_tests/cli.py
@@ -27,8 +27,11 @@ import sys
 import importlib
 from datetime import datetime, timezone
 
+from protocol_tests.version import get_harness_version
 
-VERSION = "4.3.0"
+
+# Single source of truth: pyproject.toml (via version.py), never hardcoded (issue #5)
+VERSION = get_harness_version()
 
 # ---------------------------------------------------------------------------
 # Simulate-mode helpers  (#152 — R31)

--- a/testing/test_code_quality.py
+++ b/testing/test_code_quality.py
@@ -303,5 +303,28 @@ class TestReadmeCompleteness(unittest.TestCase):
         self.assertTrue("leak" in c or "response body" in c)
 
 
+class TestRegVersionConsistency(unittest.TestCase):
+    """Issue #5 (hardcoded version): CLI VERSION must track pyproject.toml, never a literal.
+
+    Regression guard for the 4.3.0-on-4.4.2 drift: `agent-security version` reported a stale
+    hardcoded string because cli.py did not use protocol_tests.version.get_harness_version().
+    """
+    def _pyproject_version(self):
+        with open(os.path.join(REPO_ROOT, "pyproject.toml")) as f:
+            m = re.search(r'^version\s*=\s*["\']([^"\']+)["\']', f.read(), re.M)
+        self.assertIsNotNone(m, "pyproject.toml must declare a version")
+        return m.group(1)
+    def test_cli_version_matches_pyproject(self):
+        import protocol_tests.cli as cli
+        self.assertEqual(cli.VERSION, self._pyproject_version())
+    def test_cli_version_not_hardcoded_literal(self):
+        with open(os.path.join(REPO_ROOT, "protocol_tests", "cli.py")) as f:
+            src = f.read()
+        self.assertNotRegex(
+            src, r'VERSION\s*=\s*["\']\d+\.\d+',
+            "cli.py VERSION must come from version.py, not a hardcoded literal (issue #5)",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem
`agent-security version` and the `--help` banner reported **v4.3.0** on a **4.4.2** install. `protocol_tests/cli.py:31` hardcoded `VERSION = "4.3.0"` instead of using the existing pyproject-first lookup `protocol_tests.version.get_harness_version()` — the exact "hardcoded version" anti-pattern in `CLAUDE.md` (issue #5). It was the only hardcoded version remaining in shipped code, and no version-consistency test guarded it, so the drift went uncaught.

## Fix
- `cli.py`: `VERSION = get_harness_version()` — now computed from `pyproject.toml`, structurally incapable of drifting again.
- `testing/test_code_quality.py`: new `TestRegVersionConsistency` — asserts `cli.VERSION == pyproject version` **and** that no hardcoded version literal can be reintroduced.

## Validation (py3.12 venv, local CI-equivalent)
- `agent-security version` → **v4.4.2** (banner too)
- `testing/` suite: **223 passed + 56 subtests** (+2 new guards)
- `tests/`: 19 passed · ruff F821: clean · 38/38 module imports · 474-test catalog enumerates end-to-end
- Both new guards are non-vacuous (a reverted hardcode fails value-match and literal-regex)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing version strings only; no auth, data, or runtime behavior changes beyond correct version display.
> 
> **Overview**
> Fixes **stale CLI version reporting** (issue #5): `agent-security version` and help banners no longer use a hardcoded string that could drift from the installed package (e.g. v4.3.0 on a 4.4.2 install).
> 
> **`protocol_tests/cli.py`** now sets `VERSION = get_harness_version()` so the displayed version comes from **`pyproject.toml`** via the existing `protocol_tests.version` helper—the same single-source pattern described in project docs.
> 
> **`testing/test_code_quality.py`** adds **`TestRegVersionConsistency`**: asserts `cli.VERSION` matches `pyproject.toml`, and rejects reintroducing a literal `VERSION = "x.y"` assignment in `cli.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be3ee367a1ab0779a8a74cdcc757f8646df3c63c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->