### PR TITLE
fix(card-token): reject boolean amounts (v4.8.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.8.1] - 2026-07-02
+
+**Fix:** `CardTokenVerifier.authorize` treated boolean amounts as integers
+(`bool` is an `int` subclass in Python), so `amount=True` read as a charge of 1.
+Amounts must now be real positive integers; CTK-003 adds a boolean-amount case.
+Reference-verifier hardening only — no test-count or API change (532/37).
+
 ## [4.8.0] - 2026-07-02
 
 **Theme: card-network funding instrument (Visa TAP / Mastercard Agentic Tokens).**

--- a/protocol_tests/card_token_harness.py
+++ b/protocol_tests/card_token_harness.py
@@ -147,8 +147,10 @@ class CardTokenVerifier:
         #    charge would pass an upper-bound-only cap AND (via spent += amount)
         #    refund velocity budget, so bound BOTH ends.
         amount = txn.get("amount", 0)
-        if not isinstance(amount, int) or amount <= 0:
-            return VerifyOutcome(False, "non-positive transaction amount")
+        # bool is an int subclass in Python, so exclude it explicitly — a
+        # monetary amount must be a real positive integer, not True/False.
+        if isinstance(amount, bool) or not isinstance(amount, int) or amount <= 0:
+            return VerifyOutcome(False, "amount must be a positive integer")
         if amount > token.get("max_amount", 0):
             return VerifyOutcome(
                 False, f"charge {amount} exceeds per-transaction cap {token.get('max_amount')}")
@@ -372,16 +374,20 @@ class CardTokenTests:
         #     it, and spent += amount would refund velocity budget)
         neg = _txn(token, amount=-5000, counter=1)
         v_neg = CardTokenVerifier().authorize(token, neg, now)
+        # (c) boolean amount — bool is an int subclass; must not read as a charge
+        boolean = _txn(token, amount=True, counter=1)
+        v_bool = CardTokenVerifier().authorize(token, boolean, now)
         model_pass = ((not v_over.ok and "per-transaction cap" in v_over.reason)
-                      and (not v_neg.ok and "non-positive" in v_neg.reason))
+                      and (not v_neg.ok and "positive integer" in v_neg.reason)
+                      and (not v_bool.ok and "positive integer" in v_bool.reason))
         self._finish(
             test_id="CTK-003", name="Per-Transaction Amount Cap",
             category="scope", network="visa-tap/mc-agentic",
             owasp="ASI03", stride="Elevation of Privilege", severity=Severity.HIGH.value,
             ref="Visa TAP / MC Agentic Token: per-transaction amount envelope", normative="N",
             model_pass=model_pass,
-            model_reason=("over-cap and non-positive charges both rejected" if model_pass else
-                          "OVERCHARGE — a charge above the cap or a negative amount was authorized"),
+            model_reason=("over-cap, negative and boolean charges all rejected" if model_pass else
+                          "OVERCHARGE — a charge above the cap or a non-integer/negative amount was authorized"),
             attack_payload={"token": token, "transaction": over}, t0=t0)
 
     # -- CTK-004: cumulative velocity cap ---------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-security-harness"
-version = "4.8.0"
+version = "4.8.1"
 description = "532 security tests for AI agent systems - MCP, A2A, L402, x402, UCP/ACP merchant-journey, AP2 mandate + Fireblocks x402 hardening + Visa TAP / Mastercard Agentic Tokens, decision governance, AIUC-1 compliance, NIST AI 800-2 aligned"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
Follow-up to #229 addressing the remaining Bugbot finding (LOW).

**Issue:** `bool` is an `int` subclass in Python, so `isinstance(amount, int)` accepted `amount=True` as a charge of 1 — slipping the fail-closed amount guard.

**Fix:** exclude `bool` explicitly; a monetary amount must be a real positive integer. `CTK-003` gains a boolean-amount case alongside the over-cap and negative cases. Proven: `authorize(amount=True)` → rejected; `authorize(amount=15000)` → authorized.

Patch bump **4.8.0 → 4.8.1**; no test-count change (532/37). `ruff F821` clean; 12/12 simulate; regression suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small reference-verifier validation fix in the card-token harness; no public API or coverage count changes.
> 
> **Overview**
> Patches **4.8.1** hardens `CardTokenVerifier.authorize` so transaction amounts cannot be Python booleans: because `bool` subclasses `int`, `amount=True` previously slipped past `isinstance(amount, int)` and could authorize as a charge of **1**.
> 
> The amount guard now rejects booleans explicitly and uses the message **"amount must be a positive integer"**. **CTK-003** adds a `amount=True` case alongside over-cap and negative amounts. **CHANGELOG** documents the fix; **pyproject.toml** bumps **4.8.0 → 4.8.1** with no change to the advertised test/module totals (532/37).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b952e06eb9293b5ac54e293067d057dbbee36ebe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->