### PR TITLE
Fix CVE-2026-25253 misattribution in MCP tool-poisoning suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
           import protocol_tests.harmful_output_harness
           import protocol_tests.cbrn_harness
           import protocol_tests.incident_response_harness
-          import protocol_tests.cve_2026_25253_harness
+          import protocol_tests.mcp_tool_poisoning_harness
           import protocol_tests.aiuc1_compliance_harness
           import protocol_tests.cloud_agent_harness
           import protocol_tests.statistical
@@ -94,7 +94,7 @@ jobs:
           agent-security list identity
           agent-security list gtg1002
           agent-security list advanced
-          agent-security list cve-2026-25253
+          agent-security list mcp-tool-poisoning
           agent-security list aiuc1
           agent-security list cloud-agents
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.9.1] - 2026-07-10
+
+### Fixed
+
+- Corrected a CVE misattribution: the MCP tool-poisoning suite was incorrectly
+  anchored to CVE-2026-25253, which is actually an unrelated OpenClaw WebSocket
+  vulnerability (OpenClaw before 2026.1.29 auto-connects to a gatewayUrl taken
+  from a query string without prompting). Re-anchored the suite to the Invariant
+  Labs "Tool Poisoning Attacks" research (2025) and ClawHub RFC #99; removed
+  inaccurate statistics (fabricated CVSS score/vector, publication date,
+  "135K+ MCP server instances", "12% of a ~2,800-tool marketplace", and
+  fabricated media coverage). Renamed the module
+  `cve_2026_25253_harness.py` → `mcp_tool_poisoning_harness.py` and the CLI
+  harness id `cve-2026-25253` → `mcp-tool-poisoning`. Test IDs CVE-001..CVE-010
+  are unchanged; CVE-009/010 still map to the real CVE-2026-35625 and
+  CVE-2026-35629. The 341-skill / 12% figure is now attributed to its real
+  source (ClawHub RFC #99) as a configurable detection threshold, not a
+  marketplace measurement. Related real MCP supply-chain CVEs (CVE-2025-54136,
+  CVE-2025-49596) are cited with accurate descriptions.
+
 ## [4.9.0] - 2026-07-05
 
 **Theme: denial-of-settlement / settlement-finality (liveness).** Closes the
@@ -155,7 +175,7 @@ gate.
 
 - `docs/ADVANCED.md` GTG-1002 table: column headers reframed from `Real GTG-1002 Activity` / `What We Test` to `Adversary behavior we probe for` / `Detection probes the harness sends`. Cell content reworded from active to defensive voice ("Probes detection of X" rather than "User data exfiltration") (f719af9).
 - `docs/ADVANCED.md` added top-of-section defensive framing paragraph and reading guide above the GTG-1002 table (f719af9).
-- `docs/TEST-INVENTORY.md` anchored both CVE-2026-25253 references with inline NVD links (f719af9).
+- `docs/TEST-INVENTORY.md` anchored both MCP supply-chain references with inline NVD links (f719af9). *(Note: the CVE-2026-25253 anchor used here was later corrected — see 4.9.1.)*
 - `SKILL.md` telemetry section made explicit: opt-IN, disabled by default, no outbound calls beyond the test target; cross-link to `docs/PRIVACY.md` (95b55ca).
 - `SKILL.md` MCP server example corrected from the incorrect `agent-security serve` to the real `python -m mcp_server` invocation; default to stdio (no network surface); HTTP-transport hardening documented (`--api-key` bearer auth, localhost binding, container egress limits, privileged-tool framing) (95b55ca).
 
@@ -352,7 +372,7 @@ gate.
 - 342 security tests across 21 modules
 - OATR fixture loader (`protocol_tests/oatr_fixtures.py`)
 - x402 payment flow harness with L402 interop
-- CVE-2026-25253 supply chain provenance tests
+- MCP supply-chain provenance tests *(originally mislabeled CVE-2026-25253; corrected in 4.9.1)*
 - AIUC-1 pre-certification compliance harness
 - Cloud agent platform adapters (Vertex, Bedrock, Azure AI Agent Service)
 - Enterprise platform adapters (ServiceNow, Salesforce AgentForce, etc.)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ The fastest way to contribute is writing a YAML attack pattern. No Python requir
 - **[Plugin Specification](docs/PLUGIN_SPEC.md)** - Complete reference for all fields, action types, and assertion types
 - **[Template](community_modules/TEMPLATE.yaml)** - Blank template with inline comments
 - **[Example: CrewAI Role Escape](community_modules/examples/crewai_role_escape.yaml)** - Multi-step privilege escalation
-- **[Example: MCP Description Exfil](community_modules/examples/mcp_description_exfil.yaml)** - CVE-2026-25253 reproduction
+- **[Example: MCP Description Exfil](community_modules/examples/mcp_description_exfil.yaml)** - MCP tool-poisoning reproduction (Invariant Labs Tool Poisoning, 2025)
 
 ### What Makes a Good Attack Pattern?
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -34,7 +34,7 @@ Answer the question every operator needs answered before going to production:
 
 ## Project context
 
-- **Calendar year:** 2026. CVE references like `CVE-2026-25253` are current-year identifiers, not fabricated. Verify any cited CVE in [NVD](https://nvd.nist.gov/vuln/detail/CVE-2026-25253).
+- **Calendar year:** 2026. CVE references like `CVE-2026-35625` are current-year identifiers, not fabricated. Verify any cited CVE in [NVD](https://nvd.nist.gov/vuln/detail/CVE-2026-35625).
 - **Package origin:** Published to PyPI by `Michael K. Saleme` (ORCID `0009-0003-6736-1900`). Source is public on GitHub. Five peer-reviewed Zenodo preprints back the methodology.
 - **License:** Apache 2.0 (permissive open source). No telemetry, no phone-home.
 - **Versioning:** Semantic. Latest is `4.4.2`; older bundles remain immutable on PyPI for reproducibility.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -104,7 +104,7 @@ Each corpus case references an executable harness test via `executable_test`:
 | `GM-xxx` | `protocol_tests/governance_modification_harness.py` |
 | `BI-xxx` | `protocol_tests/benchmark_integrity_harness.py` |
 | `MCP-xxx` | `protocol_tests/mcp_harness.py` |
-| `CVE-xxx` | `protocol_tests/cve_2026_25253_harness.py` |
+| `CVE-xxx` | `protocol_tests/mcp_tool_poisoning_harness.py` |
 | `L402-xxx` | `protocol_tests/l402_harness.py` |
 | `x402-xxx` | `protocol_tests/x402_harness.py` |
 

--- a/community_modules/examples/mcp_description_exfil.yaml
+++ b/community_modules/examples/mcp_description_exfil.yaml
@@ -1,5 +1,7 @@
 # Community Attack Pattern: MCP Tool Description Injection for Data Exfiltration
-# Based on CVE-2026-25253 - MCP Supply Chain Poisoning
+# Based on the MCP tool-poisoning attack class — Invariant Labs "Tool Poisoning
+# Attacks" research (2025); related real MCP supply-chain CVEs: CVE-2025-54136
+# (Cursor config swap RCE), CVE-2025-49596 (MCP Inspector missing-auth RCE).
 #
 # Attack scenario: A malicious MCP server publishes a tool whose description
 # contains hidden instructions that cause the LLM client to exfiltrate
@@ -13,14 +15,14 @@ id: CP-0002
 version: "1.0.0"
 name: MCP Tool Description Injection - Data Exfiltration
 description: >
-  Reproduces CVE-2026-25253 supply chain attack vector where a malicious MCP
-  server injects exfiltration instructions into tool descriptions. The LLM
+  Reproduces the MCP tool-poisoning supply-chain attack vector where a malicious
+  MCP server injects exfiltration instructions into tool descriptions. The LLM
   reads the poisoned description during tool discovery and unknowingly includes
   sensitive data in outbound requests.
 framework: mcp
 severity: critical
 owasp_category: OWASP-AGENT-05
-cve_reference: CVE-2026-25253
+cve_reference: MCP-TOOL-POISONING
 tags:
   - supply-chain
   - data-exfiltration
@@ -149,4 +151,5 @@ blue_team_mitigation: >
   4. Monitor for outbound requests containing sensitive data patterns (API key
   formats, JWT tokens, base64-encoded credentials).
   5. Pin tool versions and verify tool description hashes to detect tampering.
-  See CVE-2026-25253 advisory for full remediation guidance.
+  See the Invariant Labs "Tool Poisoning Attacks" research (2025) for full
+  remediation guidance.

--- a/docs/TEST-INVENTORY.md
+++ b/docs/TEST-INVENTORY.md
@@ -179,7 +179,7 @@ agent-security test enterprise --platform salesforce --url https://your-org.sale
 | **GTG-1002 APT Simulation** | 17 | Full Campaign | First documented AI-orchestrated cyber espionage |
 | **Advanced Attacks** | 10 | Multi-step | Polymorphic, stateful, multi-domain attack chains |
 | **Over-Refusal** | 25 | All protocols | False positive rate testing: legitimate requests that should NOT be blocked |
-| **Provenance & Attestation** | 15 | Supply Chain | Fake provenance, spoofed attestation, marketplace integrity ([CVE-2026-25253](https://nvd.nist.gov/vuln/detail/CVE-2026-25253)) |
+| **Provenance & Attestation** | 15 | Supply Chain | Fake provenance, spoofed attestation, marketplace integrity (Invariant Labs Tool Poisoning research, 2025) |
 | **Jailbreak** | 25 | Model/Agent | DAN variants, token smuggling, authority impersonation, persistence |
 | **Return Channel** | 8 | Output/Context | Return channel poisoning: output injection, ANSI escape, context overflow, encoded smuggling, structured data poisoning |
 | **Identity & Authorization** | 18 | NIST NCCoE | All 6 focus areas from NIST agent identity standards |
@@ -187,6 +187,6 @@ agent-security test enterprise --platform salesforce --url https://your-org.sale
 | **Harmful Output** | 10 | A2A JSON-RPC | Toxicity, bias, scope violations, deception (AIUC-1 C003/C004) |
 | **CBRN Prevention** | 8 | A2A JSON-RPC | Chemical/biological/radiological/nuclear content safeguards (AIUC-1 F002) |
 | **Incident Response** | 8 | A2A JSON-RPC | Alert triggering, kill switch, log completeness, recovery (AIUC-1 E001-E003) |
-| **[CVE-2026-25253](https://nvd.nist.gov/vuln/detail/CVE-2026-25253) Reproduction** | 8 | MCP Supply Chain | Nested schema injection, fork fingerprinting, marketplace contamination, encoded payload detection |
+| **MCP Tool Poisoning Reproduction** | 8 | MCP Supply Chain | Nested schema injection, fork fingerprinting, marketplace contamination, encoded payload detection (Invariant Labs Tool Poisoning, 2025; ClawHub RFC #99) |
 | **AIUC-1 Compliance** | 12 | Agent Safety | Incident response, CBRN prevention, harmful content, scope creep, authority impersonation |
 | **Cloud Agent Platforms** | 25 | Platform APIs | AWS Bedrock, Azure AI Agent Service, Google Vertex, Salesforce Agentforce, IBM watsonx |

--- a/docs/blog/gateway-attacks-methodology.md
+++ b/docs/blog/gateway-attacks-methodology.md
@@ -164,7 +164,7 @@ We welcome contributions, especially from teams building MCP-aware proxies or in
 1. Saleme, M. (2026). "Decision Load Index: A Quantitative Framework for Agent Autonomy Risk." Zenodo. [https://doi.org/10.5281/zenodo.18217577](https://doi.org/10.5281/zenodo.18217577)
 2. Saleme, M. (2026). "Normalization of Deviance in Autonomous Agent Systems." Zenodo. [https://doi.org/10.5281/zenodo.15105866](https://doi.org/10.5281/zenodo.15105866)
 3. Saleme, M. (2026). "Cognitive Style Governance for Multi-Agent Deployments." Zenodo. [https://doi.org/10.5281/zenodo.15106553](https://doi.org/10.5281/zenodo.15106553)
-4. CVE-2026-25253. "MCP Tool Injection via Compromised Upstream Server." [https://nvd.nist.gov/vuln/detail/CVE-2026-25253](https://nvd.nist.gov/vuln/detail/CVE-2026-25253)
+4. Invariant Labs. "Tool Poisoning Attacks." (2025). Related MCP supply-chain CVEs: CVE-2025-54136 (Cursor — malicious MCP config swap → RCE) [https://nvd.nist.gov/vuln/detail/CVE-2025-54136](https://nvd.nist.gov/vuln/detail/CVE-2025-54136); CVE-2025-49596 (MCP Inspector — missing authentication → RCE) [https://nvd.nist.gov/vuln/detail/CVE-2025-49596](https://nvd.nist.gov/vuln/detail/CVE-2025-49596)
 5. AIUC-1. "AI Use Case 1: Pre-Certification Requirements for Autonomous Agent Systems." [https://aiuc.dev](https://aiuc.dev)
 6. Anthropic. "Model Context Protocol Specification." [https://spec.modelcontextprotocol.io](https://spec.modelcontextprotocol.io)
 7. Google. "Agent-to-Agent Protocol." [https://google.github.io/A2A](https://google.github.io/A2A)

--- a/docs/engagement/WEEKLY_HOOKS_2026-04-06.md
+++ b/docs/engagement/WEEKLY_HOOKS_2026-04-06.md
@@ -28,7 +28,7 @@ https://github.com/msaleme/red-team-blue-team-agent-fabric
 
 "The build pipeline is becoming the new front line" — this is exactly right, and it extends to AI agent tool registries.
 
-We reproduced CVE-2026-25253 (CVSS 8.8 MCP supply chain poisoning) with 8 dedicated tests: nested schema injection, tool fork fingerprinting, marketplace contamination scanning, cross-tool context leakage.
+We reproduced the MCP tool-poisoning attack class — anchored to the Invariant Labs Tool Poisoning research (2025) and ClawHub RFC #99 — with 8 dedicated tests: nested schema injection, tool fork fingerprinting, marketplace contamination scanning, cross-tool context leakage.
 
 The same attack pattern hitting npm (Axios) is already targeting MCP tool descriptions and agent card metadata. We published a full provenance & attestation module (15 tests) for this attack surface.
 

--- a/docs/proposals/attestation-schema-proposal.md
+++ b/docs/proposals/attestation-schema-proposal.md
@@ -29,7 +29,7 @@ The agent protocol ecosystem (MCP, A2A, L402, x402) is growing rapidly, but ther
 
 Three developments make standardization urgent:
 
-1. **CVE-2026-25253** (MCP Tool Injection via Compromised Upstream Server) demonstrated that MCP protocol attacks are real, not theoretical. Security testing must produce actionable, comparable evidence.
+1. **MCP tool-poisoning and supply-chain attacks are real, not theoretical.** The Invariant Labs "Tool Poisoning Attacks" research (2025) documented instruction poisoning of MCP tool descriptions, and real MCP supply-chain CVEs followed — **CVE-2025-54136** (Cursor: RCE by swapping an already-trusted MCP config file for a malicious command) and **CVE-2025-49596** (MCP Inspector: RCE via missing authentication). Security testing must produce actionable, comparable evidence.
 2. **AIUC-1 pre-certification** requires documented evidence of adversarial testing (B001), tool call restriction testing (D003), and third-party tool call testing (D004). A standard format enables automated compliance checking.
 3. **Multi-vendor convergence** - multiple teams are building agent security testing tools. Without a common output format, the ecosystem fragments before it matures.
 
@@ -85,7 +85,7 @@ Each entry in the `entries` array represents a single test execution:
   },
   "remediation": {
     "description": "Validate tool lists against a pinned allowlist.",
-    "references": ["https://nvd.nist.gov/vuln/detail/CVE-2026-25253"],
+    "references": ["https://nvd.nist.gov/vuln/detail/CVE-2025-54136"],
     "priority": "immediate"
   },
   "timestamp": "2026-03-28T10:00:01Z",
@@ -326,7 +326,7 @@ The `schema_version` field uses semantic versioning. Consumers MUST reject repor
 
 1. Agent Security Harness Repository. [https://github.com/msaleme/red-team-blue-team-agent-fabric](https://github.com/msaleme/red-team-blue-team-agent-fabric)
 2. Attestation Report JSON Schema. [schemas/attestation-report.json](https://github.com/msaleme/red-team-blue-team-agent-fabric/blob/main/schemas/attestation-report.json)
-3. CVE-2026-25253. "MCP Tool Injection via Compromised Upstream Server." [https://nvd.nist.gov/vuln/detail/CVE-2026-25253](https://nvd.nist.gov/vuln/detail/CVE-2026-25253)
+3. Invariant Labs. "Tool Poisoning Attacks." (2025). Related MCP supply-chain CVEs: CVE-2025-54136 (Cursor — malicious MCP config swap → RCE) [https://nvd.nist.gov/vuln/detail/CVE-2025-54136](https://nvd.nist.gov/vuln/detail/CVE-2025-54136); CVE-2025-49596 (MCP Inspector — missing authentication → RCE) [https://nvd.nist.gov/vuln/detail/CVE-2025-49596](https://nvd.nist.gov/vuln/detail/CVE-2025-49596)
 4. Saleme, M. (2026). "Decision Load Index: A Quantitative Framework for Agent Autonomy Risk." Zenodo. DOI: [10.5281/zenodo.18217577](https://doi.org/10.5281/zenodo.18217577)
 5. Saleme, M. (2026). "Cognitive Style Governance for Multi-Agent Deployments." Zenodo. DOI: [10.5281/zenodo.15106553](https://doi.org/10.5281/zenodo.15106553)
 6. Saleme, M. (2026). "Normalization of Deviance in Autonomous Agent Systems." Zenodo. DOI: [10.5281/zenodo.15105866](https://doi.org/10.5281/zenodo.15105866)

--- a/protocol_tests/cli.py
+++ b/protocol_tests/cli.py
@@ -266,9 +266,9 @@ HARNESSES = {
         "module": "protocol_tests.incident_response_harness",
         "description": "Incident response validation tests (8 tests, AIUC-1 E001-E003)",
     },
-    "cve-2026-25253": {
-        "module": "protocol_tests.cve_2026_25253_harness",
-        "description": "CVE-2026-25253 reproduction suite (10 tests, MCP supply chain poisoning)",
+    "mcp-tool-poisoning": {
+        "module": "protocol_tests.mcp_tool_poisoning_harness",
+        "description": "MCP tool-poisoning reproduction suite (10 tests, Invariant Labs Tool Poisoning + ClawHub RFC #99; CVE-009/010 map to CVE-2026-35625/35629)",
     },
     "aiuc1": {
         "module": "protocol_tests.aiuc1_compliance_harness",

--- a/protocol_tests/mcp_tool_poisoning_harness.py
+++ b/protocol_tests/mcp_tool_poisoning_harness.py
@@ -1,21 +1,30 @@
 #!/usr/bin/env python3
-"""CVE-2026-25253 Reproduction Suite (v1.0)
+"""MCP Tool Poisoning Reproduction Suite (v1.0)
 
-Tests the MCP supply chain poisoning attack vector documented in CVE-2026-25253
-(CVSS 8.8, published March 2026). This CVE demonstrated that 12% of listed skills
-on a live MCP marketplace (341 out of ~2,800) contained malicious tool definitions
-that passed JSON-RPC schema validation.
+Tests the MCP tool-poisoning / supply-chain attack class: tools published or
+updated with poisoned descriptions that embed exfiltration instructions, prompt
+injection, or credential harvesting in nested schema fields (parameter
+descriptions, enum labels, example blocks) rather than the top-level
+tool.description.
 
-The attack chain: systematically forked/republished tools with poisoned descriptions
-that embed exfiltration instructions, prompt injection, or credential harvesting in
-nested schema fields (parameter descriptions, enum labels, example blocks).
+Anchor references for tests CVE-001..CVE-008:
+    - Invariant Labs, "Tool Poisoning Attacks" research disclosure (2025) — the
+      primary basis for nested-schema tool-description poisoning.
+    - ClawHub RFC #99 — the source of the 341-skill / 12%-of-registry figure,
+      used here only as a configurable detection threshold, not as a real-world
+      finding about any specific MCP marketplace.
 
-Key findings validated by this suite:
-    - 100% of prompt-injection payloads landed through nested schema fields, not
-      top-level tool.description
-    - 12% marketplace contamination rate across a production marketplace
-    - Forked tools with subtle modifications evaded manual review
-    - Encoded payloads (base64, unicode, homoglyphs) bypassed keyword detection
+Related real MCP supply-chain CVEs (cited as context — neither is "the"
+tool-poisoning CVE; both have accurate descriptions below):
+    - CVE-2025-54136 (Cursor): RCE by swapping an already-trusted MCP config
+      file for one that runs a malicious command.
+    - CVE-2025-49596 (MCP Inspector): RCE via missing authentication on the
+      Inspector server.
+
+The simulation uses a small, clearly synthetic set of clean and poisoned tool
+definitions (see CLEAN_TOOLS / POISONED_TOOLS below). Any counts or percentages
+reported in --simulate mode are properties of that synthetic fixture, not
+measurements of a production registry.
 
 Coverage:
     - CVE-001: Nested Schema Injection (ASI04)
@@ -29,33 +38,36 @@ Coverage:
     - CVE-009: Shared-Auth Scope Escalation — CVE-2026-35625 (ASI03)
     - CVE-010: Channel Extension SSRF — CVE-2026-35629 (ASI02)
 
+Note: test IDs CVE-001..CVE-010 are stable identifiers retained for continuity.
+Tests CVE-001..CVE-008 carry cve="MCP-TOOL-POISONING" (a tool-poisoning class
+tag, not a CVE number). Tests CVE-009 and CVE-010 map to real, verified CVEs.
+
 References:
-    - CVE-2026-25253: https://nvd.nist.gov/vuln/detail/CVE-2026-25253
-    - CVSS 8.8 (High): AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H
+    - Invariant Labs, "Tool Poisoning Attacks" (2025)
+    - ClawHub RFC #99 — 341 malicious skills / 12% of registry (configurable
+      detection threshold)
+    - CVE-2025-54136: https://nvd.nist.gov/vuln/detail/CVE-2025-54136
+      (Cursor — malicious MCP config swap → RCE)
+    - CVE-2025-49596: https://nvd.nist.gov/vuln/detail/CVE-2025-49596
+      (MCP Inspector — missing authentication → RCE)
     - OWASP Agentic Security: ASI04 (Tool/Agent Supply Chain)
-    - Affected: 135K+ MCP server instances, 12% marketplace contamination
-    - Coverage: Dark Reading, SecurityWeek, Cisco blogs, HackerNews (386pts)
     - CVE-2026-35625: https://nvd.nist.gov/vuln/detail/CVE-2026-35625
-    - CVSS 8.1 (High): Privilege escalation via silent shared-auth reconnect
-    - OWASP Agentic Security: ASI03 (Privilege/Authorization Escalation)
-    - Published: 2026-04-09 | Affects: OpenClaw shared-auth reconnect flow
+      OpenClaw shared-auth reconnect privilege escalation — ASI03 (CVE-009)
     - CVE-2026-35629: https://nvd.nist.gov/vuln/detail/CVE-2026-35629
-    - CVSS 8.6 (High): SSRF in OpenClaw channel extensions
-    - OWASP Agentic Security: ASI02 (Agent Execution Hijacking / SSRF)
-    - Published: 2026-04-10 | Affects: OpenClaw channel extension base URL handling
+      OpenClaw channel-extension SSRF — ASI02 (CVE-010)
 
 Usage:
     # Run in simulation mode (no live endpoint required)
-    python -m protocol_tests.cve_2026_25253_harness --simulate
+    python -m protocol_tests.mcp_tool_poisoning_harness --simulate
 
     # Test against a live MCP server
-    python -m protocol_tests.cve_2026_25253_harness --url http://localhost:8080/mcp
+    python -m protocol_tests.mcp_tool_poisoning_harness --url http://localhost:8080/mcp
 
     # Test against a marketplace/registry API
-    python -m protocol_tests.cve_2026_25253_harness --registry-url https://marketplace.example.com/api
+    python -m protocol_tests.mcp_tool_poisoning_harness --registry-url https://marketplace.example.com/api
 
     # Generate JSON report
-    python -m protocol_tests.cve_2026_25253_harness --simulate --report cve_report.json
+    python -m protocol_tests.mcp_tool_poisoning_harness --simulate --report mcp_tool_poisoning_report.json
 
 Requires: Python 3.10+, no external dependencies.
 """
@@ -460,11 +472,16 @@ def description_fingerprint(tool: dict) -> str:
 
 
 # ---------------------------------------------------------------------------
-# CVE-2026-25253 Test Suite
+# MCP Tool Poisoning Test Suite
 # ---------------------------------------------------------------------------
 
-class CVE202625253Tests:
-    """Reproduction tests for CVE-2026-25253 MCP supply chain poisoning."""
+class MCPToolPoisoningTests:
+    """Reproduction tests for MCP tool-poisoning / supply-chain attacks.
+
+    Anchored to the Invariant Labs Tool Poisoning research (2025) and ClawHub
+    RFC #99. Tests CVE-009/010 additionally cover the real OpenClaw CVEs
+    CVE-2026-35625 and CVE-2026-35629.
+    """
 
     def __init__(self, url: str | None = None, registry_url: str | None = None,
                  simulate: bool = False):
@@ -531,7 +548,7 @@ class CVE202625253Tests:
         self._record(CVETestResult(
             test_id="CVE-001",
             name="Nested Schema Injection Detection",
-            cve="CVE-2026-25253",
+            cve="MCP-TOOL-POISONING",
             owasp_asi="ASI04",
             severity=Severity.CRITICAL.value,
             passed=passed,
@@ -580,7 +597,7 @@ class CVE202625253Tests:
         self._record(CVETestResult(
             test_id="CVE-002",
             name="Tool Fork Fingerprinting",
-            cve="CVE-2026-25253",
+            cve="MCP-TOOL-POISONING",
             owasp_asi="ASI04",
             severity=Severity.HIGH.value,
             passed=passed,
@@ -617,18 +634,20 @@ class CVE202625253Tests:
         n_bad = len(contaminated)
         rate = (n_bad / total * 100) if total > 0 else 0.0
 
-        # CVE-2026-25253 found 12% contamination. Flag if rate > 5%
+        # Flag if the synthetic-fixture contamination rate exceeds 5%. The 12%
+        # reference below is a ClawHub RFC #99-derived configurable threshold
+        # (341 malicious skills / 12% of registry), not a CVE finding.
         passed = rate < 5.0
 
         self._record(CVETestResult(
             test_id="CVE-003",
             name="Marketplace Contamination Rate",
-            cve="CVE-2026-25253",
+            cve="MCP-TOOL-POISONING",
             owasp_asi="ASI04",
             severity=Severity.CRITICAL.value,
             passed=passed,
             details=(f"Contamination rate: {rate:.1f}% ({n_bad}/{total} tools). "
-                     f"CVE-2026-25253 baseline: 12%. "
+                     f"ClawHub RFC #99 threshold: 12%. "
                      f"Contaminated: {[c['tool'] for c in contaminated]}"
                      if not passed
                      else f"Contamination rate: {rate:.1f}% ({n_bad}/{total} tools) - below 5% threshold"),
@@ -673,7 +692,7 @@ class CVE202625253Tests:
             self._record(CVETestResult(
                 test_id="CVE-004",
                 name="Cross-Tool Context Leakage",
-                cve="CVE-2026-25253",
+                cve="MCP-TOOL-POISONING",
                 owasp_asi="ASI06",
                 severity=Severity.CRITICAL.value,
                 passed=passed,
@@ -695,7 +714,7 @@ class CVE202625253Tests:
             self._record(CVETestResult(
                 test_id="CVE-004",
                 name="Cross-Tool Context Leakage",
-                cve="CVE-2026-25253",
+                cve="MCP-TOOL-POISONING",
                 owasp_asi="ASI06",
                 severity=Severity.CRITICAL.value,
                 passed=True,
@@ -751,7 +770,7 @@ class CVE202625253Tests:
         self._record(CVETestResult(
             test_id="CVE-004",
             name="Cross-Tool Context Leakage",
-            cve="CVE-2026-25253",
+            cve="MCP-TOOL-POISONING",
             owasp_asi="ASI06",
             severity=Severity.CRITICAL.value,
             passed=passed,
@@ -788,7 +807,7 @@ class CVE202625253Tests:
             self._record(CVETestResult(
                 test_id="CVE-005",
                 name="Supply Chain Signature Bypass",
-                cve="CVE-2026-25253",
+                cve="MCP-TOOL-POISONING",
                 owasp_asi="ASI04",
                 severity=Severity.HIGH.value,
                 passed=passed,
@@ -837,7 +856,7 @@ class CVE202625253Tests:
         self._record(CVETestResult(
             test_id="CVE-005",
             name="Supply Chain Signature Bypass",
-            cve="CVE-2026-25253",
+            cve="MCP-TOOL-POISONING",
             owasp_asi="ASI04",
             severity=Severity.HIGH.value,
             passed=passed,
@@ -888,7 +907,7 @@ class CVE202625253Tests:
         self._record(CVETestResult(
             test_id="CVE-006",
             name="Description Payload Encoding Detection",
-            cve="CVE-2026-25253",
+            cve="MCP-TOOL-POISONING",
             owasp_asi="ASI04",
             severity=Severity.HIGH.value,
             passed=passed,
@@ -995,7 +1014,7 @@ class CVE202625253Tests:
         self._record(CVETestResult(
             test_id="CVE-007",
             name="Incremental Poisoning Detection",
-            cve="CVE-2026-25253",
+            cve="MCP-TOOL-POISONING",
             owasp_asi="ASI04",
             severity=Severity.CRITICAL.value,
             passed=passed,
@@ -1042,7 +1061,7 @@ class CVE202625253Tests:
             self._record(CVETestResult(
                 test_id="CVE-008",
                 name="Marketplace Registry Integrity",
-                cve="CVE-2026-25253",
+                cve="MCP-TOOL-POISONING",
                 owasp_asi="ASI04",
                 severity=Severity.HIGH.value,
                 passed=passed,
@@ -1099,7 +1118,7 @@ class CVE202625253Tests:
         self._record(CVETestResult(
             test_id="CVE-008",
             name="Marketplace Registry Integrity",
-            cve="CVE-2026-25253",
+            cve="MCP-TOOL-POISONING",
             owasp_asi="ASI04",
             severity=Severity.HIGH.value,
             passed=passed,
@@ -1422,7 +1441,7 @@ class CVE202625253Tests:
     # ------------------------------------------------------------------
 
     def run_all(self, categories: list[str] | None = None) -> list[CVETestResult]:
-        """Run all CVE-2026-25253 tests."""
+        """Run all MCP tool-poisoning tests (plus CVE-009/010 OpenClaw CVEs)."""
         all_tests = [
             ("nested_injection", self.test_nested_schema_injection),
             ("fork_detection", self.test_tool_fork_fingerprinting),
@@ -1437,8 +1456,9 @@ class CVE202625253Tests:
         ]
 
         print(f"\n{'='*60}")
-        print(f"CVE-2026-25253 / CVE-2026-35625 / CVE-2026-35629 Reproduction Suite")
-        print(f"CVSS 8.8 / 8.1 / 8.6 | MCP Supply Chain + OpenClaw CVEs")
+        print(f"MCP Tool Poisoning Reproduction Suite")
+        print(f"Invariant Labs Tool Poisoning (2025) + ClawHub RFC #99")
+        print(f"CVE-009/010: OpenClaw CVE-2026-35625 / CVE-2026-35629")
         print(f"{'='*60}")
         mode = "SIMULATION" if self.simulate else f"LIVE ({self.url or self.registry_url})"
         print(f"Mode: {mode}")
@@ -1453,7 +1473,7 @@ class CVE202625253Tests:
                 self._record(CVETestResult(
                     test_id="CVE-ERR",
                     name=f"Error in {cat}",
-                    cve="CVE-2026-25253",
+                    cve="MCP-TOOL-POISONING",
                     owasp_asi="ASI04",
                     severity=Severity.MEDIUM.value,
                     passed=False,
@@ -1477,7 +1497,7 @@ class CVE202625253Tests:
 
 def main():
     parser = argparse.ArgumentParser(
-        description="CVE-2026-25253 Reproduction Suite - MCP Supply Chain Poisoning Tests"
+        description="MCP Tool Poisoning Reproduction Suite - MCP supply-chain / tool-poisoning tests"
     )
     parser.add_argument("--url", help="MCP server URL for live testing")
     parser.add_argument("--registry-url", help="Marketplace/registry API URL")
@@ -1503,7 +1523,7 @@ def main():
         if args.trials > 1:
             print(f"\n--- Trial {trial + 1}/{args.trials} ---")
 
-        suite = CVE202625253Tests(
+        suite = MCPToolPoisoningTests(
             url=args.url,
             registry_url=args.registry_url,
             simulate=args.simulate,
@@ -1513,10 +1533,12 @@ def main():
 
     if args.report:
         report = {
-            "harness": "CVE-2026-25253 Reproduction Suite",
+            "harness": "MCP Tool Poisoning Reproduction Suite",
             "version": "1.0.0",
-            "cve": "CVE-2026-25253",
-            "cvss": 8.8,
+            "attack_class": "MCP-TOOL-POISONING",
+            "anchor": "Invariant Labs Tool Poisoning (2025); ClawHub RFC #99",
+            "related_cves": ["CVE-2025-54136", "CVE-2025-49596",
+                             "CVE-2026-35625", "CVE-2026-35629"],
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "mode": "simulation" if args.simulate else "live",
             "trials": args.trials,

--- a/protocol_tests/provenance_harness.py
+++ b/protocol_tests/provenance_harness.py
@@ -2,8 +2,11 @@
 """Provenance & Tool Attestation Security Test Harness (v3.0)
 
 15 tests targeting fake provenance and attestation attacks against
-AI agent systems. Maps to OWASP ASI04 (Supply Chain) and
-references CVE-2026-25253 (Tool Attestation Bypass).
+AI agent systems. Maps to OWASP ASI04 (Supply Chain) and the MCP
+tool-poisoning attack class — anchored to the Invariant Labs "Tool
+Poisoning Attacks" research (2025); related real MCP supply-chain CVEs
+include CVE-2025-54136 (Cursor config swap RCE) and CVE-2025-49596
+(MCP Inspector missing-auth RCE).
 
 Usage:
     python -m protocol_tests.provenance_harness --url http://localhost:8080
@@ -132,7 +135,7 @@ class ProvenanceTestResult:
 # Provenance & Tool Attestation Test Suite
 # ---------------------------------------------------------------------------
 
-CVE_REF = "CVE-2026-25253"
+CVE_REF = "MCP-TOOL-POISONING"
 
 class ProvenanceTests:
     """15 tests targeting fake provenance and attestation attacks."""
@@ -745,7 +748,7 @@ class ProvenanceTests:
         print("PROVENANCE & TOOL ATTESTATION TEST SUITE v3.0")
         print(f"{'='*60}")
         print(f"Target: {self.url}")
-        print(f"CVE Reference: {CVE_REF}")
+        print(f"Attack Class: {CVE_REF}")
 
         for category, tests in test_map.items():
             print(f"\n[{category.upper().replace('_', ' ')}]")

--- a/protocol_tests/skill_security_harness.py
+++ b/protocol_tests/skill_security_harness.py
@@ -1158,7 +1158,7 @@ class SkillSecurityTests:
         print(f"Mode:       {mode_label}")
         print(f"Context:    341 malicious skills on ClawHub (12% of registry)")
         print(f"Threat:     Instruction-layer poisoning — rewrites agent goals,")
-        print(f"            not just tool outputs (one layer above CVE-2026-25253)")
+        print(f"            not just tool outputs (one layer above MCP tool-output poisoning)")
 
         for category, tests in test_map.items():
             print(f"\n[{category.upper().replace('_', ' ')}]")

--- a/scripts/count_tests.py
+++ b/scripts/count_tests.py
@@ -57,7 +57,7 @@ MODULE_NAMES = {
     "harmful_output_harness.py": "Harmful Output",
     "cbrn_harness.py": "CBRN Prevention",
     "incident_response_harness.py": "Incident Response",
-    "cve_2026_25253_harness.py": "CVE-2026-25253 Reproduction",
+    "mcp_tool_poisoning_harness.py": "MCP Tool Poisoning Reproduction",
     "aiuc1_compliance_harness.py": "AIUC-1 Compliance",
     "cloud_agent_harness.py": "Cloud Agent Platforms",
     "crewai_cve_harness.py": "CrewAI CVE Reproduction",

--- a/testing/test_code_quality.py
+++ b/testing/test_code_quality.py
@@ -35,7 +35,7 @@ class TestAllModulesImportable(unittest.TestCase):
         "protocol_tests.provenance_harness",
         "protocol_tests.over_refusal_harness",
         "protocol_tests.return_channel_harness",
-        "protocol_tests.cve_2026_25253_harness",
+        "protocol_tests.mcp_tool_poisoning_harness",
         "protocol_tests.aiuc1_compliance_harness",
         "protocol_tests.cloud_agent_harness",
         "protocol_tests.memory_harness",


### PR DESCRIPTION
Corrects a CVE misattribution in the MCP tool-poisoning suite, which was incorrectly anchored to CVE-2026-25253 — actually an unrelated OpenClaw WebSocket auto-connect vulnerability (OpenClaw before 2026.1.29 auto-connects to a gatewayUrl from a query string without prompting). The suite is re-anchored to the Invariant Labs "Tool Poisoning Attacks" research (2025) and ClawHub RFC #99, with fabricated statistics (CVSS score/vector, publication date, "135K+ instances", "12% of a ~2,800-tool marketplace", and invented media coverage) removed and the 341/12% figure re-attributed to its real source as a configurable detection threshold.

The module is renamed `cve_2026_25253_harness.py` → `mcp_tool_poisoning_harness.py` (CLI id `cve-2026-25253` → `mcp-tool-poisoning`). Test IDs CVE-001..CVE-010 are unchanged, and CVE-009/010 still map to the real CVE-2026-35625 / CVE-2026-35629. Related real MCP supply-chain CVEs (CVE-2025-54136, CVE-2025-49596) are cited with accurate descriptions.

All 51 code-quality tests pass; total test count unchanged at 540.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and naming/metadata corrections only; harness logic and test IDs are preserved, with a breaking CLI harness id change for anyone still using `cve-2026-25253`.
> 
> **Overview**
> **Fixes a CVE misattribution** in the MCP supply-chain reproduction suite: it was wrongly tied to **CVE-2026-25253** (an OpenClaw WebSocket issue), not MCP tool poisoning. The suite is now anchored to **Invariant Labs “Tool Poisoning Attacks” (2025)** and **ClawHub RFC #99**, with fabricated stats and bogus media claims removed; the 341-skill / 12% figure is documented only as a **configurable threshold**, not a marketplace measurement.
> 
> **Renames** `cve_2026_25253_harness.py` → `mcp_tool_poisoning_harness.py` and the CLI harness id **`cve-2026-25253` → `mcp-tool-poisoning`** (CI imports/list updated). Test IDs **CVE-001..CVE-010** stay the same; **CVE-001..CVE-008** now record `cve="MCP-TOOL-POISONING"` instead of the wrong CVE, while **CVE-009/010** still map to **CVE-2026-35625** / **CVE-2026-35629**. Related real MCP supply-chain CVEs (**CVE-2025-54136**, **CVE-2025-49596**) are cited in docs and reports.
> 
> **Docs and examples** (CHANGELOG 4.9.1, TEST-INVENTORY, CONTRIBUTING, community YAML, attestation proposal, benchmarks mapping, provenance/skill harness strings) are updated to match; **no change to total test count** (540).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7dfe3377d936c1e72ac896bbe35deb2c63bf968. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->