### PR TITLE
release: v4.9.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-security-harness"
-version = "4.9.0"
+version = "4.9.1"
 description = "540 security tests for AI agent systems - MCP, A2A, L402, x402, UCP/ACP merchant-journey, AP2 mandate + Fireblocks x402 hardening + Visa TAP / Mastercard Agentic Tokens + denial-of-settlement finality, decision governance, AIUC-1 compliance, NIST AI 800-2 aligned"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
Version bump to 4.9.1 to ship the CVE-2026-25253 correction (PR #235) to PyPI. Renames the MCP tool-poisoning suite, re-anchors it to Invariant Labs Tool Poisoning (2025) + ClawHub RFC #99, and removes fabricated statistics. Test IDs unchanged; 540 tests. Publishing via trusted-publishing on release.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-field metadata change with no code, dependency, or test modifications in the diff.
> 
> **Overview**
> **Release-only version bump** from `4.9.0` to `4.9.1` in `pyproject.toml` so the corrected MCP tool-poisoning work (CVE-2026-25253 misattribution fix from PR #235) can be published to PyPI via trusted publishing on release.
> 
> No application or test logic changes appear in this diff—only the semver patch increment. The project description still advertises **540** security tests and unchanged runtime dependencies (`pyyaml>=6.0`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e12a7cb88f90d3a62f0886c045bbd9bbf1a74e99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->