### PR TITLE
fix(ap2): AP2-014 is a provenance rule, not a determinism rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **AP2-014 signature-scheme rule corrected (was security-unsound).** The
+  Payment Mandate signature check rejected all "deterministic" schemes (including
+  Ed25519) with the rationale "replay risk." This was wrong: signature
+  determinism is not a replay vector (deterministic EdDSA/RFC-6979 exist to
+  remove nonce-reuse failure; replay is handled by AP2-011/012 jti and expiry),
+  and it wrongly rejected a standard, secure asymmetric scheme. The rule now
+  rejects symmetric keyed-MAC schemes (HMAC) for a Payment Mandate because they
+  carry no third-party-verifiable signer provenance, and accepts asymmetric
+  schemes regardless of determinism. AP2-014 reclassified normative N -> I
+  (inferred: standard payment-security practice, not mapped to a cited AP2
+  clause). Test count unchanged (AP2-014 retained).
+
 ### Added
 
 - **MCP-019: Composite / cross-tool description poisoning (ShareLock-class).**

--- a/protocol_tests/ap2_harness.py
+++ b/protocol_tests/ap2_harness.py
@@ -29,9 +29,12 @@ Mandate model (v0.2 — grounded in google-agentic-commerce/AP2 canonical files)
 The chain link is a hash: the Payment Mandate's ``transaction_id`` equals the
 Checkout Mandate's ``checkout_hash`` (= hash of the merchant `checkout_jwt`).
 Closed mandates bind to the presented open mandate via ``sd_hash`` and to the
-agent key via the open mandate's ``cnf`` claim. Payment Mandates MUST use a
-non-deterministic signature scheme (ECDSA), NOT a deterministic one (Ed25519),
-to resist replay.
+agent key via the open mandate's ``cnf`` claim. A Payment Mandate must carry an
+asymmetric, third-party-verifiable signature (ECDSA, EdDSA, RSA) so the payer's
+authorization is non-repudiable; a symmetric keyed-MAC scheme (e.g. HMAC) is
+rejected because it provides no signer provenance. (This is a provenance
+requirement, not a determinism one: deterministic asymmetric schemes such as
+EdDSA are fine. Replay is handled separately by jti/nonce and expiry.)
 
 Reference-verifier note (honesty): production uses SD-JWT / VC signatures over
 ES256 keys. To keep this harness stdlib-only (the repo's zero-extra-dependency
@@ -99,8 +102,10 @@ def canonical_hash(obj) -> str:
 # Reference mandate verifier
 # ---------------------------------------------------------------------------
 
-#: Deterministic signature schemes AP2 forbids for Payment Mandates.
-_DETERMINISTIC_SCHEMES = {"ed25519", "eddsa", "rsassa-pkcs1", "hmac"}
+#: Symmetric / keyed-MAC schemes rejected for Payment Mandates: they carry no
+#: signer provenance, so the payer's authorization is not third-party verifiable.
+#: Asymmetric schemes (ECDSA, EdDSA, RSA) are accepted regardless of determinism.
+_NON_PROVENANCE_SCHEMES = {"hmac", "hs256", "hs384", "hs512"}
 
 
 @dataclass
@@ -202,10 +207,11 @@ class AP2Verifier:
             return VerifyOutcome(False, "payment amount does not match bound checkout total")
         if payment.get("payee", {}).get("id") != cart.get("merchant"):
             return VerifyOutcome(False, "payee does not match bound checkout merchant")
-        # 4. signature scheme: Payment Mandate MUST be non-deterministic (ECDSA).
+        # 4. signature scheme: a Payment Mandate needs asymmetric, third-party-
+        #    verifiable provenance; symmetric keyed-MAC schemes carry none.
         scheme = str(payment.get("sig_scheme", "")).lower()
-        if scheme in _DETERMINISTIC_SCHEMES:
-            return VerifyOutcome(False, f"deterministic signature scheme '{scheme}' forbidden (replay risk)")
+        if scheme in _NON_PROVENANCE_SCHEMES:
+            return VerifyOutcome(False, f"symmetric/keyed-MAC scheme '{scheme}' lacks signer provenance")
         # 5. authorization presence.
         if human_present and not payment.get("user_authorization"):
             return VerifyOutcome(False, "missing user signature on Payment Mandate (human-present)")
@@ -689,25 +695,30 @@ class AP2MandateTests:
 
     # -- AP2-014: deterministic signature ---------------------------------
 
-    def test_ap2_014_deterministic_signature(self) -> None:
-        """AP2-014: Deterministic signature scheme rejected (HIGH).
+    def test_ap2_014_symmetric_signature(self) -> None:
+        """AP2-014: Symmetric / keyed-MAC payment signature rejected (HIGH).
 
-        Payment Mandates MUST use a non-deterministic scheme (ECDSA); a
-        deterministic one (Ed25519) MUST be rejected (replay resistance).
+        A Payment Mandate needs an asymmetric, third-party-verifiable signature so
+        the payer's authorization is non-repudiable. A symmetric keyed-MAC scheme
+        (HMAC) carries no signer provenance and must be rejected. Signature
+        determinism is NOT the criterion: asymmetric EdDSA is deterministic and
+        acceptable, and replay is handled by AP2-011/012 (jti/nonce, expiry).
+        Marked inferred (I): provenance is standard payment-security practice; we
+        have not mapped it to a specific normative AP2 clause.
         """
         t0 = time.monotonic()
         now = self._now()
         openm, checkout, payment = _valid_chain(now)
-        payment["sig_scheme"] = "ed25519"
+        payment["sig_scheme"] = "hmac"
         v = AP2Verifier().verify_payment(checkout, payment, now)
         self._finish(
-            test_id="AP2-014", name="Deterministic Signature Scheme",
+            test_id="AP2-014", name="Symmetric/Keyed-MAC Signature Scheme",
             category="crypto", mandate="PaymentMandate",
-            owasp="ASI03", stride="Tampering", severity=Severity.HIGH.value,
-            ref="AP2: PaymentMandate MUST use non-deterministic sig (not Ed25519)", normative="N",
-            model_pass=(not v.ok and "deterministic" in v.reason),
-            model_reason=(f"deterministic scheme rejected ({v.reason})" if not v.ok else
-                          "WEAK CRYPTO — a deterministic (Ed25519) payment signature was accepted"),
+            owasp="ASI03", stride="Repudiation", severity=Severity.HIGH.value,
+            ref="Payment-security practice: PaymentMandate needs asymmetric, non-repudiable signature", normative="I",
+            model_pass=(not v.ok and "provenance" in v.reason),
+            model_reason=(f"symmetric/keyed-MAC scheme rejected ({v.reason})" if not v.ok else
+                          "WEAK CRYPTO — a symmetric (HMAC) payment signature was accepted"),
             attack_payload={"payment_mandate": payment, "checkout_mandate": checkout}, t0=t0)
 
     # -- AP2-015: funding-instrument scope --------------------------------
@@ -825,7 +836,7 @@ class AP2MandateTests:
             self.test_ap2_011_payment_replay,
             self.test_ap2_012_expired_mandate,
             self.test_ap2_013_double_spend,
-            self.test_ap2_014_deterministic_signature,
+            self.test_ap2_014_symmetric_signature,
             self.test_ap2_015_funding_scope,
             self.test_ap2_016_premature_credential_release,
             self.test_ap2_017_vct_mismatch,

--- a/testing/test_code_quality.py
+++ b/testing/test_code_quality.py
@@ -451,11 +451,18 @@ class TestRegAP2(unittest.TestCase):
         self.assertTrue(v.verify_payment(checkout, payment, 1000).ok)
         self.assertFalse(v.verify_payment(checkout, payment, 1000).ok)
 
-    def test_deterministic_signature_rejected(self):
+    def test_symmetric_signature_rejected_asymmetric_accepted(self):
+        # A Payment Mandate needs asymmetric, non-repudiable provenance. Symmetric
+        # keyed-MAC (HMAC) is rejected; asymmetric schemes (incl. deterministic
+        # EdDSA) are accepted — determinism is not the criterion.
         from protocol_tests.ap2_harness import _valid_chain, AP2Verifier
         openm, checkout, payment = _valid_chain(1000)
-        payment["sig_scheme"] = "ed25519"
+        payment["sig_scheme"] = "hmac"
         self.assertFalse(AP2Verifier().verify_payment(checkout, payment, 1000).ok)
+        openm2, checkout2, payment2 = _valid_chain(1000)
+        payment2["sig_scheme"] = "ed25519"
+        self.assertTrue(AP2Verifier().verify_payment(checkout2, payment2, 1000).ok,
+                        "asymmetric EdDSA must be accepted; determinism is not the criterion")
 
     def test_funding_scope_binding(self):
         from protocol_tests.ap2_harness import _valid_chain, AP2Verifier


### PR DESCRIPTION
## Problem

AP2-014 rejected any "deterministic" Payment Mandate signature scheme (its set included `ed25519`, `eddsa`, `rsassa-pkcs1`) with the rationale **"replay risk"**, marked as a normative AP2 MUST.

This is security-unsound:
- **Determinism is not a replay vector.** Deterministic asymmetric signatures (EdDSA, RFC-6979 ECDSA) were designed specifically to remove the catastrophic nonce-reuse failure of randomized ECDSA. Message replay is prevented by `jti`/nonce and expiry, already covered by AP2-011 and AP2-012.
- It **wrongly rejected Ed25519**, a standard, secure asymmetric scheme.
- The normative "AP2 forbids Ed25519" claim was not mapped to any AP2 clause.

## Fix

Rejection is now based on the real property: a Payment Mandate needs an **asymmetric, third-party-verifiable signature** so the payer's authorization is non-repudiable. Symmetric keyed-MAC schemes (HMAC) lack signer provenance and are rejected; asymmetric schemes are accepted regardless of determinism.

- `_DETERMINISTIC_SCHEMES` -> `_NON_PROVENANCE_SCHEMES` (`{hmac, hs256, hs384, hs512}`)
- `verify_payment` reason: "symmetric/keyed-MAC scheme '…' lacks signer provenance"
- AP2-014 renamed to "Symmetric/Keyed-MAC Signature Scheme"; STRIDE Tampering -> Repudiation; normative **N -> I** (inferred: standard payment-security practice, not a cited AP2 clause); attack payload `ed25519` -> `hmac`
- `test_code_quality` guard now asserts HMAC is rejected **and** EdDSA is accepted

## Verification
- `ed25519` now accepted; `hmac` rejected with the provenance reason
- AP2 suite 17/17; `test_code_quality` + `test_vsr03_verdict_correctness` 78 OK; count unchanged (542)

Surfaced during external peer review of the accompanying methodology writeup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes payment-mandate acceptance policy in the AP2 reference verifier (Ed25519 now allowed; HMAC rejected), which could alter simulate/live verdicts for integrators that relied on the old rule.
> 
> **Overview**
> **AP2-014** no longer treats “deterministic” Payment Mandate signatures (including Ed25519) as a replay risk. The reference verifier now rejects only **symmetric keyed-MAC** schemes (`hmac`, `hs256`, etc.) that lack third-party signer provenance, and accepts asymmetric schemes regardless of determinism.
> 
> `verify_payment`, module docs, and `_NON_PROVENANCE_SCHEMES` replace the old `_DETERMINISTIC_SCHEMES` logic and error text. The harness test uses **HMAC** as the attack, renames to symmetric/keyed-MAC, shifts STRIDE to **Repudiation**, and marks the rule **normative I** (inferred). `test_code_quality` asserts HMAC is rejected and **Ed25519** is accepted. **CHANGELOG** documents the security fix; test count stays at 542.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5702b05cb58a19d674d083fcf2baf3f4053b9d80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->