### PR TITLE
docs: related-work page (AgentThread/AgentRFC + adjacent research)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ The [constitutional-agent](https://github.com/CognitiveThoughtEngine/constitutio
 | MCP Server | [docs/mcp-server.md](docs/mcp-server.md) |
 | CI/CD GitHub Action | [docs/github-action.md](docs/github-action.md) |
 | Payment Attack Taxonomy | [docs/PAYMENT-ATTACK-TAXONOMY.md](docs/PAYMENT-ATTACK-TAXONOMY.md) |
+| Related Work | [docs/RELATED-WORK.md](docs/RELATED-WORK.md) |
 | Comparison (detailed) | [docs/COMPARISON.md](docs/COMPARISON.md) |
 | Privacy & Telemetry | [docs/PRIVACY.md](docs/PRIVACY.md) |
 

--- a/docs/RELATED-WORK.md
+++ b/docs/RELATED-WORK.md
@@ -1,0 +1,25 @@
+# Related work
+
+This harness performs executable adversarial testing at the implementation and evidence surface of agent protocols: it sends real adversarial payloads and negative vectors and checks whether an implementation makes the correct accept/reject decision. It is complementary to formal-conformance, capability-binding, and delegation-protocol research, not a substitute for it. This page cites the closest work and states, honestly, where this project overlaps and where it differs.
+
+## Formal conformance for agent protocols
+
+- **AgentThread — "Formal Security Analysis of Agent Protocol Composition"** (Shenghan Zheng, Qifan Zhang, Zheng Zhang, Haonan Li, Christophe Hauser; arXiv:2606.28690, 2026), and its predecessor **AgentRFC / AgentConform** (Shenghan Zheng, Qifan Zhang; arXiv:2603.23801, 2026).
+
+  AgentThread compiles protocol specifications into TLA+ models, model-checks them against security invariants, and replays counterexamples against production SDKs through hand-written protocol adapters. It contributes a layered security scope (including an L5 audit/accountability layer), a Responsibility IR that tracks who owns each control and whether the SDK enforces it, 80 implementation tests across five protocols, and composition-only failures.
+
+  **Relationship.** AgentThread is the nearest work and is complementary. It formalizes protocol invariants and localizes responsibility. This harness works one boundary down, at the evidence artifact: it asks what an action *receipt* is entitled to prove. Its receipt-claim decomposition (integrity/provenance, occurrence, authorization, check execution/integrity) and its executable negative vectors — which construct schema-valid, correctly signed receipts whose claims are not semantically supported and show a claim-level verifier rejecting them — could serve as concrete oracle cases for adapter-level tests of audit/provenance continuity. This project does not compete on formalization or protocol coverage.
+
+## Capability binding and delegation
+
+- **Governing Dynamic Capabilities** (Ziling Zhou; arXiv:2603.14332, 2026) — capability integrity, behavioral verifiability, and interaction auditability, with cryptographic instantiations and replay-based verification. Covers much of the capability-binding and behavioral-verification ground; this project does not restate it and claims no priority over it.
+- **AIP: Agent Identity Protocol for Verifiable Delegation Across MCP and A2A** (Sunil Prakash; arXiv:2603.24775, 2026) — invocation-bound capability tokens with a 600-attempt adversarial evaluation. AIP is a delegation protocol to be conformance-tested; this harness's vectors are agnostic to the delegation scheme.
+
+## Attack primitives this harness exercises
+
+- **ShareLock: A Stealthy Multi-Tool Threshold Poisoning Attack Against MCP** (arXiv:2606.27027, 2026) — cryptographic secret-sharing of a payload across tool descriptions. MCP-019 implements a *split-payload composition* test **inspired by** ShareLock (readable-fragment reconstruction), not a reproduction of threshold sharing; see the test's docstring for the exact scope.
+- **WebMCP Tool Surface Poisoning** (arXiv:2606.06387, 2026) — mid-session tool injection (MSTI) and the case for invocation-time identity checks. MCP-020 is a snapshot-differencing test for one observable class of unbound rebinding; it does not provide invocation-time revalidation.
+
+## Static MCP scanners (complementary layer)
+
+Static description scanners (e.g. Invariant MCP-Scan, Cisco MCP Scanner) inspect tool descriptions and configuration. They are a complementary static layer; this harness adds active, wire-protocol adversarial testing and claim-level receipt verification. Use both.


### PR DESCRIPTION
Adds `docs/RELATED-WORK.md` positioning the harness as executable adversarial testing complementary to formal-conformance and capability-binding research, citing AgentThread (all five authors), AgentRFC, Governing Dynamic Capabilities, AIP, ShareLock, and WebMCP/MSTI. States overlaps and differences honestly, no priority claims. This is the 'value before ask' step ahead of researcher-to-researcher outreach. Docs-only; no test-count change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, security logic, or test inventory impact.
> 
> **Overview**
> Adds **`docs/RELATED-WORK.md`**, a documentation-only page that positions the harness as **executable adversarial testing** at the implementation/evidence layer, explicitly **complementary** to formal conformance, capability binding, and static MCP scanning—not a substitute.
> 
> The page cites **AgentThread / AgentRFC**, **Governing Dynamic Capabilities**, **AIP**, **ShareLock**, and **WebMCP/MSTI**, and maps them to existing harness ideas (receipt-claim verification, **MCP-019** / **MCP-020**) with honest scope limits (e.g., ShareLock-inspired composite test, MSTI snapshot differencing without invocation-time revalidation).
> 
> **README** gains a **Related Work** row in the documentation table linking to the new page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51620c8248ad286ca2a67152de64c18964e15da6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->