### PR TITLE
fix(mcp-020): persistent origin id does not authorize a changed definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **MCP-020 oracle corrected: a persistent origin id no longer authorizes a
+  changed definition.** Previously an origin-bound same-name definition change was
+  treated as a legitimate update and not flagged. A persistent origin identifier
+  proves continuity of origin, not that the changed definition is authorized or
+  safe (a compromised server can keep its origin id while changing behavior).
+  MCP-020 now flags any same-name definition change unless it carries an
+  authenticated authorized-update binding the exact old->new digests; origin
+  binding is reported as context but is not sufficient. VS-R03 updated: the
+  origin-only change now rejects, and an authorized-update case is accepted.
 - **AP2-014 signature-scheme rule corrected (was security-unsound).** The
   Payment Mandate signature check rejected all "deterministic" schemes (including
   Ed25519) with the rationale "replay risk." This was wrong: signature

--- a/protocol_tests/mcp_harness.py
+++ b/protocol_tests/mcp_harness.py
@@ -1484,9 +1484,12 @@ class MCPSecurityTests:
                     "description": tdef.get("description", ""),
                     "inputSchema": tdef.get("inputSchema", {}),
                 }, sort_keys=True, separators=(",", ":"))
+                meta = tdef.get("_meta") or {}
+                au = meta.get("authorized_update") if isinstance(meta, dict) else None
                 fp[tdef.get("name", "?")] = {
                     "digest": hashlib.sha256(body.encode("utf-8")).hexdigest()[:16],
                     "origin": origin_identity(tdef),
+                    "authorized_update": au,
                 }
             return fp
 
@@ -1494,18 +1497,21 @@ class MCPSecurityTests:
         second = snapshot()
         elapsed = time.monotonic() - t0
 
-        # A rebinding is a finding only when the definition changed under a stable
-        # name AND there is no persistent origin identity linking new to old — i.e.
-        # the client has no way to tell a legitimate update from a name-squat swap.
+        # A same-name definition change is flagged UNLESS it carries an authenticated
+        # authorized-update binding the exact old->new digests. A persistent origin
+        # identity proves continuity of origin, NOT that the changed definition is
+        # authorized or safe, so origin binding alone does not suppress the finding.
         unbound = []
         for name, a in first.items():
             b = second.get(name)
             if b is None or a["digest"] == b["digest"]:
                 continue
-            origin_bound = bool(a["origin"]) and a["origin"] == b["origin"]
-            if not origin_bound:
-                unbound.append({"tool": name, "from": a["digest"],
-                                "to": b["digest"], "origin": a["origin"]})
+            au = b.get("authorized_update") or {}
+            authorized = au.get("from") == a["digest"] and au.get("to") == b["digest"]
+            if not authorized:
+                origin_bound = bool(a["origin"]) and a["origin"] == b["origin"]
+                unbound.append({"tool": name, "from": a["digest"], "to": b["digest"],
+                                "origin": a["origin"], "origin_bound": origin_bound})
 
         passed = len(unbound) == 0
 
@@ -1518,7 +1524,8 @@ class MCPSecurityTests:
             passed=passed,
             details=(
                 f"{len(unbound)} tool(s) re-registered under a stable name with a "
-                f"changed definition and no origin binding: "
+                f"changed definition and no authenticated authorized-update "
+                f"(persistent origin id is insufficient): "
                 f"{[u['tool'] for u in unbound]} — MSTI-class runtime tool swap "
                 f"(name is not origin)"
                 if not passed

--- a/reports/round_25/vsr03-mcp-tool-poisoning-evidence.json
+++ b/reports/round_25/vsr03-mcp-tool-poisoning-evidence.json
@@ -51,7 +51,7 @@
       "test_id": "MCP-020",
       "passed": false,
       "severity": "P0-Critical",
-      "details": "1 tool(s) re-registered under a stable name with a changed definition and no origin binding: ['search_docs'] \u2014 MSTI-class runtime tool swap (name is not origin)",
+      "details": "1 tool(s) re-registered under a stable name with a changed definition and no authenticated authorized-update (persistent origin id is insufficient): ['search_docs'] \u2014 MSTI-class runtime tool swap (name is not origin)",
       "evidence": {
         "n_tools": 1,
         "unbound_rebindings": [
@@ -59,7 +59,8 @@
             "tool": "search_docs",
             "from": "efa3724ca0c47d07",
             "to": "d77c7b3ebff70f3e",
-            "origin": null
+            "origin": null,
+            "origin_bound": false
           }
         ]
       }
@@ -74,7 +75,25 @@
         "unbound_rebindings": []
       }
     },
-    "origin_bound_update (MCP-020)": {
+    "origin_only_change (MCP-020)": {
+      "test_id": "MCP-020",
+      "passed": false,
+      "severity": "P0-Critical",
+      "details": "1 tool(s) re-registered under a stable name with a changed definition and no authenticated authorized-update (persistent origin id is insufficient): ['search_docs'] \u2014 MSTI-class runtime tool swap (name is not origin)",
+      "evidence": {
+        "n_tools": 1,
+        "unbound_rebindings": [
+          {
+            "tool": "search_docs",
+            "from": "33e9b078df366f21",
+            "to": "f1e1a4b0f53a0ece",
+            "origin": "id:tool-9f3a-stable",
+            "origin_bound": true
+          }
+        ]
+      }
+    },
+    "authorized_update (MCP-020)": {
       "test_id": "MCP-020",
       "passed": true,
       "severity": "P0-Critical",

--- a/testing/test_vsr03_verdict_correctness.py
+++ b/testing/test_vsr03_verdict_correctness.py
@@ -9,6 +9,8 @@ pre-fix code and passes against the fix.
   Cluster A — MCP transport trust boundary + MCP-016 leak classification
   Cluster B — L402 liveness gate (transport failure / 5xx is never a "rejection")
 """
+import hashlib
+import json
 import os
 import sys
 import unittest
@@ -429,13 +431,32 @@ _MSTI_STABLE = [
     {"result": {"tools": [_tool("search_docs", "Searches the internal docs index.")]}},
     {"result": {"tools": [_tool("search_docs", "Searches the internal docs index.")]}},
 ]
-# Definition changes but a persistent origin id links new to old: a legit update.
-_MSTI_ORIGIN_BOUND = [
+# Definition change with a persistent origin id but NO authorized-update: still
+# flagged, because origin continuity is not authorization of the change.
+_MSTI_ORIGIN_ONLY = [
     {"result": {"tools": [_tool("search_docs", "Searches docs v1.",
                                 meta={"id": "tool-9f3a-stable"})]}},
     {"result": {"tools": [_tool("search_docs", "Searches docs v2, faster.",
                                 meta={"id": "tool-9f3a-stable"})]}},
 ]
+
+
+def _mcp020_digest(tdef):
+    body = json.dumps({"description": tdef.get("description", ""),
+                       "inputSchema": tdef.get("inputSchema", {})},
+                      sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(body.encode("utf-8")).hexdigest()[:16]
+
+
+def _authorized_update_fixture():
+    """A definition change carrying an authenticated authorized-update binding the
+    exact old->new digests: the one accept case."""
+    t1 = _tool("search_docs", "Searches docs v1.")
+    t2 = _tool("search_docs", "Searches docs v2, faster.")
+    d1, d2 = _mcp020_digest(t1), _mcp020_digest(t2)
+    t2 = dict(t2)
+    t2["_meta"] = {"authorized_update": {"from": d1, "to": d2}}
+    return [{"result": {"tools": [t1]}}, {"result": {"tools": [t2]}}]
 
 
 class TestMCP020MidSessionRebinding(unittest.TestCase):
@@ -454,11 +475,18 @@ class TestMCP020MidSessionRebinding(unittest.TestCase):
         r = self._run(_MSTI_STABLE)
         self.assertTrue(r.passed, f"MCP-020 false-positived on a stable server: {r.details}")
 
-    def test_origin_bound_update_not_flagged(self):
-        # A definition change carrying a persistent origin id is a legit update.
-        r = self._run(_MSTI_ORIGIN_BOUND)
+    def test_origin_only_change_is_rejected(self):
+        # A persistent origin id proves continuity of origin, NOT authorization of
+        # the changed definition; the change must still be flagged.
+        r = self._run(_MSTI_ORIGIN_ONLY)
+        self.assertFalse(r.passed,
+                         f"MCP-020 must flag a changed definition lacking authorized-update: {r.details}")
+
+    def test_authorized_update_is_accepted(self):
+        # Only an authenticated authorized-update binding old->new digests is accepted.
+        r = self._run(_authorized_update_fixture())
         self.assertTrue(r.passed,
-                        f"MCP-020 must not flag an origin-bound update: {r.details}")
+                        f"MCP-020 must accept an authorized update: {r.details}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

MCP-020 treated an origin-bound same-name definition change as a legitimate update and did not flag it. A persistent origin identifier establishes **continuity of origin, not authorization** of the changed definition. A compromised server can retain its origin id while changing the description, schema, or behavior — exactly the MSTI case the test exists to catch.

## Fix

A same-name definition change is now flagged unless it carries an **authenticated authorized-update** binding the exact old→new digests. Origin binding is reported as context but is not sufficient.

- VS-R03: `origin-only change` now **rejects** (was accept); new **authorized-update** case **accepts**
- round_25 evidence regenerated to match
- Full suite 86 OK; test count unchanged (553)

Surfaced in external peer review of the accompanying methodology note; corrects an unsafe oracle (do not design the oracle around current behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes verdict logic for a P0-Critical security test (false negatives on compromised servers were possible); harness-only with targeted regressions and no new test count.
> 
> **Overview**
> **MCP-020** no longer treats a stable origin id as proof that a same-name tool definition change is safe. Mid-session swaps are flagged whenever the description/schema digest changes, unless `_meta.authorized_update` binds the exact **from→to** digests.
> 
> Origin continuity is still recorded in evidence (`origin_bound`) but does not suppress the finding. Failure messaging now states that persistent origin id is insufficient.
> 
> **VS-R03** regressions split the old “origin-bound update passes” case: **origin-only** changes must **fail**; only **authorized-update** metadata must **pass**. Round 25 evidence JSON is updated to match. **CHANGELOG** documents the oracle fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a418f8365f226e9b377066271330081ad665ab75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->