### PR TITLE
docs(ed25519): correct docstring (no RFC message-vector interop claim)

### DIFF
--- a/protocol_tests/_ed25519.py
+++ b/protocol_tests/_ed25519.py
@@ -6,9 +6,13 @@ provenance* (a verifier holding only public keys; a party unable to forge anothe
 authority's signature) without an external dependency, honoring the repo's
 zero-extra-dependency guarantee for ``protocol_tests``.
 
-This is the RFC 8032 reference construction. It is NOT constant-time and is
-intended for test/reference use, not production signing. Verified against the
-RFC 8032 Test-1 known-answer vector in the test suite.
+This follows the RFC 8032 Ed25519 construction and parameters. It is NOT
+constant-time and is intended for test/reference use, not production signing.
+The test suite validates the curve parameters (canonical base-point encoding and
+prime subgroup order) and the signature properties this harness relies on
+(determinism, tamper detection, and cross-key unforgeability). It is NOT
+checked for byte-level interoperability against the RFC 8032 message test
+vectors, and is not a substitute for a maintained cryptographic library.
 
 API:
     secret_to_public(seed32) -> pub32


### PR DESCRIPTION
The receipt harness's Ed25519 reference follows the RFC 8032 construction and passes curve-parameter checks (canonical base point, subgroup order) and signature-property checks (determinism, tamper detection, cross-key unforgeability). However, the verifier does not accept the RFC 8032 Test-1 signature, so byte-level interoperability with the RFC message test vectors is **not** demonstrated.

Corrects an inaccurate docstring line that claimed 'verified against the RFC 8032 Test-1 known-answer vector.' Test-only; not a substitute for a maintained cryptographic library. The asymmetric-provenance property the receipt experiment relies on (an authority cannot forge another's signature) holds regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change in a test helper; no runtime or cryptographic behavior is modified.
> 
> **Overview**
> Updates the module docstring for `protocol_tests/_ed25519.py` so it no longer claims verification against the **RFC 8032 Test-1** known-answer vector.
> 
> The text now states that the implementation follows the RFC 8032 construction, lists what the **test suite actually checks** (curve parameters and harness signature properties), and explicitly notes that **byte-level interoperability with RFC message test vectors is not validated** and that this module is not a production crypto library.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 666c5674f17880aae9475dc1adcea3d229e7543d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->