### PR TITLE
docs: cite the published methodology note (Zenodo DOI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ See [docs/QUICKSTART.md](docs/QUICKSTART.md) for mock server setup, rate limitin
 | **APT simulation** | - | - | - | - | **GTG-1002 (17 tests)** |
 | **Jailbreak/over-refusal** | - | - | - | Yes | **50 tests (25 + 25 FPR)** |
 | **AIUC-1 certification** | - | - | - | - | **Maps to 19 of 20 testable requirements** (2026-Q1/Q2 set; [Q3 delta](docs/AIUC1-CROSSWALK.md)) |
-| **Research backing** | - | Cisco blog | - | Papers | **5 DOIs + 3 NIST submissions** |
+| **Research backing** | - | Cisco blog | - | Papers | **6 DOIs + 3 NIST submissions** |
 | **MCP server mode** | - | - | - | - | **Yes - invoke from any AI agent** |
 | **Statistical testing** | - | - | - | - | **Wilson CIs, multi-trial** |
 | **Total tests** | Pattern matching | YARA rules | Config checks | Model probes | **553 active tests** |
@@ -84,7 +84,7 @@ See [docs/QUICKSTART.md](docs/QUICKSTART.md) for mock server setup, rate limitin
 
 ## Research
 
-Five public preprints deposited on Zenodo (not represented as peer-reviewed publications) and three NIST submissions underpin the methodology:
+Six public preprints and notes deposited on Zenodo (not represented as peer-reviewed publications) and three NIST submissions underpin the methodology:
 
 | Publication | DOI |
 |---|---|
@@ -93,6 +93,7 @@ Five public preprints deposited on Zenodo (not represented as peer-reviewed publ
 | **Decision Load Index (DLI): A Quantitative Framework for Agent Autonomy Risk** — Measuring cognitive burden of AI agent oversight | [10.5281/zenodo.18217577](https://doi.org/10.5281/zenodo.18217577) |
 | **Normalization of Deviance in Autonomous Agent Systems** — Foundational research on behavioral drift patterns | [10.5281/zenodo.15105866](https://doi.org/10.5281/zenodo.15105866) |
 | **Cognitive Style Governance for Multi-Agent Deployments** — Governance mechanisms for managing cognitive style across multi-agent systems | [10.5281/zenodo.15106553](https://doi.org/10.5281/zenodo.15106553) |
+| **Claim-Level Negative Testing for Agent-Governance Evidence** — Receipt-claim decomposition; the RCL-001..011 receipt-verification module in this harness | [10.5281/zenodo.21418701](https://doi.org/10.5281/zenodo.21418701) |
 
 ---
 

--- a/docs/RELATED-WORK.md
+++ b/docs/RELATED-WORK.md
@@ -2,6 +2,10 @@
 
 This harness performs executable adversarial testing at the implementation and evidence surface of agent protocols: it sends real adversarial payloads and negative vectors and checks whether an implementation makes the correct accept/reject decision. It is complementary to formal-conformance, capability-binding, and delegation-protocol research, not a substitute for it. This page cites the closest work and states, honestly, where this project overlaps and where it differs.
 
+## This project's methodology note
+
+The receipt claim-level module (RCL-001..011) is described in a short position-and-methodology note, **"Claim-Level Negative Testing for Agent-Governance Evidence"** (Saleme, 2026): a four-property decomposition of an action receipt (integrity/provenance; execution occurrence and outcome; authorization; check execution and integrity), and executable negative vectors that construct correctly signed but semantically unsupported receipts and show a claim-level verifier rejecting them. Concept DOI: [10.5281/zenodo.21418701](https://doi.org/10.5281/zenodo.21418701). It positions this harness as the executable complement to the formal-conformance and capability-binding work below.
+
 ## Formal conformance for agent protocols
 
 - **AgentThread — "Formal Security Analysis of Agent Protocol Composition"** (Shenghan Zheng, Qifan Zhang, Zheng Zhang, Haonan Li, Christophe Hauser; arXiv:2606.28690, 2026), and its predecessor **AgentRFC / AgentConform** (Shenghan Zheng, Qifan Zhang; arXiv:2603.23801, 2026).


### PR DESCRIPTION
Cites the newly published note **"Claim-Level Negative Testing for Agent-Governance Evidence"** (concept DOI [10.5281/zenodo.21418701](https://doi.org/10.5281/zenodo.21418701)) in `docs/RELATED-WORK.md` and the README research table. Docs-only; no test-count change. Closes the loop so the repo points at its own published methodology note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only citation and positioning updates; no runtime, test, or dependency changes.
> 
> **Overview**
> Documentation now links the published methodology note **"Claim-Level Negative Testing for Agent-Governance Evidence"** (Zenodo [10.5281/zenodo.21418701](https://doi.org/10.5281/zenodo.21418701)) to the existing **RCL-001..011** receipt-claim tests.
> 
> The README comparison table and Research section bump research backing from **5 to 6 DOIs**, widen the Zenodo wording to include “notes,” and add a table row tying the note to receipt-claim decomposition. **`docs/RELATED-WORK.md`** gains a **This project's methodology note** section that summarizes the four-property receipt decomposition and negative vectors, and frames the harness as the executable complement to formal-conformance work already discussed on that page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 681a1cda4b2030a003ed381d7d50b90052cc4c31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->