### PR TITLE
fix(vs-r02): extract live AgentCore x402 proof

### DIFF
--- a/protocol_tests/agentcore_payments_harness.py
+++ b/protocol_tests/agentcore_payments_harness.py
@@ -2995,27 +2995,33 @@ def test_agentcore_signtime_cross_instrument_delegation_isolation() -> AgentCore
 
     findings["cleanup"]["positive_session"] = _vsr02_delete_session(dp, user_id, pm_arn, control_session)
     findings["cleanup"]["alternate_session"] = _vsr02_delete_session(dp, user_id, pm_arn, alternate_session)
-    if instrument_b:
+    # A create response that aliases the granted control instrument is not a
+    # disposable test resource.  Never delete the live delegation instrument.
+    if instrument_b and instrument_b != instrument_a:
         try:
             dp.delete_payment_instrument(userId=user_id, paymentManagerArn=pm_arn, paymentConnectorId=connector_id, paymentInstrumentId=instrument_b)
             findings["cleanup"]["alternate_instrument"] = "deleted"
         except Exception as exc:
             findings["cleanup"]["alternate_instrument"] = f"{type(exc).__name__}: {str(exc)[:120]}"
+    elif instrument_b:
+        findings["cleanup"]["alternate_instrument"] = "not_deleted_matches_granted_instrument"
 
     control_signed = findings["positive_control"].get("status") == PROOF_GENERATED
     alternate_signed = findings["alternate_attempt"].get("status") == PROOF_GENERATED
-    measurement_clean = control_signed and bool(instrument_b) and findings["alternate_attempt"].get("attempted") == "true"
+    distinct_instrument = bool(instrument_b) and instrument_b != instrument_a
+    measurement_clean = control_signed and distinct_instrument and findings["alternate_attempt"].get("attempted") == "true"
     alternate_status = findings["alternate_attempt"].get("status", "")
     explicit_denial = _vsr02_explicit_delegation_denial(alternate_status)
     isolation_holds = measurement_clean and explicit_denial
     verdict = (
         "isolation_observed" if isolation_holds else
         "delegation_scope_not_instrument_bound_at_sign_time" if measurement_clean and alternate_signed else
+        "not_evaluated_instrument_not_distinct" if instrument_b and not distinct_instrument else
         "inconclusive_platform_error" if measurement_clean else "measurement_incomplete"
     )
     details = (
         "SCOPE: proof-only delegated-signing isolation probe, burn-address payTo, 0 gas. "
-        f"Positive control signed={control_signed}; distinct instrument B created={bool(instrument_b)}; "
+        f"Positive control signed={control_signed}; distinct instrument B created={distinct_instrument}; "
         f"instrument-B signed={alternate_signed}; alternate status={alternate_status}. "
         "Only an explicit access/control-plane denial supports isolation. Generic platform errors are inconclusive; no settlement was attempted."
     )

--- a/protocol_tests/agentcore_payments_harness.py
+++ b/protocol_tests/agentcore_payments_harness.py
@@ -2988,7 +2988,7 @@ def test_agentcore_signtime_cross_instrument_delegation_isolation() -> AgentCore
     alternate_session, alternate_error = _vsr02_create_session(dp, user_id, agent_name, pm_arn)
     findings["alternate_attempt"]["session_create_error"] = alternate_error
     if alternate_session and instrument_b:
-        findings["alternate_attempt"] = _vsr02_sign_probe(
+        findings["alternate_attempt"] |= _vsr02_sign_probe(
             dp, user_id=user_id, agent_name=agent_name, pm_arn=pm_arn,
             session_id=alternate_session, instrument_id=instrument_b, description="ACP-014 alternate instrument",
         )
@@ -3075,7 +3075,7 @@ def test_agentcore_signtime_shared_user_multi_instrument_isolation() -> AgentCor
     alternate_session, alternate_error = _vsr02_create_session(dp, user_id, agent_name, pm_arn)
     findings["alternate_attempt"]["session_create_error"] = alternate_error
     if alternate_session and instrument_b and instrument_b != instrument_a:
-        findings["alternate_attempt"] = _vsr02_sign_probe(dp, user_id=user_id, agent_name=agent_name, pm_arn=pm_arn, session_id=alternate_session, instrument_id=instrument_b, description="ACP-015 same-user second instrument")
+        findings["alternate_attempt"] |= _vsr02_sign_probe(dp, user_id=user_id, agent_name=agent_name, pm_arn=pm_arn, session_id=alternate_session, instrument_id=instrument_b, description="ACP-015 same-user second instrument")
 
     findings["cleanup"]["positive_session"] = _vsr02_delete_session(dp, user_id, pm_arn, control_session)
     findings["cleanup"]["alternate_session"] = _vsr02_delete_session(dp, user_id, pm_arn, alternate_session)
@@ -3124,9 +3124,9 @@ def test_agentcore_signtime_cross_agent_delegation_isolation() -> AgentCoreTestR
     granted_agent = os.environ.get(ENV_VSR02_AGENT_NAME, VSR02_AGENT_NAME_DEFAULT)
     # Allow independent reproductions to substitute a fresh alternate identity
     # without changing the test logic or the granted control identity.
-    attacker_agent = os.environ.get(
-        "AGENTCORE_VSR02_ALTERNATE_AGENT_NAME", "vs-r02-attacker-agent"
-    )
+    configured_alternate_agent = os.environ.get("AGENTCORE_VSR02_ALTERNATE_AGENT_NAME", "")
+    attacker_agent = configured_alternate_agent.strip() or "vs-r02-attacker-agent"
+    distinct_alternate_agent = attacker_agent != granted_agent
     instrument_id = os.environ.get(ENV_VSR02_INSTRUMENT_ID, VSR02_INSTRUMENT_ID_DEFAULT)
     findings: dict[str, Any] = {"positive_control": {}, "cross_agent_attempt": {}, "cleanup": {}}
 
@@ -3135,27 +3135,31 @@ def test_agentcore_signtime_cross_agent_delegation_isolation() -> AgentCoreTestR
     if control_session:
         findings["positive_control"] |= _vsr02_sign_probe(dp, user_id=user_id, agent_name=granted_agent, pm_arn=pm_arn, session_id=control_session, instrument_id=instrument_id, description="ACP-019 positive control")
 
-    attacker_session, attacker_error = _vsr02_create_session(dp, user_id, attacker_agent, pm_arn)
+    if distinct_alternate_agent:
+        attacker_session, attacker_error = _vsr02_create_session(dp, user_id, attacker_agent, pm_arn)
+    else:
+        attacker_session, attacker_error = "", "not_created_alternate_agent_matches_granted_agent"
     findings["cross_agent_attempt"]["session_create_error"] = attacker_error
     if attacker_session:
-        findings["cross_agent_attempt"] = _vsr02_sign_probe(dp, user_id=user_id, agent_name=attacker_agent, pm_arn=pm_arn, session_id=attacker_session, instrument_id=instrument_id, description="ACP-019 cross-agent attempt")
+        findings["cross_agent_attempt"] |= _vsr02_sign_probe(dp, user_id=user_id, agent_name=attacker_agent, pm_arn=pm_arn, session_id=attacker_session, instrument_id=instrument_id, description="ACP-019 cross-agent attempt")
 
     findings["cleanup"]["positive_session"] = _vsr02_delete_session(dp, user_id, pm_arn, control_session)
     findings["cleanup"]["attacker_session"] = _vsr02_delete_session(dp, user_id, pm_arn, attacker_session)
     control_signed = findings["positive_control"].get("status") == PROOF_GENERATED
     attacker_signed = findings["cross_agent_attempt"].get("status") == PROOF_GENERATED
-    measurement_clean = control_signed and findings["cross_agent_attempt"].get("attempted") == "true"
+    measurement_clean = control_signed and distinct_alternate_agent and findings["cross_agent_attempt"].get("attempted") == "true"
     attacker_status = findings["cross_agent_attempt"].get("status", "")
     explicit_denial = _vsr02_explicit_delegation_denial(attacker_status)
     isolation_holds = measurement_clean and explicit_denial
     verdict = (
         "isolation_observed" if isolation_holds else
         "delegation_scope_not_agent_bound_at_sign_time" if measurement_clean and attacker_signed else
+        "not_evaluated_alternate_agent_not_distinct" if not distinct_alternate_agent else
         "inconclusive_platform_error" if measurement_clean else "measurement_incomplete"
     )
     details = (
         "SCOPE: same-user cross-agent delegated-signing isolation probe, burn-address payTo, 0 gas. "
-        f"Positive control signed={control_signed}; alternate-agent signed={attacker_signed}; alternate status={attacker_status}. "
+        f"Positive control signed={control_signed}; alternate agent distinct={distinct_alternate_agent}; alternate-agent signed={attacker_signed}; alternate status={attacker_status}. "
         "A positive-control success followed by alternate-agent success is a reproduction candidate, not a final security conclusion."
     )
     return AgentCoreTestResult(

--- a/protocol_tests/agentcore_payments_harness.py
+++ b/protocol_tests/agentcore_payments_harness.py
@@ -2861,6 +2861,304 @@ def test_agentcore_signtime_cross_session_aggregate_tier_a() -> AgentCoreTestRes
     )
 
 
+def _vsr02_create_session(dp: Any, user_id: str, agent_name: str, pm_arn: str) -> tuple[str, str]:
+    """Create one tightly capped Tier-A session, returning ``(id, error)``."""
+    try:
+        response = dp.create_payment_session(
+            userId=user_id,
+            agentName=agent_name,
+            paymentManagerArn=pm_arn,
+            limits={"maxSpendAmount": {"value": "0.02", "currency": "USD"}},
+            expiryTimeInMinutes=15,
+            clientToken=str(uuid.uuid4()),
+        )
+        session_id = response.get("paymentSession", response).get("paymentSessionId", "")
+        return session_id, "" if session_id else "create returned no paymentSessionId"
+    except Exception as exc:
+        return "", f"{type(exc).__name__}: {str(exc)[:200]}"
+
+
+def _vsr02_sign_probe(
+    dp: Any,
+    *,
+    user_id: str,
+    agent_name: str,
+    pm_arn: str,
+    session_id: str,
+    instrument_id: str,
+    description: str,
+) -> dict[str, str]:
+    """Make one Tier-A sign-only request and retain a bounded raw outcome.
+
+    This helper always uses the burn address and never submits a proof to a
+    merchant or facilitator.  A returned ``PROOF_GENERATED`` therefore means
+    only that the delegated-signing path was reached, not that anything settled.
+    """
+    try:
+        response = dp.process_payment(
+            userId=user_id,
+            agentName=agent_name,
+            paymentManagerArn=pm_arn,
+            paymentSessionId=session_id,
+            paymentInstrumentId=instrument_id,
+            paymentType="CRYPTO_X402",
+            paymentInput={"cryptoX402": {"version": "1", "payload": _build_x402_exact_payload("10000", description=description)}},
+            clientToken=str(uuid.uuid4()),
+        )
+        status, method = _extract_payment_status(response)
+        return {
+            "attempted": "true",
+            "status": status or "UNRECOGNIZED_RESPONSE",
+            "status_extraction_method": method or "none",
+            "raw_outcome": str(response)[:400],
+        }
+    except Exception as exc:
+        return {
+            "attempted": "true",
+            "status": type(exc).__name__,
+            "status_extraction_method": "none",
+            "raw_outcome": str(exc)[:400],
+        }
+
+
+def _vsr02_delete_session(dp: Any, user_id: str, pm_arn: str, session_id: str) -> str:
+    if not session_id:
+        return "not-created"
+    try:
+        dp.delete_payment_session(userId=user_id, paymentManagerArn=pm_arn, paymentSessionId=session_id)
+        return "deleted"
+    except Exception as exc:
+        return f"{type(exc).__name__}: {str(exc)[:120]}"
+
+
+def _vsr02_explicit_delegation_denial(status: str) -> bool:
+    """Return true only for an interpretable access/control-plane rejection.
+
+    A generic server failure, timeout, or retry exhaustion is not evidence that
+    isolation held.  This deliberately excludes ``InternalServerException`` so
+    the Tier-A result cannot convert an opaque platform error into a security
+    claim.
+    """
+    return status in {"AccessDeniedException", "ResourceNotFoundException", "ValidationException"}
+
+
+def test_agentcore_signtime_cross_instrument_delegation_isolation() -> AgentCoreTestResult:
+    """ACP-014: probe whether a grant for instrument A signs for instrument B.
+
+    The test first proves the currently granted tuple can reach
+    ``PROOF_GENERATED`` in this run. It then creates a distinct embedded-wallet
+    instrument under the same user/agent and attempts the identical proof-only
+    request with that new instrument.  It makes no merchant submission and
+    deletes the temporary session/instrument during cleanup.
+
+    A denial after the positive control is sign-time isolation evidence.  It is
+    deliberately tagged E2.5 rather than E5: no on-chain settlement occurs.
+    """
+    t0 = time.monotonic()
+    region = os.environ.get(ENV_REGION, "us-east-1")
+    dp = _get_agentcore_client(service="bedrock-agentcore")
+    pm_arn = os.environ.get("AGENTCORE_PAYMENT_MANAGER_ARN", "")
+    connector_id = os.environ.get("AGENTCORE_PAYMENT_CONNECTOR_ID", "")
+    user_id = os.environ.get(ENV_VSR02_USER_ID, VSR02_USER_ID_DEFAULT)
+    agent_name = os.environ.get(ENV_VSR02_AGENT_NAME, VSR02_AGENT_NAME_DEFAULT)
+    instrument_a = os.environ.get(ENV_VSR02_INSTRUMENT_ID, VSR02_INSTRUMENT_ID_DEFAULT)
+    findings: dict[str, Any] = {"positive_control": {}, "alternate_instrument": {}, "alternate_attempt": {}, "cleanup": {}}
+
+    control_session, control_error = _vsr02_create_session(dp, user_id, agent_name, pm_arn)
+    findings["positive_control"]["session_create_error"] = control_error
+    if control_session:
+        findings["positive_control"] |= _vsr02_sign_probe(
+            dp, user_id=user_id, agent_name=agent_name, pm_arn=pm_arn,
+            session_id=control_session, instrument_id=instrument_a, description="ACP-014 positive control",
+        )
+
+    instrument_b = ""
+    try:
+        response = dp.create_payment_instrument(
+            userId=user_id, agentName=agent_name, paymentManagerArn=pm_arn,
+            paymentConnectorId=connector_id, paymentInstrumentType="EMBEDDED_CRYPTO_WALLET",
+            paymentInstrumentDetails={"embeddedCryptoWallet": {"network": "ETHEREUM", "linkedAccounts": [{"email": {"emailAddress": "vsr02-acp014-instrument-b@example.test"}}]}},
+            clientToken=str(uuid.uuid4()),
+        )
+        instrument_b = response.get("paymentInstrument", response).get("paymentInstrumentId", "")
+        findings["alternate_instrument"] = {"created": bool(instrument_b), "id_distinct_from_a": instrument_b != instrument_a}
+    except Exception as exc:
+        findings["alternate_instrument"] = {"created": False, "error": f"{type(exc).__name__}: {str(exc)[:300]}"}
+
+    alternate_session, alternate_error = _vsr02_create_session(dp, user_id, agent_name, pm_arn)
+    findings["alternate_attempt"]["session_create_error"] = alternate_error
+    if alternate_session and instrument_b:
+        findings["alternate_attempt"] = _vsr02_sign_probe(
+            dp, user_id=user_id, agent_name=agent_name, pm_arn=pm_arn,
+            session_id=alternate_session, instrument_id=instrument_b, description="ACP-014 alternate instrument",
+        )
+
+    findings["cleanup"]["positive_session"] = _vsr02_delete_session(dp, user_id, pm_arn, control_session)
+    findings["cleanup"]["alternate_session"] = _vsr02_delete_session(dp, user_id, pm_arn, alternate_session)
+    if instrument_b:
+        try:
+            dp.delete_payment_instrument(userId=user_id, paymentManagerArn=pm_arn, paymentConnectorId=connector_id, paymentInstrumentId=instrument_b)
+            findings["cleanup"]["alternate_instrument"] = "deleted"
+        except Exception as exc:
+            findings["cleanup"]["alternate_instrument"] = f"{type(exc).__name__}: {str(exc)[:120]}"
+
+    control_signed = findings["positive_control"].get("status") == PROOF_GENERATED
+    alternate_signed = findings["alternate_attempt"].get("status") == PROOF_GENERATED
+    measurement_clean = control_signed and bool(instrument_b) and findings["alternate_attempt"].get("attempted") == "true"
+    alternate_status = findings["alternate_attempt"].get("status", "")
+    explicit_denial = _vsr02_explicit_delegation_denial(alternate_status)
+    isolation_holds = measurement_clean and explicit_denial
+    verdict = (
+        "isolation_observed" if isolation_holds else
+        "delegation_scope_not_instrument_bound_at_sign_time" if measurement_clean and alternate_signed else
+        "inconclusive_platform_error" if measurement_clean else "measurement_incomplete"
+    )
+    details = (
+        "SCOPE: proof-only delegated-signing isolation probe, burn-address payTo, 0 gas. "
+        f"Positive control signed={control_signed}; distinct instrument B created={bool(instrument_b)}; "
+        f"instrument-B signed={alternate_signed}; alternate status={alternate_status}. "
+        "Only an explicit access/control-plane denial supports isolation. Generic platform errors are inconclusive; no settlement was attempted."
+    )
+    return AgentCoreTestResult(
+        test_id="ACP-014", name="Cross-Instrument Delegation Isolation (Tier A)",
+        category="delegation_isolation", owasp_asi="ASI03", severity=Severity.HIGH.value,
+        passed=measurement_clean, details=details, region=region, session_id=control_session,
+        request_sent={"operation": "positive-control ProcessPayment(A) + ProcessPayment(B), sign-only", "pay_to": BURN_PAYTO, "tier": "A (proof-only, 0 gas)"},
+        response_received={**findings, "isolation_holds_at_sign_time": isolation_holds, "verdict": verdict, "target_evidence_class": "E5", "claim_boundary": "E2.5 sign-time only; not settlement evidence"},
+        csg_mapping="HC-6: delegated authority must remain instrument-bound", estimated_impact="fund_theft", estimated_severity="high",
+        elapsed_s=round(time.monotonic() - t0, 3), evidence_class="E2.5",
+    )
+
+
+def test_agentcore_signtime_shared_user_multi_instrument_isolation() -> AgentCoreTestResult:
+    """ACP-015: probe whether a same-email second instrument inherits a grant.
+
+    Unlike ACP-014, the temporary instrument deliberately uses the same email
+    identity as the granted instrument. A distinct returned instrument ID is a
+    prerequisite. If the API deduplicates it, the result is inconclusive rather
+    than evidence of isolation or leakage.
+    """
+    t0 = time.monotonic()
+    region = os.environ.get(ENV_REGION, "us-east-1")
+    dp = _get_agentcore_client(service="bedrock-agentcore")
+    pm_arn = os.environ.get("AGENTCORE_PAYMENT_MANAGER_ARN", "")
+    connector_id = os.environ.get("AGENTCORE_PAYMENT_CONNECTOR_ID", "")
+    user_id = os.environ.get(ENV_VSR02_USER_ID, VSR02_USER_ID_DEFAULT)
+    agent_name = os.environ.get(ENV_VSR02_AGENT_NAME, VSR02_AGENT_NAME_DEFAULT)
+    instrument_a = os.environ.get(ENV_VSR02_INSTRUMENT_ID, VSR02_INSTRUMENT_ID_DEFAULT)
+    findings: dict[str, Any] = {"positive_control": {}, "same_email_instrument": {}, "alternate_attempt": {}, "cleanup": {}}
+
+    control_session, control_error = _vsr02_create_session(dp, user_id, agent_name, pm_arn)
+    findings["positive_control"]["session_create_error"] = control_error
+    if control_session:
+        findings["positive_control"] |= _vsr02_sign_probe(dp, user_id=user_id, agent_name=agent_name, pm_arn=pm_arn, session_id=control_session, instrument_id=instrument_a, description="ACP-015 positive control")
+
+    instrument_b = ""
+    try:
+        response = dp.create_payment_instrument(
+            userId=user_id, agentName=agent_name, paymentManagerArn=pm_arn,
+            paymentConnectorId=connector_id, paymentInstrumentType="EMBEDDED_CRYPTO_WALLET",
+            paymentInstrumentDetails={"embeddedCryptoWallet": {"network": "ETHEREUM", "linkedAccounts": [{"email": {"emailAddress": "vsr02-wallet-hub@example.test"}}]}},
+            clientToken=str(uuid.uuid4()),
+        )
+        instrument_b = response.get("paymentInstrument", response).get("paymentInstrumentId", "")
+        findings["same_email_instrument"] = {"created": bool(instrument_b), "id_distinct_from_a": instrument_b != instrument_a}
+    except Exception as exc:
+        findings["same_email_instrument"] = {"created": False, "error": f"{type(exc).__name__}: {str(exc)[:300]}"}
+
+    alternate_session, alternate_error = _vsr02_create_session(dp, user_id, agent_name, pm_arn)
+    findings["alternate_attempt"]["session_create_error"] = alternate_error
+    if alternate_session and instrument_b and instrument_b != instrument_a:
+        findings["alternate_attempt"] = _vsr02_sign_probe(dp, user_id=user_id, agent_name=agent_name, pm_arn=pm_arn, session_id=alternate_session, instrument_id=instrument_b, description="ACP-015 same-user second instrument")
+
+    findings["cleanup"]["positive_session"] = _vsr02_delete_session(dp, user_id, pm_arn, control_session)
+    findings["cleanup"]["alternate_session"] = _vsr02_delete_session(dp, user_id, pm_arn, alternate_session)
+    if instrument_b and instrument_b != instrument_a:
+        try:
+            dp.delete_payment_instrument(userId=user_id, paymentManagerArn=pm_arn, paymentConnectorId=connector_id, paymentInstrumentId=instrument_b)
+            findings["cleanup"]["same_email_instrument"] = "deleted"
+        except Exception as exc:
+            findings["cleanup"]["same_email_instrument"] = f"{type(exc).__name__}: {str(exc)[:120]}"
+
+    control_signed = findings["positive_control"].get("status") == PROOF_GENERATED
+    distinct = findings["same_email_instrument"].get("id_distinct_from_a") is True
+    alternate_signed = findings["alternate_attempt"].get("status") == PROOF_GENERATED
+    measurement_clean = control_signed and distinct and findings["alternate_attempt"].get("attempted") == "true"
+    alternate_status = findings["alternate_attempt"].get("status", "")
+    explicit_denial = _vsr02_explicit_delegation_denial(alternate_status)
+    isolation_holds = measurement_clean and explicit_denial
+    verdict = (
+        "isolation_observed" if isolation_holds else
+        "delegation_scope_not_instrument_bound_at_sign_time" if measurement_clean and alternate_signed else
+        "inconclusive_platform_error" if measurement_clean else "measurement_incomplete"
+    )
+    details = (
+        "SCOPE: same-user, proof-only delegated-signing isolation probe, 0 gas. "
+        f"Positive control signed={control_signed}; distinct same-email instrument created={distinct}; second instrument signed={alternate_signed}; alternate status={alternate_status}. "
+        "If the service deduplicates the second instrument or returns a generic platform error, this test is explicitly inconclusive."
+    )
+    return AgentCoreTestResult(
+        test_id="ACP-015", name="Shared-User Multi-Instrument Delegation Isolation (Tier A)",
+        category="delegation_isolation", owasp_asi="ASI03", severity=Severity.HIGH.value,
+        passed=measurement_clean, details=details, region=region, session_id=control_session,
+        request_sent={"operation": "positive-control ProcessPayment(A) + same-user ProcessPayment(B), sign-only", "pay_to": BURN_PAYTO, "tier": "A (proof-only, 0 gas)"},
+        response_received={**findings, "isolation_holds_at_sign_time": isolation_holds, "verdict": verdict, "target_evidence_class": "E5", "claim_boundary": "E2.5 sign-time only; not settlement evidence"},
+        csg_mapping="HC-6: a per-user identity must not silently widen an instrument grant", estimated_impact="fund_theft", estimated_severity="high",
+        elapsed_s=round(time.monotonic() - t0, 3), evidence_class="E2.5",
+    )
+
+
+def test_agentcore_signtime_cross_agent_delegation_isolation() -> AgentCoreTestResult:
+    """ACP-019: probe whether a grant leaks across agent names for one user."""
+    t0 = time.monotonic()
+    region = os.environ.get(ENV_REGION, "us-east-1")
+    dp = _get_agentcore_client(service="bedrock-agentcore")
+    pm_arn = os.environ.get("AGENTCORE_PAYMENT_MANAGER_ARN", "")
+    user_id = os.environ.get(ENV_VSR02_USER_ID, VSR02_USER_ID_DEFAULT)
+    granted_agent = os.environ.get(ENV_VSR02_AGENT_NAME, VSR02_AGENT_NAME_DEFAULT)
+    attacker_agent = "vs-r02-attacker-agent"
+    instrument_id = os.environ.get(ENV_VSR02_INSTRUMENT_ID, VSR02_INSTRUMENT_ID_DEFAULT)
+    findings: dict[str, Any] = {"positive_control": {}, "cross_agent_attempt": {}, "cleanup": {}}
+
+    control_session, control_error = _vsr02_create_session(dp, user_id, granted_agent, pm_arn)
+    findings["positive_control"]["session_create_error"] = control_error
+    if control_session:
+        findings["positive_control"] |= _vsr02_sign_probe(dp, user_id=user_id, agent_name=granted_agent, pm_arn=pm_arn, session_id=control_session, instrument_id=instrument_id, description="ACP-019 positive control")
+
+    attacker_session, attacker_error = _vsr02_create_session(dp, user_id, attacker_agent, pm_arn)
+    findings["cross_agent_attempt"]["session_create_error"] = attacker_error
+    if attacker_session:
+        findings["cross_agent_attempt"] = _vsr02_sign_probe(dp, user_id=user_id, agent_name=attacker_agent, pm_arn=pm_arn, session_id=attacker_session, instrument_id=instrument_id, description="ACP-019 cross-agent attempt")
+
+    findings["cleanup"]["positive_session"] = _vsr02_delete_session(dp, user_id, pm_arn, control_session)
+    findings["cleanup"]["attacker_session"] = _vsr02_delete_session(dp, user_id, pm_arn, attacker_session)
+    control_signed = findings["positive_control"].get("status") == PROOF_GENERATED
+    attacker_signed = findings["cross_agent_attempt"].get("status") == PROOF_GENERATED
+    measurement_clean = control_signed and findings["cross_agent_attempt"].get("attempted") == "true"
+    attacker_status = findings["cross_agent_attempt"].get("status", "")
+    explicit_denial = _vsr02_explicit_delegation_denial(attacker_status)
+    isolation_holds = measurement_clean and explicit_denial
+    verdict = (
+        "isolation_observed" if isolation_holds else
+        "delegation_scope_not_agent_bound_at_sign_time" if measurement_clean and attacker_signed else
+        "inconclusive_platform_error" if measurement_clean else "measurement_incomplete"
+    )
+    details = (
+        "SCOPE: same-user cross-agent delegated-signing isolation probe, burn-address payTo, 0 gas. "
+        f"Positive control signed={control_signed}; alternate-agent signed={attacker_signed}; alternate status={attacker_status}. "
+        "A positive-control success followed by alternate-agent success is a reproduction candidate, not a final security conclusion."
+    )
+    return AgentCoreTestResult(
+        test_id="ACP-019", name="Cross-Agent Delegation Isolation (Tier A)",
+        category="delegation_isolation", owasp_asi="ASI03", severity=Severity.HIGH.value,
+        passed=measurement_clean, details=details, region=region, agent_id=f"{granted_agent},{attacker_agent}", session_id=control_session,
+        request_sent={"operation": "positive-control ProcessPayment(granted agent) + ProcessPayment(alternate agent), sign-only", "pay_to": BURN_PAYTO, "tier": "A (proof-only, 0 gas)"},
+        response_received={**findings, "isolation_holds_at_sign_time": isolation_holds, "verdict": verdict, "target_evidence_class": "E5", "claim_boundary": "E2.5 sign-time only; not settlement evidence"},
+        csg_mapping="HC-6: delegated authority must remain agent-name-bound", estimated_impact="fund_theft", estimated_severity="high",
+        elapsed_s=round(time.monotonic() - t0, 3), evidence_class="E2.5",
+    )
+
+
 VS_R02_TIER_A_TESTS: dict[str, list[str]] = {
     "spend_cap_enforcement": [
         "test_agentcore_signtime_spend_fragmentation",       # ACP-009
@@ -2869,6 +3167,11 @@ VS_R02_TIER_A_TESTS: dict[str, list[str]] = {
     ],
     "402_terms_validation": [
         "test_agentcore_signtime_terms_forgery",              # ACP-011
+    ],
+    "delegation_isolation": [
+        "test_agentcore_signtime_cross_instrument_delegation_isolation",  # ACP-014
+        "test_agentcore_signtime_shared_user_multi_instrument_isolation", # ACP-015
+        "test_agentcore_signtime_cross_agent_delegation_isolation",        # ACP-019
     ],
 }
 # NOTE: intentionally NOT merged into ALL_TESTS and NOT registered in

--- a/protocol_tests/agentcore_payments_harness.py
+++ b/protocol_tests/agentcore_payments_harness.py
@@ -3352,6 +3352,24 @@ def _extract_settlement_proof(resp: Any) -> tuple[dict | str | None, str]:
     if not isinstance(payment, dict):
         return None, ""
 
+    # AgentCore's live ProcessPayment response nests the signed x402 material
+    # under paymentOutput.cryptoX402.payload. Preserve the explicit path
+    # rather than flattening arbitrary response fields: the proof must still
+    # carry both a real authorization and signature before it is usable.
+    output = payment.get("paymentOutput")
+    if isinstance(output, dict):
+        crypto_x402 = output.get("cryptoX402")
+        if isinstance(crypto_x402, dict):
+            payload = crypto_x402.get("payload")
+            if isinstance(payload, dict):
+                auth = payload.get("authorization")
+                sig = payload.get("signature")
+                if isinstance(auth, dict) and sig:
+                    return {
+                        "authorization": auth,
+                        "signature": sig,
+                    }, "structured_dict_with_signature:paymentOutput.cryptoX402.payload"
+
     # Candidate 1: already an X-PAYMENT-ready base64 string (real signature
     # embedded by construction, if this path is ever actually hit).
     for key in ("xPayment", "paymentHeader", "signedPayment", "signedXPayment"):

--- a/protocol_tests/agentcore_payments_harness.py
+++ b/protocol_tests/agentcore_payments_harness.py
@@ -277,7 +277,7 @@ VSR02_AGENT_NAME_DEFAULT = "vs-r01-cdp-grant-probe"
 VSR02_INSTRUMENT_ID_DEFAULT = "payment-instrument-YQFWKtbGbKUuiMF"
 
 # x402 "exact" scheme EIP-712 domain fields for the settlement asset. Public
-# x402 spec convention for a USDC-class asset is name="USD Coin", version="2".
+# Base Sepolia USDC's on-chain name() is "USDC" and its EIP-712 version is "2".
 # UNVERIFIED against a live AgentCore response captured in this repo — every
 # VS-R01 call was rejected before reaching delegated signing, and the
 # 2026-06-08 PROOF_GENERATED verification ran outside version control (see
@@ -285,7 +285,7 @@ VSR02_INSTRUMENT_ID_DEFAULT = "payment-instrument-YQFWKtbGbKUuiMF"
 # the first live run; override via AGENTCORE_X402_EXTRA_NAME /
 # AGENTCORE_X402_EXTRA_VERSION if the default below is wrong, or if AgentCore
 # expects additional `extra` sub-fields not modeled here.
-X402_EXTRA_NAME_DEFAULT = "USD Coin"
+X402_EXTRA_NAME_DEFAULT = "USDC"
 X402_EXTRA_VERSION_DEFAULT = "2"
 
 # Burn address — every VS-R02 Tier-A test signs against this payTo, never a
@@ -3483,9 +3483,14 @@ def _tier_b_submit_for_settlement(merchant: Any, raw_proof: Any, test_id: str, u
     _tier_b_record_spend(test_id, settled_usd, tx_hash)
     if settle_success:
         print(f"[TIER-B-TX] {test_id}: settled tx={tx_hash} amount=${usd_amount}")
+    # The live client records only request/requirements digests and a bounded
+    # response excerpt.  Surface that metadata in the result manifest, never
+    # the reusable authorization itself.
+    facilitator_exchange = getattr(getattr(merchant, "facilitator", None), "last_exchange", None)
     return {
         "settle_attempted": True, "settle_http_status": http_status, "settle_body": body,
         "settle_success": settle_success, "tx_hash": tx_hash,
+        "facilitator_exchange": facilitator_exchange,
     }
 
 
@@ -3576,7 +3581,7 @@ def test_agentcore_settle_receipt_nonce_reuse() -> AgentCoreTestResult:
             dp, pm_arn, findings["session_id"], user_id, agent_name, instrument_id,
             settle_amount_units, merchant, "ACP-012 first settle", "ACP-012-first",
         )
-        if findings["first_settle"].get("proof_extracted"):
+        if findings["first_settle"].get("settle_success"):
             raw_proof = findings["first_settle"].get("raw_proof")
             replay_result = _tier_b_submit_for_settlement(merchant, raw_proof, "ACP-012-replay", usd_amount)
             findings["replay_settle"] = replay_result
@@ -3584,7 +3589,7 @@ def test_agentcore_settle_receipt_nonce_reuse() -> AgentCoreTestResult:
             if replay_result.get("settle_success"):
                 findings["ANOMALY_replay_settled"] = True
         else:
-            findings["replay_settle"] = {"note": "skipped — first settle did not produce an extractable proof, $0 spent"}
+            findings["replay_settle"] = {"note": "skipped — first settlement did not succeed; fail closed after the first refusal"}
 
     if findings["session_id"]:
         try:

--- a/protocol_tests/agentcore_payments_harness.py
+++ b/protocol_tests/agentcore_payments_harness.py
@@ -3116,7 +3116,11 @@ def test_agentcore_signtime_cross_agent_delegation_isolation() -> AgentCoreTestR
     pm_arn = os.environ.get("AGENTCORE_PAYMENT_MANAGER_ARN", "")
     user_id = os.environ.get(ENV_VSR02_USER_ID, VSR02_USER_ID_DEFAULT)
     granted_agent = os.environ.get(ENV_VSR02_AGENT_NAME, VSR02_AGENT_NAME_DEFAULT)
-    attacker_agent = "vs-r02-attacker-agent"
+    # Allow independent reproductions to substitute a fresh alternate identity
+    # without changing the test logic or the granted control identity.
+    attacker_agent = os.environ.get(
+        "AGENTCORE_VSR02_ALTERNATE_AGENT_NAME", "vs-r02-attacker-agent"
+    )
     instrument_id = os.environ.get(ENV_VSR02_INSTRUMENT_ID, VSR02_INSTRUMENT_ID_DEFAULT)
     findings: dict[str, Any] = {"positive_control": {}, "cross_agent_attempt": {}, "cleanup": {}}
 

--- a/protocol_tests/x402_merchant.py
+++ b/protocol_tests/x402_merchant.py
@@ -41,6 +41,7 @@ import base64
 import hashlib
 import json
 import sys
+import urllib.error
 import urllib.request
 from dataclasses import dataclass, field, asdict
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -66,6 +67,10 @@ class PaymentRequirements:
     description: str = "VS-R02 synthetic merchant resource"
     max_timeout_seconds: int = 120
     scheme: str = "exact"
+    # Required to reconstruct the EIP-712 domain used for an EIP-3009 USDC
+    # authorization.  AgentCore signs this domain from the original 402
+    # challenge, so the relay must present the same domain to /verify.
+    extra: dict = field(default_factory=lambda: {"name": "USDC", "version": "2"})
 
     def to_accepts(self) -> dict:
         return {
@@ -78,6 +83,7 @@ class PaymentRequirements:
             "payTo": self.pay_to,
             "asset": self.asset,
             "maxTimeoutSeconds": self.max_timeout_seconds,
+            "extra": self.extra,
         }
 
     def challenge_body(self) -> dict:
@@ -198,21 +204,71 @@ class CoinbaseFacilitator(FacilitatorClient):
     """Live facilitator — POSTs to the real x402 facilitator. Used only in the
     live-stack session (`--live`); never exercised in CI."""
 
-    def __init__(self, base_url: str = DEFAULT_FACILITATOR, timeout: float = 20.0):
+    def __init__(self, base_url: str = DEFAULT_FACILITATOR, timeout: float = 20.0,
+                 user_agent: str = "x402-vsr02-harness/1.0"):
         self.base_url = base_url.rstrip("/")
         self.timeout = timeout
+        self.user_agent = user_agent
+        # Deliberately metadata-only.  This supports the Tier-B evidence
+        # manifest without retaining a reusable signed authorization.
+        self.last_exchange: dict = {}
+
+    @staticmethod
+    def _decode_payment_payload(payment: ParsedPayment) -> dict:
+        """Turn the wire-format X-PAYMENT header into the facilitator body.
+
+        ``ParsedPayment.raw`` is the base64-encoded HTTP header.  The
+        facilitator API expects the decoded x402 payment object under
+        ``paymentPayload``; sending the header string makes the facilitator
+        see ``paymentPayload.x402Version`` as undefined.  Decode locally and
+        fail closed before making a live request if it is not an object.
+        """
+        try:
+            decoded = base64.b64decode(payment.raw, validate=True)
+            payload = json.loads(decoded)
+        except Exception as e:
+            raise ValueError(f"undecodable X-PAYMENT header: {type(e).__name__}: {e}") from e
+        if not isinstance(payload, dict):
+            raise ValueError("decoded X-PAYMENT header is not a JSON object")
+        if payload.get("x402Version") != X402_VERSION:
+            raise ValueError(
+                f"decoded X-PAYMENT x402Version {payload.get('x402Version')!r} "
+                f"does not match configured version {X402_VERSION}"
+            )
+        return payload
 
     def _post(self, path: str, body: dict) -> dict:
+        request_url = self.base_url + path
+        request_bytes = json.dumps(body, separators=(",", ":")).encode()
         req = urllib.request.Request(
-            self.base_url + path, data=json.dumps(body).encode(),
-            headers={"Content-Type": "application/json"}, method="POST")
-        with urllib.request.urlopen(req, timeout=self.timeout) as r:
-            return json.loads(r.read())
+            request_url, data=request_bytes,
+            headers={"Content-Type": "application/json", "User-Agent": self.user_agent}, method="POST")
+        self.last_exchange = {
+            "url": request_url,
+            "user_agent": self.user_agent,
+            "request_x402_version": body.get("x402Version"),
+            "payment_payload_shape": type(body.get("paymentPayload")).__name__,
+            "payment_payload_sha256": hashlib.sha256(
+                json.dumps(body.get("paymentPayload"), sort_keys=True, separators=(",", ":")).encode()
+            ).hexdigest(),
+            "payment_requirements_sha256": hashlib.sha256(
+                json.dumps(body.get("paymentRequirements"), sort_keys=True, separators=(",", ":")).encode()
+            ).hexdigest(),
+        }
+        try:
+            with urllib.request.urlopen(req, timeout=self.timeout) as r:
+                raw = r.read()
+                self.last_exchange.update({"http_status": r.status, "response": raw.decode("utf-8", "replace")[:1000]})
+                return json.loads(raw)
+        except urllib.error.HTTPError as e:
+            response = e.read().decode("utf-8", "replace")[:1000]
+            self.last_exchange.update({"http_status": e.code, "response": response})
+            raise RuntimeError(f"HTTP {e.code}: {response}") from e
 
     def verify(self, payment, req):
         try:
             r = self._post("/verify", {"x402Version": X402_VERSION,
-                                       "paymentPayload": payment.raw,
+                                       "paymentPayload": self._decode_payment_payload(payment),
                                        "paymentRequirements": req.to_accepts()})
             return SettleResult(bool(r.get("isValid")), reason=r.get("invalidReason", ""))
         except Exception as e:
@@ -221,7 +277,7 @@ class CoinbaseFacilitator(FacilitatorClient):
     def settle(self, payment, req):
         try:
             r = self._post("/settle", {"x402Version": X402_VERSION,
-                                       "paymentPayload": payment.raw,
+                                       "paymentPayload": self._decode_payment_payload(payment),
                                        "paymentRequirements": req.to_accepts()})
             return SettleResult(bool(r.get("success")), tx_hash=r.get("transaction", ""),
                                 reason=r.get("errorReason", ""), network=r.get("network", ""))

--- a/reports/round_24/VS-R02-tier-a-runbook.md
+++ b/reports/round_24/VS-R02-tier-a-runbook.md
@@ -138,6 +138,19 @@ This is exactly the overclaim class the taxonomy doc exists to catch (E3-strengt
 
 ## After the run
 
+### ACP-019 controlled reproduction - 2026-07-18
+
+Two fresh alternate agent identities, each tested after a new successful
+granted-agent positive control, independently returned PROOF_GENERATED:
+vs-r02-independent-control-c and vs-r02-independent-control-d. Every request
+used the Tier-A burn-address payload and both sessions were deleted. The
+retained artifacts are acp-019-independent-c.json and
+acp-019-independent-d.json.
+
+This reproduces the observed sign-time behavior across distinct alternate
+agent names. It remains **E2.5, proof-only, pre-settlement evidence** and is
+not by itself a security conclusion or a basis for public disclosure.
+
 - Inspect every `errors` array and every `UNRECOGNIZED*` status string in the result JSONs before trusting `passed`. `passed` on these four tests only means "the measurement completed cleanly," not "the security property holds" — same convention as VS-R01's audit-corrected ACP-002/ACP-004.
 - If `_extract_payment_status` never returns `PROOF_GENERATED` on any test, the most likely causes in order: (1) the WalletHub grant expired or was scoped to a different identity, (2) the `extra` payload shape is wrong, (3) the response-status field-name guess is wrong. Check `session_a_sign_response` / raw response strings in the JSON to disambiguate before re-running.
 - Write `testing/CRITICAL_EVALUATION_VS-R02_{date}.md` and `reports/round_24/VS-R02-independent-review-package.md` per the VS-R02 test-plan deliverables table, after applying the same audit-correction pass VS-R01 went through (see `vault/projects/vs-r01-acp-audit-2026-05-26.md` for the pattern: verdicts get rescoped when a test's premise turns out to be tautological or the wrong layer).

--- a/reports/round_24/VS-R02-tier-b-runbook.md
+++ b/reports/round_24/VS-R02-tier-b-runbook.md
@@ -2,7 +2,7 @@
 
 **Scope:** ACP-012 (receipt nonce reuse), ACP-016 full (cross-session aggregate at settlement), ACP-017 (delegation/authorization expiry, sign-time vs settlement-time), ACP-018 (revoke-and-immediately-spend race). Unlike Tier A, every test in this round **settles on-chain — real Base Sepolia gas + USDC, real transaction hashes.**
 
-**Status as of 2026-07-18: settlement not yet reached. The wallet is funded and ACP-012 reached `PROOF_GENERATED`, but the configured facilitator rejected `/verify` with HTTP 403 before any settlement. No transaction hash was issued and no USDC was spent. Do not run additional Tier-B cases until the facilitator integration is validated.**
+**Status as of 2026-07-18: HOLD. Settlement has not been reached. ACP-012 reached `PROOF_GENERATED`, but the selected facilitator refused the old request before settlement. Four compatibility defects are reconciled: the adapter supplied the base64 `X-PAYMENT` header string where `/verify` expects the decoded payment object; x402.org returned Cloudflare `error code: 1010` only to Python's default `Python-urllib/*` user agent; the merchant relay omitted the `extra.name` / `extra.version` EIP-712 domain from `paymentRequirements`; and the assumed token name was wrong. Base Sepolia USDC contract `0x036CbD53842c5426634e7929541eC2318f3dCF7e` returns `USDC` from `name()` on two read-only RPCs, while the old `USD Coin` domain caused `invalid_exact_evm_token_name_mismatch`. With all four corrections in place, the final ACP-012 attempt reached facilitator transaction simulation but returned HTTP 200 / `invalid_exact_evm_transaction_simulation_failed`, without a transaction hash or an explanatory detail. The run ended fail-closed: 0 test USDC, 0 payer-side ETH, no replay. x402.org currently advertises v1 `base-sepolia` as well as v2 `eip155:84532`, so version mismatch is not the demonstrated cause. Do not retry or run ACP-016/017/018 until this simulation failure is grounded by facilitator diagnostics or a non-guesswork preflight reconciliation.**
 
 **Branch:** `vs-r02/skeleton`. **Code:** `protocol_tests/agentcore_payments_harness.py` (functions `test_agentcore_settle_*`, appended after the Tier-A `test_agentcore_signtime_*` stubs). **Merchant:** `protocol_tests/x402_merchant.py` (vendored, uncommitted — see provenance note below). **Env:** `scripts/vs-r02-env.sh` (unchanged — same env extends to Tier B; the Tier B code adds its own `AGENTCORE_TIER_B_SETTLE_OK` gate on top).
 
@@ -80,7 +80,7 @@ I additionally ran an **offline sanity check** (no network, no AWS) wiring the h
 
 If any test behaves anomalously (e.g. ACP-012's replay unexpectedly settles), the ledger will show the real amount and the suite-cap check will halt further spending once $0.10 is reached — it will not silently keep going. **If ACP-012 reports `ANOMALY_replay_settled: true`, stop immediately and verify manually against the actual chain state before running anything further or citing the result anywhere.**
 
-Gas is separate from the USDC caps above (paid in ETH, not tracked by `_tier_b_spend_ledger`) — budget the ETH faucet amount in §1 for it; if the x402 facilitator sponsors gas as expected, actual ETH consumption should be near zero, but the wallet should hold a buffer regardless.
+**Approved payer-side gas ceiling: exactly 0 Base Sepolia ETH per attempt.** The selected x402.org facilitator submits the EIP-3009 transaction, so a wallet-originated gas transaction is not expected. If any preflight, response, or wallet prompt indicates payer gas is required, stop before broadcast and preserve the evidence. This ceiling is separate from the 0.02 test-USDC per-attempt and 0.10 test-USDC suite caps; neither cap may be relaxed during a run.
 
 ---
 
@@ -122,6 +122,7 @@ Check `response_received.first_settle.proof_extraction_method` and facilitator r
 - `structured_dict_with_signature:paymentOutput.cryptoX402.payload` → the observed AgentCore handoff worked. Continue only if the first facilitator verification succeeds.
 - `"none"` → AgentCore did not return anything `_extract_settlement_proof` recognizes. **$0 was spent** (the test never reached `merchant.handle()`). Inspect only the response schema, extend the candidate-key list deliberately, and re-run ACP-012 before any other case.
 - A 4xx/5xx facilitator refusal after proof extraction → **stop all Tier-B cases.** This is an integration blocker, not settlement evidence. Capture the status and sanitized reason, then validate the configured facilitator endpoint/authorization before retrying.
+- Before enabling the settlement gate, confirm the facilitator evidence manifest includes: the `/supported` capability snapshot, facilitator URL, request payment/requirements digests, HTTP status, and bounded redacted response body. Never retain a reusable signed authorization in that manifest.
 
 **Step 3 — run the remaining three, saving result JSONs:**
 

--- a/reports/round_24/VS-R02-tier-b-runbook.md
+++ b/reports/round_24/VS-R02-tier-b-runbook.md
@@ -2,7 +2,7 @@
 
 **Scope:** ACP-012 (receipt nonce reuse), ACP-016 full (cross-session aggregate at settlement), ACP-017 (delegation/authorization expiry, sign-time vs settlement-time), ACP-018 (revoke-and-immediately-spend race). Unlike Tier A, every test in this round **settles on-chain — real Base Sepolia gas + USDC, real transaction hashes.**
 
-**Status as of 2026-07-11: NOT YET RUN. The VS-R02 wallet is UNFUNDED. This runbook stages the tests push-button ready; funding is the only blocker.**
+**Status as of 2026-07-18: settlement not yet reached. The wallet is funded and ACP-012 reached `PROOF_GENERATED`, but the configured facilitator rejected `/verify` with HTTP 403 before any settlement. No transaction hash was issued and no USDC was spent. Do not run additional Tier-B cases until the facilitator integration is validated.**
 
 **Branch:** `vs-r02/skeleton`. **Code:** `protocol_tests/agentcore_payments_harness.py` (functions `test_agentcore_settle_*`, appended after the Tier-A `test_agentcore_signtime_*` stubs). **Merchant:** `protocol_tests/x402_merchant.py` (vendored, uncommitted — see provenance note below). **Env:** `scripts/vs-r02-env.sh` (unchanged — same env extends to Tier B; the Tier B code adds its own `AGENTCORE_TIER_B_SETTLE_OK` gate on top).
 
@@ -42,7 +42,7 @@ The delegation is live and valid to **2026-09-09** on wallet `0x7889454DF1EB44B2
 
 I additionally ran an **offline sanity check** (no network, no AWS) wiring the harness's new `_tier_b_submit_for_settlement()` helper against `MockFacilitator`: sign→extract→submit→settle succeeded, and a same-nonce replay was correctly rejected. This confirms the harness-to-merchant plumbing is correct; it does **not** confirm the AgentCore-to-harness plumbing (see below), which can only be confirmed live.
 
-**The one genuinely unverified link:** does AgentCore's `ProcessPayment`, on `PROOF_GENERATED`, actually **return** the signed authorization/proof to the caller — or does AgentCore settle it internally and never expose the raw signed material? Nobody has a captured live `PROOF_GENERATED` response in this repo (same gap the Tier-A runbook already flags for `_extract_payment_status`'s field-name guess — this is one layer deeper: not just "what key holds the status" but "does a signed, resubmittable proof even come back at all"). `_extract_settlement_proof()` in the harness code is a best-effort, multi-candidate-key probe with a hard requirement: it only accepts a proof that carries a **real signature** alongside the authorization fields — never fabricates one. If nothing matches, extraction returns `(None, "")` and **no settlement is attempted, $0 is spent.**
+**Observed AgentCore handoff, 2026-07-18:** a live `PROOF_GENERATED` response returns the signed material at `paymentOutput.cryptoX402.payload`, with `authorization` and `signature` fields. `_extract_settlement_proof()` now recognizes that exact path and still requires both fields before returning a usable proof. The first live ACP-012 attempt therefore reached the real facilitator, which returned HTTP 403 on `/verify`; no transaction was broadcast. The remaining integration question is facilitator authorization or endpoint compatibility, not whether AgentCore returns a signed proof.
 
 **If this assumption is wrong** (AgentCore settles internally, no proof is exposed), the on-chain question can still be answered, just with a different plan:
 
@@ -102,7 +102,7 @@ source scripts/vs-r02-env.sh
 **Step 1 — collect-only sanity check (safe with or without creds, no gate needed):**
 
 ```bash
-PYTHONPATH="$PWD" pytest --collect-only -q protocol_tests/agentcore_payments_harness.py -k settle
+PYTEST_COLLECT_ONLY=1 PYTHONPATH="$PWD" pytest --collect-only -q protocol_tests/agentcore_payments_harness.py -k settle
 ```
 
 **Step 2 — run ACP-012 alone first** (cheapest, and the one that tells you immediately whether the proof-extraction assumption in §2 holds):
@@ -118,9 +118,10 @@ print(json.dumps(dataclasses.asdict(r), indent=2))
 "
 ```
 
-Check `response_received.first_settle.proof_extraction_method` in the output:
-- Starts with `encoded_string:` or `structured_dict_with_signature:` → extraction worked, Plan A confirmed. Proceed to Step 3.
-- `"none"` → AgentCore did not return anything `_extract_settlement_proof` recognizes. **$0 was spent** (the test never reached `merchant.handle()`). Inspect `response_received.first_settle.sign_response_excerpt` for the raw response, decide whether to extend the candidate-key list in `_extract_settlement_proof` or fall back to Plan B (§2).
+Check `response_received.first_settle.proof_extraction_method` and facilitator result in the output:
+- `structured_dict_with_signature:paymentOutput.cryptoX402.payload` → the observed AgentCore handoff worked. Continue only if the first facilitator verification succeeds.
+- `"none"` → AgentCore did not return anything `_extract_settlement_proof` recognizes. **$0 was spent** (the test never reached `merchant.handle()`). Inspect only the response schema, extend the candidate-key list deliberately, and re-run ACP-012 before any other case.
+- A 4xx/5xx facilitator refusal after proof extraction → **stop all Tier-B cases.** This is an integration blocker, not settlement evidence. Capture the status and sanitized reason, then validate the configured facilitator endpoint/authorization before retrying.
 
 **Step 3 — run the remaining three, saving result JSONs:**
 

--- a/reports/round_24/acp-019-independent-.json
+++ b/reports/round_24/acp-019-independent-.json
@@ -1,0 +1,47 @@
+{
+  "test_id": "ACP-019",
+  "name": "Cross-Agent Delegation Isolation (Tier A)",
+  "category": "delegation_isolation",
+  "owasp_asi": "ASI03",
+  "severity": "P1-High",
+  "passed": true,
+  "details": "SCOPE: same-user cross-agent delegated-signing isolation probe, burn-address payTo, 0 gas. Positive control signed=True; alternate-agent signed=True; alternate status=PROOF_GENERATED. A positive-control success followed by alternate-agent success is a reproduction candidate, not a final security conclusion.",
+  "region": "us-east-1",
+  "endpoint": "",
+  "agent_id": "vs-r01-cdp-grant-probe,",
+  "session_id": "payment-session-BBngh9EjhD6dcmt",
+  "request_sent": {
+    "operation": "positive-control ProcessPayment(granted agent) + ProcessPayment(alternate agent), sign-only",
+    "pay_to": "0x000000000000000000000000000000000000dEaD",
+    "tier": "A (proof-only, 0 gas)"
+  },
+  "response_received": {
+    "positive_control": {
+      "session_create_error": "",
+      "attempted": "true",
+      "status": "PROOF_GENERATED",
+      "status_extraction_method": "structured_key:status",
+      "raw_outcome": "{'ResponseMetadata': {'RequestId': '85ea288b-aef1-4789-9811-48d8b78d66f6', 'HTTPStatusCode': 200, 'HTTPHeaders': {'date': 'Sat, 18 Jul 2026 02:50:17 GMT', 'content-type': 'application/json', 'content-length': '903', 'connection': 'keep-alive', 'x-amzn-requestid': '85ea288b-aef1-4789-9811-48d8b78d66f6', 'strict-transport-security': 'max-age=47304000; includeSubDomains', 'x-frame-options': 'DENY', '"
+    },
+    "cross_agent_attempt": {
+      "attempted": "true",
+      "status": "PROOF_GENERATED",
+      "status_extraction_method": "structured_key:status",
+      "raw_outcome": "{'ResponseMetadata': {'RequestId': '59e45bfe-45a5-42ca-96eb-31235f982386', 'HTTPStatusCode': 200, 'HTTPHeaders': {'date': 'Sat, 18 Jul 2026 02:50:17 GMT', 'content-type': 'application/json', 'content-length': '903', 'connection': 'keep-alive', 'x-amzn-requestid': '59e45bfe-45a5-42ca-96eb-31235f982386', 'strict-transport-security': 'max-age=47304000; includeSubDomains', 'x-frame-options': 'DENY', '"
+    },
+    "cleanup": {
+      "positive_session": "deleted",
+      "attacker_session": "deleted"
+    },
+    "isolation_holds_at_sign_time": false,
+    "verdict": "delegation_scope_not_agent_bound_at_sign_time",
+    "target_evidence_class": "E5",
+    "claim_boundary": "E2.5 sign-time only; not settlement evidence"
+  },
+  "csg_mapping": "HC-6: delegated authority must remain agent-name-bound",
+  "estimated_impact": "fund_theft",
+  "estimated_severity": "high",
+  "elapsed_s": 2.473,
+  "timestamp": "2026-07-18T02:50:18.356691+00:00",
+  "evidence_class": "E2.5"
+}

--- a/reports/round_24/acp-019-independent-c.json
+++ b/reports/round_24/acp-019-independent-c.json
@@ -1,0 +1,47 @@
+{
+  "test_id": "ACP-019",
+  "name": "Cross-Agent Delegation Isolation (Tier A)",
+  "category": "delegation_isolation",
+  "owasp_asi": "ASI03",
+  "severity": "P1-High",
+  "passed": true,
+  "details": "SCOPE: same-user cross-agent delegated-signing isolation probe, burn-address payTo, 0 gas. Positive control signed=True; alternate-agent signed=True; alternate status=PROOF_GENERATED. A positive-control success followed by alternate-agent success is a reproduction candidate, not a final security conclusion.",
+  "region": "us-east-1",
+  "endpoint": "",
+  "agent_id": "vs-r01-cdp-grant-probe,vs-r02-independent-control-c",
+  "session_id": "payment-session-2IB4iC7IroVeCxN",
+  "request_sent": {
+    "operation": "positive-control ProcessPayment(granted agent) + ProcessPayment(alternate agent), sign-only",
+    "pay_to": "0x000000000000000000000000000000000000dEaD",
+    "tier": "A (proof-only, 0 gas)"
+  },
+  "response_received": {
+    "positive_control": {
+      "session_create_error": "",
+      "attempted": "true",
+      "status": "PROOF_GENERATED",
+      "status_extraction_method": "structured_key:status",
+      "raw_outcome": "{'ResponseMetadata': {'RequestId': '02b3c2df-6ce2-4174-b555-de0f4b379ffe', 'HTTPStatusCode': 200, 'HTTPHeaders': {'date': 'Sat, 18 Jul 2026 02:50:49 GMT', 'content-type': 'application/json', 'content-length': '903', 'connection': 'keep-alive', 'x-amzn-requestid': '02b3c2df-6ce2-4174-b555-de0f4b379ffe', 'strict-transport-security': 'max-age=47304000; includeSubDomains', 'x-frame-options': 'DENY', '"
+    },
+    "cross_agent_attempt": {
+      "attempted": "true",
+      "status": "PROOF_GENERATED",
+      "status_extraction_method": "structured_key:status",
+      "raw_outcome": "{'ResponseMetadata': {'RequestId': '3bcf3230-56da-47a4-be51-1bfabd5cf06c', 'HTTPStatusCode': 200, 'HTTPHeaders': {'date': 'Sat, 18 Jul 2026 02:50:50 GMT', 'content-type': 'application/json', 'content-length': '903', 'connection': 'keep-alive', 'x-amzn-requestid': '3bcf3230-56da-47a4-be51-1bfabd5cf06c', 'strict-transport-security': 'max-age=47304000; includeSubDomains', 'x-frame-options': 'DENY', '"
+    },
+    "cleanup": {
+      "positive_session": "deleted",
+      "attacker_session": "deleted"
+    },
+    "isolation_holds_at_sign_time": false,
+    "verdict": "delegation_scope_not_agent_bound_at_sign_time",
+    "target_evidence_class": "E5",
+    "claim_boundary": "E2.5 sign-time only; not settlement evidence"
+  },
+  "csg_mapping": "HC-6: delegated authority must remain agent-name-bound",
+  "estimated_impact": "fund_theft",
+  "estimated_severity": "high",
+  "elapsed_s": 2.587,
+  "timestamp": "2026-07-18T02:50:51.208060+00:00",
+  "evidence_class": "E2.5"
+}

--- a/reports/round_24/acp-019-independent-d.json
+++ b/reports/round_24/acp-019-independent-d.json
@@ -1,0 +1,47 @@
+{
+  "test_id": "ACP-019",
+  "name": "Cross-Agent Delegation Isolation (Tier A)",
+  "category": "delegation_isolation",
+  "owasp_asi": "ASI03",
+  "severity": "P1-High",
+  "passed": true,
+  "details": "SCOPE: same-user cross-agent delegated-signing isolation probe, burn-address payTo, 0 gas. Positive control signed=True; alternate-agent signed=True; alternate status=PROOF_GENERATED. A positive-control success followed by alternate-agent success is a reproduction candidate, not a final security conclusion.",
+  "region": "us-east-1",
+  "endpoint": "",
+  "agent_id": "vs-r01-cdp-grant-probe,vs-r02-independent-control-d",
+  "session_id": "payment-session-FTVK0cJ08G77vgy",
+  "request_sent": {
+    "operation": "positive-control ProcessPayment(granted agent) + ProcessPayment(alternate agent), sign-only",
+    "pay_to": "0x000000000000000000000000000000000000dEaD",
+    "tier": "A (proof-only, 0 gas)"
+  },
+  "response_received": {
+    "positive_control": {
+      "session_create_error": "",
+      "attempted": "true",
+      "status": "PROOF_GENERATED",
+      "status_extraction_method": "structured_key:status",
+      "raw_outcome": "{'ResponseMetadata': {'RequestId': '626ae6ce-3522-43ba-a0b3-69b33f42976d', 'HTTPStatusCode': 200, 'HTTPHeaders': {'date': 'Sat, 18 Jul 2026 02:50:52 GMT', 'content-type': 'application/json', 'content-length': '903', 'connection': 'keep-alive', 'x-amzn-requestid': '626ae6ce-3522-43ba-a0b3-69b33f42976d', 'strict-transport-security': 'max-age=47304000; includeSubDomains', 'x-frame-options': 'DENY', '"
+    },
+    "cross_agent_attempt": {
+      "attempted": "true",
+      "status": "PROOF_GENERATED",
+      "status_extraction_method": "structured_key:status",
+      "raw_outcome": "{'ResponseMetadata': {'RequestId': '7e3b40f4-5fcc-4c46-b13a-0d076fc8e4ca', 'HTTPStatusCode': 200, 'HTTPHeaders': {'date': 'Sat, 18 Jul 2026 02:50:53 GMT', 'content-type': 'application/json', 'content-length': '903', 'connection': 'keep-alive', 'x-amzn-requestid': '7e3b40f4-5fcc-4c46-b13a-0d076fc8e4ca', 'strict-transport-security': 'max-age=47304000; includeSubDomains', 'x-frame-options': 'DENY', '"
+    },
+    "cleanup": {
+      "positive_session": "deleted",
+      "attacker_session": "deleted"
+    },
+    "isolation_holds_at_sign_time": false,
+    "verdict": "delegation_scope_not_agent_bound_at_sign_time",
+    "target_evidence_class": "E5",
+    "claim_boundary": "E2.5 sign-time only; not settlement evidence"
+  },
+  "csg_mapping": "HC-6: delegated authority must remain agent-name-bound",
+  "estimated_impact": "fund_theft",
+  "estimated_severity": "high",
+  "elapsed_s": 2.286,
+  "timestamp": "2026-07-18T02:50:53.786015+00:00",
+  "evidence_class": "E2.5"
+}

--- a/tests/test_agentcore_vsr02_regressions.py
+++ b/tests/test_agentcore_vsr02_regressions.py
@@ -1,0 +1,73 @@
+"""Offline regressions for VS-R02 evidence-manifest safety controls."""
+
+import os
+
+# The harness has an explicit live-net import gate. These tests replace every
+# network-facing helper before calling a probe.
+os.environ.setdefault("AGENTCORE_LIVE_NET_OK", "1")
+os.environ.setdefault("AGENTCORE_TESTNET_WALLET", "0x0000000000000000000000000000000000000001")
+
+import protocol_tests.agentcore_payments_harness as harness
+
+
+class FakePaymentClient:
+    def __init__(self, created_instrument_id="temporary-b"):
+        self.created_instrument_id = created_instrument_id
+        self.deleted_instruments = []
+
+    def create_payment_instrument(self, **_kwargs):
+        return {"paymentInstrument": {"paymentInstrumentId": self.created_instrument_id}}
+
+    def delete_payment_instrument(self, **kwargs):
+        self.deleted_instruments.append(kwargs["paymentInstrumentId"])
+
+
+def _install_offline_probe(monkeypatch, client):
+    sessions = iter((("control-session", "control-session-note"), ("alternate-session", "alternate-session-note")))
+    monkeypatch.setattr(harness, "_get_agentcore_client", lambda **_kwargs: client)
+    monkeypatch.setattr(harness, "_vsr02_create_session", lambda *_args, **_kwargs: next(sessions))
+    monkeypatch.setattr(harness, "_vsr02_delete_session", lambda *_args, **_kwargs: "deleted")
+    monkeypatch.setattr(
+        harness,
+        "_vsr02_sign_probe",
+        lambda *_args, **_kwargs: {"status": harness.PROOF_GENERATED, "attempted": "true"},
+    )
+
+
+def test_acp014_aliased_grant_is_not_deleted_or_reported_as_a_leak(monkeypatch):
+    """A deduplicated create response must never affect the granted instrument."""
+    monkeypatch.setenv(harness.ENV_VSR02_INSTRUMENT_ID, "granted-instrument")
+    client = FakePaymentClient(created_instrument_id="granted-instrument")
+    _install_offline_probe(monkeypatch, client)
+
+    result = harness.test_agentcore_signtime_cross_instrument_delegation_isolation()
+    manifest = result.response_received
+
+    assert client.deleted_instruments == []
+    assert manifest["cleanup"]["alternate_instrument"] == "not_deleted_matches_granted_instrument"
+    assert manifest["verdict"] == "not_evaluated_instrument_not_distinct"
+    assert manifest["alternate_attempt"]["session_create_error"] == "alternate-session-note"
+    assert result.passed is False
+
+
+def test_acp019_whitespace_alternate_agent_uses_the_safe_default(monkeypatch):
+    monkeypatch.setenv(harness.ENV_VSR02_AGENT_NAME, "granted-agent")
+    monkeypatch.setenv("AGENTCORE_VSR02_ALTERNATE_AGENT_NAME", "  \t")
+    client = FakePaymentClient()
+    _install_offline_probe(monkeypatch, client)
+
+    result = harness.test_agentcore_signtime_cross_agent_delegation_isolation()
+
+    assert result.agent_id == "granted-agent,vs-r02-attacker-agent"
+    assert result.response_received["cross_agent_attempt"]["session_create_error"] == "alternate-session-note"
+    assert result.response_received["verdict"] == "delegation_scope_not_agent_bound_at_sign_time"
+
+
+def test_acp015_alternate_probe_preserves_session_metadata(monkeypatch):
+    monkeypatch.setenv(harness.ENV_VSR02_INSTRUMENT_ID, "granted-instrument")
+    client = FakePaymentClient(created_instrument_id="temporary-b")
+    _install_offline_probe(monkeypatch, client)
+
+    result = harness.test_agentcore_signtime_shared_user_multi_instrument_isolation()
+
+    assert result.response_received["alternate_attempt"]["session_create_error"] == "alternate-session-note"


### PR DESCRIPTION
## Summary
- recognize the observed `paymentOutput.cryptoX402.payload` signed-proof response path
- preserve fail-closed behavior: authorization and signature are both required before settlement
- record the collection-gate correction and the live facilitator HTTP 403 stop condition in the Tier-B runbook

## Validation
- `PYTEST_COLLECT_ONLY=1 PYTHONPATH="$PWD" pytest --collect-only -q protocol_tests/agentcore_payments_harness.py -k settle` (4 collected)
- nested proof-extraction assertion against the observed response shape
- live ACP-012 reached `PROOF_GENERATED` and extracted the signed proof; facilitator `/verify` returned HTTP 403, so no transaction hash was issued and no USDC was spent

## Scope
This PR does not claim a settlement result. Additional Tier-B tests remain stopped until the facilitator integration is validated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes touch delegated-signing security probes, live facilitator integration, and documented cross-agent sign-time behavior; mis-scoped verdicts or settlement gating could over-claim risk or spend test funds.
> 
> **Overview**
> Aligns the VS-R02 harness and x402 merchant relay with **observed live AgentCore and facilitator behavior**, and adds **Tier-A delegation-isolation probes** (ACP-014/015/019) that are staged but not yet wired into the main CLI.
> 
> **Settlement path:** `_extract_settlement_proof` now reads signed material from `paymentOutput.cryptoX402.payload` (authorization + signature required). Default x402 EIP-712 token name is **`USDC`** (not `USD Coin`). The merchant advertises `extra.name` / `extra.version` on 402 accepts, sends **decoded** payment JSON to `/verify` and `/settle`, uses a custom **User-Agent**, and records **metadata-only** `last_exchange` digests for Tier-B manifests. ACP-012 replay runs only after **`settle_success`**, not merely proof extraction.
> 
> **Tier-A isolation:** Shared helpers (`_vsr02_create_session`, `_vsr02_sign_probe`, etc.) drive burn-address, sign-only tests; explicit control-plane denials count as isolation evidence, while `PROOF_GENERATED` on an alternate instrument/agent is flagged as a reproduction candidate (E2.5, not settlement). Runbooks document live ACP-019 repros and Tier-B **HOLD** after facilitator compatibility fixes still hit simulation failure.
> 
> **Tests:** Offline regressions guard cleanup when instrument create aliases the grant and alternate-agent env handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ac427b490c3bd64bdc59915f1619509115f6d75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->