### PR TITLE
fix(vs-r02): preflight Tier-B facilitator relay

### DIFF
--- a/protocol_tests/agentcore_payments_harness.py
+++ b/protocol_tests/agentcore_payments_harness.py
@@ -3432,6 +3432,7 @@ def _tier_b_sign(
     dp: Any, pm_arn: str, session_id: str, user_id: str, agent_name: str,
     instrument_id: str, amount_units: str, description: str,
     max_timeout_seconds: int = 60, resource: str = "https://vsr02-tier-b-probe.example/data",
+    payment_requirements: Any | None = None,
 ) -> dict:
     """Sign-only step: ProcessPayment via CDP delegated signing + best-effort
     proof extraction. No cap-check, no settlement attempt — the caller
@@ -3442,9 +3443,24 @@ def _tier_b_sign(
         "sign_status": "", "status_extraction_method": "", "sign_response_excerpt": "",
         "proof_extracted": False, "proof_extraction_method": "", "raw_proof": None,
     }
-    payload = _build_x402_exact_payload(
-        amount_units, pay_to=BURN_PAYTO, description=description, resource=resource,
-    )
+    if payment_requirements is not None:
+        # The signed challenge and the relay's /verify requirements must be
+        # byte-for-byte equivalent in their relevant fields.  The prior
+        # Tier-B construction used a 60-second signed challenge but let the
+        # merchant advertise its 120-second default, an avoidable mismatch
+        # immediately before the facilitator's opaque simulation step.
+        amount_units = payment_requirements.max_amount_required
+        resource = payment_requirements.resource
+        max_timeout_seconds = payment_requirements.max_timeout_seconds
+        extra = payment_requirements.extra if isinstance(payment_requirements.extra, dict) else {}
+        payload = _build_x402_exact_payload(
+            amount_units, pay_to=payment_requirements.pay_to, description=description,
+            resource=resource, extra_name=extra.get("name"), extra_version=extra.get("version"),
+        )
+    else:
+        payload = _build_x402_exact_payload(
+            amount_units, pay_to=BURN_PAYTO, description=description, resource=resource,
+        )
     payload["maxTimeoutSeconds"] = max_timeout_seconds
     try:
         resp = dp.process_payment(
@@ -3518,6 +3534,7 @@ def _tier_b_sign_and_settle(
     result = _tier_b_sign(
         dp, pm_arn, session_id, user_id, agent_name, instrument_id,
         amount_units, description, max_timeout_seconds, resource=merchant.req.resource,
+        payment_requirements=merchant.req,
     )
     if not result.get("proof_extracted"):
         result.update({"settle_attempted": False, "settle_success": False, "tx_hash": ""})
@@ -3885,6 +3902,7 @@ def test_agentcore_settle_delegation_expiry_boundary() -> AgentCoreTestResult:
         within = _tier_b_sign(
             dp, pm_arn, findings["session_id"], user_id, agent_name, instrument_id,
             settle_amount_units, "ACP-017 within-window", short_timeout_s, resource=merchant.req.resource,
+            payment_requirements=merchant.req,
         )
         if within.get("proof_extracted"):
             within.update(_tier_b_submit_for_settlement(merchant, within["raw_proof"], "ACP-017-within", usd_amount))
@@ -3895,6 +3913,7 @@ def test_agentcore_settle_delegation_expiry_boundary() -> AgentCoreTestResult:
         late = _tier_b_sign(
             dp, pm_arn, findings["session_id"], user_id, agent_name, instrument_id,
             settle_amount_units, "ACP-017 past-window", short_timeout_s, resource=merchant.req.resource,
+            payment_requirements=merchant.req,
         )
         findings["past_window_sign_status"] = late.get("sign_status")
         findings["past_window_proof_extracted"] = late.get("proof_extracted")

--- a/protocol_tests/agentcore_payments_harness.py
+++ b/protocol_tests/agentcore_payments_harness.py
@@ -3539,7 +3539,10 @@ def _tier_b_sign_and_settle(
     if not result.get("proof_extracted"):
         result.update({"settle_attempted": False, "settle_success": False, "tx_hash": ""})
         return result
-    usd_amount = round(int(amount_units) / 1_000_000, 6)
+    # `_tier_b_sign` signs the amount in merchant.req whenever requirements
+    # are supplied.  Caps and the evidence ledger must therefore use that
+    # same amount, never the caller's now-overridden convenience argument.
+    usd_amount = round(int(merchant.req.max_amount_required) / 1_000_000, 6)
     settle_result = _tier_b_submit_for_settlement(merchant, result["raw_proof"], test_id, usd_amount)
     result.update(settle_result)
     return result

--- a/protocol_tests/agentcore_payments_harness.py
+++ b/protocol_tests/agentcore_payments_harness.py
@@ -3873,7 +3873,13 @@ def test_agentcore_settle_delegation_expiry_boundary() -> AgentCoreTestResult:
 
     x402_merchant = _import_x402_merchant()
     merchant_req = x402_merchant.PaymentRequirements(
-        pay_to=BURN_PAYTO, max_amount_required=settle_amount_units, resource="/vsr02-acp-017",
+        # ACP-017's expiry probe must sign against a requirement whose own
+        # validity window is short.  `_tier_b_sign` intentionally takes its
+        # timeout from this object to keep the signed challenge and relay
+        # request identical, so leaving this at the 120-second default would
+        # make the eight-second wait a non-expiry test.
+        pay_to=BURN_PAYTO, max_amount_required=settle_amount_units,
+        resource="/vsr02-acp-017", max_timeout_seconds=short_timeout_s,
     )
     merchant = x402_merchant.SyntheticMerchant(merchant_req, x402_merchant.CoinbaseFacilitator())
     usd_amount = round(int(settle_amount_units) / 1_000_000, 6)

--- a/protocol_tests/x402_merchant.py
+++ b/protocol_tests/x402_merchant.py
@@ -237,6 +237,79 @@ class CoinbaseFacilitator(FacilitatorClient):
             )
         return payload
 
+    @classmethod
+    def preflight_verify_request(cls, payment: ParsedPayment,
+                                 req: PaymentRequirements) -> dict:
+        """Validate locally knowable `/verify` invariants before transport.
+
+        This is intentionally not a signature verifier: EIP-712 signature
+        recovery and authorization-state simulation belong to the facilitator.
+        It does, however, prevent an avoidable live call when the x402 envelope
+        or relay requirements disagree on scheme, network, asset, recipient,
+        amount, or the EIP-712 domain metadata.  The returned report contains
+        no authorization or signature material and is safe for the evidence
+        manifest.
+        """
+        errors: list[str] = []
+        try:
+            payload = cls._decode_payment_payload(payment)
+        except ValueError as exc:
+            return {"ok": False, "errors": [str(exc)]}
+
+        if payload.get("x402Version") != X402_VERSION:
+            errors.append("payment x402Version does not match configured version")
+        if payload.get("scheme") != req.scheme:
+            errors.append("payment scheme does not match payment requirements")
+        if payload.get("network") != req.network:
+            errors.append("payment network does not match payment requirements")
+
+        envelope = payload.get("payload")
+        if not isinstance(envelope, dict):
+            errors.append("payment payload is not an object")
+            envelope = {}
+        if not envelope.get("signature"):
+            errors.append("payment signature is missing")
+        authorization = envelope.get("authorization", {})
+        if not isinstance(authorization, dict):
+            errors.append("payment authorization is not an object")
+            authorization = {}
+
+        if str(authorization.get("to", "")).lower() != req.pay_to.lower():
+            errors.append("authorization recipient does not match payment requirements")
+        try:
+            value = int(str(authorization.get("value", "")))
+            maximum = int(req.max_amount_required)
+            if value < 0 or value > maximum:
+                errors.append("authorization value is outside payment requirements")
+        except (TypeError, ValueError):
+            errors.append("authorization value is not an integer")
+
+        for field_name in ("validAfter", "validBefore"):
+            try:
+                int(str(authorization.get(field_name, "")))
+            except (TypeError, ValueError):
+                errors.append(f"authorization {field_name} is not an integer")
+        try:
+            if int(str(authorization.get("validAfter", ""))) > int(str(authorization.get("validBefore", ""))):
+                errors.append("authorization validAfter is later than validBefore")
+        except (TypeError, ValueError):
+            pass
+
+        extra = req.extra if isinstance(req.extra, dict) else {}
+        if not str(extra.get("name", "")).strip() or not str(extra.get("version", "")).strip():
+            errors.append("payment requirements omit EIP-712 name or version")
+        if not isinstance(req.max_timeout_seconds, int) or req.max_timeout_seconds <= 0:
+            errors.append("payment requirements maxTimeoutSeconds is invalid")
+
+        return {
+            "ok": not errors,
+            "errors": errors,
+            "x402_version": payload.get("x402Version"),
+            "scheme": payload.get("scheme"),
+            "network": payload.get("network"),
+            "requirement_timeout_seconds": req.max_timeout_seconds,
+        }
+
     def _post(self, path: str, body: dict) -> dict:
         request_url = self.base_url + path
         request_bytes = json.dumps(body, separators=(",", ":")).encode()
@@ -267,6 +340,10 @@ class CoinbaseFacilitator(FacilitatorClient):
 
     def verify(self, payment, req):
         try:
+            preflight = self.preflight_verify_request(payment, req)
+            self.last_exchange = {"preflight": preflight}
+            if not preflight["ok"]:
+                return SettleResult(False, reason="local preflight failed: " + "; ".join(preflight["errors"]))
             r = self._post("/verify", {"x402Version": X402_VERSION,
                                        "paymentPayload": self._decode_payment_payload(payment),
                                        "paymentRequirements": req.to_accepts()})

--- a/tests/test_agentcore_vsr02_regressions.py
+++ b/tests/test_agentcore_vsr02_regressions.py
@@ -8,6 +8,7 @@ os.environ.setdefault("AGENTCORE_LIVE_NET_OK", "1")
 os.environ.setdefault("AGENTCORE_TESTNET_WALLET", "0x0000000000000000000000000000000000000001")
 
 import protocol_tests.agentcore_payments_harness as harness
+from protocol_tests.x402_merchant import CoinbaseFacilitator, PaymentRequirements, parse_x_payment
 
 
 class FakePaymentClient:
@@ -71,3 +72,47 @@ def test_acp015_alternate_probe_preserves_session_metadata(monkeypatch):
     result = harness.test_agentcore_signtime_shared_user_multi_instrument_isolation()
 
     assert result.response_received["alternate_attempt"]["session_create_error"] == "alternate-session-note"
+
+
+def test_tier_b_preflight_rejects_requirement_mismatch_without_transport():
+    """A wrong recipient must fail locally before a live facilitator call."""
+    header = harness._encode_x_payment_with_real_signature({
+        "authorization": {
+            "from": "0x1111111111111111111111111111111111111111",
+            "to": "0x2222222222222222222222222222222222222222",
+            "value": "10000", "validAfter": "1", "validBefore": "2", "nonce": "0x" + "00" * 32,
+        },
+        "signature": "0x" + "11" * 65,
+    })
+    report = CoinbaseFacilitator.preflight_verify_request(
+        parse_x_payment(header), PaymentRequirements(pay_to="0x3333333333333333333333333333333333333333"),
+    )
+
+    assert report["ok"] is False
+    assert "authorization recipient does not match payment requirements" in report["errors"]
+
+
+def test_tier_b_sign_uses_the_exact_relay_requirement_shape():
+    """The signed challenge must not drift from the relay's timeout/domain."""
+    class Client:
+        def process_payment(self, **kwargs):
+            self.kwargs = kwargs
+            return {"status": "DENIED"}
+
+    client = Client()
+    req = PaymentRequirements(
+        pay_to="0x1111111111111111111111111111111111111111",
+        max_amount_required="10000", resource="/acp-preflight", max_timeout_seconds=120,
+        extra={"name": "USDC", "version": "2"},
+    )
+    harness._tier_b_sign(
+        client, "pm", "session", "user", "agent", "instrument", "99999", "test",
+        max_timeout_seconds=5, payment_requirements=req,
+    )
+    payload = client.kwargs["paymentInput"]["cryptoX402"]["payload"]
+
+    assert payload["maxAmountRequired"] == req.max_amount_required
+    assert payload["resource"] == req.resource
+    assert payload["payTo"] == req.pay_to
+    assert payload["maxTimeoutSeconds"] == req.max_timeout_seconds
+    assert payload["extra"] == req.extra

--- a/tests/test_agentcore_vsr02_regressions.py
+++ b/tests/test_agentcore_vsr02_regressions.py
@@ -124,3 +124,26 @@ def test_acp017_expiry_probe_constructs_a_short_lived_requirement():
     source = inspect.getsource(harness.test_agentcore_settle_delegation_expiry_boundary)
 
     assert "max_timeout_seconds=short_timeout_s" in source
+
+
+def test_tier_b_cap_uses_the_amount_that_was_actually_signed(monkeypatch):
+    """A stale wrapper argument cannot under-report a requirement-backed spend."""
+    req = PaymentRequirements(
+        pay_to="0x1111111111111111111111111111111111111111", max_amount_required="10000",
+    )
+    merchant = type("Merchant", (), {"req": req})()
+    observed = {}
+
+    monkeypatch.setattr(harness, "_tier_b_sign", lambda *_args, **_kwargs: {
+        "proof_extracted": True, "raw_proof": {"authorization": {}, "signature": "sig"},
+    })
+    monkeypatch.setattr(
+        harness, "_tier_b_submit_for_settlement",
+        lambda _merchant, _proof, _test_id, usd_amount: observed.update(usd_amount=usd_amount) or {},
+    )
+
+    harness._tier_b_sign_and_settle(
+        object(), "pm", "session", "user", "agent", "instrument", "1", merchant, "test", "ACP-test",
+    )
+
+    assert observed["usd_amount"] == 0.01

--- a/tests/test_agentcore_vsr02_regressions.py
+++ b/tests/test_agentcore_vsr02_regressions.py
@@ -1,5 +1,6 @@
 """Offline regressions for VS-R02 evidence-manifest safety controls."""
 
+import inspect
 import os
 
 # The harness has an explicit live-net import gate. These tests replace every
@@ -116,3 +117,10 @@ def test_tier_b_sign_uses_the_exact_relay_requirement_shape():
     assert payload["payTo"] == req.pay_to
     assert payload["maxTimeoutSeconds"] == req.max_timeout_seconds
     assert payload["extra"] == req.extra
+
+
+def test_acp017_expiry_probe_constructs_a_short_lived_requirement():
+    """Its expiry wait must exceed the timeout used for the signed challenge."""
+    source = inspect.getsource(harness.test_agentcore_settle_delegation_expiry_boundary)
+
+    assert "max_timeout_seconds=short_timeout_s" in source


### PR DESCRIPTION
## Summary
- Build the Tier-B signed challenge and merchant relay from one payment-requirement object, eliminating the discovered 60s-versus-120s timeout drift.
- Add a local, metadata-only preflight before facilitator `/verify` for x402 version, envelope shape, signature presence, scheme, network, recipient, amount, validity fields, EIP-712 metadata, and timeout.
- Add offline regressions for no-transport mismatch rejection and exact requirement propagation.

## Safety
- No settlement retry was run.
- ACP-012 remains on HOLD pending grounded facilitator simulation diagnostics.
- The preflight does not retain or expose reusable signed authorizations.

## Verification
- `python3 -m pytest -q tests/test_agentcore_vsr02_regressions.py` (5 passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Harness and test-merchant changes only; no production auth or payment paths. Preflight reduces accidental live facilitator calls and does not expose signed authorizations in manifests.
> 
> **Overview**
> **Tier-B signing and relay alignment** — `_tier_b_sign` can take optional `payment_requirements` and builds the signed x402 payload from that object (amount, resource, timeout, payTo, EIP-712 `extra`) so the CDP challenge matches what the synthetic merchant sends to `/verify`, fixing the prior 60s-signed vs 120s-advertised timeout mismatch. `_tier_b_sign_and_settle` passes `merchant.req` through and derives USD caps from `merchant.req.max_amount_required`, not the caller’s convenience `amount_units`. **ACP-017** sets `max_timeout_seconds` on `PaymentRequirements` to the short probe window and passes `payment_requirements=merchant.req` into both sign paths so the past-window wait is a real expiry test.
> 
> **Facilitator preflight** — `CoinbaseFacilitator.preflight_verify_request` checks locally knowable invariants (x402 version, scheme/network, recipient, amount bounds, validity fields, EIP-712 metadata, timeout) without signature recovery; `verify()` fails closed before any HTTP call when preflight fails.
> 
> **Tests** — Offline regressions cover mismatch rejection without transport, exact requirement propagation into `_tier_b_sign`, ACP-017 short-lived requirement construction, and cap/ledger amount tied to the signed requirement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9cf6170e4a22e5fad965a7d2a9ff416a378b959. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->