### PR TITLE
feat(conformance): RCL receipt-claim vectors (9 reject + 2 accept)

### DIFF
--- a/conformance/receipt-claim/README.md
+++ b/conformance/receipt-claim/README.md
@@ -1,0 +1,50 @@
+# Receipt-claim conformance vectors (RCL)
+
+Portable, machine-readable conformance vectors for **claim-level receipt verification**: each vector is a receipt whose **envelope signature verifies** but whose **claims are (in)valid on semantic grounds**. A conforming verifier must reach the recorded decision by recomputing evidence bindings, not by checking the signature.
+
+These are generated from this repo's own claim-level verifier ([`protocol_tests/receipt_claim_harness.py`](../../protocol_tests/receipt_claim_harness.py), the RCL family), so `expected_result` and `harness_reason` are ground-truth verifier output rather than hand-authored expectations. Any receipt/trust-envelope implementation can run its own verifier over the same fixtures and compare.
+
+## The model
+
+An action receipt decomposes into four separately assessable properties, and signing supports only the first:
+
+```
+integrity/provenance | authorization | occurrence | check (execution + integrity)
+```
+
+Evidence for the last three must be attested by **distinct trust domains** (authorization authority, execution/settlement authority, independent checker authority), never by the receipt emitter, which the threat model permits to lie. The emitter can validly re-sign its own envelope; it cannot forge another authority's attestation (Ed25519, one keypair per domain, verifier holds only the public keys).
+
+## Contents
+
+**9 reject vectors + 2 acceptance controls.** The acceptance controls (`RCL-008`, `RCL-009`) exist so an implementation cannot pass by rejecting everything.
+
+Each fixture carries an `evidence_binding` descriptor naming exactly what a verifier must recompute from referenced evidence, so a vector is not satisfiable with string-level checks: the admitted action digest, the action's tool-set digest, per-property attestor + independence flag, the check's `policy_digest`, and the freshness window.
+
+| ID | Result | Phase | Recomputation the verifier must fail | Reason code |
+|---|---|---|---|---|
+| RCL-001 | reject | post-execution | occurrence evidence omitted | `OCCURRENCE_EVIDENCE_MISSING` |
+| RCL-002 | reject | admission | check evidence tampered after attestation | `CHECK_EVIDENCE_TAMPERED` |
+| RCL-003 | reject | admission | check transcript outside the freshness window | `CHECK_TRANSCRIPT_STALE` |
+| RCL-004 | reject | admission | check `input_digest` != action tool-set digest | `CHECK_TOOLSET_DIGEST_MISMATCH` |
+| RCL-005 | reject | admission | authorization bound to different params than requested | `AUTHORIZATION_PARAMS_MISMATCH` |
+| RCL-006 | reject | post-execution | occurrence ack `action_digest` != admitted action | `OCCURRENCE_ACTION_LINKAGE_MISMATCH` |
+| RCL-007 | reject | admission | check attested by the emitter, not an independent authority | `CHECK_ATTESTOR_NOT_INDEPENDENT` |
+| RCL-008 | **accept** | admission+post-execution | control: all four properties independently supported | `ACCEPT_ALL_PROPERTIES_SUPPORTED` |
+| RCL-009 | **accept** | admission | control: clean wired MCP-019 check, verdict pass | `ACCEPT_ALL_PROPERTIES_SUPPORTED` |
+| RCL-010 | reject | admission | wired MCP-019 verdict is fail, carried honestly | `CHECK_OUTPUT_FAIL` |
+| RCL-011 | reject | admission | passing check bound to a different tool set than the action uses | `CHECK_TOOLSET_DIGEST_MISMATCH` |
+
+`RCL-005` and `RCL-006` are the phase pair: `RCL-005` fails at **admission** because the authorization evidence does not authorize the requested action before execution; `RCL-006` fails at **post-execution** because the execution acknowledgement does not link back to the admitted action. Same trust problem, different phase, different invariant.
+
+`RCL-009/010/011` bind the **MCP-019 composite tool-poisoning** detector through the receipt path, so a receipt claiming "the admitted tool set was checked" is accepted only when a verifier can recompute that the check covered the same tool-set digest and that the verdict supports the claim.
+
+## Files
+
+- `fixtures/RCL-0NN.json` — one per case: the full receipt, the `evidence_binding` descriptor, the expected decision/phase/reason, and the verbatim `harness_reason`.
+- `fixtures/index.json` — summary index.
+- `generate.py` — regenerates the fixtures from the verifier.
+- `verify_fixtures.py` — replays every fixture through the verifier and asserts the recorded result (exits non-zero on mismatch).
+
+## Reproducibility
+
+Deterministic Ed25519 test keys (fixed seeds) and a fixed timestamp make the fixtures reproducible byte-for-byte from the verifier. The signatures are the harness's own test-domain keys; the vectors' value is the **evidence-binding structure and the recomputation each verifier must perform**, which is signature-scheme independent, so the reason codes here map cleanly onto external receipt / trust-envelope models.

--- a/conformance/receipt-claim/fixtures/RCL-001.json
+++ b/conformance/receipt-claim/fixtures/RCL-001.json
@@ -1,0 +1,69 @@
+{
+  "test_id": "RCL-001",
+  "name": "Omitted mandatory evidence",
+  "expected_result": "reject",
+  "expected_phase": "post-execution",
+  "violated_binding": "occurrence evidence omitted",
+  "reason_code": "OCCURRENCE_EVIDENCE_MISSING",
+  "harness_reason": "occurrence: missing evidence",
+  "evidence_binding": {
+    "admitted_action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+    "action_tool_set_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+    "referenced_evidence": {
+      "authorization": {
+        "present": true,
+        "attestor": "authz",
+        "independent_of_emitter": true,
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "params_digest": "29b774d0a454b86f6375f55fd90c804e6ba03b2eaee1e88f07a19afa73c70174"
+      },
+      "occurrence": {
+        "present": false
+      },
+      "check": {
+        "present": true,
+        "attestor": "checker",
+        "independent_of_emitter": true,
+        "input_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+        "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+        "output": "pass",
+        "issued_at": 1750000000,
+        "checker_id": "tool-scan",
+        "version": "1.0"
+      }
+    },
+    "attestor_independence_ok": true,
+    "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+    "freshness_window_seconds": 300
+  },
+  "recomputation_boundary": "occurrence evidence omitted",
+  "envelope_signature_valid": true,
+  "receipt": {
+    "action": {
+      "tool": "transfer",
+      "params": {
+        "to": "acct-A",
+        "amount": 100
+      }
+    },
+    "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+    "tool_set_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+    "claims": {
+      "authorization": {
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "params_digest": "29b774d0a454b86f6375f55fd90c804e6ba03b2eaee1e88f07a19afa73c70174",
+        "sig": "f05e7e4b011f73e79fc2e0faad5ea2c1c8b0bc4edd14e515a1c6a8b2b2711e7b2830897168ece5510e6501789cd1b53650bb08b9e9e82b949cba23adbd0b770c"
+      },
+      "check": {
+        "checker_id": "tool-scan",
+        "version": "1.0",
+        "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+        "input_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+        "output": "pass",
+        "issued_at": 1750000000,
+        "sig": "b489115dd3fe0269d4879eb728be602be737be59f190f0c471e52f131d94368c32911fc77680e7ae56d02b730d190129b719d981dd3f46c8e87b9051730f770f"
+      }
+    },
+    "envelope_sig": "68c8ada0833b470f3ec6acebe6d102394c68a434b50893d3a39445eb069e397faba856dd90b8227bd784b38b390b0a816c16329bef6ab36003bcabead30a0e0a"
+  }
+}

--- a/conformance/receipt-claim/fixtures/RCL-002.json
+++ b/conformance/receipt-claim/fixtures/RCL-002.json
@@ -1,0 +1,78 @@
+{
+  "test_id": "RCL-002",
+  "name": "Substituted evidence, re-signed envelope",
+  "expected_result": "reject",
+  "expected_phase": "admission",
+  "violated_binding": "check evidence tampered after attestation",
+  "reason_code": "CHECK_EVIDENCE_TAMPERED",
+  "harness_reason": "check: checker attestation does not verify (substituted or forged)",
+  "evidence_binding": {
+    "admitted_action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+    "action_tool_set_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+    "referenced_evidence": {
+      "authorization": {
+        "present": true,
+        "attestor": "authz",
+        "independent_of_emitter": true,
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "params_digest": "29b774d0a454b86f6375f55fd90c804e6ba03b2eaee1e88f07a19afa73c70174"
+      },
+      "occurrence": {
+        "present": true,
+        "attestor": "exec",
+        "independent_of_emitter": true,
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "outcome_digest": "212e659146dac83f09f639fe16f4316e2fc5ecb37c3f99ee67e31eb7a73bb0f9"
+      },
+      "check": {
+        "present": true,
+        "attestor": null,
+        "independent_of_emitter": true,
+        "input_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+        "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+        "output": "pass",
+        "issued_at": 1750000000,
+        "checker_id": "tool-scan",
+        "version": "1.0"
+      }
+    },
+    "attestor_independence_ok": true,
+    "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+    "freshness_window_seconds": 300
+  },
+  "recomputation_boundary": "check evidence tampered after attestation",
+  "envelope_signature_valid": true,
+  "receipt": {
+    "action": {
+      "tool": "transfer",
+      "params": {
+        "to": "acct-A",
+        "amount": 100
+      }
+    },
+    "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+    "tool_set_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+    "claims": {
+      "authorization": {
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "params_digest": "29b774d0a454b86f6375f55fd90c804e6ba03b2eaee1e88f07a19afa73c70174",
+        "sig": "f05e7e4b011f73e79fc2e0faad5ea2c1c8b0bc4edd14e515a1c6a8b2b2711e7b2830897168ece5510e6501789cd1b53650bb08b9e9e82b949cba23adbd0b770c"
+      },
+      "occurrence": {
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "outcome_digest": "212e659146dac83f09f639fe16f4316e2fc5ecb37c3f99ee67e31eb7a73bb0f9",
+        "sig": "880e3c9840c24bb4961efad424b151388af174c35f24ba6faf922bd388a114786bfcb67cbeed03f1ef689c578cfd5610f45492212ba4de30156062a98bc66d0c"
+      },
+      "check": {
+        "checker_id": "tool-scan",
+        "version": "1.0",
+        "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+        "input_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+        "output": "pass",
+        "issued_at": 1750000000,
+        "sig": "2aff2fa4ddc0d04f0c4216b429121911f6ffe0ebafcb82d3cfd9442e7c68e6e0ad3a5e67d7fcb7b00cd8b6e218ee7442ceb184bd55a5dfb666728548880b8507"
+      }
+    },
+    "envelope_sig": "23157e82ae22db5683cbef6bbf11e333fd1928470235b67f705fb88252d6f4f561986184bbff21b474bbeca057fb16f49eba2f0a283fdf56e9d6f547523dc204"
+  }
+}

--- a/conformance/receipt-claim/fixtures/RCL-002.json
+++ b/conformance/receipt-claim/fixtures/RCL-002.json
@@ -27,7 +27,7 @@
       "check": {
         "present": true,
         "attestor": null,
-        "independent_of_emitter": true,
+        "independent_of_emitter": false,
         "input_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
         "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
         "output": "pass",
@@ -36,7 +36,7 @@
         "version": "1.0"
       }
     },
-    "attestor_independence_ok": true,
+    "attestor_independence_ok": false,
     "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
     "freshness_window_seconds": 300
   },

--- a/conformance/receipt-claim/fixtures/RCL-003.json
+++ b/conformance/receipt-claim/fixtures/RCL-003.json
@@ -1,0 +1,78 @@
+{
+  "test_id": "RCL-003",
+  "name": "Stale checker transcript",
+  "expected_result": "reject",
+  "expected_phase": "admission",
+  "violated_binding": "check transcript outside the freshness window",
+  "reason_code": "CHECK_TRANSCRIPT_STALE",
+  "harness_reason": "check: stale transcript (outside freshness window)",
+  "evidence_binding": {
+    "admitted_action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+    "action_tool_set_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+    "referenced_evidence": {
+      "authorization": {
+        "present": true,
+        "attestor": "authz",
+        "independent_of_emitter": true,
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "params_digest": "29b774d0a454b86f6375f55fd90c804e6ba03b2eaee1e88f07a19afa73c70174"
+      },
+      "occurrence": {
+        "present": true,
+        "attestor": "exec",
+        "independent_of_emitter": true,
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "outcome_digest": "212e659146dac83f09f639fe16f4316e2fc5ecb37c3f99ee67e31eb7a73bb0f9"
+      },
+      "check": {
+        "present": true,
+        "attestor": "checker",
+        "independent_of_emitter": true,
+        "input_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+        "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+        "output": "pass",
+        "issued_at": 1749999640,
+        "checker_id": "tool-scan",
+        "version": "1.0"
+      }
+    },
+    "attestor_independence_ok": true,
+    "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+    "freshness_window_seconds": 300
+  },
+  "recomputation_boundary": "check transcript outside the freshness window",
+  "envelope_signature_valid": true,
+  "receipt": {
+    "action": {
+      "tool": "transfer",
+      "params": {
+        "to": "acct-A",
+        "amount": 100
+      }
+    },
+    "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+    "tool_set_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+    "claims": {
+      "authorization": {
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "params_digest": "29b774d0a454b86f6375f55fd90c804e6ba03b2eaee1e88f07a19afa73c70174",
+        "sig": "f05e7e4b011f73e79fc2e0faad5ea2c1c8b0bc4edd14e515a1c6a8b2b2711e7b2830897168ece5510e6501789cd1b53650bb08b9e9e82b949cba23adbd0b770c"
+      },
+      "occurrence": {
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "outcome_digest": "212e659146dac83f09f639fe16f4316e2fc5ecb37c3f99ee67e31eb7a73bb0f9",
+        "sig": "880e3c9840c24bb4961efad424b151388af174c35f24ba6faf922bd388a114786bfcb67cbeed03f1ef689c578cfd5610f45492212ba4de30156062a98bc66d0c"
+      },
+      "check": {
+        "checker_id": "tool-scan",
+        "version": "1.0",
+        "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+        "input_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+        "output": "pass",
+        "issued_at": 1749999640,
+        "sig": "a1f88ae0e5997a7fcae21551cd84cec080705f9c1956369bf5f59096c3d94cc46c7680c6c2b5cef3caf0016938a490c68ca2924801078bc91fff0f536b921b0e"
+      }
+    },
+    "envelope_sig": "d8dc36ca354e15e0a31af881093bd9809b1afb6f49228b18da7ddddd87e9993af65a551cce0e2b2b7ea217cc58c973847b66fe73a7d63e3ff9da06b848308006"
+  }
+}

--- a/conformance/receipt-claim/fixtures/RCL-004.json
+++ b/conformance/receipt-claim/fixtures/RCL-004.json
@@ -1,0 +1,78 @@
+{
+  "test_id": "RCL-004",
+  "name": "Check bound to the wrong tool-set digest",
+  "expected_result": "reject",
+  "expected_phase": "admission",
+  "violated_binding": "check bound to a different tool-set digest",
+  "reason_code": "CHECK_TOOLSET_DIGEST_MISMATCH",
+  "harness_reason": "check: result bound to the wrong tool-set digest",
+  "evidence_binding": {
+    "admitted_action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+    "action_tool_set_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+    "referenced_evidence": {
+      "authorization": {
+        "present": true,
+        "attestor": "authz",
+        "independent_of_emitter": true,
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "params_digest": "29b774d0a454b86f6375f55fd90c804e6ba03b2eaee1e88f07a19afa73c70174"
+      },
+      "occurrence": {
+        "present": true,
+        "attestor": "exec",
+        "independent_of_emitter": true,
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "outcome_digest": "212e659146dac83f09f639fe16f4316e2fc5ecb37c3f99ee67e31eb7a73bb0f9"
+      },
+      "check": {
+        "present": true,
+        "attestor": "checker",
+        "independent_of_emitter": true,
+        "input_digest": "5c57b9d021cbc7b1ec6f4b223561bf556d4690d4dc662ab3c32f58425ff10bb2",
+        "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+        "output": "pass",
+        "issued_at": 1750000000,
+        "checker_id": "tool-scan",
+        "version": "1.0"
+      }
+    },
+    "attestor_independence_ok": true,
+    "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+    "freshness_window_seconds": 300
+  },
+  "recomputation_boundary": "check bound to a different tool-set digest",
+  "envelope_signature_valid": true,
+  "receipt": {
+    "action": {
+      "tool": "transfer",
+      "params": {
+        "to": "acct-A",
+        "amount": 100
+      }
+    },
+    "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+    "tool_set_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+    "claims": {
+      "authorization": {
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "params_digest": "29b774d0a454b86f6375f55fd90c804e6ba03b2eaee1e88f07a19afa73c70174",
+        "sig": "f05e7e4b011f73e79fc2e0faad5ea2c1c8b0bc4edd14e515a1c6a8b2b2711e7b2830897168ece5510e6501789cd1b53650bb08b9e9e82b949cba23adbd0b770c"
+      },
+      "occurrence": {
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "outcome_digest": "212e659146dac83f09f639fe16f4316e2fc5ecb37c3f99ee67e31eb7a73bb0f9",
+        "sig": "880e3c9840c24bb4961efad424b151388af174c35f24ba6faf922bd388a114786bfcb67cbeed03f1ef689c578cfd5610f45492212ba4de30156062a98bc66d0c"
+      },
+      "check": {
+        "checker_id": "tool-scan",
+        "version": "1.0",
+        "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+        "input_digest": "5c57b9d021cbc7b1ec6f4b223561bf556d4690d4dc662ab3c32f58425ff10bb2",
+        "output": "pass",
+        "issued_at": 1750000000,
+        "sig": "e98a8ad524d165fe17d33f35905531f4d478acc26a94eaeed340ed4d1391970f8b6460f0395687abf72d8bc6df0491f2f1baf1af343b66f37fc79f067f4d3f04"
+      }
+    },
+    "envelope_sig": "a6ef64dbd66eec04fc53699350f14835da542a1053d1abbd149d89c27c30f99c8b69d82f6c0aa7dbee01cb1a5d8091ea7ddef6fbc633b966cbbe38951c0a8005"
+  }
+}

--- a/conformance/receipt-claim/fixtures/RCL-005.json
+++ b/conformance/receipt-claim/fixtures/RCL-005.json
@@ -1,0 +1,78 @@
+{
+  "test_id": "RCL-005",
+  "name": "Authorization bound to different parameters",
+  "expected_result": "reject",
+  "expected_phase": "admission",
+  "violated_binding": "authorization bound to different params than requested",
+  "reason_code": "AUTHORIZATION_PARAMS_MISMATCH",
+  "harness_reason": "authorization: params do not match the action",
+  "evidence_binding": {
+    "admitted_action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+    "action_tool_set_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+    "referenced_evidence": {
+      "authorization": {
+        "present": true,
+        "attestor": "authz",
+        "independent_of_emitter": true,
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "params_digest": "874ef3c2436820bb8580c58ba75d2f788ee2e6f6ad65892d1d8d3d081885d73a"
+      },
+      "occurrence": {
+        "present": true,
+        "attestor": "exec",
+        "independent_of_emitter": true,
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "outcome_digest": "212e659146dac83f09f639fe16f4316e2fc5ecb37c3f99ee67e31eb7a73bb0f9"
+      },
+      "check": {
+        "present": true,
+        "attestor": "checker",
+        "independent_of_emitter": true,
+        "input_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+        "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+        "output": "pass",
+        "issued_at": 1750000000,
+        "checker_id": "tool-scan",
+        "version": "1.0"
+      }
+    },
+    "attestor_independence_ok": true,
+    "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+    "freshness_window_seconds": 300
+  },
+  "recomputation_boundary": "authorization bound to different params than requested",
+  "envelope_signature_valid": true,
+  "receipt": {
+    "action": {
+      "tool": "transfer",
+      "params": {
+        "to": "acct-A",
+        "amount": 100
+      }
+    },
+    "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+    "tool_set_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+    "claims": {
+      "authorization": {
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "params_digest": "874ef3c2436820bb8580c58ba75d2f788ee2e6f6ad65892d1d8d3d081885d73a",
+        "sig": "371ae60835cfa993f6779c61cc2a67fbb8b64af346a24a6c03551e7d9d61e3441b958658e4328e1ec71af489fb71142a797f90722fa93c0043886cb27bf20204"
+      },
+      "occurrence": {
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "outcome_digest": "212e659146dac83f09f639fe16f4316e2fc5ecb37c3f99ee67e31eb7a73bb0f9",
+        "sig": "880e3c9840c24bb4961efad424b151388af174c35f24ba6faf922bd388a114786bfcb67cbeed03f1ef689c578cfd5610f45492212ba4de30156062a98bc66d0c"
+      },
+      "check": {
+        "checker_id": "tool-scan",
+        "version": "1.0",
+        "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+        "input_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+        "output": "pass",
+        "issued_at": 1750000000,
+        "sig": "b489115dd3fe0269d4879eb728be602be737be59f190f0c471e52f131d94368c32911fc77680e7ae56d02b730d190129b719d981dd3f46c8e87b9051730f770f"
+      }
+    },
+    "envelope_sig": "c6787087a53031154531786151f4e8f42eb98b94c0dce2570aca6fc296ee6d22b74c1f16af1918a8052146488ca7d55e91c2d3f2e34118072ee6b9f226d5b400"
+  }
+}

--- a/conformance/receipt-claim/fixtures/RCL-006.json
+++ b/conformance/receipt-claim/fixtures/RCL-006.json
@@ -1,0 +1,78 @@
+{
+  "test_id": "RCL-006",
+  "name": "Execution ack bound to another action",
+  "expected_result": "reject",
+  "expected_phase": "post-execution",
+  "violated_binding": "occurrence ack bound to another action",
+  "reason_code": "OCCURRENCE_ACTION_LINKAGE_MISMATCH",
+  "harness_reason": "occurrence: acknowledgment bound to another action",
+  "evidence_binding": {
+    "admitted_action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+    "action_tool_set_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+    "referenced_evidence": {
+      "authorization": {
+        "present": true,
+        "attestor": "authz",
+        "independent_of_emitter": true,
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "params_digest": "29b774d0a454b86f6375f55fd90c804e6ba03b2eaee1e88f07a19afa73c70174"
+      },
+      "occurrence": {
+        "present": true,
+        "attestor": "exec",
+        "independent_of_emitter": true,
+        "action_digest": "369931621f322d545ad0ab97f873e20e5c8a0f43c0b49915d5c979b32e4a6d7f",
+        "outcome_digest": "212e659146dac83f09f639fe16f4316e2fc5ecb37c3f99ee67e31eb7a73bb0f9"
+      },
+      "check": {
+        "present": true,
+        "attestor": "checker",
+        "independent_of_emitter": true,
+        "input_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+        "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+        "output": "pass",
+        "issued_at": 1750000000,
+        "checker_id": "tool-scan",
+        "version": "1.0"
+      }
+    },
+    "attestor_independence_ok": true,
+    "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+    "freshness_window_seconds": 300
+  },
+  "recomputation_boundary": "occurrence ack bound to another action",
+  "envelope_signature_valid": true,
+  "receipt": {
+    "action": {
+      "tool": "transfer",
+      "params": {
+        "to": "acct-A",
+        "amount": 100
+      }
+    },
+    "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+    "tool_set_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+    "claims": {
+      "authorization": {
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "params_digest": "29b774d0a454b86f6375f55fd90c804e6ba03b2eaee1e88f07a19afa73c70174",
+        "sig": "f05e7e4b011f73e79fc2e0faad5ea2c1c8b0bc4edd14e515a1c6a8b2b2711e7b2830897168ece5510e6501789cd1b53650bb08b9e9e82b949cba23adbd0b770c"
+      },
+      "occurrence": {
+        "action_digest": "369931621f322d545ad0ab97f873e20e5c8a0f43c0b49915d5c979b32e4a6d7f",
+        "outcome_digest": "212e659146dac83f09f639fe16f4316e2fc5ecb37c3f99ee67e31eb7a73bb0f9",
+        "sig": "2bbc8fe0510d1a4363aae97aa6ec96f3c1e5d8583e61cbecad39f1b24e57b9a83d217e7cd5a6b220c4575e71223cbd1eb410c1d48daeb72cc01b629c7ca4660e"
+      },
+      "check": {
+        "checker_id": "tool-scan",
+        "version": "1.0",
+        "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+        "input_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+        "output": "pass",
+        "issued_at": 1750000000,
+        "sig": "b489115dd3fe0269d4879eb728be602be737be59f190f0c471e52f131d94368c32911fc77680e7ae56d02b730d190129b719d981dd3f46c8e87b9051730f770f"
+      }
+    },
+    "envelope_sig": "65cf85d93051e95cda869f6a4d7eab83d8ee513c599fa54244668a43ae0e2ef4ca0c23c621ec02c9f9662a9f817f3a456a8fbcf8345b2403bd2e552d6e098102"
+  }
+}

--- a/conformance/receipt-claim/fixtures/RCL-007.json
+++ b/conformance/receipt-claim/fixtures/RCL-007.json
@@ -1,0 +1,78 @@
+{
+  "test_id": "RCL-007",
+  "name": "Emitter self-assertion, no independent attestation",
+  "expected_result": "reject",
+  "expected_phase": "admission",
+  "violated_binding": "check attested by emitter, not an independent authority",
+  "reason_code": "CHECK_ATTESTOR_NOT_INDEPENDENT",
+  "harness_reason": "check: attested by the emitter, not the checker authority",
+  "evidence_binding": {
+    "admitted_action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+    "action_tool_set_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+    "referenced_evidence": {
+      "authorization": {
+        "present": true,
+        "attestor": "authz",
+        "independent_of_emitter": true,
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "params_digest": "29b774d0a454b86f6375f55fd90c804e6ba03b2eaee1e88f07a19afa73c70174"
+      },
+      "occurrence": {
+        "present": true,
+        "attestor": "exec",
+        "independent_of_emitter": true,
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "outcome_digest": "212e659146dac83f09f639fe16f4316e2fc5ecb37c3f99ee67e31eb7a73bb0f9"
+      },
+      "check": {
+        "present": true,
+        "attestor": "emitter",
+        "independent_of_emitter": false,
+        "input_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+        "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+        "output": "pass",
+        "issued_at": 1750000000,
+        "checker_id": "tool-scan",
+        "version": "1.0"
+      }
+    },
+    "attestor_independence_ok": false,
+    "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+    "freshness_window_seconds": 300
+  },
+  "recomputation_boundary": "check attested by emitter, not an independent authority",
+  "envelope_signature_valid": true,
+  "receipt": {
+    "action": {
+      "tool": "transfer",
+      "params": {
+        "to": "acct-A",
+        "amount": 100
+      }
+    },
+    "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+    "tool_set_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+    "claims": {
+      "authorization": {
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "params_digest": "29b774d0a454b86f6375f55fd90c804e6ba03b2eaee1e88f07a19afa73c70174",
+        "sig": "f05e7e4b011f73e79fc2e0faad5ea2c1c8b0bc4edd14e515a1c6a8b2b2711e7b2830897168ece5510e6501789cd1b53650bb08b9e9e82b949cba23adbd0b770c"
+      },
+      "occurrence": {
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "outcome_digest": "212e659146dac83f09f639fe16f4316e2fc5ecb37c3f99ee67e31eb7a73bb0f9",
+        "sig": "880e3c9840c24bb4961efad424b151388af174c35f24ba6faf922bd388a114786bfcb67cbeed03f1ef689c578cfd5610f45492212ba4de30156062a98bc66d0c"
+      },
+      "check": {
+        "checker_id": "tool-scan",
+        "version": "1.0",
+        "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+        "input_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+        "output": "pass",
+        "issued_at": 1750000000,
+        "sig": "4930941add58ebbcba94204017e969b23c18832e72b7c5b17987a8f9aacb7c787ec9ebb02fd76a4775417248d57004eae5d1644b6ec105102a203004c74a570c"
+      }
+    },
+    "envelope_sig": "b5d9316370812b8a423fbb8e60b8b6b33fd08f8de28e15e5c91abf48db4a2fb4e63b906c2003f0f7b83d97362366bf6e5644ccfd7f7c9e362a34eceb31920701"
+  }
+}

--- a/conformance/receipt-claim/fixtures/RCL-008.json
+++ b/conformance/receipt-claim/fixtures/RCL-008.json
@@ -1,0 +1,78 @@
+{
+  "test_id": "RCL-008",
+  "name": "Fully-supported receipt accepted (control)",
+  "expected_result": "accept",
+  "expected_phase": "admission+post-execution",
+  "violated_binding": "control: all four properties supported",
+  "reason_code": "ACCEPT_ALL_PROPERTIES_SUPPORTED",
+  "harness_reason": "all four properties independently supported",
+  "evidence_binding": {
+    "admitted_action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+    "action_tool_set_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+    "referenced_evidence": {
+      "authorization": {
+        "present": true,
+        "attestor": "authz",
+        "independent_of_emitter": true,
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "params_digest": "29b774d0a454b86f6375f55fd90c804e6ba03b2eaee1e88f07a19afa73c70174"
+      },
+      "occurrence": {
+        "present": true,
+        "attestor": "exec",
+        "independent_of_emitter": true,
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "outcome_digest": "212e659146dac83f09f639fe16f4316e2fc5ecb37c3f99ee67e31eb7a73bb0f9"
+      },
+      "check": {
+        "present": true,
+        "attestor": "checker",
+        "independent_of_emitter": true,
+        "input_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+        "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+        "output": "pass",
+        "issued_at": 1750000000,
+        "checker_id": "tool-scan",
+        "version": "1.0"
+      }
+    },
+    "attestor_independence_ok": true,
+    "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+    "freshness_window_seconds": 300
+  },
+  "recomputation_boundary": "control: all four properties supported",
+  "envelope_signature_valid": true,
+  "receipt": {
+    "action": {
+      "tool": "transfer",
+      "params": {
+        "to": "acct-A",
+        "amount": 100
+      }
+    },
+    "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+    "tool_set_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+    "claims": {
+      "authorization": {
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "params_digest": "29b774d0a454b86f6375f55fd90c804e6ba03b2eaee1e88f07a19afa73c70174",
+        "sig": "f05e7e4b011f73e79fc2e0faad5ea2c1c8b0bc4edd14e515a1c6a8b2b2711e7b2830897168ece5510e6501789cd1b53650bb08b9e9e82b949cba23adbd0b770c"
+      },
+      "occurrence": {
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "outcome_digest": "212e659146dac83f09f639fe16f4316e2fc5ecb37c3f99ee67e31eb7a73bb0f9",
+        "sig": "880e3c9840c24bb4961efad424b151388af174c35f24ba6faf922bd388a114786bfcb67cbeed03f1ef689c578cfd5610f45492212ba4de30156062a98bc66d0c"
+      },
+      "check": {
+        "checker_id": "tool-scan",
+        "version": "1.0",
+        "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+        "input_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+        "output": "pass",
+        "issued_at": 1750000000,
+        "sig": "b489115dd3fe0269d4879eb728be602be737be59f190f0c471e52f131d94368c32911fc77680e7ae56d02b730d190129b719d981dd3f46c8e87b9051730f770f"
+      }
+    },
+    "envelope_sig": "9a28b2cbc02f6f18c0d69456548fa42f8b50adbb76200578b5a2f0bdeb8fac44d4c973db0d61b1e16a92324717e8e4f9d7e9234e5c8251285d97c2bc64e4690d"
+  }
+}

--- a/conformance/receipt-claim/fixtures/RCL-009.json
+++ b/conformance/receipt-claim/fixtures/RCL-009.json
@@ -1,0 +1,77 @@
+{
+  "test_id": "RCL-009",
+  "name": "Wired MCP-019 check (clean) accepted",
+  "expected_result": "accept",
+  "expected_phase": "admission",
+  "violated_binding": "control: clean wired check accepted",
+  "reason_code": "ACCEPT_ALL_PROPERTIES_SUPPORTED",
+  "harness_reason": "all four properties independently supported",
+  "evidence_binding": {
+    "admitted_action_digest": "5558294fdc17c8ffe2f8036a59fd8b7ea23c735e7ff773e4a424bcb5623139dc",
+    "action_tool_set_digest": "935a529bdd6d83f3507a160616ac86968089d7da06d70b59dc66c70c4df091d2",
+    "referenced_evidence": {
+      "authorization": {
+        "present": true,
+        "attestor": "authz",
+        "independent_of_emitter": true,
+        "action_digest": "5558294fdc17c8ffe2f8036a59fd8b7ea23c735e7ff773e4a424bcb5623139dc",
+        "params_digest": "846774f5f795e29d6d3c2fd04cdef645d4c71798e6fde0c86f94737cb2c33071"
+      },
+      "occurrence": {
+        "present": true,
+        "attestor": "exec",
+        "independent_of_emitter": true,
+        "action_digest": "5558294fdc17c8ffe2f8036a59fd8b7ea23c735e7ff773e4a424bcb5623139dc",
+        "outcome_digest": "212e659146dac83f09f639fe16f4316e2fc5ecb37c3f99ee67e31eb7a73bb0f9"
+      },
+      "check": {
+        "present": true,
+        "attestor": "checker",
+        "independent_of_emitter": true,
+        "input_digest": "935a529bdd6d83f3507a160616ac86968089d7da06d70b59dc66c70c4df091d2",
+        "policy_digest": "e6fd7138c3ca7c972fc4c3042573bc15eb73d961f8848334dad5749367987a9a",
+        "output": "pass",
+        "issued_at": 1750000000,
+        "checker_id": "mcp-019-composite",
+        "version": "1.0"
+      }
+    },
+    "attestor_independence_ok": true,
+    "policy_digest": "e6fd7138c3ca7c972fc4c3042573bc15eb73d961f8848334dad5749367987a9a",
+    "freshness_window_seconds": 300
+  },
+  "recomputation_boundary": "control: clean wired check accepted",
+  "envelope_signature_valid": true,
+  "receipt": {
+    "action": {
+      "tool": "invoke",
+      "params": {
+        "which": "transfer"
+      }
+    },
+    "action_digest": "5558294fdc17c8ffe2f8036a59fd8b7ea23c735e7ff773e4a424bcb5623139dc",
+    "tool_set_digest": "935a529bdd6d83f3507a160616ac86968089d7da06d70b59dc66c70c4df091d2",
+    "claims": {
+      "authorization": {
+        "action_digest": "5558294fdc17c8ffe2f8036a59fd8b7ea23c735e7ff773e4a424bcb5623139dc",
+        "params_digest": "846774f5f795e29d6d3c2fd04cdef645d4c71798e6fde0c86f94737cb2c33071",
+        "sig": "5c84b626f11accc50bc5671472daf34c32e43c658dfd9fa2151f07076bd5d7d68d4d48a4db929a2e2b8972c620545dad9092eeab3e5b9719643a1ab91808830b"
+      },
+      "occurrence": {
+        "action_digest": "5558294fdc17c8ffe2f8036a59fd8b7ea23c735e7ff773e4a424bcb5623139dc",
+        "outcome_digest": "212e659146dac83f09f639fe16f4316e2fc5ecb37c3f99ee67e31eb7a73bb0f9",
+        "sig": "16847edd553ae69ab4f3d07497b8fce3fd6104894349880b21754561abe97fd809785d5d66d14ffe5849dba4fa4a7d780d34d9ed955ff5f72c6fe5e7e5b5b70d"
+      },
+      "check": {
+        "checker_id": "mcp-019-composite",
+        "version": "1.0",
+        "policy_digest": "e6fd7138c3ca7c972fc4c3042573bc15eb73d961f8848334dad5749367987a9a",
+        "input_digest": "935a529bdd6d83f3507a160616ac86968089d7da06d70b59dc66c70c4df091d2",
+        "output": "pass",
+        "issued_at": 1750000000,
+        "sig": "bb1d955433351d16f0eeb0cc9b34baf803ebf8570b1f7245769ce3ff980decd6e1481ac7e17305cde9732c064d9f33cd03200a88b17cae39aa2529b079c0c50d"
+      }
+    },
+    "envelope_sig": "2ae6e11e6416ad762e333f1af450a4f7c75c2e06bb94a3ad44bbdae1330ff6fc8d4aace00179b0da251714ea9372f26cb3357c7861fd8acd5d4a354f8adaf80f"
+  }
+}

--- a/conformance/receipt-claim/fixtures/RCL-010.json
+++ b/conformance/receipt-claim/fixtures/RCL-010.json
@@ -1,0 +1,77 @@
+{
+  "test_id": "RCL-010",
+  "name": "Wired MCP-019 check (composite found) rejected",
+  "expected_result": "reject",
+  "expected_phase": "admission",
+  "violated_binding": "wired MCP-019 verdict is fail",
+  "reason_code": "CHECK_OUTPUT_FAIL",
+  "harness_reason": "check: recorded output is not a pass",
+  "evidence_binding": {
+    "admitted_action_digest": "5558294fdc17c8ffe2f8036a59fd8b7ea23c735e7ff773e4a424bcb5623139dc",
+    "action_tool_set_digest": "64f53a5a25ced4a18c4aa03551e025b514b83fecc694ef9aea179bdf69a6a603",
+    "referenced_evidence": {
+      "authorization": {
+        "present": true,
+        "attestor": "authz",
+        "independent_of_emitter": true,
+        "action_digest": "5558294fdc17c8ffe2f8036a59fd8b7ea23c735e7ff773e4a424bcb5623139dc",
+        "params_digest": "846774f5f795e29d6d3c2fd04cdef645d4c71798e6fde0c86f94737cb2c33071"
+      },
+      "occurrence": {
+        "present": true,
+        "attestor": "exec",
+        "independent_of_emitter": true,
+        "action_digest": "5558294fdc17c8ffe2f8036a59fd8b7ea23c735e7ff773e4a424bcb5623139dc",
+        "outcome_digest": "212e659146dac83f09f639fe16f4316e2fc5ecb37c3f99ee67e31eb7a73bb0f9"
+      },
+      "check": {
+        "present": true,
+        "attestor": "checker",
+        "independent_of_emitter": true,
+        "input_digest": "64f53a5a25ced4a18c4aa03551e025b514b83fecc694ef9aea179bdf69a6a603",
+        "policy_digest": "e6fd7138c3ca7c972fc4c3042573bc15eb73d961f8848334dad5749367987a9a",
+        "output": "fail",
+        "issued_at": 1750000000,
+        "checker_id": "mcp-019-composite",
+        "version": "1.0"
+      }
+    },
+    "attestor_independence_ok": true,
+    "policy_digest": "e6fd7138c3ca7c972fc4c3042573bc15eb73d961f8848334dad5749367987a9a",
+    "freshness_window_seconds": 300
+  },
+  "recomputation_boundary": "wired MCP-019 verdict is fail",
+  "envelope_signature_valid": true,
+  "receipt": {
+    "action": {
+      "tool": "invoke",
+      "params": {
+        "which": "transfer"
+      }
+    },
+    "action_digest": "5558294fdc17c8ffe2f8036a59fd8b7ea23c735e7ff773e4a424bcb5623139dc",
+    "tool_set_digest": "64f53a5a25ced4a18c4aa03551e025b514b83fecc694ef9aea179bdf69a6a603",
+    "claims": {
+      "authorization": {
+        "action_digest": "5558294fdc17c8ffe2f8036a59fd8b7ea23c735e7ff773e4a424bcb5623139dc",
+        "params_digest": "846774f5f795e29d6d3c2fd04cdef645d4c71798e6fde0c86f94737cb2c33071",
+        "sig": "5c84b626f11accc50bc5671472daf34c32e43c658dfd9fa2151f07076bd5d7d68d4d48a4db929a2e2b8972c620545dad9092eeab3e5b9719643a1ab91808830b"
+      },
+      "occurrence": {
+        "action_digest": "5558294fdc17c8ffe2f8036a59fd8b7ea23c735e7ff773e4a424bcb5623139dc",
+        "outcome_digest": "212e659146dac83f09f639fe16f4316e2fc5ecb37c3f99ee67e31eb7a73bb0f9",
+        "sig": "16847edd553ae69ab4f3d07497b8fce3fd6104894349880b21754561abe97fd809785d5d66d14ffe5849dba4fa4a7d780d34d9ed955ff5f72c6fe5e7e5b5b70d"
+      },
+      "check": {
+        "checker_id": "mcp-019-composite",
+        "version": "1.0",
+        "policy_digest": "e6fd7138c3ca7c972fc4c3042573bc15eb73d961f8848334dad5749367987a9a",
+        "input_digest": "64f53a5a25ced4a18c4aa03551e025b514b83fecc694ef9aea179bdf69a6a603",
+        "output": "fail",
+        "issued_at": 1750000000,
+        "sig": "a5a7fb9478f2b0e0d0e8bef62f331e2204f1333096f17e5db42876cf572dfd0e93be85be527fb4c48011b44a9f8087dbb6b5410f6339aae1e5458c2fe69f050d"
+      }
+    },
+    "envelope_sig": "560f9da708e7a432a2c75007e3f4603b7ba4deb470c8c9dadca57ce788559af87d58e04397f97aeafe5f29b32e1585875fdccf8e4303a2f74b518509bba5d109"
+  }
+}

--- a/conformance/receipt-claim/fixtures/RCL-011.json
+++ b/conformance/receipt-claim/fixtures/RCL-011.json
@@ -1,0 +1,77 @@
+{
+  "test_id": "RCL-011",
+  "name": "Wired MCP-019 check bound to wrong tool set rejected",
+  "expected_result": "reject",
+  "expected_phase": "admission",
+  "violated_binding": "wired check bound to the wrong tool set",
+  "reason_code": "CHECK_TOOLSET_DIGEST_MISMATCH",
+  "harness_reason": "check: result bound to the wrong tool-set digest",
+  "evidence_binding": {
+    "admitted_action_digest": "5558294fdc17c8ffe2f8036a59fd8b7ea23c735e7ff773e4a424bcb5623139dc",
+    "action_tool_set_digest": "64f53a5a25ced4a18c4aa03551e025b514b83fecc694ef9aea179bdf69a6a603",
+    "referenced_evidence": {
+      "authorization": {
+        "present": true,
+        "attestor": "authz",
+        "independent_of_emitter": true,
+        "action_digest": "5558294fdc17c8ffe2f8036a59fd8b7ea23c735e7ff773e4a424bcb5623139dc",
+        "params_digest": "846774f5f795e29d6d3c2fd04cdef645d4c71798e6fde0c86f94737cb2c33071"
+      },
+      "occurrence": {
+        "present": true,
+        "attestor": "exec",
+        "independent_of_emitter": true,
+        "action_digest": "5558294fdc17c8ffe2f8036a59fd8b7ea23c735e7ff773e4a424bcb5623139dc",
+        "outcome_digest": "212e659146dac83f09f639fe16f4316e2fc5ecb37c3f99ee67e31eb7a73bb0f9"
+      },
+      "check": {
+        "present": true,
+        "attestor": "checker",
+        "independent_of_emitter": true,
+        "input_digest": "935a529bdd6d83f3507a160616ac86968089d7da06d70b59dc66c70c4df091d2",
+        "policy_digest": "e6fd7138c3ca7c972fc4c3042573bc15eb73d961f8848334dad5749367987a9a",
+        "output": "pass",
+        "issued_at": 1750000000,
+        "checker_id": "mcp-019-composite",
+        "version": "1.0"
+      }
+    },
+    "attestor_independence_ok": true,
+    "policy_digest": "e6fd7138c3ca7c972fc4c3042573bc15eb73d961f8848334dad5749367987a9a",
+    "freshness_window_seconds": 300
+  },
+  "recomputation_boundary": "wired check bound to the wrong tool set",
+  "envelope_signature_valid": true,
+  "receipt": {
+    "action": {
+      "tool": "invoke",
+      "params": {
+        "which": "transfer"
+      }
+    },
+    "action_digest": "5558294fdc17c8ffe2f8036a59fd8b7ea23c735e7ff773e4a424bcb5623139dc",
+    "tool_set_digest": "64f53a5a25ced4a18c4aa03551e025b514b83fecc694ef9aea179bdf69a6a603",
+    "claims": {
+      "authorization": {
+        "action_digest": "5558294fdc17c8ffe2f8036a59fd8b7ea23c735e7ff773e4a424bcb5623139dc",
+        "params_digest": "846774f5f795e29d6d3c2fd04cdef645d4c71798e6fde0c86f94737cb2c33071",
+        "sig": "5c84b626f11accc50bc5671472daf34c32e43c658dfd9fa2151f07076bd5d7d68d4d48a4db929a2e2b8972c620545dad9092eeab3e5b9719643a1ab91808830b"
+      },
+      "occurrence": {
+        "action_digest": "5558294fdc17c8ffe2f8036a59fd8b7ea23c735e7ff773e4a424bcb5623139dc",
+        "outcome_digest": "212e659146dac83f09f639fe16f4316e2fc5ecb37c3f99ee67e31eb7a73bb0f9",
+        "sig": "16847edd553ae69ab4f3d07497b8fce3fd6104894349880b21754561abe97fd809785d5d66d14ffe5849dba4fa4a7d780d34d9ed955ff5f72c6fe5e7e5b5b70d"
+      },
+      "check": {
+        "checker_id": "mcp-019-composite",
+        "version": "1.0",
+        "policy_digest": "e6fd7138c3ca7c972fc4c3042573bc15eb73d961f8848334dad5749367987a9a",
+        "input_digest": "935a529bdd6d83f3507a160616ac86968089d7da06d70b59dc66c70c4df091d2",
+        "output": "pass",
+        "issued_at": 1750000000,
+        "sig": "bb1d955433351d16f0eeb0cc9b34baf803ebf8570b1f7245769ce3ff980decd6e1481ac7e17305cde9732c064d9f33cd03200a88b17cae39aa2529b079c0c50d"
+      }
+    },
+    "envelope_sig": "09e7d9c21473ede44d647d2a09b9c760b27d113b2c63056cd131c57d9d69f73e7abe9308ee5aa14c4634cacce2510a506df311507308d1adde706cc949c5490b"
+  }
+}

--- a/conformance/receipt-claim/fixtures/index.json
+++ b/conformance/receipt-claim/fixtures/index.json
@@ -1,0 +1,97 @@
+{
+  "suite": "RCL receipt-claim conformance vectors",
+  "source": "protocol_tests/receipt_claim_harness.py",
+  "reject_vectors": 9,
+  "acceptance_controls": 2,
+  "freshness_window_seconds": 300,
+  "cases": [
+    {
+      "test_id": "RCL-001",
+      "name": "Omitted mandatory evidence",
+      "expected_result": "reject",
+      "phase": "post-execution",
+      "reason_code": "OCCURRENCE_EVIDENCE_MISSING",
+      "harness_reason": "occurrence: missing evidence"
+    },
+    {
+      "test_id": "RCL-002",
+      "name": "Substituted evidence, re-signed envelope",
+      "expected_result": "reject",
+      "phase": "admission",
+      "reason_code": "CHECK_EVIDENCE_TAMPERED",
+      "harness_reason": "check: checker attestation does not verify (substituted or forged)"
+    },
+    {
+      "test_id": "RCL-003",
+      "name": "Stale checker transcript",
+      "expected_result": "reject",
+      "phase": "admission",
+      "reason_code": "CHECK_TRANSCRIPT_STALE",
+      "harness_reason": "check: stale transcript (outside freshness window)"
+    },
+    {
+      "test_id": "RCL-004",
+      "name": "Check bound to the wrong tool-set digest",
+      "expected_result": "reject",
+      "phase": "admission",
+      "reason_code": "CHECK_TOOLSET_DIGEST_MISMATCH",
+      "harness_reason": "check: result bound to the wrong tool-set digest"
+    },
+    {
+      "test_id": "RCL-005",
+      "name": "Authorization bound to different parameters",
+      "expected_result": "reject",
+      "phase": "admission",
+      "reason_code": "AUTHORIZATION_PARAMS_MISMATCH",
+      "harness_reason": "authorization: params do not match the action"
+    },
+    {
+      "test_id": "RCL-006",
+      "name": "Execution ack bound to another action",
+      "expected_result": "reject",
+      "phase": "post-execution",
+      "reason_code": "OCCURRENCE_ACTION_LINKAGE_MISMATCH",
+      "harness_reason": "occurrence: acknowledgment bound to another action"
+    },
+    {
+      "test_id": "RCL-007",
+      "name": "Emitter self-assertion, no independent attestation",
+      "expected_result": "reject",
+      "phase": "admission",
+      "reason_code": "CHECK_ATTESTOR_NOT_INDEPENDENT",
+      "harness_reason": "check: attested by the emitter, not the checker authority"
+    },
+    {
+      "test_id": "RCL-008",
+      "name": "Fully-supported receipt accepted (control)",
+      "expected_result": "accept",
+      "phase": "admission+post-execution",
+      "reason_code": "ACCEPT_ALL_PROPERTIES_SUPPORTED",
+      "harness_reason": "all four properties independently supported"
+    },
+    {
+      "test_id": "RCL-009",
+      "name": "Wired MCP-019 check (clean) accepted",
+      "expected_result": "accept",
+      "phase": "admission",
+      "reason_code": "ACCEPT_ALL_PROPERTIES_SUPPORTED",
+      "harness_reason": "all four properties independently supported"
+    },
+    {
+      "test_id": "RCL-010",
+      "name": "Wired MCP-019 check (composite found) rejected",
+      "expected_result": "reject",
+      "phase": "admission",
+      "reason_code": "CHECK_OUTPUT_FAIL",
+      "harness_reason": "check: recorded output is not a pass"
+    },
+    {
+      "test_id": "RCL-011",
+      "name": "Wired MCP-019 check bound to wrong tool set rejected",
+      "expected_result": "reject",
+      "phase": "admission",
+      "reason_code": "CHECK_TOOLSET_DIGEST_MISMATCH",
+      "harness_reason": "check: result bound to the wrong tool-set digest"
+    }
+  ]
+}

--- a/conformance/receipt-claim/generate.py
+++ b/conformance/receipt-claim/generate.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Generate the RCL receipt-claim conformance vectors from the harness verifier.
+
+Each vector is a receipt whose envelope signature verifies but whose claims are
+(in)valid on semantic grounds. Values are produced by the working ClaimLevelVerifier
+in protocol_tests/receipt_claim_harness.py, not hand-authored, so `expected_result`
+and `harness_reason` are ground truth. Run from the repo root:
+
+    python conformance/receipt-claim/generate.py
+"""
+import json, os, sys
+REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, REPO)
+from protocol_tests import receipt_claim_harness as R
+
+OUT = os.path.join(REPO, "conformance", "receipt-claim", "fixtures")
+os.makedirs(OUT, exist_ok=True)
+now = R.ReceiptClaimTests().now
+V = R.ClaimLevelVerifier(now)
+
+
+def who_signed(block):
+    if not isinstance(block, dict):
+        return None
+    for auth in ("checker", "authz", "exec", "emitter"):
+        if R._attest_ok(auth, block):
+            return auth
+    return None
+
+
+# Per case: receipt-lifecycle phase, the binding a verifier must fail, and a
+# harness-native reason code (maps 1:1 to the verifier's reason string).
+META = {
+ "RCL-001": ("post-execution", "occurrence evidence omitted",                       "OCCURRENCE_EVIDENCE_MISSING"),
+ "RCL-002": ("admission",      "check evidence tampered after attestation",          "CHECK_EVIDENCE_TAMPERED"),
+ "RCL-003": ("admission",      "check transcript outside the freshness window",       "CHECK_TRANSCRIPT_STALE"),
+ "RCL-004": ("admission",      "check bound to a different tool-set digest",           "CHECK_TOOLSET_DIGEST_MISMATCH"),
+ "RCL-005": ("admission",      "authorization bound to different params than requested","AUTHORIZATION_PARAMS_MISMATCH"),
+ "RCL-006": ("post-execution", "occurrence ack bound to another action",              "OCCURRENCE_ACTION_LINKAGE_MISMATCH"),
+ "RCL-007": ("admission",      "check attested by emitter, not an independent authority","CHECK_ATTESTOR_NOT_INDEPENDENT"),
+ "RCL-008": ("admission+post-execution", "control: all four properties supported",     "ACCEPT_ALL_PROPERTIES_SUPPORTED"),
+ "RCL-009": ("admission",      "control: clean wired check accepted",                  "ACCEPT_ALL_PROPERTIES_SUPPORTED"),
+ "RCL-010": ("admission",      "wired MCP-019 verdict is fail",                        "CHECK_OUTPUT_FAIL"),
+ "RCL-011": ("admission",      "wired check bound to the wrong tool set",              "CHECK_TOOLSET_DIGEST_MISMATCH"),
+}
+
+
+def build(tid):
+    if tid == "RCL-008":
+        return R.build_valid_receipt(now)
+    if tid == "RCL-009":
+        return R.build_tool_context_receipt(now, R._CLEAN_TOOLS)
+    if tid == "RCL-010":
+        return R.build_tool_context_receipt(now, R._SHARELOCK_TOOLS)
+    if tid == "RCL-011":
+        return R.build_tool_context_receipt(now, R._CLEAN_TOOLS, action_tools=R._SHARELOCK_TOOLS)
+    return dict((t[0], t[2]) for t in R.NEGATIVES)[tid](now)
+
+
+NAMES = dict((t[0], t[1]) for t in R.NEGATIVES)
+NAMES.update({"RCL-008": "Fully-supported receipt accepted (control)",
+              "RCL-009": "Wired MCP-019 check (clean) accepted",
+              "RCL-010": "Wired MCP-019 check (composite found) rejected",
+              "RCL-011": "Wired MCP-019 check bound to wrong tool set rejected"})
+
+index = []
+for tid in [f"RCL-{i:03d}" for i in range(1, 12)]:
+    rcpt = build(tid)
+    out = V.verify(rcpt)
+    env = V.verify_envelope(rcpt)
+    phase, binding, code = META[tid]
+    claims = rcpt.get("claims", {})
+    ev = {}
+    for prop in ("authorization", "occurrence", "check"):
+        b = claims.get(prop)
+        if b is None:
+            ev[prop] = {"present": False}
+            continue
+        rec = {"present": True, "attestor": who_signed(b),
+               "independent_of_emitter": who_signed(b) != "emitter"}
+        for f in ("action_digest", "params_digest", "outcome_digest",
+                  "input_digest", "policy_digest", "output", "issued_at",
+                  "checker_id", "version"):
+            if f in b:
+                rec[f] = b[f]
+        ev[prop] = rec
+    fixture = {
+        "test_id": tid,
+        "name": NAMES[tid],
+        "expected_result": out.verdict,          # accept | reject  (ground truth)
+        "expected_phase": phase,                 # admission | post-execution | both
+        "violated_binding": binding,
+        "reason_code": code,
+        "harness_reason": out.reason,            # verbatim verifier output
+        # Evidence-binding descriptor: exactly what a verifier must recompute
+        # from referenced evidence, so the vector is not satisfiable at the
+        # string level.
+        "evidence_binding": {
+            "admitted_action_digest": rcpt.get("action_digest"),
+            "action_tool_set_digest": rcpt.get("tool_set_digest"),
+            "referenced_evidence": ev,
+            "attestor_independence_ok": all(
+                v.get("independent_of_emitter", True) for v in ev.values() if v.get("present")),
+            "policy_digest": (claims.get("check") or {}).get("policy_digest"),
+            "freshness_window_seconds": R.FRESHNESS_WINDOW,
+        },
+        "recomputation_boundary": binding,
+        "envelope_signature_valid": env,         # always True: envelope-valid, claim-(in)valid
+        "receipt": rcpt,
+    }
+    with open(os.path.join(OUT, f"{tid}.json"), "w") as f:
+        json.dump(fixture, f, indent=2)
+    index.append({"test_id": tid, "name": NAMES[tid], "expected_result": out.verdict,
+                  "phase": phase, "reason_code": code, "harness_reason": out.reason})
+
+with open(os.path.join(OUT, "index.json"), "w") as f:
+    json.dump({"suite": "RCL receipt-claim conformance vectors",
+               "source": "protocol_tests/receipt_claim_harness.py",
+               "reject_vectors": sum(1 for x in index if x["expected_result"] == "reject"),
+               "acceptance_controls": sum(1 for x in index if x["expected_result"] == "accept"),
+               "freshness_window_seconds": R.FRESHNESS_WINDOW,
+               "cases": index}, f, indent=2)
+
+print(f"wrote {len(index)} fixtures to {OUT}")
+for x in index:
+    print(f"  {x['test_id']} {x['expected_result']:6} [{x['phase']}] {x['reason_code']}")

--- a/conformance/receipt-claim/generate.py
+++ b/conformance/receipt-claim/generate.py
@@ -77,7 +77,7 @@ for tid in [f"RCL-{i:03d}" for i in range(1, 12)]:
             ev[prop] = {"present": False}
             continue
         rec = {"present": True, "attestor": who_signed(b),
-               "independent_of_emitter": who_signed(b) != "emitter"}
+               "independent_of_emitter": who_signed(b) not in (None, "emitter")}
         for f in ("action_digest", "params_digest", "outcome_digest",
                   "input_digest", "policy_digest", "output", "issued_at",
                   "checker_id", "version"):

--- a/conformance/receipt-claim/verify_fixtures.py
+++ b/conformance/receipt-claim/verify_fixtures.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Replay every RCL conformance vector through the claim-level verifier and assert
+each reaches its recorded `expected_result`. This is what makes the vectors a
+conformance suite rather than static data: a receipt implementation can run its
+own verifier over the same fixtures and compare.
+
+    python conformance/receipt-claim/verify_fixtures.py     # exits non-zero on mismatch
+"""
+import glob, json, os, sys
+REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, REPO)
+from protocol_tests.receipt_claim_harness import ClaimLevelVerifier, ReceiptClaimTests
+
+FIX = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fixtures")
+
+
+def run():
+    now = ReceiptClaimTests().now
+    v = ClaimLevelVerifier(now)
+    failures = []
+    files = sorted(glob.glob(os.path.join(FIX, "RCL-*.json")))
+    for path in files:
+        fx = json.load(open(path))
+        # every vector is envelope-valid by construction; the claim verdict is the test
+        if not v.verify_envelope(fx["receipt"]):
+            failures.append((fx["test_id"], "envelope signature did not verify"))
+            continue
+        got = v.verify(fx["receipt"]).verdict
+        if got != fx["expected_result"]:
+            failures.append((fx["test_id"], f"expected {fx['expected_result']}, got {got}"))
+    print(f"receipt-claim conformance: {len(files) - len(failures)}/{len(files)} vectors match")
+    for tid, why in failures:
+        print(f"  MISMATCH {tid}: {why}")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/conformance/receipt-claim/verify_fixtures.py
+++ b/conformance/receipt-claim/verify_fixtures.py
@@ -19,6 +19,9 @@ def run():
     v = ClaimLevelVerifier(now)
     failures = []
     files = sorted(glob.glob(os.path.join(FIX, "RCL-*.json")))
+    if not files:
+        print(f"receipt-claim conformance: no fixtures found under {FIX} (fail closed)")
+        return 1
     for path in files:
         fx = json.load(open(path))
         # every vector is envelope-valid by construction; the claim verdict is the test


### PR DESCRIPTION
Publishes the RCL receipt-claim family as **portable, machine-readable conformance vectors** — a reusable artifact on our own surface.

Each vector is a receipt that is **envelope-valid but claim-(in)valid**: a conforming verifier must reach the recorded decision by recomputing evidence bindings, not by checking the signature. **9 reject vectors + 2 acceptance controls** (the controls stop an implementation from passing by rejecting everything).

### What's here
`conformance/receipt-claim/`
- `fixtures/RCL-001..011.json` + `index.json` — each carries an `evidence_binding` descriptor (admitted-action digest, tool-set digest, per-property attestor + independence flag, `policy_digest`, freshness window), the recomputation boundary, expected phase (admission vs post-execution), decision, and a harness-native reason code. `expected_result` and `harness_reason` are **ground-truth output** from `ClaimLevelVerifier`, not hand-authored.
- `generate.py` — regenerates the fixtures from the verifier.
- `verify_fixtures.py` — replays every fixture through the verifier and asserts the recorded result (**11/11 match**; exits non-zero on mismatch).

### Notes
- `RCL-005` (admission authorization mismatch) vs `RCL-006` (post-execution linkage mismatch) are the phase pair.
- `RCL-009/010/011` bind the real **MCP-019** composite-poisoning detector through the receipt path, so "the admitted tool set was checked" is only accepted when a verifier can recompute that the check covered the same tool-set digest.
- Reproducible byte-for-byte (deterministic Ed25519 test keys + fixed timestamp).
- **No new harness test IDs** — test count unchanged at 553. Fixtures are force-added past the `*.json` ignore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds conformance fixtures and tooling only; no production verifier or runtime behavior changes.
> 
> **Overview**
> Adds **`conformance/receipt-claim/`** as portable **RCL** vectors for claim-level receipt verification: each case is an **envelope-valid** receipt where accept/reject must come from **recomputing evidence bindings**, not signature checks alone.
> 
> The suite ships **11 JSON fixtures** (`RCL-001`–`RCL-011`) plus `index.json`, each with an `evidence_binding` descriptor, expected phase (admission vs post-execution), `reason_code`, and harness-ground-truth `expected_result` / `harness_reason`. Coverage includes **9 reject** scenarios (missing occurrence, tampered check, stale transcript, tool-set digest mismatch, auth param mismatch, occurrence linkage mismatch, non-independent check attestor, MCP-019 fail verdict, wrong-tool-set pass) and **2 accept controls** so implementations cannot pass by rejecting everything. **`RCL-009`–`011`** wire the **MCP-019** composite checker through the receipt path.
> 
> **`generate.py`** regenerates fixtures from `protocol_tests/receipt_claim_harness.py`; **`verify_fixtures.py`** replays all vectors through `ClaimLevelVerifier` and fails on mismatch. **`README.md`** documents the threat model, case table, and reproducibility (deterministic Ed25519 test keys).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd92a39d3d8b571ee1c20958a82ecb3e2f7b01b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->