### PR TITLE
fix: require supported MCP SDK versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,17 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install package
-        run: pip install -e . pyyaml pytest
+      - name: Install package with MCP server extra
+        run: pip install -e '.[mcp-server]' pyyaml pytest
+
+      - name: Verify packaged MCP server installation
+        run: |
+          pip install build
+          python -m build --wheel
+          pip uninstall -y agent-security-harness
+          wheel=$(find dist -name '*.whl' -print -quit)
+          pip install "${wheel}[mcp-server]"
+          python -c "from mcp_server.server import create_server; assert create_server().name == 'Agent Security Harness'"
 
       - name: Verify CLI
         run: |
@@ -60,6 +69,7 @@ jobs:
           import protocol_tests.cloud_agent_harness
           import protocol_tests.statistical
           import protocol_tests.cli
+          import mcp_server.server
           import protocol_tests.kill_switch_harness
           import protocol_tests.watermark_harness
           import protocol_tests.memory_harness

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -159,8 +159,7 @@ def create_server(api_key: str | None = None) -> FastMCP:
 
     mcp = FastMCP(
         "Agent Security Harness",
-        version="1.0.0",
-        description=(
+        instructions=(
             "Security testing tools for AI agent systems. "
             "553 tests across MCP, A2A, L402, x402, and identity protocols."
         ),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-mcp-server = ["mcp>=1.0.0"]
+mcp-server = ["mcp>=1.28.1,<2"]
 
 [project.urls]
 Homepage = "https://github.com/msaleme/red-team-blue-team-agent-fabric"
@@ -63,4 +63,4 @@ agent-security = "protocol_tests.cli:main"
 ash = "protocol_tests.cli:main"
 
 [tool.setuptools.packages.find]
-include = ["protocol_tests*", "scripts*"]
+include = ["protocol_tests*", "scripts*", "mcp_server*"]


### PR DESCRIPTION
## Summary
- raise the optional MCP server extra to `mcp>=1.28.1,<2`
- adapt the FastMCP factory to the current constructor API
- ship `mcp_server` in built distributions
- add CI coverage that installs the built wheel with the MCP extra and imports the server

## Validation
- clean editable install with the MCP extra
- `287 passed, 69 subtests passed`
- clean wheel-extra install and `create_server()` smoke test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging and CI changes with a small constructor API update; no auth, data, or core harness logic changes.
> 
> **Overview**
> Aligns the optional MCP server with **MCP SDK 1.28+** and makes sure the **`mcp_server`** package actually ships in wheels.
> 
> The **`mcp-server`** extra is pinned to `mcp>=1.28.1,<2`, and **`create_server()`** now passes **`instructions`** into **`FastMCP`** instead of the removed **`version`** / **`description`** constructor args. **`setuptools`** package discovery now includes **`mcp_server*`**.
> 
> CI installs with **`.[mcp-server]`**, builds a wheel, reinstalls it with the MCP extra, and smoke-tests **`create_server()`**; the module import check also loads **`mcp_server.server`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c3b5dacebbf4c1f0bc3432aacad28325dad7551. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->