### PR TITLE
test(mcp): add cache revocation probe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,17 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install package
-        run: pip install -e . pyyaml pytest
+      - name: Install package with MCP server extra
+        run: pip install -e '.[mcp-server]' pyyaml pytest
+
+      - name: Verify packaged MCP server installation
+        run: |
+          pip install build
+          python -m build --wheel
+          pip uninstall -y agent-security-harness
+          wheel=$(find dist -name '*.whl' -print -quit)
+          pip install "${wheel}[mcp-server]"
+          python -c "from mcp_server.server import create_server; assert create_server().name == 'Agent Security Harness'"
 
       - name: Verify CLI
         run: |
@@ -60,6 +69,7 @@ jobs:
           import protocol_tests.cloud_agent_harness
           import protocol_tests.statistical
           import protocol_tests.cli
+          import mcp_server.server
           import protocol_tests.kill_switch_harness
           import protocol_tests.watermark_harness
           import protocol_tests.memory_harness

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 [![PyPI version](https://badge.fury.io/py/agent-security-harness.svg)](https://pypi.org/project/agent-security-harness/)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![Apache 2.0 License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/security%20tests-560-green.svg)](#three-layers-of-agent-decision-security)
+[![Tests](https://img.shields.io/badge/security%20tests-561-green.svg)](#three-layers-of-agent-decision-security)
 [![ClawScan](https://img.shields.io/badge/ClawScan-Benign-brightgreen)](https://clawhub.ai/msaleme/agent-security-harness)
 [![Static Analysis](https://img.shields.io/badge/Static%20Analysis-Benign-brightgreen)](https://clawhub.ai/msaleme/agent-security-harness)
 [![VirusTotal](https://img.shields.io/badge/VirusTotal-0%2F92_Clean-brightgreen)](https://www.virustotal.com/gui/url/37318967b56cd3cc1678972ebf0c53dbd37868b67ba3f6891447d53d51767cd2)
 
 **Even if an agent is properly authenticated and authorized, can it still be manipulated into unsafe or policy-violating behavior?**
 
-560 executable security tests across 38 modules (verified 2026-07-22 via `scripts/count_tests.py`). MCP + A2A + L402 + x402 wire-protocol testing, plus UCP/ACP merchant-journey, AP2 mandate-chain, Fireblocks x402 hardening, Visa TAP / Mastercard Agentic Token funding-instrument, and denial-of-settlement finality conformance across the full agentic-payments stack. Decision-layer attack scenarios. One `pip install` away.
+561 executable security tests across 38 modules (verified 2026-07-22 via `scripts/count_tests.py`). MCP + A2A + L402 + x402 wire-protocol testing, plus UCP/ACP merchant-journey, AP2 mandate-chain, Fireblocks x402 hardening, Visa TAP / Mastercard Agentic Token funding-instrument, and denial-of-settlement finality conformance across the full agentic-payments stack. Decision-layer attack scenarios. One `pip install` away.
 
 ```
 $ agent-security test mcp --url http://localhost:8080/mcp
@@ -76,7 +76,7 @@ See [docs/QUICKSTART.md](docs/QUICKSTART.md) for mock server setup, rate limitin
 | **Research backing** | - | Cisco blog | - | Papers | **6 DOIs + 3 NIST submissions** |
 | **MCP server mode** | - | - | - | - | **Yes - invoke from any AI agent** |
 | **Statistical testing** | - | - | - | - | **Wilson CIs, multi-trial** |
-| **Total tests** | Pattern matching | YARA rules | Config checks | Model probes | **560 active tests** |
+| **Total tests** | Pattern matching | YARA rules | Config checks | Model probes | **561 active tests** |
 
 **Use both.** Scan with [Invariant MCP-Scan](https://github.com/invariantlabs-ai/mcp-scan) or [Cisco MCP Scanner](https://github.com/cisco-ai-defense/mcp-scanner) for static analysis. Test with this framework for active exploitation. They're complementary layers.
 
@@ -110,7 +110,7 @@ The [constitutional-agent](https://github.com/CognitiveThoughtEngine/constitutio
 | Resource | Link |
 |---|---|
 | Expanded Quick Start | [docs/QUICKSTART.md](docs/QUICKSTART.md) |
-| Full Test Inventory (560 tests) | [docs/TEST-INVENTORY.md](docs/TEST-INVENTORY.md) |
+| Full Test Inventory (561 tests) | [docs/TEST-INVENTORY.md](docs/TEST-INVENTORY.md) |
 | AIUC-1 Crosswalk | [docs/AIUC1-CROSSWALK.md](docs/AIUC1-CROSSWALK.md) |
 | Advanced Capabilities | [docs/ADVANCED.md](docs/ADVANCED.md) |
 | MCP Server | [docs/mcp-server.md](docs/mcp-server.md) |

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 [![PyPI version](https://badge.fury.io/py/agent-security-harness.svg)](https://pypi.org/project/agent-security-harness/)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![Apache 2.0 License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/security%20tests-561-green.svg)](#three-layers-of-agent-decision-security)
+[![Tests](https://img.shields.io/badge/security%20tests-562-green.svg)](#three-layers-of-agent-decision-security)
 [![ClawScan](https://img.shields.io/badge/ClawScan-Benign-brightgreen)](https://clawhub.ai/msaleme/agent-security-harness)
 [![Static Analysis](https://img.shields.io/badge/Static%20Analysis-Benign-brightgreen)](https://clawhub.ai/msaleme/agent-security-harness)
 [![VirusTotal](https://img.shields.io/badge/VirusTotal-0%2F92_Clean-brightgreen)](https://www.virustotal.com/gui/url/37318967b56cd3cc1678972ebf0c53dbd37868b67ba3f6891447d53d51767cd2)
 
 **Even if an agent is properly authenticated and authorized, can it still be manipulated into unsafe or policy-violating behavior?**
 
-561 executable security tests across 38 modules (verified 2026-07-22 via `scripts/count_tests.py`). MCP + A2A + L402 + x402 wire-protocol testing, plus UCP/ACP merchant-journey, AP2 mandate-chain, Fireblocks x402 hardening, Visa TAP / Mastercard Agentic Token funding-instrument, and denial-of-settlement finality conformance across the full agentic-payments stack. Decision-layer attack scenarios. One `pip install` away.
+562 executable security tests across 38 modules (verified 2026-07-22 via `scripts/count_tests.py`). MCP + A2A + L402 + x402 wire-protocol testing, plus UCP/ACP merchant-journey, AP2 mandate-chain, Fireblocks x402 hardening, Visa TAP / Mastercard Agentic Token funding-instrument, and denial-of-settlement finality conformance across the full agentic-payments stack. Decision-layer attack scenarios. One `pip install` away.
 
 ```
 $ agent-security test mcp --url http://localhost:8080/mcp
@@ -76,7 +76,7 @@ See [docs/QUICKSTART.md](docs/QUICKSTART.md) for mock server setup, rate limitin
 | **Research backing** | - | Cisco blog | - | Papers | **6 DOIs + 3 NIST submissions** |
 | **MCP server mode** | - | - | - | - | **Yes - invoke from any AI agent** |
 | **Statistical testing** | - | - | - | - | **Wilson CIs, multi-trial** |
-| **Total tests** | Pattern matching | YARA rules | Config checks | Model probes | **561 active tests** |
+| **Total tests** | Pattern matching | YARA rules | Config checks | Model probes | **562 active tests** |
 
 **Use both.** Scan with [Invariant MCP-Scan](https://github.com/invariantlabs-ai/mcp-scan) or [Cisco MCP Scanner](https://github.com/cisco-ai-defense/mcp-scanner) for static analysis. Test with this framework for active exploitation. They're complementary layers.
 
@@ -110,7 +110,7 @@ The [constitutional-agent](https://github.com/CognitiveThoughtEngine/constitutio
 | Resource | Link |
 |---|---|
 | Expanded Quick Start | [docs/QUICKSTART.md](docs/QUICKSTART.md) |
-| Full Test Inventory (561 tests) | [docs/TEST-INVENTORY.md](docs/TEST-INVENTORY.md) |
+| Full Test Inventory (562 tests) | [docs/TEST-INVENTORY.md](docs/TEST-INVENTORY.md) |
 | AIUC-1 Crosswalk | [docs/AIUC1-CROSSWALK.md](docs/AIUC1-CROSSWALK.md) |
 | Advanced Capabilities | [docs/ADVANCED.md](docs/ADVANCED.md) |
 | MCP Server | [docs/mcp-server.md](docs/mcp-server.md) |

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 [![PyPI version](https://badge.fury.io/py/agent-security-harness.svg)](https://pypi.org/project/agent-security-harness/)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![Apache 2.0 License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/security%20tests-553-green.svg)](#three-layers-of-agent-decision-security)
+[![Tests](https://img.shields.io/badge/security%20tests-560-green.svg)](#three-layers-of-agent-decision-security)
 [![ClawScan](https://img.shields.io/badge/ClawScan-Benign-brightgreen)](https://clawhub.ai/msaleme/agent-security-harness)
 [![Static Analysis](https://img.shields.io/badge/Static%20Analysis-Benign-brightgreen)](https://clawhub.ai/msaleme/agent-security-harness)
 [![VirusTotal](https://img.shields.io/badge/VirusTotal-0%2F92_Clean-brightgreen)](https://www.virustotal.com/gui/url/37318967b56cd3cc1678972ebf0c53dbd37868b67ba3f6891447d53d51767cd2)
 
 **Even if an agent is properly authenticated and authorized, can it still be manipulated into unsafe or policy-violating behavior?**
 
-553 executable security tests across 38 modules (verified 2026-07-17 via `scripts/count_tests.py`). MCP + A2A + L402 + x402 wire-protocol testing, plus UCP/ACP merchant-journey, AP2 mandate-chain, Fireblocks x402 hardening, Visa TAP / Mastercard Agentic Token funding-instrument, and denial-of-settlement finality conformance across the full agentic-payments stack. Decision-layer attack scenarios. One `pip install` away.
+560 executable security tests across 38 modules (verified 2026-07-22 via `scripts/count_tests.py`). MCP + A2A + L402 + x402 wire-protocol testing, plus UCP/ACP merchant-journey, AP2 mandate-chain, Fireblocks x402 hardening, Visa TAP / Mastercard Agentic Token funding-instrument, and denial-of-settlement finality conformance across the full agentic-payments stack. Decision-layer attack scenarios. One `pip install` away.
 
 ```
 $ agent-security test mcp --url http://localhost:8080/mcp
@@ -76,7 +76,7 @@ See [docs/QUICKSTART.md](docs/QUICKSTART.md) for mock server setup, rate limitin
 | **Research backing** | - | Cisco blog | - | Papers | **6 DOIs + 3 NIST submissions** |
 | **MCP server mode** | - | - | - | - | **Yes - invoke from any AI agent** |
 | **Statistical testing** | - | - | - | - | **Wilson CIs, multi-trial** |
-| **Total tests** | Pattern matching | YARA rules | Config checks | Model probes | **553 active tests** |
+| **Total tests** | Pattern matching | YARA rules | Config checks | Model probes | **560 active tests** |
 
 **Use both.** Scan with [Invariant MCP-Scan](https://github.com/invariantlabs-ai/mcp-scan) or [Cisco MCP Scanner](https://github.com/cisco-ai-defense/mcp-scanner) for static analysis. Test with this framework for active exploitation. They're complementary layers.
 
@@ -110,7 +110,7 @@ The [constitutional-agent](https://github.com/CognitiveThoughtEngine/constitutio
 | Resource | Link |
 |---|---|
 | Expanded Quick Start | [docs/QUICKSTART.md](docs/QUICKSTART.md) |
-| Full Test Inventory (553 tests) | [docs/TEST-INVENTORY.md](docs/TEST-INVENTORY.md) |
+| Full Test Inventory (560 tests) | [docs/TEST-INVENTORY.md](docs/TEST-INVENTORY.md) |
 | AIUC-1 Crosswalk | [docs/AIUC1-CROSSWALK.md](docs/AIUC1-CROSSWALK.md) |
 | Advanced Capabilities | [docs/ADVANCED.md](docs/ADVANCED.md) |
 | MCP Server | [docs/mcp-server.md](docs/mcp-server.md) |

--- a/conformance/receipt-claim/README.md
+++ b/conformance/receipt-claim/README.md
@@ -1,0 +1,50 @@
+# Receipt-claim conformance vectors (RCL)
+
+Portable, machine-readable conformance vectors for **claim-level receipt verification**: each vector is a receipt whose **envelope signature verifies** but whose **claims are (in)valid on semantic grounds**. A conforming verifier must reach the recorded decision by recomputing evidence bindings, not by checking the signature.
+
+These are generated from this repo's own claim-level verifier ([`protocol_tests/receipt_claim_harness.py`](../../protocol_tests/receipt_claim_harness.py), the RCL family), so `expected_result` and `harness_reason` are ground-truth verifier output rather than hand-authored expectations. Any receipt/trust-envelope implementation can run its own verifier over the same fixtures and compare.
+
+## The model
+
+An action receipt decomposes into four separately assessable properties, and signing supports only the first:
+
+```
+integrity/provenance | authorization | occurrence | check (execution + integrity)
+```
+
+Evidence for the last three must be attested by **distinct trust domains** (authorization authority, execution/settlement authority, independent checker authority), never by the receipt emitter, which the threat model permits to lie. The emitter can validly re-sign its own envelope; it cannot forge another authority's attestation (Ed25519, one keypair per domain, verifier holds only the public keys).
+
+## Contents
+
+**9 reject vectors + 2 acceptance controls.** The acceptance controls (`RCL-008`, `RCL-009`) exist so an implementation cannot pass by rejecting everything.
+
+Each fixture carries an `evidence_binding` descriptor naming exactly what a verifier must recompute from referenced evidence, so a vector is not satisfiable with string-level checks: the admitted action digest, the action's tool-set digest, per-property attestor + independence flag, the check's `policy_digest`, and the freshness window.
+
+| ID | Result | Phase | Recomputation the verifier must fail | Reason code |
+|---|---|---|---|---|
+| RCL-001 | reject | post-execution | occurrence evidence omitted | `OCCURRENCE_EVIDENCE_MISSING` |
+| RCL-002 | reject | admission | check evidence tampered after attestation | `CHECK_EVIDENCE_TAMPERED` |
+| RCL-003 | reject | admission | check transcript outside the freshness window | `CHECK_TRANSCRIPT_STALE` |
+| RCL-004 | reject | admission | check `input_digest` != action tool-set digest | `CHECK_TOOLSET_DIGEST_MISMATCH` |
+| RCL-005 | reject | admission | authorization bound to different params than requested | `AUTHORIZATION_PARAMS_MISMATCH` |
+| RCL-006 | reject | post-execution | occurrence ack `action_digest` != admitted action | `OCCURRENCE_ACTION_LINKAGE_MISMATCH` |
+| RCL-007 | reject | admission | check attested by the emitter, not an independent authority | `CHECK_ATTESTOR_NOT_INDEPENDENT` |
+| RCL-008 | **accept** | admission+post-execution | control: all four properties independently supported | `ACCEPT_ALL_PROPERTIES_SUPPORTED` |
+| RCL-009 | **accept** | admission | control: clean wired MCP-019 check, verdict pass | `ACCEPT_ALL_PROPERTIES_SUPPORTED` |
+| RCL-010 | reject | admission | wired MCP-019 verdict is fail, carried honestly | `CHECK_OUTPUT_FAIL` |
+| RCL-011 | reject | admission | passing check bound to a different tool set than the action uses | `CHECK_TOOLSET_DIGEST_MISMATCH` |
+
+`RCL-005` and `RCL-006` are the phase pair: `RCL-005` fails at **admission** because the authorization evidence does not authorize the requested action before execution; `RCL-006` fails at **post-execution** because the execution acknowledgement does not link back to the admitted action. Same trust problem, different phase, different invariant.
+
+`RCL-009/010/011` bind the **MCP-019 composite tool-poisoning** detector through the receipt path, so a receipt claiming "the admitted tool set was checked" is accepted only when a verifier can recompute that the check covered the same tool-set digest and that the verdict supports the claim.
+
+## Files
+
+- `fixtures/RCL-0NN.json` — one per case: the full receipt, the `evidence_binding` descriptor, the expected decision/phase/reason, and the verbatim `harness_reason`.
+- `fixtures/index.json` — summary index.
+- `generate.py` — regenerates the fixtures from the verifier.
+- `verify_fixtures.py` — replays every fixture through the verifier and asserts the recorded result (exits non-zero on mismatch).
+
+## Reproducibility
+
+Deterministic Ed25519 test keys (fixed seeds) and a fixed timestamp make the fixtures reproducible byte-for-byte from the verifier. The signatures are the harness's own test-domain keys; the vectors' value is the **evidence-binding structure and the recomputation each verifier must perform**, which is signature-scheme independent, so the reason codes here map cleanly onto external receipt / trust-envelope models.

--- a/conformance/receipt-claim/fixtures/RCL-001.json
+++ b/conformance/receipt-claim/fixtures/RCL-001.json
@@ -1,0 +1,69 @@
+{
+  "test_id": "RCL-001",
+  "name": "Omitted mandatory evidence",
+  "expected_result": "reject",
+  "expected_phase": "post-execution",
+  "violated_binding": "occurrence evidence omitted",
+  "reason_code": "OCCURRENCE_EVIDENCE_MISSING",
+  "harness_reason": "occurrence: missing evidence",
+  "evidence_binding": {
+    "admitted_action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+    "action_tool_set_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+    "referenced_evidence": {
+      "authorization": {
+        "present": true,
+        "attestor": "authz",
+        "independent_of_emitter": true,
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "params_digest": "29b774d0a454b86f6375f55fd90c804e6ba03b2eaee1e88f07a19afa73c70174"
+      },
+      "occurrence": {
+        "present": false
+      },
+      "check": {
+        "present": true,
+        "attestor": "checker",
+        "independent_of_emitter": true,
+        "input_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+        "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+        "output": "pass",
+        "issued_at": 1750000000,
+        "checker_id": "tool-scan",
+        "version": "1.0"
+      }
+    },
+    "attestor_independence_ok": true,
+    "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+    "freshness_window_seconds": 300
+  },
+  "recomputation_boundary": "occurrence evidence omitted",
+  "envelope_signature_valid": true,
+  "receipt": {
+    "action": {
+      "tool": "transfer",
+      "params": {
+        "to": "acct-A",
+        "amount": 100
+      }
+    },
+    "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+    "tool_set_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+    "claims": {
+      "authorization": {
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "params_digest": "29b774d0a454b86f6375f55fd90c804e6ba03b2eaee1e88f07a19afa73c70174",
+        "sig": "f05e7e4b011f73e79fc2e0faad5ea2c1c8b0bc4edd14e515a1c6a8b2b2711e7b2830897168ece5510e6501789cd1b53650bb08b9e9e82b949cba23adbd0b770c"
+      },
+      "check": {
+        "checker_id": "tool-scan",
+        "version": "1.0",
+        "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+        "input_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+        "output": "pass",
+        "issued_at": 1750000000,
+        "sig": "b489115dd3fe0269d4879eb728be602be737be59f190f0c471e52f131d94368c32911fc77680e7ae56d02b730d190129b719d981dd3f46c8e87b9051730f770f"
+      }
+    },
+    "envelope_sig": "68c8ada0833b470f3ec6acebe6d102394c68a434b50893d3a39445eb069e397faba856dd90b8227bd784b38b390b0a816c16329bef6ab36003bcabead30a0e0a"
+  }
+}

--- a/conformance/receipt-claim/fixtures/RCL-002.json
+++ b/conformance/receipt-claim/fixtures/RCL-002.json
@@ -1,0 +1,78 @@
+{
+  "test_id": "RCL-002",
+  "name": "Substituted evidence, re-signed envelope",
+  "expected_result": "reject",
+  "expected_phase": "admission",
+  "violated_binding": "check evidence tampered after attestation",
+  "reason_code": "CHECK_EVIDENCE_TAMPERED",
+  "harness_reason": "check: checker attestation does not verify (substituted or forged)",
+  "evidence_binding": {
+    "admitted_action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+    "action_tool_set_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+    "referenced_evidence": {
+      "authorization": {
+        "present": true,
+        "attestor": "authz",
+        "independent_of_emitter": true,
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "params_digest": "29b774d0a454b86f6375f55fd90c804e6ba03b2eaee1e88f07a19afa73c70174"
+      },
+      "occurrence": {
+        "present": true,
+        "attestor": "exec",
+        "independent_of_emitter": true,
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "outcome_digest": "212e659146dac83f09f639fe16f4316e2fc5ecb37c3f99ee67e31eb7a73bb0f9"
+      },
+      "check": {
+        "present": true,
+        "attestor": null,
+        "independent_of_emitter": false,
+        "input_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+        "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+        "output": "pass",
+        "issued_at": 1750000000,
+        "checker_id": "tool-scan",
+        "version": "1.0"
+      }
+    },
+    "attestor_independence_ok": false,
+    "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+    "freshness_window_seconds": 300
+  },
+  "recomputation_boundary": "check evidence tampered after attestation",
+  "envelope_signature_valid": true,
+  "receipt": {
+    "action": {
+      "tool": "transfer",
+      "params": {
+        "to": "acct-A",
+        "amount": 100
+      }
+    },
+    "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+    "tool_set_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+    "claims": {
+      "authorization": {
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "params_digest": "29b774d0a454b86f6375f55fd90c804e6ba03b2eaee1e88f07a19afa73c70174",
+        "sig": "f05e7e4b011f73e79fc2e0faad5ea2c1c8b0bc4edd14e515a1c6a8b2b2711e7b2830897168ece5510e6501789cd1b53650bb08b9e9e82b949cba23adbd0b770c"
+      },
+      "occurrence": {
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "outcome_digest": "212e659146dac83f09f639fe16f4316e2fc5ecb37c3f99ee67e31eb7a73bb0f9",
+        "sig": "880e3c9840c24bb4961efad424b151388af174c35f24ba6faf922bd388a114786bfcb67cbeed03f1ef689c578cfd5610f45492212ba4de30156062a98bc66d0c"
+      },
+      "check": {
+        "checker_id": "tool-scan",
+        "version": "1.0",
+        "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+        "input_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+        "output": "pass",
+        "issued_at": 1750000000,
+        "sig": "2aff2fa4ddc0d04f0c4216b429121911f6ffe0ebafcb82d3cfd9442e7c68e6e0ad3a5e67d7fcb7b00cd8b6e218ee7442ceb184bd55a5dfb666728548880b8507"
+      }
+    },
+    "envelope_sig": "23157e82ae22db5683cbef6bbf11e333fd1928470235b67f705fb88252d6f4f561986184bbff21b474bbeca057fb16f49eba2f0a283fdf56e9d6f547523dc204"
+  }
+}

--- a/conformance/receipt-claim/fixtures/RCL-003.json
+++ b/conformance/receipt-claim/fixtures/RCL-003.json
@@ -1,0 +1,78 @@
+{
+  "test_id": "RCL-003",
+  "name": "Stale checker transcript",
+  "expected_result": "reject",
+  "expected_phase": "admission",
+  "violated_binding": "check transcript outside the freshness window",
+  "reason_code": "CHECK_TRANSCRIPT_STALE",
+  "harness_reason": "check: stale transcript (outside freshness window)",
+  "evidence_binding": {
+    "admitted_action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+    "action_tool_set_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+    "referenced_evidence": {
+      "authorization": {
+        "present": true,
+        "attestor": "authz",
+        "independent_of_emitter": true,
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "params_digest": "29b774d0a454b86f6375f55fd90c804e6ba03b2eaee1e88f07a19afa73c70174"
+      },
+      "occurrence": {
+        "present": true,
+        "attestor": "exec",
+        "independent_of_emitter": true,
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "outcome_digest": "212e659146dac83f09f639fe16f4316e2fc5ecb37c3f99ee67e31eb7a73bb0f9"
+      },
+      "check": {
+        "present": true,
+        "attestor": "checker",
+        "independent_of_emitter": true,
+        "input_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+        "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+        "output": "pass",
+        "issued_at": 1749999640,
+        "checker_id": "tool-scan",
+        "version": "1.0"
+      }
+    },
+    "attestor_independence_ok": true,
+    "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+    "freshness_window_seconds": 300
+  },
+  "recomputation_boundary": "check transcript outside the freshness window",
+  "envelope_signature_valid": true,
+  "receipt": {
+    "action": {
+      "tool": "transfer",
+      "params": {
+        "to": "acct-A",
+        "amount": 100
+      }
+    },
+    "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+    "tool_set_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+    "claims": {
+      "authorization": {
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "params_digest": "29b774d0a454b86f6375f55fd90c804e6ba03b2eaee1e88f07a19afa73c70174",
+        "sig": "f05e7e4b011f73e79fc2e0faad5ea2c1c8b0bc4edd14e515a1c6a8b2b2711e7b2830897168ece5510e6501789cd1b53650bb08b9e9e82b949cba23adbd0b770c"
+      },
+      "occurrence": {
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "outcome_digest": "212e659146dac83f09f639fe16f4316e2fc5ecb37c3f99ee67e31eb7a73bb0f9",
+        "sig": "880e3c9840c24bb4961efad424b151388af174c35f24ba6faf922bd388a114786bfcb67cbeed03f1ef689c578cfd5610f45492212ba4de30156062a98bc66d0c"
+      },
+      "check": {
+        "checker_id": "tool-scan",
+        "version": "1.0",
+        "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+        "input_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+        "output": "pass",
+        "issued_at": 1749999640,
+        "sig": "a1f88ae0e5997a7fcae21551cd84cec080705f9c1956369bf5f59096c3d94cc46c7680c6c2b5cef3caf0016938a490c68ca2924801078bc91fff0f536b921b0e"
+      }
+    },
+    "envelope_sig": "d8dc36ca354e15e0a31af881093bd9809b1afb6f49228b18da7ddddd87e9993af65a551cce0e2b2b7ea217cc58c973847b66fe73a7d63e3ff9da06b848308006"
+  }
+}

--- a/conformance/receipt-claim/fixtures/RCL-004.json
+++ b/conformance/receipt-claim/fixtures/RCL-004.json
@@ -1,0 +1,78 @@
+{
+  "test_id": "RCL-004",
+  "name": "Check bound to the wrong tool-set digest",
+  "expected_result": "reject",
+  "expected_phase": "admission",
+  "violated_binding": "check bound to a different tool-set digest",
+  "reason_code": "CHECK_TOOLSET_DIGEST_MISMATCH",
+  "harness_reason": "check: result bound to the wrong tool-set digest",
+  "evidence_binding": {
+    "admitted_action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+    "action_tool_set_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+    "referenced_evidence": {
+      "authorization": {
+        "present": true,
+        "attestor": "authz",
+        "independent_of_emitter": true,
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "params_digest": "29b774d0a454b86f6375f55fd90c804e6ba03b2eaee1e88f07a19afa73c70174"
+      },
+      "occurrence": {
+        "present": true,
+        "attestor": "exec",
+        "independent_of_emitter": true,
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "outcome_digest": "212e659146dac83f09f639fe16f4316e2fc5ecb37c3f99ee67e31eb7a73bb0f9"
+      },
+      "check": {
+        "present": true,
+        "attestor": "checker",
+        "independent_of_emitter": true,
+        "input_digest": "5c57b9d021cbc7b1ec6f4b223561bf556d4690d4dc662ab3c32f58425ff10bb2",
+        "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+        "output": "pass",
+        "issued_at": 1750000000,
+        "checker_id": "tool-scan",
+        "version": "1.0"
+      }
+    },
+    "attestor_independence_ok": true,
+    "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+    "freshness_window_seconds": 300
+  },
+  "recomputation_boundary": "check bound to a different tool-set digest",
+  "envelope_signature_valid": true,
+  "receipt": {
+    "action": {
+      "tool": "transfer",
+      "params": {
+        "to": "acct-A",
+        "amount": 100
+      }
+    },
+    "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+    "tool_set_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+    "claims": {
+      "authorization": {
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "params_digest": "29b774d0a454b86f6375f55fd90c804e6ba03b2eaee1e88f07a19afa73c70174",
+        "sig": "f05e7e4b011f73e79fc2e0faad5ea2c1c8b0bc4edd14e515a1c6a8b2b2711e7b2830897168ece5510e6501789cd1b53650bb08b9e9e82b949cba23adbd0b770c"
+      },
+      "occurrence": {
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "outcome_digest": "212e659146dac83f09f639fe16f4316e2fc5ecb37c3f99ee67e31eb7a73bb0f9",
+        "sig": "880e3c9840c24bb4961efad424b151388af174c35f24ba6faf922bd388a114786bfcb67cbeed03f1ef689c578cfd5610f45492212ba4de30156062a98bc66d0c"
+      },
+      "check": {
+        "checker_id": "tool-scan",
+        "version": "1.0",
+        "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+        "input_digest": "5c57b9d021cbc7b1ec6f4b223561bf556d4690d4dc662ab3c32f58425ff10bb2",
+        "output": "pass",
+        "issued_at": 1750000000,
+        "sig": "e98a8ad524d165fe17d33f35905531f4d478acc26a94eaeed340ed4d1391970f8b6460f0395687abf72d8bc6df0491f2f1baf1af343b66f37fc79f067f4d3f04"
+      }
+    },
+    "envelope_sig": "a6ef64dbd66eec04fc53699350f14835da542a1053d1abbd149d89c27c30f99c8b69d82f6c0aa7dbee01cb1a5d8091ea7ddef6fbc633b966cbbe38951c0a8005"
+  }
+}

--- a/conformance/receipt-claim/fixtures/RCL-005.json
+++ b/conformance/receipt-claim/fixtures/RCL-005.json
@@ -1,0 +1,78 @@
+{
+  "test_id": "RCL-005",
+  "name": "Authorization bound to different parameters",
+  "expected_result": "reject",
+  "expected_phase": "admission",
+  "violated_binding": "authorization bound to different params than requested",
+  "reason_code": "AUTHORIZATION_PARAMS_MISMATCH",
+  "harness_reason": "authorization: params do not match the action",
+  "evidence_binding": {
+    "admitted_action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+    "action_tool_set_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+    "referenced_evidence": {
+      "authorization": {
+        "present": true,
+        "attestor": "authz",
+        "independent_of_emitter": true,
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "params_digest": "874ef3c2436820bb8580c58ba75d2f788ee2e6f6ad65892d1d8d3d081885d73a"
+      },
+      "occurrence": {
+        "present": true,
+        "attestor": "exec",
+        "independent_of_emitter": true,
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "outcome_digest": "212e659146dac83f09f639fe16f4316e2fc5ecb37c3f99ee67e31eb7a73bb0f9"
+      },
+      "check": {
+        "present": true,
+        "attestor": "checker",
+        "independent_of_emitter": true,
+        "input_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+        "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+        "output": "pass",
+        "issued_at": 1750000000,
+        "checker_id": "tool-scan",
+        "version": "1.0"
+      }
+    },
+    "attestor_independence_ok": true,
+    "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+    "freshness_window_seconds": 300
+  },
+  "recomputation_boundary": "authorization bound to different params than requested",
+  "envelope_signature_valid": true,
+  "receipt": {
+    "action": {
+      "tool": "transfer",
+      "params": {
+        "to": "acct-A",
+        "amount": 100
+      }
+    },
+    "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+    "tool_set_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+    "claims": {
+      "authorization": {
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "params_digest": "874ef3c2436820bb8580c58ba75d2f788ee2e6f6ad65892d1d8d3d081885d73a",
+        "sig": "371ae60835cfa993f6779c61cc2a67fbb8b64af346a24a6c03551e7d9d61e3441b958658e4328e1ec71af489fb71142a797f90722fa93c0043886cb27bf20204"
+      },
+      "occurrence": {
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "outcome_digest": "212e659146dac83f09f639fe16f4316e2fc5ecb37c3f99ee67e31eb7a73bb0f9",
+        "sig": "880e3c9840c24bb4961efad424b151388af174c35f24ba6faf922bd388a114786bfcb67cbeed03f1ef689c578cfd5610f45492212ba4de30156062a98bc66d0c"
+      },
+      "check": {
+        "checker_id": "tool-scan",
+        "version": "1.0",
+        "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+        "input_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+        "output": "pass",
+        "issued_at": 1750000000,
+        "sig": "b489115dd3fe0269d4879eb728be602be737be59f190f0c471e52f131d94368c32911fc77680e7ae56d02b730d190129b719d981dd3f46c8e87b9051730f770f"
+      }
+    },
+    "envelope_sig": "c6787087a53031154531786151f4e8f42eb98b94c0dce2570aca6fc296ee6d22b74c1f16af1918a8052146488ca7d55e91c2d3f2e34118072ee6b9f226d5b400"
+  }
+}

--- a/conformance/receipt-claim/fixtures/RCL-006.json
+++ b/conformance/receipt-claim/fixtures/RCL-006.json
@@ -1,0 +1,78 @@
+{
+  "test_id": "RCL-006",
+  "name": "Execution ack bound to another action",
+  "expected_result": "reject",
+  "expected_phase": "post-execution",
+  "violated_binding": "occurrence ack bound to another action",
+  "reason_code": "OCCURRENCE_ACTION_LINKAGE_MISMATCH",
+  "harness_reason": "occurrence: acknowledgment bound to another action",
+  "evidence_binding": {
+    "admitted_action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+    "action_tool_set_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+    "referenced_evidence": {
+      "authorization": {
+        "present": true,
+        "attestor": "authz",
+        "independent_of_emitter": true,
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "params_digest": "29b774d0a454b86f6375f55fd90c804e6ba03b2eaee1e88f07a19afa73c70174"
+      },
+      "occurrence": {
+        "present": true,
+        "attestor": "exec",
+        "independent_of_emitter": true,
+        "action_digest": "369931621f322d545ad0ab97f873e20e5c8a0f43c0b49915d5c979b32e4a6d7f",
+        "outcome_digest": "212e659146dac83f09f639fe16f4316e2fc5ecb37c3f99ee67e31eb7a73bb0f9"
+      },
+      "check": {
+        "present": true,
+        "attestor": "checker",
+        "independent_of_emitter": true,
+        "input_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+        "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+        "output": "pass",
+        "issued_at": 1750000000,
+        "checker_id": "tool-scan",
+        "version": "1.0"
+      }
+    },
+    "attestor_independence_ok": true,
+    "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+    "freshness_window_seconds": 300
+  },
+  "recomputation_boundary": "occurrence ack bound to another action",
+  "envelope_signature_valid": true,
+  "receipt": {
+    "action": {
+      "tool": "transfer",
+      "params": {
+        "to": "acct-A",
+        "amount": 100
+      }
+    },
+    "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+    "tool_set_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+    "claims": {
+      "authorization": {
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "params_digest": "29b774d0a454b86f6375f55fd90c804e6ba03b2eaee1e88f07a19afa73c70174",
+        "sig": "f05e7e4b011f73e79fc2e0faad5ea2c1c8b0bc4edd14e515a1c6a8b2b2711e7b2830897168ece5510e6501789cd1b53650bb08b9e9e82b949cba23adbd0b770c"
+      },
+      "occurrence": {
+        "action_digest": "369931621f322d545ad0ab97f873e20e5c8a0f43c0b49915d5c979b32e4a6d7f",
+        "outcome_digest": "212e659146dac83f09f639fe16f4316e2fc5ecb37c3f99ee67e31eb7a73bb0f9",
+        "sig": "2bbc8fe0510d1a4363aae97aa6ec96f3c1e5d8583e61cbecad39f1b24e57b9a83d217e7cd5a6b220c4575e71223cbd1eb410c1d48daeb72cc01b629c7ca4660e"
+      },
+      "check": {
+        "checker_id": "tool-scan",
+        "version": "1.0",
+        "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+        "input_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+        "output": "pass",
+        "issued_at": 1750000000,
+        "sig": "b489115dd3fe0269d4879eb728be602be737be59f190f0c471e52f131d94368c32911fc77680e7ae56d02b730d190129b719d981dd3f46c8e87b9051730f770f"
+      }
+    },
+    "envelope_sig": "65cf85d93051e95cda869f6a4d7eab83d8ee513c599fa54244668a43ae0e2ef4ca0c23c621ec02c9f9662a9f817f3a456a8fbcf8345b2403bd2e552d6e098102"
+  }
+}

--- a/conformance/receipt-claim/fixtures/RCL-007.json
+++ b/conformance/receipt-claim/fixtures/RCL-007.json
@@ -1,0 +1,78 @@
+{
+  "test_id": "RCL-007",
+  "name": "Emitter self-assertion, no independent attestation",
+  "expected_result": "reject",
+  "expected_phase": "admission",
+  "violated_binding": "check attested by emitter, not an independent authority",
+  "reason_code": "CHECK_ATTESTOR_NOT_INDEPENDENT",
+  "harness_reason": "check: attested by the emitter, not the checker authority",
+  "evidence_binding": {
+    "admitted_action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+    "action_tool_set_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+    "referenced_evidence": {
+      "authorization": {
+        "present": true,
+        "attestor": "authz",
+        "independent_of_emitter": true,
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "params_digest": "29b774d0a454b86f6375f55fd90c804e6ba03b2eaee1e88f07a19afa73c70174"
+      },
+      "occurrence": {
+        "present": true,
+        "attestor": "exec",
+        "independent_of_emitter": true,
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "outcome_digest": "212e659146dac83f09f639fe16f4316e2fc5ecb37c3f99ee67e31eb7a73bb0f9"
+      },
+      "check": {
+        "present": true,
+        "attestor": "emitter",
+        "independent_of_emitter": false,
+        "input_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+        "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+        "output": "pass",
+        "issued_at": 1750000000,
+        "checker_id": "tool-scan",
+        "version": "1.0"
+      }
+    },
+    "attestor_independence_ok": false,
+    "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+    "freshness_window_seconds": 300
+  },
+  "recomputation_boundary": "check attested by emitter, not an independent authority",
+  "envelope_signature_valid": true,
+  "receipt": {
+    "action": {
+      "tool": "transfer",
+      "params": {
+        "to": "acct-A",
+        "amount": 100
+      }
+    },
+    "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+    "tool_set_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+    "claims": {
+      "authorization": {
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "params_digest": "29b774d0a454b86f6375f55fd90c804e6ba03b2eaee1e88f07a19afa73c70174",
+        "sig": "f05e7e4b011f73e79fc2e0faad5ea2c1c8b0bc4edd14e515a1c6a8b2b2711e7b2830897168ece5510e6501789cd1b53650bb08b9e9e82b949cba23adbd0b770c"
+      },
+      "occurrence": {
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "outcome_digest": "212e659146dac83f09f639fe16f4316e2fc5ecb37c3f99ee67e31eb7a73bb0f9",
+        "sig": "880e3c9840c24bb4961efad424b151388af174c35f24ba6faf922bd388a114786bfcb67cbeed03f1ef689c578cfd5610f45492212ba4de30156062a98bc66d0c"
+      },
+      "check": {
+        "checker_id": "tool-scan",
+        "version": "1.0",
+        "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+        "input_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+        "output": "pass",
+        "issued_at": 1750000000,
+        "sig": "4930941add58ebbcba94204017e969b23c18832e72b7c5b17987a8f9aacb7c787ec9ebb02fd76a4775417248d57004eae5d1644b6ec105102a203004c74a570c"
+      }
+    },
+    "envelope_sig": "b5d9316370812b8a423fbb8e60b8b6b33fd08f8de28e15e5c91abf48db4a2fb4e63b906c2003f0f7b83d97362366bf6e5644ccfd7f7c9e362a34eceb31920701"
+  }
+}

--- a/conformance/receipt-claim/fixtures/RCL-008.json
+++ b/conformance/receipt-claim/fixtures/RCL-008.json
@@ -1,0 +1,78 @@
+{
+  "test_id": "RCL-008",
+  "name": "Fully-supported receipt accepted (control)",
+  "expected_result": "accept",
+  "expected_phase": "admission+post-execution",
+  "violated_binding": "control: all four properties supported",
+  "reason_code": "ACCEPT_ALL_PROPERTIES_SUPPORTED",
+  "harness_reason": "all four properties independently supported",
+  "evidence_binding": {
+    "admitted_action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+    "action_tool_set_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+    "referenced_evidence": {
+      "authorization": {
+        "present": true,
+        "attestor": "authz",
+        "independent_of_emitter": true,
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "params_digest": "29b774d0a454b86f6375f55fd90c804e6ba03b2eaee1e88f07a19afa73c70174"
+      },
+      "occurrence": {
+        "present": true,
+        "attestor": "exec",
+        "independent_of_emitter": true,
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "outcome_digest": "212e659146dac83f09f639fe16f4316e2fc5ecb37c3f99ee67e31eb7a73bb0f9"
+      },
+      "check": {
+        "present": true,
+        "attestor": "checker",
+        "independent_of_emitter": true,
+        "input_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+        "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+        "output": "pass",
+        "issued_at": 1750000000,
+        "checker_id": "tool-scan",
+        "version": "1.0"
+      }
+    },
+    "attestor_independence_ok": true,
+    "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+    "freshness_window_seconds": 300
+  },
+  "recomputation_boundary": "control: all four properties supported",
+  "envelope_signature_valid": true,
+  "receipt": {
+    "action": {
+      "tool": "transfer",
+      "params": {
+        "to": "acct-A",
+        "amount": 100
+      }
+    },
+    "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+    "tool_set_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+    "claims": {
+      "authorization": {
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "params_digest": "29b774d0a454b86f6375f55fd90c804e6ba03b2eaee1e88f07a19afa73c70174",
+        "sig": "f05e7e4b011f73e79fc2e0faad5ea2c1c8b0bc4edd14e515a1c6a8b2b2711e7b2830897168ece5510e6501789cd1b53650bb08b9e9e82b949cba23adbd0b770c"
+      },
+      "occurrence": {
+        "action_digest": "357499b8cc7e421263cfffa710d3e7186cb72eef6a0f257736899fd3626d1e7b",
+        "outcome_digest": "212e659146dac83f09f639fe16f4316e2fc5ecb37c3f99ee67e31eb7a73bb0f9",
+        "sig": "880e3c9840c24bb4961efad424b151388af174c35f24ba6faf922bd388a114786bfcb67cbeed03f1ef689c578cfd5610f45492212ba4de30156062a98bc66d0c"
+      },
+      "check": {
+        "checker_id": "tool-scan",
+        "version": "1.0",
+        "policy_digest": "12a90b7960539fe3f366d696a3671e71dfe93b8504c4d857b88bbd2aed0262a3",
+        "input_digest": "2adfb73e809af065623f8c679e89874a106b205353730c753266fd1095795df6",
+        "output": "pass",
+        "issued_at": 1750000000,
+        "sig": "b489115dd3fe0269d4879eb728be602be737be59f190f0c471e52f131d94368c32911fc77680e7ae56d02b730d190129b719d981dd3f46c8e87b9051730f770f"
+      }
+    },
+    "envelope_sig": "9a28b2cbc02f6f18c0d69456548fa42f8b50adbb76200578b5a2f0bdeb8fac44d4c973db0d61b1e16a92324717e8e4f9d7e9234e5c8251285d97c2bc64e4690d"
+  }
+}

--- a/conformance/receipt-claim/fixtures/RCL-009.json
+++ b/conformance/receipt-claim/fixtures/RCL-009.json
@@ -1,0 +1,77 @@
+{
+  "test_id": "RCL-009",
+  "name": "Wired MCP-019 check (clean) accepted",
+  "expected_result": "accept",
+  "expected_phase": "admission",
+  "violated_binding": "control: clean wired check accepted",
+  "reason_code": "ACCEPT_ALL_PROPERTIES_SUPPORTED",
+  "harness_reason": "all four properties independently supported",
+  "evidence_binding": {
+    "admitted_action_digest": "5558294fdc17c8ffe2f8036a59fd8b7ea23c735e7ff773e4a424bcb5623139dc",
+    "action_tool_set_digest": "935a529bdd6d83f3507a160616ac86968089d7da06d70b59dc66c70c4df091d2",
+    "referenced_evidence": {
+      "authorization": {
+        "present": true,
+        "attestor": "authz",
+        "independent_of_emitter": true,
+        "action_digest": "5558294fdc17c8ffe2f8036a59fd8b7ea23c735e7ff773e4a424bcb5623139dc",
+        "params_digest": "846774f5f795e29d6d3c2fd04cdef645d4c71798e6fde0c86f94737cb2c33071"
+      },
+      "occurrence": {
+        "present": true,
+        "attestor": "exec",
+        "independent_of_emitter": true,
+        "action_digest": "5558294fdc17c8ffe2f8036a59fd8b7ea23c735e7ff773e4a424bcb5623139dc",
+        "outcome_digest": "212e659146dac83f09f639fe16f4316e2fc5ecb37c3f99ee67e31eb7a73bb0f9"
+      },
+      "check": {
+        "present": true,
+        "attestor": "checker",
+        "independent_of_emitter": true,
+        "input_digest": "935a529bdd6d83f3507a160616ac86968089d7da06d70b59dc66c70c4df091d2",
+        "policy_digest": "e6fd7138c3ca7c972fc4c3042573bc15eb73d961f8848334dad5749367987a9a",
+        "output": "pass",
+        "issued_at": 1750000000,
+        "checker_id": "mcp-019-composite",
+        "version": "1.0"
+      }
+    },
+    "attestor_independence_ok": true,
+    "policy_digest": "e6fd7138c3ca7c972fc4c3042573bc15eb73d961f8848334dad5749367987a9a",
+    "freshness_window_seconds": 300
+  },
+  "recomputation_boundary": "control: clean wired check accepted",
+  "envelope_signature_valid": true,
+  "receipt": {
+    "action": {
+      "tool": "invoke",
+      "params": {
+        "which": "transfer"
+      }
+    },
+    "action_digest": "5558294fdc17c8ffe2f8036a59fd8b7ea23c735e7ff773e4a424bcb5623139dc",
+    "tool_set_digest": "935a529bdd6d83f3507a160616ac86968089d7da06d70b59dc66c70c4df091d2",
+    "claims": {
+      "authorization": {
+        "action_digest": "5558294fdc17c8ffe2f8036a59fd8b7ea23c735e7ff773e4a424bcb5623139dc",
+        "params_digest": "846774f5f795e29d6d3c2fd04cdef645d4c71798e6fde0c86f94737cb2c33071",
+        "sig": "5c84b626f11accc50bc5671472daf34c32e43c658dfd9fa2151f07076bd5d7d68d4d48a4db929a2e2b8972c620545dad9092eeab3e5b9719643a1ab91808830b"
+      },
+      "occurrence": {
+        "action_digest": "5558294fdc17c8ffe2f8036a59fd8b7ea23c735e7ff773e4a424bcb5623139dc",
+        "outcome_digest": "212e659146dac83f09f639fe16f4316e2fc5ecb37c3f99ee67e31eb7a73bb0f9",
+        "sig": "16847edd553ae69ab4f3d07497b8fce3fd6104894349880b21754561abe97fd809785d5d66d14ffe5849dba4fa4a7d780d34d9ed955ff5f72c6fe5e7e5b5b70d"
+      },
+      "check": {
+        "checker_id": "mcp-019-composite",
+        "version": "1.0",
+        "policy_digest": "e6fd7138c3ca7c972fc4c3042573bc15eb73d961f8848334dad5749367987a9a",
+        "input_digest": "935a529bdd6d83f3507a160616ac86968089d7da06d70b59dc66c70c4df091d2",
+        "output": "pass",
+        "issued_at": 1750000000,
+        "sig": "bb1d955433351d16f0eeb0cc9b34baf803ebf8570b1f7245769ce3ff980decd6e1481ac7e17305cde9732c064d9f33cd03200a88b17cae39aa2529b079c0c50d"
+      }
+    },
+    "envelope_sig": "2ae6e11e6416ad762e333f1af450a4f7c75c2e06bb94a3ad44bbdae1330ff6fc8d4aace00179b0da251714ea9372f26cb3357c7861fd8acd5d4a354f8adaf80f"
+  }
+}

--- a/conformance/receipt-claim/fixtures/RCL-010.json
+++ b/conformance/receipt-claim/fixtures/RCL-010.json
@@ -1,0 +1,77 @@
+{
+  "test_id": "RCL-010",
+  "name": "Wired MCP-019 check (composite found) rejected",
+  "expected_result": "reject",
+  "expected_phase": "admission",
+  "violated_binding": "wired MCP-019 verdict is fail",
+  "reason_code": "CHECK_OUTPUT_FAIL",
+  "harness_reason": "check: recorded output is not a pass",
+  "evidence_binding": {
+    "admitted_action_digest": "5558294fdc17c8ffe2f8036a59fd8b7ea23c735e7ff773e4a424bcb5623139dc",
+    "action_tool_set_digest": "64f53a5a25ced4a18c4aa03551e025b514b83fecc694ef9aea179bdf69a6a603",
+    "referenced_evidence": {
+      "authorization": {
+        "present": true,
+        "attestor": "authz",
+        "independent_of_emitter": true,
+        "action_digest": "5558294fdc17c8ffe2f8036a59fd8b7ea23c735e7ff773e4a424bcb5623139dc",
+        "params_digest": "846774f5f795e29d6d3c2fd04cdef645d4c71798e6fde0c86f94737cb2c33071"
+      },
+      "occurrence": {
+        "present": true,
+        "attestor": "exec",
+        "independent_of_emitter": true,
+        "action_digest": "5558294fdc17c8ffe2f8036a59fd8b7ea23c735e7ff773e4a424bcb5623139dc",
+        "outcome_digest": "212e659146dac83f09f639fe16f4316e2fc5ecb37c3f99ee67e31eb7a73bb0f9"
+      },
+      "check": {
+        "present": true,
+        "attestor": "checker",
+        "independent_of_emitter": true,
+        "input_digest": "64f53a5a25ced4a18c4aa03551e025b514b83fecc694ef9aea179bdf69a6a603",
+        "policy_digest": "e6fd7138c3ca7c972fc4c3042573bc15eb73d961f8848334dad5749367987a9a",
+        "output": "fail",
+        "issued_at": 1750000000,
+        "checker_id": "mcp-019-composite",
+        "version": "1.0"
+      }
+    },
+    "attestor_independence_ok": true,
+    "policy_digest": "e6fd7138c3ca7c972fc4c3042573bc15eb73d961f8848334dad5749367987a9a",
+    "freshness_window_seconds": 300
+  },
+  "recomputation_boundary": "wired MCP-019 verdict is fail",
+  "envelope_signature_valid": true,
+  "receipt": {
+    "action": {
+      "tool": "invoke",
+      "params": {
+        "which": "transfer"
+      }
+    },
+    "action_digest": "5558294fdc17c8ffe2f8036a59fd8b7ea23c735e7ff773e4a424bcb5623139dc",
+    "tool_set_digest": "64f53a5a25ced4a18c4aa03551e025b514b83fecc694ef9aea179bdf69a6a603",
+    "claims": {
+      "authorization": {
+        "action_digest": "5558294fdc17c8ffe2f8036a59fd8b7ea23c735e7ff773e4a424bcb5623139dc",
+        "params_digest": "846774f5f795e29d6d3c2fd04cdef645d4c71798e6fde0c86f94737cb2c33071",
+        "sig": "5c84b626f11accc50bc5671472daf34c32e43c658dfd9fa2151f07076bd5d7d68d4d48a4db929a2e2b8972c620545dad9092eeab3e5b9719643a1ab91808830b"
+      },
+      "occurrence": {
+        "action_digest": "5558294fdc17c8ffe2f8036a59fd8b7ea23c735e7ff773e4a424bcb5623139dc",
+        "outcome_digest": "212e659146dac83f09f639fe16f4316e2fc5ecb37c3f99ee67e31eb7a73bb0f9",
+        "sig": "16847edd553ae69ab4f3d07497b8fce3fd6104894349880b21754561abe97fd809785d5d66d14ffe5849dba4fa4a7d780d34d9ed955ff5f72c6fe5e7e5b5b70d"
+      },
+      "check": {
+        "checker_id": "mcp-019-composite",
+        "version": "1.0",
+        "policy_digest": "e6fd7138c3ca7c972fc4c3042573bc15eb73d961f8848334dad5749367987a9a",
+        "input_digest": "64f53a5a25ced4a18c4aa03551e025b514b83fecc694ef9aea179bdf69a6a603",
+        "output": "fail",
+        "issued_at": 1750000000,
+        "sig": "a5a7fb9478f2b0e0d0e8bef62f331e2204f1333096f17e5db42876cf572dfd0e93be85be527fb4c48011b44a9f8087dbb6b5410f6339aae1e5458c2fe69f050d"
+      }
+    },
+    "envelope_sig": "560f9da708e7a432a2c75007e3f4603b7ba4deb470c8c9dadca57ce788559af87d58e04397f97aeafe5f29b32e1585875fdccf8e4303a2f74b518509bba5d109"
+  }
+}

--- a/conformance/receipt-claim/fixtures/RCL-011.json
+++ b/conformance/receipt-claim/fixtures/RCL-011.json
@@ -1,0 +1,77 @@
+{
+  "test_id": "RCL-011",
+  "name": "Wired MCP-019 check bound to wrong tool set rejected",
+  "expected_result": "reject",
+  "expected_phase": "admission",
+  "violated_binding": "wired check bound to the wrong tool set",
+  "reason_code": "CHECK_TOOLSET_DIGEST_MISMATCH",
+  "harness_reason": "check: result bound to the wrong tool-set digest",
+  "evidence_binding": {
+    "admitted_action_digest": "5558294fdc17c8ffe2f8036a59fd8b7ea23c735e7ff773e4a424bcb5623139dc",
+    "action_tool_set_digest": "64f53a5a25ced4a18c4aa03551e025b514b83fecc694ef9aea179bdf69a6a603",
+    "referenced_evidence": {
+      "authorization": {
+        "present": true,
+        "attestor": "authz",
+        "independent_of_emitter": true,
+        "action_digest": "5558294fdc17c8ffe2f8036a59fd8b7ea23c735e7ff773e4a424bcb5623139dc",
+        "params_digest": "846774f5f795e29d6d3c2fd04cdef645d4c71798e6fde0c86f94737cb2c33071"
+      },
+      "occurrence": {
+        "present": true,
+        "attestor": "exec",
+        "independent_of_emitter": true,
+        "action_digest": "5558294fdc17c8ffe2f8036a59fd8b7ea23c735e7ff773e4a424bcb5623139dc",
+        "outcome_digest": "212e659146dac83f09f639fe16f4316e2fc5ecb37c3f99ee67e31eb7a73bb0f9"
+      },
+      "check": {
+        "present": true,
+        "attestor": "checker",
+        "independent_of_emitter": true,
+        "input_digest": "935a529bdd6d83f3507a160616ac86968089d7da06d70b59dc66c70c4df091d2",
+        "policy_digest": "e6fd7138c3ca7c972fc4c3042573bc15eb73d961f8848334dad5749367987a9a",
+        "output": "pass",
+        "issued_at": 1750000000,
+        "checker_id": "mcp-019-composite",
+        "version": "1.0"
+      }
+    },
+    "attestor_independence_ok": true,
+    "policy_digest": "e6fd7138c3ca7c972fc4c3042573bc15eb73d961f8848334dad5749367987a9a",
+    "freshness_window_seconds": 300
+  },
+  "recomputation_boundary": "wired check bound to the wrong tool set",
+  "envelope_signature_valid": true,
+  "receipt": {
+    "action": {
+      "tool": "invoke",
+      "params": {
+        "which": "transfer"
+      }
+    },
+    "action_digest": "5558294fdc17c8ffe2f8036a59fd8b7ea23c735e7ff773e4a424bcb5623139dc",
+    "tool_set_digest": "64f53a5a25ced4a18c4aa03551e025b514b83fecc694ef9aea179bdf69a6a603",
+    "claims": {
+      "authorization": {
+        "action_digest": "5558294fdc17c8ffe2f8036a59fd8b7ea23c735e7ff773e4a424bcb5623139dc",
+        "params_digest": "846774f5f795e29d6d3c2fd04cdef645d4c71798e6fde0c86f94737cb2c33071",
+        "sig": "5c84b626f11accc50bc5671472daf34c32e43c658dfd9fa2151f07076bd5d7d68d4d48a4db929a2e2b8972c620545dad9092eeab3e5b9719643a1ab91808830b"
+      },
+      "occurrence": {
+        "action_digest": "5558294fdc17c8ffe2f8036a59fd8b7ea23c735e7ff773e4a424bcb5623139dc",
+        "outcome_digest": "212e659146dac83f09f639fe16f4316e2fc5ecb37c3f99ee67e31eb7a73bb0f9",
+        "sig": "16847edd553ae69ab4f3d07497b8fce3fd6104894349880b21754561abe97fd809785d5d66d14ffe5849dba4fa4a7d780d34d9ed955ff5f72c6fe5e7e5b5b70d"
+      },
+      "check": {
+        "checker_id": "mcp-019-composite",
+        "version": "1.0",
+        "policy_digest": "e6fd7138c3ca7c972fc4c3042573bc15eb73d961f8848334dad5749367987a9a",
+        "input_digest": "935a529bdd6d83f3507a160616ac86968089d7da06d70b59dc66c70c4df091d2",
+        "output": "pass",
+        "issued_at": 1750000000,
+        "sig": "bb1d955433351d16f0eeb0cc9b34baf803ebf8570b1f7245769ce3ff980decd6e1481ac7e17305cde9732c064d9f33cd03200a88b17cae39aa2529b079c0c50d"
+      }
+    },
+    "envelope_sig": "09e7d9c21473ede44d647d2a09b9c760b27d113b2c63056cd131c57d9d69f73e7abe9308ee5aa14c4634cacce2510a506df311507308d1adde706cc949c5490b"
+  }
+}

--- a/conformance/receipt-claim/fixtures/index.json
+++ b/conformance/receipt-claim/fixtures/index.json
@@ -1,0 +1,97 @@
+{
+  "suite": "RCL receipt-claim conformance vectors",
+  "source": "protocol_tests/receipt_claim_harness.py",
+  "reject_vectors": 9,
+  "acceptance_controls": 2,
+  "freshness_window_seconds": 300,
+  "cases": [
+    {
+      "test_id": "RCL-001",
+      "name": "Omitted mandatory evidence",
+      "expected_result": "reject",
+      "phase": "post-execution",
+      "reason_code": "OCCURRENCE_EVIDENCE_MISSING",
+      "harness_reason": "occurrence: missing evidence"
+    },
+    {
+      "test_id": "RCL-002",
+      "name": "Substituted evidence, re-signed envelope",
+      "expected_result": "reject",
+      "phase": "admission",
+      "reason_code": "CHECK_EVIDENCE_TAMPERED",
+      "harness_reason": "check: checker attestation does not verify (substituted or forged)"
+    },
+    {
+      "test_id": "RCL-003",
+      "name": "Stale checker transcript",
+      "expected_result": "reject",
+      "phase": "admission",
+      "reason_code": "CHECK_TRANSCRIPT_STALE",
+      "harness_reason": "check: stale transcript (outside freshness window)"
+    },
+    {
+      "test_id": "RCL-004",
+      "name": "Check bound to the wrong tool-set digest",
+      "expected_result": "reject",
+      "phase": "admission",
+      "reason_code": "CHECK_TOOLSET_DIGEST_MISMATCH",
+      "harness_reason": "check: result bound to the wrong tool-set digest"
+    },
+    {
+      "test_id": "RCL-005",
+      "name": "Authorization bound to different parameters",
+      "expected_result": "reject",
+      "phase": "admission",
+      "reason_code": "AUTHORIZATION_PARAMS_MISMATCH",
+      "harness_reason": "authorization: params do not match the action"
+    },
+    {
+      "test_id": "RCL-006",
+      "name": "Execution ack bound to another action",
+      "expected_result": "reject",
+      "phase": "post-execution",
+      "reason_code": "OCCURRENCE_ACTION_LINKAGE_MISMATCH",
+      "harness_reason": "occurrence: acknowledgment bound to another action"
+    },
+    {
+      "test_id": "RCL-007",
+      "name": "Emitter self-assertion, no independent attestation",
+      "expected_result": "reject",
+      "phase": "admission",
+      "reason_code": "CHECK_ATTESTOR_NOT_INDEPENDENT",
+      "harness_reason": "check: attested by the emitter, not the checker authority"
+    },
+    {
+      "test_id": "RCL-008",
+      "name": "Fully-supported receipt accepted (control)",
+      "expected_result": "accept",
+      "phase": "admission+post-execution",
+      "reason_code": "ACCEPT_ALL_PROPERTIES_SUPPORTED",
+      "harness_reason": "all four properties independently supported"
+    },
+    {
+      "test_id": "RCL-009",
+      "name": "Wired MCP-019 check (clean) accepted",
+      "expected_result": "accept",
+      "phase": "admission",
+      "reason_code": "ACCEPT_ALL_PROPERTIES_SUPPORTED",
+      "harness_reason": "all four properties independently supported"
+    },
+    {
+      "test_id": "RCL-010",
+      "name": "Wired MCP-019 check (composite found) rejected",
+      "expected_result": "reject",
+      "phase": "admission",
+      "reason_code": "CHECK_OUTPUT_FAIL",
+      "harness_reason": "check: recorded output is not a pass"
+    },
+    {
+      "test_id": "RCL-011",
+      "name": "Wired MCP-019 check bound to wrong tool set rejected",
+      "expected_result": "reject",
+      "phase": "admission",
+      "reason_code": "CHECK_TOOLSET_DIGEST_MISMATCH",
+      "harness_reason": "check: result bound to the wrong tool-set digest"
+    }
+  ]
+}

--- a/conformance/receipt-claim/generate.py
+++ b/conformance/receipt-claim/generate.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Generate the RCL receipt-claim conformance vectors from the harness verifier.
+
+Each vector is a receipt whose envelope signature verifies but whose claims are
+(in)valid on semantic grounds. Values are produced by the working ClaimLevelVerifier
+in protocol_tests/receipt_claim_harness.py, not hand-authored, so `expected_result`
+and `harness_reason` are ground truth. Run from the repo root:
+
+    python conformance/receipt-claim/generate.py
+"""
+import json, os, sys
+REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, REPO)
+from protocol_tests import receipt_claim_harness as R
+
+OUT = os.path.join(REPO, "conformance", "receipt-claim", "fixtures")
+os.makedirs(OUT, exist_ok=True)
+now = R.ReceiptClaimTests().now
+V = R.ClaimLevelVerifier(now)
+
+
+def who_signed(block):
+    if not isinstance(block, dict):
+        return None
+    for auth in ("checker", "authz", "exec", "emitter"):
+        if R._attest_ok(auth, block):
+            return auth
+    return None
+
+
+# Per case: receipt-lifecycle phase, the binding a verifier must fail, and a
+# harness-native reason code (maps 1:1 to the verifier's reason string).
+META = {
+ "RCL-001": ("post-execution", "occurrence evidence omitted",                       "OCCURRENCE_EVIDENCE_MISSING"),
+ "RCL-002": ("admission",      "check evidence tampered after attestation",          "CHECK_EVIDENCE_TAMPERED"),
+ "RCL-003": ("admission",      "check transcript outside the freshness window",       "CHECK_TRANSCRIPT_STALE"),
+ "RCL-004": ("admission",      "check bound to a different tool-set digest",           "CHECK_TOOLSET_DIGEST_MISMATCH"),
+ "RCL-005": ("admission",      "authorization bound to different params than requested","AUTHORIZATION_PARAMS_MISMATCH"),
+ "RCL-006": ("post-execution", "occurrence ack bound to another action",              "OCCURRENCE_ACTION_LINKAGE_MISMATCH"),
+ "RCL-007": ("admission",      "check attested by emitter, not an independent authority","CHECK_ATTESTOR_NOT_INDEPENDENT"),
+ "RCL-008": ("admission+post-execution", "control: all four properties supported",     "ACCEPT_ALL_PROPERTIES_SUPPORTED"),
+ "RCL-009": ("admission",      "control: clean wired check accepted",                  "ACCEPT_ALL_PROPERTIES_SUPPORTED"),
+ "RCL-010": ("admission",      "wired MCP-019 verdict is fail",                        "CHECK_OUTPUT_FAIL"),
+ "RCL-011": ("admission",      "wired check bound to the wrong tool set",              "CHECK_TOOLSET_DIGEST_MISMATCH"),
+}
+
+
+def build(tid):
+    if tid == "RCL-008":
+        return R.build_valid_receipt(now)
+    if tid == "RCL-009":
+        return R.build_tool_context_receipt(now, R._CLEAN_TOOLS)
+    if tid == "RCL-010":
+        return R.build_tool_context_receipt(now, R._SHARELOCK_TOOLS)
+    if tid == "RCL-011":
+        return R.build_tool_context_receipt(now, R._CLEAN_TOOLS, action_tools=R._SHARELOCK_TOOLS)
+    return dict((t[0], t[2]) for t in R.NEGATIVES)[tid](now)
+
+
+NAMES = dict((t[0], t[1]) for t in R.NEGATIVES)
+NAMES.update({"RCL-008": "Fully-supported receipt accepted (control)",
+              "RCL-009": "Wired MCP-019 check (clean) accepted",
+              "RCL-010": "Wired MCP-019 check (composite found) rejected",
+              "RCL-011": "Wired MCP-019 check bound to wrong tool set rejected"})
+
+index = []
+for tid in [f"RCL-{i:03d}" for i in range(1, 12)]:
+    rcpt = build(tid)
+    out = V.verify(rcpt)
+    env = V.verify_envelope(rcpt)
+    phase, binding, code = META[tid]
+    claims = rcpt.get("claims", {})
+    ev = {}
+    for prop in ("authorization", "occurrence", "check"):
+        b = claims.get(prop)
+        if b is None:
+            ev[prop] = {"present": False}
+            continue
+        rec = {"present": True, "attestor": who_signed(b),
+               "independent_of_emitter": who_signed(b) not in (None, "emitter")}
+        for f in ("action_digest", "params_digest", "outcome_digest",
+                  "input_digest", "policy_digest", "output", "issued_at",
+                  "checker_id", "version"):
+            if f in b:
+                rec[f] = b[f]
+        ev[prop] = rec
+    fixture = {
+        "test_id": tid,
+        "name": NAMES[tid],
+        "expected_result": out.verdict,          # accept | reject  (ground truth)
+        "expected_phase": phase,                 # admission | post-execution | both
+        "violated_binding": binding,
+        "reason_code": code,
+        "harness_reason": out.reason,            # verbatim verifier output
+        # Evidence-binding descriptor: exactly what a verifier must recompute
+        # from referenced evidence, so the vector is not satisfiable at the
+        # string level.
+        "evidence_binding": {
+            "admitted_action_digest": rcpt.get("action_digest"),
+            "action_tool_set_digest": rcpt.get("tool_set_digest"),
+            "referenced_evidence": ev,
+            "attestor_independence_ok": all(
+                v.get("independent_of_emitter", True) for v in ev.values() if v.get("present")),
+            "policy_digest": (claims.get("check") or {}).get("policy_digest"),
+            "freshness_window_seconds": R.FRESHNESS_WINDOW,
+        },
+        "recomputation_boundary": binding,
+        "envelope_signature_valid": env,         # always True: envelope-valid, claim-(in)valid
+        "receipt": rcpt,
+    }
+    with open(os.path.join(OUT, f"{tid}.json"), "w") as f:
+        json.dump(fixture, f, indent=2)
+    index.append({"test_id": tid, "name": NAMES[tid], "expected_result": out.verdict,
+                  "phase": phase, "reason_code": code, "harness_reason": out.reason})
+
+with open(os.path.join(OUT, "index.json"), "w") as f:
+    json.dump({"suite": "RCL receipt-claim conformance vectors",
+               "source": "protocol_tests/receipt_claim_harness.py",
+               "reject_vectors": sum(1 for x in index if x["expected_result"] == "reject"),
+               "acceptance_controls": sum(1 for x in index if x["expected_result"] == "accept"),
+               "freshness_window_seconds": R.FRESHNESS_WINDOW,
+               "cases": index}, f, indent=2)
+
+print(f"wrote {len(index)} fixtures to {OUT}")
+for x in index:
+    print(f"  {x['test_id']} {x['expected_result']:6} [{x['phase']}] {x['reason_code']}")

--- a/conformance/receipt-claim/verify_fixtures.py
+++ b/conformance/receipt-claim/verify_fixtures.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Replay every RCL conformance vector through the claim-level verifier and assert
+each reaches its recorded `expected_result`. This is what makes the vectors a
+conformance suite rather than static data: a receipt implementation can run its
+own verifier over the same fixtures and compare.
+
+    python conformance/receipt-claim/verify_fixtures.py     # exits non-zero on mismatch
+"""
+import glob, json, os, sys
+REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, REPO)
+from protocol_tests.receipt_claim_harness import ClaimLevelVerifier, ReceiptClaimTests
+
+FIX = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fixtures")
+
+
+def run():
+    now = ReceiptClaimTests().now
+    v = ClaimLevelVerifier(now)
+    failures = []
+    files = sorted(glob.glob(os.path.join(FIX, "RCL-*.json")))
+    if not files:
+        print(f"receipt-claim conformance: no fixtures found under {FIX} (fail closed)")
+        return 1
+    for path in files:
+        fx = json.load(open(path))
+        # every vector is envelope-valid by construction; the claim verdict is the test
+        if not v.verify_envelope(fx["receipt"]):
+            failures.append((fx["test_id"], "envelope signature did not verify"))
+            continue
+        got = v.verify(fx["receipt"]).verdict
+        if got != fx["expected_result"]:
+            failures.append((fx["test_id"], f"expected {fx['expected_result']}, got {got}"))
+    print(f"receipt-claim conformance: {len(files) - len(failures)}/{len(files)} vectors match")
+    for tid, why in failures:
+        print(f"  MISMATCH {tid}: {why}")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/docs/proposals/CROSS-PROTOCOL-SCHEMA-RESOLUTION.md
+++ b/docs/proposals/CROSS-PROTOCOL-SCHEMA-RESOLUTION.md
@@ -1,0 +1,94 @@
+# Cross-Protocol Schema-Resolution Test Family
+
+## Status
+
+Initial fixture layer implemented in `protocol_tests/schema_resolution.py` and
+`testing/test_schema_resolution.py`. This family is not a finding against A2A,
+MCP, or a particular implementation. It describes consumer-side conformance
+and hardening tests prompted by schema-generation defects such as unresolved
+relative `$ref` values, draft-keyword inconsistencies, and field-name ambiguity.
+
+## Security boundary
+
+JSON Schema permits external references. An external `$ref` is not, by itself,
+evidence that a consumer fetches it or that a vulnerability exists. The security
+property under test is the consumer's resolver policy:
+
+> An unresolved schema reference must not cause implicit network, filesystem,
+> package-registry, or mutable dependency acquisition.
+
+The control is not merely local canonicalization. Canonicalization does not
+establish resource provenance or integrity. Consumers should resolve only from
+an allowlisted, locally registered, version-pinned schema set, and fail closed
+when a reference is unavailable or not authorized.
+
+## Scope
+
+The same fixtures run against A2A and MCP consumer paths that validate Agent
+Cards, task/input artifacts, tool definitions, resource metadata, or other
+protocol-declared schemas. A run must identify the consumer being evaluated
+(gateway, SDK, receiving agent, or validator library) and the resolver policy
+it is expected to enforce.
+
+No live public endpoint should be used as a reference target. Fixtures use a
+test-controlled loopback HTTP listener, a test-controlled local file, and a
+registered pinned bundle so resolver behavior can be observed directly.
+
+## Test boundaries
+
+### 1. Resolution policy
+
+- **XSR-001 - unresolved HTTP reference:** present an otherwise valid document
+  whose `$ref` points to a controlled HTTP listener. Pass when validation fails
+  closed without contacting the listener.
+- **XSR-002 - unresolved filesystem reference:** present a `file:` reference to
+  a controlled sentinel. Pass when validation fails closed without opening the
+  sentinel.
+- **XSR-003 - mutable registry reference:** resolve an identifier whose content
+  changes between validation attempts. Pass only when an allowlisted,
+  version-pinned local registration is used and the mutation is not accepted.
+- **XSR-004 - self-contained bundle control:** validate the same document as a
+  compound Draft 2020-12 schema using local `$defs`. Pass when no external
+  acquisition occurs and the document is interpreted consistently.
+
+### 2. Validator differential
+
+- **XSR-005 - draft keyword differential:** run the same fixture through each
+  declared validation boundary with `$schema`, legacy `definitions`, and Draft
+  2020-12 `$defs` variants. Fail when accept/reject outcomes differ without an
+  explicit compatibility policy.
+- **XSR-006 - pattern-property differential:** compare gateway, SDK, and
+  receiving-agent interpretation of `patternProperties`, `additionalProperties`,
+  and explicit properties. Fail when an unrecognized property reaches a
+  downstream value despite being rejected or ignored upstream.
+
+### 3. Wire-format ambiguity
+
+- **XSR-007 - equivalent-field collision:** provide camelCase and snake_case
+  spellings of one semantic field in the same payload. Pass only when the
+  contract rejects the collision or applies one documented, consistent rule.
+- **XSR-008 - split-path propagation:** send each spelling independently through
+  gateway, SDK, and receiving agent. Fail when equivalent semantic input reaches
+  materially different downstream values without an explicit versioned contract.
+
+## Evidence and reporting
+
+Each result records:
+
+- protocol and consumer boundary evaluated;
+- schema identifier, allowed registry entry, and immutable version or digest;
+- attempted acquisition channel and whether it was actually contacted;
+- validator outcome at each boundary and downstream normalized value;
+- fixture-only evidence, not an attribution to the protocol specification.
+
+An unexpected external acquisition is a consumer hardening failure. It is not
+reported as a protocol vulnerability unless a reproducible, scoped consumer
+impact is demonstrated. A validator differential is an interoperability finding
+until it demonstrates a security-relevant downstream divergence.
+
+## Recommended publication posture
+
+Generated protocol schemas should be published as self-contained bundles. Until
+then, consumers should disable dynamic external `$ref` retrieval and resolve
+references only from an allowlisted, locally registered, version-pinned schema
+set. Unresolved references should fail closed.

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -159,8 +159,7 @@ def create_server(api_key: str | None = None) -> FastMCP:
 
     mcp = FastMCP(
         "Agent Security Harness",
-        version="1.0.0",
-        description=(
+        instructions=(
             "Security testing tools for AI agent systems. "
             "553 tests across MCP, A2A, L402, x402, and identity protocols."
         ),

--- a/protocol_tests/mcp_harness.py
+++ b/protocol_tests/mcp_harness.py
@@ -151,6 +151,15 @@ def jsonrpc_notification(method: str, params: dict | None = None) -> dict:
     return msg
 
 
+def _probe_failed(response: dict | None) -> bool:
+    """Whether a configured probe failed before it could yield a valid result."""
+    return not response or bool(
+        response.get("_error")
+        or response.get("_status", 200) >= 400
+        or "error" in response
+    )
+
+
 # ---------------------------------------------------------------------------
 # Transport layer
 # ---------------------------------------------------------------------------
@@ -712,6 +721,16 @@ class MCPSecurityTests:
 
         initial = jsonrpc_request(self.mrtr_probe["method"], dict(self.mrtr_probe.get("params") or {}))
         initial_response = self.transport.send(initial)
+        if _probe_failed(initial_response):
+            self._record(MCPTestResult(
+                test_id="MCP-RC-002", name="MRTR requestState Integrity",
+                category="mrtr_request_state", owasp_asi="ASI02",
+                severity=Severity.HIGH.value, passed=False,
+                details="Configured MRTR probe failed before requestState validation",
+                mcp_method=initial["method"], request_sent=initial,
+                response_received=initial_response, elapsed_s=round(time.monotonic() - t0, 3),
+            ))
+            return
         result = initial_response.get("result", {}) if initial_response else {}
         state = result.get("requestState")
         if result.get("resultType") != "input_required" or not isinstance(state, str) or not state:
@@ -766,6 +785,16 @@ class MCPSecurityTests:
 
         initial = jsonrpc_request(self.mrtr_probe["method"], dict(self.mrtr_probe.get("params") or {}))
         initial_response = self.transport.send(initial)
+        if _probe_failed(initial_response):
+            self._record(MCPTestResult(
+                test_id="MCP-RC-003", name="MRTR requestState Replay Protection",
+                category="mrtr_request_state", owasp_asi="ASI02",
+                severity=Severity.HIGH.value, passed=False,
+                details="Configured MRTR probe failed before replay validation",
+                mcp_method=initial["method"], request_sent=initial,
+                response_received=initial_response, elapsed_s=round(time.monotonic() - t0, 3),
+            ))
+            return
         result = initial_response.get("result", {}) if initial_response else {}
         state = result.get("requestState")
         if result.get("resultType") != "input_required" or not isinstance(state, str) or not state:
@@ -833,6 +862,16 @@ class MCPSecurityTests:
 
         initial = jsonrpc_request(self.mrtr_probe["method"], dict(self.mrtr_probe.get("params") or {}))
         initial_response = self.transport.send(initial)
+        if _probe_failed(initial_response):
+            self._record(MCPTestResult(
+                test_id="MCP-RC-004", name="MRTR requestState Principal Binding",
+                category="mrtr_request_state", owasp_asi="ASI02",
+                severity=Severity.HIGH.value, passed=False,
+                details="Configured MRTR probe failed before principal-binding validation",
+                mcp_method=initial["method"], request_sent=initial,
+                response_received=initial_response, elapsed_s=round(time.monotonic() - t0, 3),
+            ))
+            return
         result = initial_response.get("result", {}) if initial_response else {}
         state = result.get("requestState")
         if result.get("resultType") != "input_required" or not isinstance(state, str) or not state:
@@ -889,6 +928,16 @@ class MCPSecurityTests:
 
         initial = jsonrpc_request(self.mrtr_probe["method"], dict(self.mrtr_probe.get("params") or {}))
         initial_response = self.transport.send(initial)
+        if _probe_failed(initial_response):
+            self._record(MCPTestResult(
+                test_id="MCP-RC-005", name="MRTR requestState Request Binding",
+                category="mrtr_request_state", owasp_asi="ASI02",
+                severity=Severity.HIGH.value, passed=False,
+                details="Configured MRTR probe failed before request-binding validation",
+                mcp_method=initial["method"], request_sent=initial,
+                response_received=initial_response, elapsed_s=round(time.monotonic() - t0, 3),
+            ))
+            return
         result = initial_response.get("result", {}) if initial_response else {}
         state = result.get("requestState")
         if result.get("resultType") != "input_required" or not isinstance(state, str) or not state:
@@ -950,6 +999,16 @@ class MCPSecurityTests:
             return
         create = jsonrpc_request(self.handle_create["method"], dict(self.handle_create.get("params") or {}))
         created = self.transport.send(create)
+        if _probe_failed(created):
+            self._record(MCPTestResult(
+                test_id="MCP-RC-006", name="Explicit Handle Cross-Principal Isolation",
+                category="explicit_handle_isolation", owasp_asi="ASI02",
+                severity=Severity.HIGH.value, passed=False,
+                details="Configured handle-create fixture failed before isolation validation",
+                mcp_method=create["method"], request_sent=create, response_received=created,
+                elapsed_s=round(time.monotonic() - t0, 3),
+            ))
+            return
         handle = _json_path(created, self.handle_create.get("handlePath", "result.handle"))
         if not isinstance(handle, str) or not handle:
             self._record(MCPTestResult(
@@ -997,7 +1056,7 @@ class MCPSecurityTests:
         response = self.transport.send(msg)
         result = response.get("result", {}) if response else {}
         scope, ttl = result.get("cacheScope"), result.get("ttlMs")
-        passed = scope in {"public", "private"} and isinstance(ttl, int) and ttl >= 0
+        passed = scope in {"public", "private"} and type(ttl) is int and ttl >= 0
         self._record(MCPTestResult(
             test_id="MCP-RC-007", name="Cache Scope Metadata",
             category="cache_security", owasp_asi="ASI04", severity=Severity.MEDIUM.value,
@@ -1036,38 +1095,51 @@ class MCPSecurityTests:
             ))
             return
 
-        invalidate = jsonrpc_request(
-            self.cache_invalidation["method"], dict(self.cache_invalidation.get("params") or {})
-        )
-        invalidation_response = self.transport.send(invalidate)
-        invalidation_failed = not invalidation_response or bool(
-            invalidation_response.get("_error")
-            or invalidation_response.get("_status", 200) >= 400
-            or "error" in invalidation_response
-        )
         verify = jsonrpc_request(self.cache_verify["method"], dict(self.cache_verify.get("params") or {}))
-        verification_response = self.transport.send(verify)
-        result = verification_response.get("result", {}) if verification_response else {}
-        tools = result.get("tools")
-        if not isinstance(tools, list):
+        before_response = self.transport.send(verify)
+        before_result = before_response.get("result", {}) if before_response else {}
+        before_tools = before_result.get("tools")
+        if not isinstance(before_tools, list):
             passed = False
-            details = "Verification did not return a tools list after authorized invalidation"
+            details = "Pre-invalidation verification did not return a tools list"
+            invalidation_response = None
+            verification_response = None
+        elif self.cache_forbidden_tool not in {
+            tool.get("name") for tool in before_tools if isinstance(tool, dict)
+        }:
+            passed = False
+            details = "Revoked capability was not discoverable before invalidation"
+            invalidation_response = None
+            verification_response = None
         else:
-            names = {tool.get("name") for tool in tools if isinstance(tool, dict)}
-            passed = not invalidation_failed and self.cache_forbidden_tool not in names
-            details = (
-                "Revoked capability was absent from the post-invalidation tools list"
-                if passed else "Revoked capability remained discoverable after invalidation"
+            invalidate = jsonrpc_request(
+                self.cache_invalidation["method"], dict(self.cache_invalidation.get("params") or {})
             )
-            if invalidation_failed:
-                details = "Authorized cache invalidation request was rejected or failed"
+            invalidation_response = self.transport.send(invalidate)
+            invalidation_failed = _probe_failed(invalidation_response)
+            verification_response = self.transport.send(verify)
+            result = verification_response.get("result", {}) if verification_response else {}
+            tools = result.get("tools")
+            if not isinstance(tools, list):
+                passed = False
+                details = "Post-invalidation verification did not return a tools list"
+            else:
+                names = {tool.get("name") for tool in tools if isinstance(tool, dict)}
+                passed = not invalidation_failed and self.cache_forbidden_tool not in names
+                details = (
+                    "Revoked capability was absent from the post-invalidation tools list"
+                    if passed else "Revoked capability remained discoverable after invalidation"
+                )
+                if invalidation_failed:
+                    details = "Authorized cache invalidation request was rejected or failed"
         self._record(MCPTestResult(
             test_id="MCP-RC-008", name="Cached Capability Revocation",
             category="cache_security", owasp_asi="ASI04", severity=Severity.HIGH.value,
             passed=passed, details=details, mcp_method=verify["method"],
-            request_sent={"invalidate": invalidate, "verify": verify,
+            request_sent={"verify": verify,
                           "forbidden_tool": self.cache_forbidden_tool},
-            response_received={"invalidation": invalidation_response, "verification": verification_response},
+            response_received={"before": before_response, "invalidation": invalidation_response,
+                               "after": verification_response},
             elapsed_s=round(time.monotonic() - t0, 3),
         ))
 
@@ -1100,7 +1172,7 @@ class MCPSecurityTests:
         response = self.transport.send(msg)
         result = response.get("result", {}) if response else {}
         scope, ttl = result.get("cacheScope"), result.get("ttlMs")
-        passed = scope in {"public", "private"} and isinstance(ttl, int) and ttl >= 0
+        passed = scope in {"public", "private"} and type(ttl) is int and ttl >= 0
         self._record(MCPTestResult(
             test_id="MCP-RC-009", name="Resource Cache Metadata",
             category="cache_security", owasp_asi="ASI04", severity=Severity.MEDIUM.value,

--- a/protocol_tests/mcp_harness.py
+++ b/protocol_tests/mcp_harness.py
@@ -452,6 +452,9 @@ class MCPSecurityTests:
         handle_create: dict | None = None,
         handle_access: dict | None = None,
         handle_attacker_headers: dict | None = None,
+        cache_invalidation: dict | None = None,
+        cache_verify: dict | None = None,
+        cache_forbidden_tool: str | None = None,
     ):
         self.transport = transport
         self.results: list[MCPTestResult] = []
@@ -466,6 +469,9 @@ class MCPSecurityTests:
         self.handle_create = handle_create
         self.handle_access = handle_access
         self.handle_attacker_headers = handle_attacker_headers
+        self.cache_invalidation = cache_invalidation
+        self.cache_verify = cache_verify
+        self.cache_forbidden_tool = cache_forbidden_tool
         self.selected_protocol_version: str | None = None
 
     def _record(self, result: MCPTestResult):
@@ -997,6 +1003,69 @@ class MCPSecurityTests:
             details=(f"tools/list declares cacheScope={scope!r}, ttlMs={ttl!r}" if passed
                      else "tools/list omitted valid cacheScope and/or non-negative ttlMs"),
             mcp_method="tools/list", request_sent=msg, response_received=response,
+            elapsed_s=round(time.monotonic() - t0, 3),
+        ))
+
+    def test_mcp_cache_revocation(self):
+        """MCP-RC-008: an authorized capability revocation must invalidate cached tools.
+
+        This probe never invokes a discovered tool.  It requires an explicitly
+        authorized invalidation request and then performs a read-only tools/list
+        verification, reporting not-applicable when no fixture is supplied.
+        """
+        t0 = time.monotonic()
+        if self.simulate:
+            self._record(MCPTestResult(
+                test_id="MCP-RC-008", name="Cached Capability Revocation",
+                category="cache_security", owasp_asi="ASI04", severity=Severity.HIGH.value,
+                passed=True, details="[simulate] Compiled cache-invalidation and stale-capability vector",
+                mcp_method="tools/list", elapsed_s=round(time.monotonic() - t0, 3),
+            ))
+            return
+        if (not getattr(self.transport, "is_modern", False) or not self.cache_invalidation
+                or not self.cache_verify or not self.cache_forbidden_tool):
+            self._record(MCPTestResult(
+                test_id="MCP-RC-008", name="Cached Capability Revocation",
+                category="cache_security", owasp_asi="ASI04", severity=Severity.HIGH.value,
+                passed=True,
+                details=("Not applicable: requires modern mode plus authorized cache invalidation, "
+                         "verification, and forbidden-tool fixtures"),
+                mcp_method="tools/list", elapsed_s=round(time.monotonic() - t0, 3),
+            ))
+            return
+
+        invalidate = jsonrpc_request(
+            self.cache_invalidation["method"], dict(self.cache_invalidation.get("params") or {})
+        )
+        invalidation_response = self.transport.send(invalidate)
+        invalidation_failed = not invalidation_response or bool(
+            invalidation_response.get("_error")
+            or invalidation_response.get("_status", 200) >= 400
+            or "error" in invalidation_response
+        )
+        verify = jsonrpc_request(self.cache_verify["method"], dict(self.cache_verify.get("params") or {}))
+        verification_response = self.transport.send(verify)
+        result = verification_response.get("result", {}) if verification_response else {}
+        tools = result.get("tools")
+        if not isinstance(tools, list):
+            passed = False
+            details = "Verification did not return a tools list after authorized invalidation"
+        else:
+            names = {tool.get("name") for tool in tools if isinstance(tool, dict)}
+            passed = not invalidation_failed and self.cache_forbidden_tool not in names
+            details = (
+                "Revoked capability was absent from the post-invalidation tools list"
+                if passed else "Revoked capability remained discoverable after invalidation"
+            )
+            if invalidation_failed:
+                details = "Authorized cache invalidation request was rejected or failed"
+        self._record(MCPTestResult(
+            test_id="MCP-RC-008", name="Cached Capability Revocation",
+            category="cache_security", owasp_asi="ASI04", severity=Severity.HIGH.value,
+            passed=passed, details=details, mcp_method=verify["method"],
+            request_sent={"invalidate": invalidate, "verify": verify,
+                          "forbidden_tool": self.cache_forbidden_tool},
+            response_received={"invalidation": invalidation_response, "verification": verification_response},
             elapsed_s=round(time.monotonic() - t0, 3),
         ))
 
@@ -2540,7 +2609,7 @@ class MCPSecurityTests:
                 self.test_mcp_request_state_request_binding,
             ],
             "explicit_handle_isolation": [self.test_mcp_explicit_handle_isolation],
-            "cache_security": [self.test_mcp_cache_scope_metadata],
+            "cache_security": [self.test_mcp_cache_scope_metadata, self.test_mcp_cache_revocation],
             "capability_negotiation": [
                 self.test_mcp_capability_escalation,
                 self.test_mcp_protocol_version_downgrade,
@@ -2763,6 +2832,9 @@ def main():
     ap.add_argument("--handle-create", help="Authorized handle-creation request as JSON (method, params, optional handlePath).")
     ap.add_argument("--handle-access", help="Authorized handle-access request as JSON; use $HANDLE in params as the created-handle placeholder.")
     ap.add_argument("--handle-attacker-header", action="append", default=[], help="Attacker identity header for explicit-handle isolation, key:value.")
+    ap.add_argument("--cache-invalidation", help="Authorized JSON-RPC request that revokes a capability and invalidates its cache entry.")
+    ap.add_argument("--cache-verify", help="Read-only JSON-RPC request that returns the post-invalidation tools list.")
+    ap.add_argument("--cache-forbidden-tool", help="Tool name that must be absent after --cache-invalidation.")
     ap.add_argument(
         "--protocol-version",
         choices=[MODERN_PROTOCOL_VERSION, AUTO_PROTOCOL_VERSION, DIFFERENTIAL_PROTOCOL_VERSION],
@@ -2812,6 +2884,7 @@ def main():
     mrtr_altered_probe = None
     handle_create = handle_access = None
     handle_attacker_headers = {}
+    cache_invalidation = cache_verify = None
     if args.mrtr_probe:
         try:
             mrtr_probe = json.loads(args.mrtr_probe)
@@ -2866,6 +2939,24 @@ def main():
         handle_attacker_headers[key.strip()] = value.strip()
     if any((handle_create, handle_access, handle_attacker_headers)) and not all((handle_create, handle_access, handle_attacker_headers)):
         ap.error("--handle-create, --handle-access, and --handle-attacker-header must be supplied together")
+    for option, raw in (("--cache-invalidation", args.cache_invalidation), ("--cache-verify", args.cache_verify)):
+        if raw:
+            try:
+                parsed = json.loads(raw)
+            except json.JSONDecodeError as exc:
+                ap.error(f"{option} must be a JSON object: {exc.msg}")
+            if not isinstance(parsed, dict) or not isinstance(parsed.get("method"), str):
+                ap.error(f"{option} must be a JSON object with a string 'method'")
+            if "params" in parsed and not isinstance(parsed["params"], dict):
+                ap.error(f"{option} 'params' must be a JSON object")
+            if option == "--cache-invalidation":
+                cache_invalidation = parsed
+            else:
+                cache_verify = parsed
+    if any((cache_invalidation, cache_verify, args.cache_forbidden_tool)) and not all(
+        (cache_invalidation, cache_verify, args.cache_forbidden_tool)
+    ):
+        ap.error("--cache-invalidation, --cache-verify, and --cache-forbidden-tool must be supplied together")
     for header in args.mrtr_attacker_header:
         if ":" not in header:
             ap.error("--mrtr-attacker-header must use key:value form")
@@ -2905,7 +2996,9 @@ def main():
                                      mrtr_input_responses=mrtr_input_responses,
                                      mrtr_attacker_headers=mrtr_attacker_headers,
                                      mrtr_altered_probe=mrtr_altered_probe, handle_create=handle_create,
-                                     handle_access=handle_access, handle_attacker_headers=handle_attacker_headers)
+                                     handle_access=handle_access, handle_attacker_headers=handle_attacker_headers,
+                                     cache_invalidation=cache_invalidation, cache_verify=cache_verify,
+                                     cache_forbidden_tool=args.cache_forbidden_tool)
             try:
                 results = suite.run_all(categories=categories)
                 return build_report(
@@ -2944,7 +3037,9 @@ def main():
                                      mrtr_input_responses=mrtr_input_responses,
                                      mrtr_attacker_headers=mrtr_attacker_headers,
                                      mrtr_altered_probe=mrtr_altered_probe, handle_create=handle_create,
-                                     handle_access=handle_access, handle_attacker_headers=handle_attacker_headers)
+                                     handle_access=handle_access, handle_attacker_headers=handle_attacker_headers,
+                                     cache_invalidation=cache_invalidation, cache_verify=cache_verify,
+                                     cache_forbidden_tool=args.cache_forbidden_tool)
             try:
                 return {"results": suite.run_all(categories=categories)}
             finally:
@@ -2968,7 +3063,9 @@ def main():
                                  mrtr_input_responses=mrtr_input_responses,
                                  mrtr_attacker_headers=mrtr_attacker_headers,
                                  mrtr_altered_probe=mrtr_altered_probe, handle_create=handle_create,
-                                 handle_access=handle_access, handle_attacker_headers=handle_attacker_headers)
+                                 handle_access=handle_access, handle_attacker_headers=handle_attacker_headers,
+                                 cache_invalidation=cache_invalidation, cache_verify=cache_verify,
+                                 cache_forbidden_tool=args.cache_forbidden_tool)
         conn_error = None
         try:
             results = suite.run_all(categories=categories)

--- a/protocol_tests/mcp_harness.py
+++ b/protocol_tests/mcp_harness.py
@@ -34,6 +34,7 @@ Requires: Python 3.10+, no external dependencies for core tests.
 from __future__ import annotations
 
 import argparse
+import base64
 import json
 import re
 import os
@@ -59,6 +60,34 @@ from protocol_tests._utils import (
 )
 
 
+# Preserve the harness's existing Streamable HTTP baseline. Dual-era discovery
+# will select newer legacy revisions when a target advertises them.
+LEGACY_PROTOCOL_VERSION = "2025-03-26"
+MODERN_PROTOCOL_VERSION = "2026-07-28"
+AUTO_PROTOCOL_VERSION = "auto"
+DIFFERENTIAL_PROTOCOL_VERSION = "differential"
+HARNESS_CLIENT_INFO = {"name": "agent-security-harness", "version": "4.9.1"}
+
+
+def _header_value(value: object) -> str:
+    """Encode an MCP mirrored-header value per the 2026-07-28 draft.
+
+    HTTP field values must be plain visible ASCII without leading/trailing
+    whitespace. Values outside that subset (and literal base64 sentinels) use
+    the protocol's UTF-8 base64 sentinel form.
+    """
+    value = str(value)
+    safe = (
+        value == value.strip()
+        and all(0x21 <= ord(char) <= 0x7E for char in value)
+        and not (value.startswith("=?base64?") and value.endswith("?="))
+    )
+    if safe:
+        return value
+    encoded = base64.b64encode(value.encode("utf-8")).decode("ascii")
+    return f"=?base64?{encoded}?="
+
+
 def _sanitize_url(url: str) -> str:
     """Remove credentials from URL for safe display in error messages and reports."""
     try:
@@ -69,6 +98,27 @@ def _sanitize_url(url: str) -> str:
     except Exception:
         pass
     return url
+
+
+def _json_path(value: object, path: str) -> object | None:
+    """Resolve a simple dotted path in a JSON result for opt-in test fixtures."""
+    current = value
+    for part in path.split("."):
+        if not isinstance(current, dict) or part not in current:
+            return None
+        current = current[part]
+    return current
+
+
+def _replace_handle(value: object, handle: str) -> object:
+    """Deep-copy JSON-compatible fixture data while replacing $HANDLE tokens."""
+    if isinstance(value, str):
+        return value.replace("$HANDLE", handle)
+    if isinstance(value, list):
+        return [_replace_handle(item, handle) for item in value]
+    if isinstance(value, dict):
+        return {key: _replace_handle(item, handle) for key, item in value.items()}
+    return value
 
 
 # ---------------------------------------------------------------------------
@@ -108,10 +158,21 @@ def jsonrpc_notification(method: str, params: dict | None = None) -> dict:
 class MCPTransport:
     """Abstract base for MCP transports."""
 
+    # Only HTTP transports can faithfully apply an alternate request principal
+    # through header overrides. Tests that require that property must not claim
+    # to exercise it over stdio.
+    supports_header_overrides = False
+
     def send(self, message: dict) -> dict | None:
         raise NotImplementedError
 
-    def send_raw(self, raw_bytes: bytes) -> bytes | None:
+    def send_raw(
+        self,
+        raw_bytes: bytes,
+        *,
+        mcp_method: str | None = None,
+        mcp_name: str | None = None,
+    ) -> bytes | None:
         """Send raw bytes (for malformed message testing)."""
         raise NotImplementedError
 
@@ -142,33 +203,90 @@ def _strip_server_sentinels(obj):
 class StreamableHTTPTransport(MCPTransport):
     """MCP over Streamable HTTP (POST with JSON-RPC 2.0 body).
 
-    Per MCP spec (2025-03-26): client sends POST requests with
-    Content-Type: application/json, server responds with application/json
-    or text/event-stream for streaming.
+    Supports legacy session-based Streamable HTTP and the stateless
+    ``2026-07-28`` revision. Modern requests carry their identity and
+    capabilities in the JSON-RPC body and mirror routable fields into headers.
     """
 
-    def __init__(self, url: str, headers: dict | None = None):
+    supports_header_overrides = True
+
+    def __init__(
+        self,
+        url: str,
+        headers: dict | None = None,
+        protocol_version: str | None = None,
+        client_info: dict | None = None,
+        client_capabilities: dict | None = None,
+    ):
         self.url = url
         self.headers = headers or {}
+        self.protocol_version = protocol_version
+        self.client_info = client_info or HARNESS_CLIENT_INFO.copy()
+        self.client_capabilities = client_capabilities or {}
         self.session_id: str | None = None
 
-    def send(self, message: dict) -> dict | None:
-        data = json.dumps(message).encode("utf-8")
+    @property
+    def is_modern(self) -> bool:
+        return self.protocol_version == MODERN_PROTOCOL_VERSION
+
+    @property
+    def is_auto(self) -> bool:
+        """Whether protocol selection should probe stateless discovery first."""
+        return self.protocol_version == AUTO_PROTOCOL_VERSION
+
+    def _prepare_modern_message(self, message: dict) -> dict:
+        """Return a copy with required 2026-07-28 request metadata."""
+        prepared = {**message}
+        params = dict(prepared.get("params") or {})
+        meta = dict(params.get("_meta") or {})
+        meta.setdefault("io.modelcontextprotocol/protocolVersion", self.protocol_version)
+        meta.setdefault("io.modelcontextprotocol/clientInfo", self.client_info)
+        meta.setdefault("io.modelcontextprotocol/clientCapabilities", self.client_capabilities)
+        params["_meta"] = meta
+        prepared["params"] = params
+        return prepared
+
+    def _request_headers(self, message: dict) -> dict:
         headers = {
             "Content-Type": "application/json",
             "Accept": "application/json, text/event-stream",
             **self.headers,
         }
-        if self.session_id:
+        if self.is_modern:
+            params = message.get("params") or {}
+            headers["MCP-Protocol-Version"] = self.protocol_version
+            headers["Mcp-Method"] = _header_value(message.get("method", ""))
+            if message.get("method") in {"tools/call", "resources/read", "prompts/get"}:
+                name = params.get("name", params.get("uri"))
+                if name is not None:
+                    headers["Mcp-Name"] = _header_value(name)
+        elif self.session_id:
             headers["Mcp-Session-Id"] = self.session_id
+        return headers
+
+    def send(self, message: dict, *, header_overrides: dict | None = None) -> dict | None:
+        """Send a JSON-RPC request, optionally overriding final HTTP fields.
+
+        Header overrides are intentionally available to security probes so the
+        harness can verify that gateways reject routing fields which disagree
+        with the JSON-RPC body. Production callers should not use them.
+        """
+        if self.is_modern:
+            message = self._prepare_modern_message(message)
+        data = json.dumps(message).encode("utf-8")
+        headers = self._request_headers(message)
+        if header_overrides:
+            headers.update(header_overrides)
 
         req = urllib.request.Request(self.url, data=data, headers=headers, method="POST")
         try:
             with urllib.request.urlopen(req, timeout=15) as resp:
-                # Capture session ID from response headers
-                sid = resp.headers.get("Mcp-Session-Id")
-                if sid:
-                    self.session_id = sid
+                if not self.is_modern:
+                    # Sessions were removed in 2026-07-28. Keep this only for
+                    # explicit legacy operation.
+                    sid = resp.headers.get("Mcp-Session-Id")
+                    if sid:
+                        self.session_id = sid
 
                 content_type = resp.headers.get("Content-Type", "")
                 body = resp.read().decode("utf-8")
@@ -193,9 +311,27 @@ class StreamableHTTPTransport(MCPTransport):
         except Exception as e:
             return {"_error": True, "_exception": str(e)}
 
-    def send_raw(self, raw_bytes: bytes) -> bytes | None:
-        headers = {"Content-Type": "application/json"}
-        if self.session_id:
+    def send_raw(
+        self,
+        raw_bytes: bytes,
+        *,
+        mcp_method: str | None = None,
+        mcp_name: str | None = None,
+    ) -> bytes | None:
+        """Send a deliberately raw payload while preserving selected transport semantics.
+
+        Stateless MCP still requires routing headers for malformed, batch, and
+        oversized-body probes. Callers supply the intended operation because a
+        deliberately malformed body cannot be trusted or parsed to derive it.
+        """
+        headers = {"Content-Type": "application/json", "Accept": "application/json, text/event-stream", **self.headers}
+        if self.is_modern:
+            headers["MCP-Protocol-Version"] = self.protocol_version
+            if mcp_method is not None:
+                headers["Mcp-Method"] = _header_value(mcp_method)
+            if mcp_name is not None:
+                headers["Mcp-Name"] = _header_value(mcp_name)
+        elif self.session_id:
             headers["Mcp-Session-Id"] = self.session_id
         req = urllib.request.Request(self.url, data=raw_bytes, headers=headers, method="POST")
         try:
@@ -241,7 +377,15 @@ class StdioTransport(MCPTransport):
                 return _strip_server_sentinels(json.loads(resp_line))
         return None
 
-    def send_raw(self, raw_bytes: bytes) -> bytes | None:
+    def send_raw(
+        self,
+        raw_bytes: bytes,
+        *,
+        mcp_method: str | None = None,
+        mcp_name: str | None = None,
+    ) -> bytes | None:
+        # Stdio has no HTTP headers. Keep the common interface so raw probes
+        # retain their intent when run against either transport.
         self.proc.stdin.write(raw_bytes + b"\n")
         self.proc.stdin.flush()
         import select
@@ -296,13 +440,33 @@ class MCPTestResult:
 class MCPSecurityTests:
     """Protocol-level security tests for MCP servers."""
 
-    def __init__(self, transport: MCPTransport, json_output: bool = False, simulate: bool = False):
+    def __init__(
+        self,
+        transport: MCPTransport,
+        json_output: bool = False,
+        simulate: bool = False,
+        mrtr_probe: dict | None = None,
+        mrtr_input_responses: dict | None = None,
+        mrtr_attacker_headers: dict | None = None,
+        mrtr_altered_probe: dict | None = None,
+        handle_create: dict | None = None,
+        handle_access: dict | None = None,
+        handle_attacker_headers: dict | None = None,
+    ):
         self.transport = transport
         self.results: list[MCPTestResult] = []
         self.server_info: dict = {}
         self.server_capabilities: dict = {}
         self.json_output = json_output or os.environ.get("AGENT_SECURITY_JSON_OUTPUT") == "1"
         self.simulate = simulate
+        self.mrtr_probe = mrtr_probe
+        self.mrtr_input_responses = mrtr_input_responses
+        self.mrtr_attacker_headers = mrtr_attacker_headers
+        self.mrtr_altered_probe = mrtr_altered_probe
+        self.handle_create = handle_create
+        self.handle_access = handle_access
+        self.handle_attacker_headers = handle_attacker_headers
+        self.selected_protocol_version: str | None = None
 
     def _record(self, result: MCPTestResult):
         self.results.append(result)
@@ -315,11 +479,26 @@ class MCPSecurityTests:
     # ------------------------------------------------------------------
 
     def initialize(self) -> bool:
-        """Perform MCP initialize handshake."""
+        """Establish legacy state or discover a stateless modern server."""
         if not self.json_output:
             print("\n[Initializing MCP connection]")
+        if getattr(self.transport, "is_auto", False):
+            # The RC requires server/discover for stateless servers. Probe it with
+            # the complete modern request envelope first; only then fall back to
+            # the legacy handshake for deployed servers that do not implement it.
+            self.transport.protocol_version = MODERN_PROTOCOL_VERSION
+            if self._discover_modern_server(quiet=True):
+                self.selected_protocol_version = MODERN_PROTOCOL_VERSION
+                return True
+            self.transport.protocol_version = LEGACY_PROTOCOL_VERSION
+            self.transport.session_id = None
+        if getattr(self.transport, "is_modern", False):
+            discovered = self._discover_modern_server()
+            if discovered:
+                self.selected_protocol_version = MODERN_PROTOCOL_VERSION
+            return discovered
         msg = jsonrpc_request("initialize", {
-            "protocolVersion": "2025-03-26",
+            "protocolVersion": LEGACY_PROTOCOL_VERSION,
             "capabilities": {},
             "clientInfo": {
                 "name": "red-team-mcp-harness",
@@ -335,6 +514,7 @@ class MCPSecurityTests:
                 print(f"  {err_msg}", file=sys.stderr)
             self._connection_error = err_msg
             return False
+
         except socket.timeout:
             url = _sanitize_url(getattr(self.transport, "url", "unknown"))
             err_msg = f"Could not connect to {url} — is the server running? (connection timed out)"
@@ -373,15 +553,37 @@ class MCPSecurityTests:
                       f"v{self.server_info.get('version', '?')}")
                 print(f"  Capabilities: {list(self.server_capabilities.keys())}")
 
-            # Send initialized notification
             self.transport.send(jsonrpc_notification("notifications/initialized"))
+            self.selected_protocol_version = LEGACY_PROTOCOL_VERSION
+            # Auto-mode discovery failure is expected when falling back to a
+            # legacy server. Do not leak it into a successful legacy report.
+            self._connection_error = None
             return True
-        else:
-            err_msg = f"Initialize failed: {resp}"
+
+        err_msg = f"Initialize failed: {resp}"
+        if not self.json_output:
+            print(f"  ⚠️  {err_msg}")
+        self._connection_error = err_msg
+        return False
+
+    def _discover_modern_server(self, quiet: bool = False) -> bool:
+        """Discover capabilities without creating a protocol-level session."""
+        msg = jsonrpc_request("server/discover", {})
+        resp = self.transport.send(msg)
+        if resp and "result" in resp:
+            result = resp["result"]
+            self.server_info = result.get("serverInfo", {})
+            self.server_capabilities = result.get("capabilities", {})
             if not self.json_output:
-                print(f"  ⚠️  {err_msg}")
-            self._connection_error = err_msg
-            return False
+                print(f"  Server: {self.server_info.get('name', 'unknown')} "
+                      f"v{self.server_info.get('version', '?')}")
+                print(f"  Capabilities: {list(self.server_capabilities.keys())}")
+            return True
+
+        self._connection_error = f"Modern server discovery failed: {resp}"
+        if not self.json_output and not quiet:
+            print(f"  ⚠️  {self._connection_error}")
+        return False
 
     # ------------------------------------------------------------------
     # Category 1: Tool Discovery Poisoning (ASI04)
@@ -433,6 +635,369 @@ class MCPSecurityTests:
             request_sent=msg,
             response_received=resp,
             elapsed_s=round(elapsed, 3),
+        ))
+
+    def test_mcp_stateless_header_body_binding(self):
+        """MCP-RC-001: A stateless server must reject conflicting routing metadata."""
+        t0 = time.monotonic()
+        msg = jsonrpc_request("tools/list", {})
+        forged = {"Mcp-Method": "tools/call", "Mcp-Name": "__mcp_header_probe__"}
+        if self.simulate:
+            self._record(MCPTestResult(
+                test_id="MCP-RC-001", name="Stateless Header/Body Binding",
+                category="stateless_header_binding", owasp_asi="ASI02",
+                severity=Severity.HIGH.value, passed=True,
+                details="[simulate] Compiled conflicting method/name routing fields",
+                mcp_method="tools/list", request_sent={"body": msg, "headers": forged},
+                elapsed_s=round(time.monotonic() - t0, 3),
+            ))
+            return
+        if not getattr(self.transport, "is_modern", False):
+            self._record(MCPTestResult(
+                test_id="MCP-RC-001", name="Stateless Header/Body Binding",
+                category="stateless_header_binding", owasp_asi="ASI02",
+                severity=Severity.HIGH.value, passed=True,
+                details="Not applicable: target selected a legacy MCP transport",
+                mcp_method="tools/list", elapsed_s=round(time.monotonic() - t0, 3),
+            ))
+            return
+
+        resp = self.transport.send(msg, header_overrides=forged)
+        rejected = bool(resp and (resp.get("_error") or resp.get("_status", 200) >= 400 or "error" in resp))
+        self._record(MCPTestResult(
+            test_id="MCP-RC-001", name="Stateless Header/Body Binding",
+            category="stateless_header_binding", owasp_asi="ASI02",
+            severity=Severity.HIGH.value, passed=rejected,
+            details=("Server rejected conflicting Mcp-Method/Mcp-Name routing fields" if rejected
+                     else "Server accepted conflicting header and JSON-RPC routing fields"),
+            mcp_method="tools/list", request_sent={"body": msg, "headers": forged},
+            response_received=resp, elapsed_s=round(time.monotonic() - t0, 3),
+        ))
+
+    def test_mcp_request_state_integrity(self):
+        """MCP-RC-002: A tampered MRTR requestState must be rejected.
+
+        The probe is opt-in because only an authorized test endpoint can safely
+        expose a workflow that returns ``resultType: input_required``. A server
+        that does not expose MRTR on the supplied probe is reported as not
+        applicable rather than treated as secure.
+        """
+        t0 = time.monotonic()
+        if self.simulate:
+            self._record(MCPTestResult(
+                test_id="MCP-RC-002", name="MRTR requestState Integrity",
+                category="mrtr_request_state", owasp_asi="ASI02",
+                severity=Severity.HIGH.value, passed=True,
+                details="[simulate] Compiled tampered requestState retry vector",
+                mcp_method="tools/call", elapsed_s=round(time.monotonic() - t0, 3),
+            ))
+            return
+        if not getattr(self.transport, "is_modern", False) or not self.mrtr_probe:
+            self._record(MCPTestResult(
+                test_id="MCP-RC-002", name="MRTR requestState Integrity",
+                category="mrtr_request_state", owasp_asi="ASI02",
+                severity=Severity.HIGH.value, passed=True,
+                details="Not applicable: requires modern mode and an authorized --mrtr-probe request",
+                mcp_method="tools/call", elapsed_s=round(time.monotonic() - t0, 3),
+            ))
+            return
+
+        initial = jsonrpc_request(self.mrtr_probe["method"], dict(self.mrtr_probe.get("params") or {}))
+        initial_response = self.transport.send(initial)
+        result = initial_response.get("result", {}) if initial_response else {}
+        state = result.get("requestState")
+        if result.get("resultType") != "input_required" or not isinstance(state, str) or not state:
+            self._record(MCPTestResult(
+                test_id="MCP-RC-002", name="MRTR requestState Integrity",
+                category="mrtr_request_state", owasp_asi="ASI02",
+                severity=Severity.HIGH.value, passed=True,
+                details="Not applicable: probe did not return an InputRequiredResult with requestState",
+                mcp_method=initial["method"], request_sent=initial,
+                response_received=initial_response, elapsed_s=round(time.monotonic() - t0, 3),
+            ))
+            return
+
+        tampered = state[:-1] + ("A" if state[-1] != "A" else "B")
+        retry_params = dict(self.mrtr_probe.get("params") or {})
+        retry_params["requestState"] = tampered
+        retry_params["inputResponses"] = {}
+        retry = jsonrpc_request(self.mrtr_probe["method"], retry_params)
+        response = self.transport.send(retry)
+        rejected = bool(response and (response.get("_error") or response.get("_status", 200) >= 400 or "error" in response))
+        self._record(MCPTestResult(
+            test_id="MCP-RC-002", name="MRTR requestState Integrity",
+            category="mrtr_request_state", owasp_asi="ASI02",
+            severity=Severity.HIGH.value, passed=rejected,
+            details=("Server rejected a tampered requestState" if rejected
+                     else "Server accepted a tampered requestState on an MRTR retry"),
+            mcp_method=initial["method"], request_sent={"initial": initial, "retry": retry},
+            response_received=response, elapsed_s=round(time.monotonic() - t0, 3),
+        ))
+
+    def test_mcp_request_state_replay(self):
+        """MCP-RC-003: A completed one-time MRTR continuation must not replay."""
+        t0 = time.monotonic()
+        if self.simulate:
+            self._record(MCPTestResult(
+                test_id="MCP-RC-003", name="MRTR requestState Replay Protection",
+                category="mrtr_request_state", owasp_asi="ASI02",
+                severity=Severity.HIGH.value, passed=True,
+                details="[simulate] Compiled exact requestState replay vector",
+                mcp_method="tools/call", elapsed_s=round(time.monotonic() - t0, 3),
+            ))
+            return
+        if not getattr(self.transport, "is_modern", False) or not self.mrtr_probe or self.mrtr_input_responses is None:
+            self._record(MCPTestResult(
+                test_id="MCP-RC-003", name="MRTR requestState Replay Protection",
+                category="mrtr_request_state", owasp_asi="ASI02",
+                severity=Severity.HIGH.value, passed=True,
+                details="Not applicable: requires modern mode, --mrtr-probe, and authorized --mrtr-input-responses",
+                mcp_method="tools/call", elapsed_s=round(time.monotonic() - t0, 3),
+            ))
+            return
+
+        initial = jsonrpc_request(self.mrtr_probe["method"], dict(self.mrtr_probe.get("params") or {}))
+        initial_response = self.transport.send(initial)
+        result = initial_response.get("result", {}) if initial_response else {}
+        state = result.get("requestState")
+        if result.get("resultType") != "input_required" or not isinstance(state, str) or not state:
+            self._record(MCPTestResult(
+                test_id="MCP-RC-003", name="MRTR requestState Replay Protection",
+                category="mrtr_request_state", owasp_asi="ASI02",
+                severity=Severity.HIGH.value, passed=True,
+                details="Not applicable: probe did not return an InputRequiredResult with requestState",
+                mcp_method=initial["method"], request_sent=initial,
+                response_received=initial_response, elapsed_s=round(time.monotonic() - t0, 3),
+            ))
+            return
+
+        retry_params = dict(self.mrtr_probe.get("params") or {})
+        retry_params.update({"requestState": state, "inputResponses": self.mrtr_input_responses})
+        completion = self.transport.send(jsonrpc_request(self.mrtr_probe["method"], retry_params))
+        completion_result = completion.get("result", {}) if completion else {}
+        if completion_result.get("resultType") == "input_required":
+            self._record(MCPTestResult(
+                test_id="MCP-RC-003", name="MRTR requestState Replay Protection",
+                category="mrtr_request_state", owasp_asi="ASI02",
+                severity=Severity.HIGH.value, passed=True,
+                details="Not applicable: supplied input responses did not complete the authorized continuation",
+                mcp_method=initial["method"], response_received=completion,
+                elapsed_s=round(time.monotonic() - t0, 3),
+            ))
+            return
+
+        replay = self.transport.send(jsonrpc_request(self.mrtr_probe["method"], retry_params))
+        rejected = bool(replay and (replay.get("_error") or replay.get("_status", 200) >= 400 or "error" in replay))
+        self._record(MCPTestResult(
+            test_id="MCP-RC-003", name="MRTR requestState Replay Protection",
+            category="mrtr_request_state", owasp_asi="ASI02",
+            severity=Severity.HIGH.value, passed=rejected,
+            details=("Server rejected exact replay after a completed continuation" if rejected
+                     else "Server accepted exact requestState replay after completion"),
+            mcp_method=initial["method"],
+            request_sent={"initial": initial, "retry_params": retry_params},
+            response_received=replay, elapsed_s=round(time.monotonic() - t0, 3),
+        ))
+
+    def test_mcp_request_state_principal_binding(self):
+        """MCP-RC-004: requestState from one principal must fail for another."""
+        t0 = time.monotonic()
+        if self.simulate:
+            self._record(MCPTestResult(
+                test_id="MCP-RC-004", name="MRTR requestState Principal Binding",
+                category="mrtr_request_state", owasp_asi="ASI02",
+                severity=Severity.HIGH.value, passed=True,
+                details="[simulate] Compiled cross-principal requestState reuse vector",
+                mcp_method="tools/call", elapsed_s=round(time.monotonic() - t0, 3),
+            ))
+            return
+        if (not getattr(self.transport, "is_modern", False) or not self.mrtr_probe
+                or self.mrtr_input_responses is None or not self.mrtr_attacker_headers):
+            self._record(MCPTestResult(
+                test_id="MCP-RC-004", name="MRTR requestState Principal Binding",
+                category="mrtr_request_state", owasp_asi="ASI02",
+                severity=Severity.HIGH.value, passed=True,
+                details=("Not applicable: requires modern mode, authorized probe/input responses, "
+                         "and --mrtr-attacker-header"),
+                mcp_method="tools/call", elapsed_s=round(time.monotonic() - t0, 3),
+            ))
+            return
+
+        initial = jsonrpc_request(self.mrtr_probe["method"], dict(self.mrtr_probe.get("params") or {}))
+        initial_response = self.transport.send(initial)
+        result = initial_response.get("result", {}) if initial_response else {}
+        state = result.get("requestState")
+        if result.get("resultType") != "input_required" or not isinstance(state, str) or not state:
+            self._record(MCPTestResult(
+                test_id="MCP-RC-004", name="MRTR requestState Principal Binding",
+                category="mrtr_request_state", owasp_asi="ASI02",
+                severity=Severity.HIGH.value, passed=True,
+                details="Not applicable: probe did not return an InputRequiredResult with requestState",
+                mcp_method=initial["method"], request_sent=initial,
+                response_received=initial_response, elapsed_s=round(time.monotonic() - t0, 3),
+            ))
+            return
+
+        retry_params = dict(self.mrtr_probe.get("params") or {})
+        retry_params.update({"requestState": state, "inputResponses": self.mrtr_input_responses})
+        retry = jsonrpc_request(self.mrtr_probe["method"], retry_params)
+        response = self.transport.send(retry, header_overrides=self.mrtr_attacker_headers)
+        rejected = bool(response and (response.get("_error") or response.get("_status", 200) >= 400 or "error" in response))
+        self._record(MCPTestResult(
+            test_id="MCP-RC-004", name="MRTR requestState Principal Binding",
+            category="mrtr_request_state", owasp_asi="ASI02",
+            severity=Severity.HIGH.value, passed=rejected,
+            details=("Server rejected requestState presented by a different principal" if rejected
+                     else "Server accepted requestState presented under attacker identity"),
+            mcp_method=initial["method"],
+            request_sent={"initial": initial, "cross_principal_retry": retry,
+                          "attacker_headers": sorted(self.mrtr_attacker_headers)},
+            response_received=response, elapsed_s=round(time.monotonic() - t0, 3),
+        ))
+
+    def test_mcp_request_state_request_binding(self):
+        """MCP-RC-005: requestState must not authorize a different request."""
+        t0 = time.monotonic()
+        if self.simulate:
+            self._record(MCPTestResult(
+                test_id="MCP-RC-005", name="MRTR requestState Request Binding",
+                category="mrtr_request_state", owasp_asi="ASI02",
+                severity=Severity.HIGH.value, passed=True,
+                details="[simulate] Compiled cross-request requestState reuse vector",
+                mcp_method="tools/call", elapsed_s=round(time.monotonic() - t0, 3),
+            ))
+            return
+        if (not getattr(self.transport, "is_modern", False) or not self.mrtr_probe
+                or self.mrtr_input_responses is None or not self.mrtr_altered_probe):
+            self._record(MCPTestResult(
+                test_id="MCP-RC-005", name="MRTR requestState Request Binding",
+                category="mrtr_request_state", owasp_asi="ASI02",
+                severity=Severity.HIGH.value, passed=True,
+                details=("Not applicable: requires modern mode, authorized probe/input responses, "
+                         "and --mrtr-altered-probe"),
+                mcp_method="tools/call", elapsed_s=round(time.monotonic() - t0, 3),
+            ))
+            return
+
+        initial = jsonrpc_request(self.mrtr_probe["method"], dict(self.mrtr_probe.get("params") or {}))
+        initial_response = self.transport.send(initial)
+        result = initial_response.get("result", {}) if initial_response else {}
+        state = result.get("requestState")
+        if result.get("resultType") != "input_required" or not isinstance(state, str) or not state:
+            self._record(MCPTestResult(
+                test_id="MCP-RC-005", name="MRTR requestState Request Binding",
+                category="mrtr_request_state", owasp_asi="ASI02",
+                severity=Severity.HIGH.value, passed=True,
+                details="Not applicable: probe did not return an InputRequiredResult with requestState",
+                mcp_method=initial["method"], request_sent=initial,
+                response_received=initial_response, elapsed_s=round(time.monotonic() - t0, 3),
+            ))
+            return
+
+        altered_params = dict(self.mrtr_altered_probe.get("params") or {})
+        altered_params.update({"requestState": state, "inputResponses": self.mrtr_input_responses})
+        altered = jsonrpc_request(self.mrtr_altered_probe["method"], altered_params)
+        response = self.transport.send(altered)
+        rejected = bool(response and (response.get("_error") or response.get("_status", 200) >= 400 or "error" in response))
+        self._record(MCPTestResult(
+            test_id="MCP-RC-005", name="MRTR requestState Request Binding",
+            category="mrtr_request_state", owasp_asi="ASI02",
+            severity=Severity.HIGH.value, passed=rejected,
+            details=("Server rejected requestState replayed on a different request" if rejected
+                     else "Server accepted requestState replayed on a different request"),
+            mcp_method=initial["method"],
+            request_sent={"initial": initial, "altered_retry": altered},
+            response_received=response, elapsed_s=round(time.monotonic() - t0, 3),
+        ))
+
+    def test_mcp_explicit_handle_isolation(self):
+        """MCP-RC-006: A model-visible handle must not cross principals."""
+        t0 = time.monotonic()
+        if self.simulate:
+            self._record(MCPTestResult(
+                test_id="MCP-RC-006", name="Explicit Handle Cross-Principal Isolation",
+                category="explicit_handle_isolation", owasp_asi="ASI02",
+                severity=Severity.HIGH.value, passed=True,
+                details="[simulate] Compiled cross-principal explicit-handle substitution vector",
+                mcp_method="tools/call", elapsed_s=round(time.monotonic() - t0, 3),
+            ))
+            return
+        if not getattr(self.transport, "supports_header_overrides", False):
+            self._record(MCPTestResult(
+                test_id="MCP-RC-006", name="Explicit Handle Cross-Principal Isolation",
+                category="explicit_handle_isolation", owasp_asi="ASI02",
+                severity=Severity.HIGH.value, passed=True,
+                details="Not applicable: requires an HTTP transport that can present alternate-principal headers",
+                mcp_method="tools/call", elapsed_s=round(time.monotonic() - t0, 3),
+            ))
+            return
+        if not self.handle_create or not self.handle_access or not self.handle_attacker_headers:
+            self._record(MCPTestResult(
+                test_id="MCP-RC-006", name="Explicit Handle Cross-Principal Isolation",
+                category="explicit_handle_isolation", owasp_asi="ASI02",
+                severity=Severity.HIGH.value, passed=True,
+                details="Not applicable: requires authorized handle create/access fixtures and attacker headers",
+                mcp_method="tools/call", elapsed_s=round(time.monotonic() - t0, 3),
+            ))
+            return
+        create = jsonrpc_request(self.handle_create["method"], dict(self.handle_create.get("params") or {}))
+        created = self.transport.send(create)
+        handle = _json_path(created, self.handle_create.get("handlePath", "result.handle"))
+        if not isinstance(handle, str) or not handle:
+            self._record(MCPTestResult(
+                test_id="MCP-RC-006", name="Explicit Handle Cross-Principal Isolation",
+                category="explicit_handle_isolation", owasp_asi="ASI02",
+                severity=Severity.HIGH.value, passed=True,
+                details="Not applicable: create fixture did not return a string handle at handlePath",
+                mcp_method=create["method"], request_sent=create, response_received=created,
+                elapsed_s=round(time.monotonic() - t0, 3),
+            ))
+            return
+        access = jsonrpc_request(self.handle_access["method"], _replace_handle(dict(self.handle_access.get("params") or {}), handle))
+        response = self.transport.send(access, header_overrides=self.handle_attacker_headers)
+        rejected = bool(response and (response.get("_error") or response.get("_status", 200) >= 400 or "error" in response))
+        self._record(MCPTestResult(
+            test_id="MCP-RC-006", name="Explicit Handle Cross-Principal Isolation",
+            category="explicit_handle_isolation", owasp_asi="ASI02",
+            severity=Severity.HIGH.value, passed=rejected,
+            details=("Server rejected a handle presented by a different principal" if rejected
+                     else "Server accepted a handle presented by a different principal"),
+            mcp_method=access["method"], request_sent={"create": create, "cross_principal_access": access},
+            response_received=response, elapsed_s=round(time.monotonic() - t0, 3),
+        ))
+
+    def test_mcp_cache_scope_metadata(self):
+        """MCP-RC-007: Modern tool listings must declare cache scope and TTL."""
+        t0 = time.monotonic()
+        if self.simulate:
+            self._record(MCPTestResult(
+                test_id="MCP-RC-007", name="Cache Scope Metadata",
+                category="cache_security", owasp_asi="ASI04", severity=Severity.MEDIUM.value,
+                passed=True, details="[simulate] Compiled modern tools/list cache metadata check",
+                mcp_method="tools/list", elapsed_s=round(time.monotonic() - t0, 3),
+            ))
+            return
+        if not getattr(self.transport, "is_modern", False):
+            self._record(MCPTestResult(
+                test_id="MCP-RC-007", name="Cache Scope Metadata",
+                category="cache_security", owasp_asi="ASI04", severity=Severity.MEDIUM.value,
+                passed=True, details="Not applicable: target selected a legacy MCP transport",
+                mcp_method="tools/list", elapsed_s=round(time.monotonic() - t0, 3),
+            ))
+            return
+        msg = jsonrpc_request("tools/list", {})
+        response = self.transport.send(msg)
+        result = response.get("result", {}) if response else {}
+        scope, ttl = result.get("cacheScope"), result.get("ttlMs")
+        passed = scope in {"public", "private"} and isinstance(ttl, int) and ttl >= 0
+        self._record(MCPTestResult(
+            test_id="MCP-RC-007", name="Cache Scope Metadata",
+            category="cache_security", owasp_asi="ASI04", severity=Severity.MEDIUM.value,
+            passed=passed,
+            details=(f"tools/list declares cacheScope={scope!r}, ttlMs={ttl!r}" if passed
+                     else "tools/list omitted valid cacheScope and/or non-negative ttlMs"),
+            mcp_method="tools/list", request_sent=msg, response_received=response,
+            elapsed_s=round(time.monotonic() - t0, 3),
         ))
 
     def test_mcp_tool_description_injection(self):
@@ -847,7 +1412,7 @@ class MCPSecurityTests:
 
         handled_count = 0
         for raw in malformed_messages:
-            resp_bytes = self.transport.send_raw(raw)
+            resp_bytes = self.transport.send_raw(raw, mcp_method="tools/list")
             if resp_bytes:
                 try:
                     resp = json.loads(resp_bytes)
@@ -897,7 +1462,7 @@ class MCPSecurityTests:
             ))
             return
 
-        resp_bytes = self.transport.send_raw(batch_json)
+        resp_bytes = self.transport.send_raw(batch_json, mcp_method="tools/list")
         elapsed = time.monotonic() - t0
 
         # Pass if server either rejected (4xx) or responded within reasonable time
@@ -1914,7 +2479,9 @@ class MCPSecurityTests:
         # Live mode: send the oversized body and check the server's reaction.
         # A patched server (>= 0.2.22) should return HTTP 413 or a JSON-RPC error.
         # A vulnerable server may hang, crash, or return an unexpected 5xx.
-        resp_bytes = self.transport.send_raw(oversized_payload)
+        resp_bytes = self.transport.send_raw(
+            oversized_payload, mcp_method="tools/call", mcp_name="any_tool"
+        )
         elapsed = time.monotonic() - t0
 
         resp_preview = ""
@@ -1963,6 +2530,17 @@ class MCPSecurityTests:
                 self.test_mcp_tool_list_injection,
                 self.test_mcp_tool_description_injection,
             ],
+            "stateless_header_binding": [
+                self.test_mcp_stateless_header_body_binding,
+            ],
+            "mrtr_request_state": [
+                self.test_mcp_request_state_integrity,
+                self.test_mcp_request_state_replay,
+                self.test_mcp_request_state_principal_binding,
+                self.test_mcp_request_state_request_binding,
+            ],
+            "explicit_handle_isolation": [self.test_mcp_explicit_handle_isolation],
+            "cache_security": [self.test_mcp_cache_scope_metadata],
             "capability_negotiation": [
                 self.test_mcp_capability_escalation,
                 self.test_mcp_protocol_version_downgrade,
@@ -2063,7 +2641,11 @@ class MCPSecurityTests:
 # Report generation
 # ---------------------------------------------------------------------------
 
-def build_report(results: list[MCPTestResult], error: str | None = None) -> dict:
+def build_report(
+    results: list[MCPTestResult],
+    error: str | None = None,
+    protocol_version: str | None = None,
+) -> dict:
     """Build report dict from results."""
     report = {
         "suite": "MCP Protocol Security Tests v3.0",
@@ -2077,12 +2659,66 @@ def build_report(results: list[MCPTestResult], error: str | None = None) -> dict
     }
     if error:
         report["error"] = error
+    if protocol_version:
+        report["protocol_version"] = protocol_version
     return report
 
 
-def generate_report(results: list[MCPTestResult], output_path: str):
+def build_differential_report(legacy: dict, modern: dict) -> dict:
+    """Compare equivalent security claims across legacy and stateless runs.
+
+    A differing verdict is evidence that a protocol migration changed observable
+    enforcement. It is not, by itself, a finding: callers must inspect the
+    version-tagged request/response evidence before assigning a security claim.
+    """
+    legacy_by_id = {result["test_id"]: result for result in legacy.get("results", [])}
+    modern_by_id = {result["test_id"]: result for result in modern.get("results", [])}
+    claims = []
+    for test_id in sorted(legacy_by_id.keys() | modern_by_id.keys()):
+        before = legacy_by_id.get(test_id)
+        after = modern_by_id.get(test_id)
+        if before is None:
+            status = "modern_only"
+        elif after is None:
+            status = "legacy_only"
+        elif before.get("passed") == after.get("passed"):
+            status = "equivalent"
+        else:
+            status = "changed"
+        claims.append({
+            "test_id": test_id,
+            "legacy_passed": before.get("passed") if before else None,
+            "modern_passed": after.get("passed") if after else None,
+            "status": status,
+        })
+    return {
+        "suite": "MCP Protocol Security Differential",
+        "legacy": legacy,
+        "modern": modern,
+        "summary": {
+            "equivalent": sum(c["status"] == "equivalent" for c in claims),
+            "changed": sum(c["status"] == "changed" for c in claims),
+            "legacy_only": sum(c["status"] == "legacy_only" for c in claims),
+            "modern_only": sum(c["status"] == "modern_only" for c in claims),
+        },
+        "claims": claims,
+    }
+
+
+def report_has_failure(report: dict) -> bool:
+    """Return whether a completed protocol report is unsafe to treat as passing."""
+    return bool(report.get("error")) or any(
+        not result.get("passed", False) for result in report.get("results", [])
+    )
+
+
+def generate_report(
+    results: list[MCPTestResult],
+    output_path: str,
+    protocol_version: str | None = None,
+):
     """Write JSON report."""
-    report = build_report(results)
+    report = build_report(results, protocol_version=protocol_version)
     with open(output_path, "w") as f:
         json.dump(report, f, indent=2, default=str)
     print(f"Report written to {output_path}")
@@ -2103,6 +2739,37 @@ def main():
     ap.add_argument("--json", action="store_true", dest="json_output",
                     help="Output results as JSON to stdout (no human-readable text)")
     ap.add_argument("--header", action="append", default=[], help="Extra HTTP headers (key:value)")
+    ap.add_argument(
+        "--mrtr-probe",
+        help=("Authorized test request as JSON, for example "
+              "'{\"method\":\"tools/call\",\"params\":{\"name\":\"approval_probe\",\"arguments\":{}}}'. "
+              "Enables MRTR requestState integrity tests only."),
+    )
+    ap.add_argument(
+        "--mrtr-input-responses",
+        help=("Authorized InputResponses JSON for completing an MRTR probe. "
+              "Enables exact-state replay testing after the continuation completes."),
+    )
+    ap.add_argument(
+        "--mrtr-attacker-header", action="append", default=[],
+        help=("Header override for an authorized cross-principal MRTR test, key:value. "
+              "Repeat for multiple headers."),
+    )
+    ap.add_argument(
+        "--mrtr-altered-probe",
+        help=("Authorized alternate request as JSON for cross-request MRTR binding tests. "
+              "It must differ materially from --mrtr-probe."),
+    )
+    ap.add_argument("--handle-create", help="Authorized handle-creation request as JSON (method, params, optional handlePath).")
+    ap.add_argument("--handle-access", help="Authorized handle-access request as JSON; use $HANDLE in params as the created-handle placeholder.")
+    ap.add_argument("--handle-attacker-header", action="append", default=[], help="Attacker identity header for explicit-handle isolation, key:value.")
+    ap.add_argument(
+        "--protocol-version",
+        choices=[MODERN_PROTOCOL_VERSION, AUTO_PROTOCOL_VERSION, DIFFERENTIAL_PROTOCOL_VERSION],
+        help=("Use the stateless 2026-07-28 protocol flow, or 'auto' to probe "
+              "server/discover with modern metadata before falling back to legacy initialization. "
+              "Use 'differential' to run and compare explicit legacy and stateless claims."),
+    )
     ap.add_argument("--trials", type=int, default=1, help="Run each test N times for statistical analysis (NIST AI 800-2)")
     ap.add_argument("--simulate", action="store_true", help="Run in simulate mode (no live endpoint needed)")
     args = ap.parse_args()
@@ -2131,9 +2798,85 @@ def main():
                 print("ERROR: --command required for stdio transport", file=sys.stderr)
             sys.exit(1)
 
-    categories = args.categories.split(",") if args.categories else None
+    if args.transport == "stdio" and args.protocol_version:
+        ap.error(
+            "--protocol-version currently requires --transport http: the RC's "
+            "per-request routing-header and header-bound principal probes cannot "
+            "be faithfully exercised over stdio"
+        )
 
-    def _make_transport():
+    categories = args.categories.split(",") if args.categories else None
+    mrtr_probe = None
+    mrtr_input_responses = None
+    mrtr_attacker_headers = {}
+    mrtr_altered_probe = None
+    handle_create = handle_access = None
+    handle_attacker_headers = {}
+    if args.mrtr_probe:
+        try:
+            mrtr_probe = json.loads(args.mrtr_probe)
+        except json.JSONDecodeError as exc:
+            ap.error(f"--mrtr-probe must be a JSON object: {exc.msg}")
+        if not isinstance(mrtr_probe, dict) or not isinstance(mrtr_probe.get("method"), str):
+            ap.error("--mrtr-probe must be a JSON object with a string 'method'")
+        if "params" in mrtr_probe and not isinstance(mrtr_probe["params"], dict):
+            ap.error("--mrtr-probe 'params' must be a JSON object")
+    if args.mrtr_input_responses:
+        try:
+            mrtr_input_responses = json.loads(args.mrtr_input_responses)
+        except json.JSONDecodeError as exc:
+            ap.error(f"--mrtr-input-responses must be a JSON object: {exc.msg}")
+        if not isinstance(mrtr_input_responses, dict):
+            ap.error("--mrtr-input-responses must be a JSON object")
+    if mrtr_input_responses is not None and mrtr_probe is None:
+        ap.error("--mrtr-input-responses requires --mrtr-probe")
+    if args.mrtr_altered_probe:
+        try:
+            mrtr_altered_probe = json.loads(args.mrtr_altered_probe)
+        except json.JSONDecodeError as exc:
+            ap.error(f"--mrtr-altered-probe must be a JSON object: {exc.msg}")
+        if not isinstance(mrtr_altered_probe, dict) or not isinstance(mrtr_altered_probe.get("method"), str):
+            ap.error("--mrtr-altered-probe must be a JSON object with a string 'method'")
+        if "params" in mrtr_altered_probe and not isinstance(mrtr_altered_probe["params"], dict):
+            ap.error("--mrtr-altered-probe 'params' must be a JSON object")
+    if mrtr_altered_probe is not None and (mrtr_probe is None or mrtr_input_responses is None):
+        ap.error("--mrtr-altered-probe requires --mrtr-probe and --mrtr-input-responses")
+    if mrtr_altered_probe == mrtr_probe and mrtr_altered_probe is not None:
+        ap.error("--mrtr-altered-probe must differ from --mrtr-probe")
+    for option, raw in (("--handle-create", args.handle_create), ("--handle-access", args.handle_access)):
+        if raw:
+            try:
+                parsed = json.loads(raw)
+            except json.JSONDecodeError as exc:
+                ap.error(f"{option} must be a JSON object: {exc.msg}")
+            if not isinstance(parsed, dict) or not isinstance(parsed.get("method"), str):
+                ap.error(f"{option} must be a JSON object with a string 'method'")
+            if "params" in parsed and not isinstance(parsed["params"], dict):
+                ap.error(f"{option} 'params' must be a JSON object")
+            if option == "--handle-create":
+                handle_create = parsed
+            else:
+                handle_access = parsed
+    for header in args.handle_attacker_header:
+        if ":" not in header:
+            ap.error("--handle-attacker-header must use key:value form")
+        key, value = header.split(":", 1)
+        if not key.strip():
+            ap.error("--handle-attacker-header must include a header name")
+        handle_attacker_headers[key.strip()] = value.strip()
+    if any((handle_create, handle_access, handle_attacker_headers)) and not all((handle_create, handle_access, handle_attacker_headers)):
+        ap.error("--handle-create, --handle-access, and --handle-attacker-header must be supplied together")
+    for header in args.mrtr_attacker_header:
+        if ":" not in header:
+            ap.error("--mrtr-attacker-header must use key:value form")
+        key, value = header.split(":", 1)
+        if not key.strip():
+            ap.error("--mrtr-attacker-header must include a header name")
+        mrtr_attacker_headers[key.strip()] = value.strip()
+    if mrtr_attacker_headers and (mrtr_probe is None or mrtr_input_responses is None):
+        ap.error("--mrtr-attacker-header requires --mrtr-probe and --mrtr-input-responses")
+
+    def _make_transport(protocol_version: str | None = None):
         """Create a fresh transport instance to avoid state bleed between trials."""
         if args.simulate:
             return None
@@ -2142,9 +2885,52 @@ def main():
             for h in args.header:
                 k, v = h.split(":", 1)
                 hdrs[k.strip()] = v.strip()
-            return StreamableHTTPTransport(args.url, headers=hdrs)
+            return StreamableHTTPTransport(
+                args.url,
+                headers=hdrs,
+                protocol_version=protocol_version if protocol_version is not None else args.protocol_version,
+            )
         else:
             return StdioTransport(args.command.split())
+
+    if args.protocol_version == DIFFERENTIAL_PROTOCOL_VERSION:
+        if args.trials > 1:
+            ap.error("--protocol-version differential does not support --trials; compare one run per protocol")
+        if args.simulate:
+            ap.error("--protocol-version differential requires a reachable HTTP target")
+
+        def _run_protocol(protocol_version: str) -> dict:
+            transport = _make_transport(protocol_version)
+            suite = MCPSecurityTests(transport, json_output=json_output, mrtr_probe=mrtr_probe,
+                                     mrtr_input_responses=mrtr_input_responses,
+                                     mrtr_attacker_headers=mrtr_attacker_headers,
+                                     mrtr_altered_probe=mrtr_altered_probe, handle_create=handle_create,
+                                     handle_access=handle_access, handle_attacker_headers=handle_attacker_headers)
+            try:
+                results = suite.run_all(categories=categories)
+                return build_report(
+                    results,
+                    error=getattr(suite, "_connection_error", None),
+                    protocol_version=suite.selected_protocol_version or protocol_version,
+                )
+            finally:
+                transport.close()
+
+        differential = build_differential_report(
+            _run_protocol(LEGACY_PROTOCOL_VERSION),
+            _run_protocol(MODERN_PROTOCOL_VERSION),
+        )
+        if args.report:
+            with open(args.report, "w") as f:
+                json.dump(differential, f, indent=2, default=str)
+            if not json_output:
+                print(f"Report written to {args.report}")
+        if json_output:
+            print(json.dumps(differential, indent=2, default=str))
+        failed = any(report_has_failure(report) for report in (
+            differential["legacy"], differential["modern"]
+        ))
+        sys.exit(1 if failed else 0)
 
     if args.trials > 1:
         # Multi-trial statistical mode via shared trial runner
@@ -2154,7 +2940,11 @@ def main():
 
         def _single_run():
             transport = _make_transport()
-            suite = MCPSecurityTests(transport, json_output=json_output, simulate=args.simulate)
+            suite = MCPSecurityTests(transport, json_output=json_output, simulate=args.simulate, mrtr_probe=mrtr_probe,
+                                     mrtr_input_responses=mrtr_input_responses,
+                                     mrtr_attacker_headers=mrtr_attacker_headers,
+                                     mrtr_altered_probe=mrtr_altered_probe, handle_create=handle_create,
+                                     handle_access=handle_access, handle_attacker_headers=handle_attacker_headers)
             try:
                 return {"results": suite.run_all(categories=categories)}
             finally:
@@ -2174,7 +2964,11 @@ def main():
     else:
         # Single run mode - create transport only here
         transport = _make_transport()
-        suite = MCPSecurityTests(transport, json_output=json_output, simulate=args.simulate)
+        suite = MCPSecurityTests(transport, json_output=json_output, simulate=args.simulate, mrtr_probe=mrtr_probe,
+                                 mrtr_input_responses=mrtr_input_responses,
+                                 mrtr_attacker_headers=mrtr_attacker_headers,
+                                 mrtr_altered_probe=mrtr_altered_probe, handle_create=handle_create,
+                                 handle_access=handle_access, handle_attacker_headers=handle_attacker_headers)
         conn_error = None
         try:
             results = suite.run_all(categories=categories)
@@ -2184,10 +2978,10 @@ def main():
                 transport.close()
 
         if args.report:
-            generate_report(results, args.report)
+            generate_report(results, args.report, protocol_version=suite.selected_protocol_version)
 
         if json_output:
-            report = build_report(results, error=conn_error)
+            report = build_report(results, error=conn_error, protocol_version=suite.selected_protocol_version)
             print(json.dumps(report, indent=2, default=str))
 
     # Exit code

--- a/protocol_tests/mcp_harness.py
+++ b/protocol_tests/mcp_harness.py
@@ -455,6 +455,7 @@ class MCPSecurityTests:
         cache_invalidation: dict | None = None,
         cache_verify: dict | None = None,
         cache_forbidden_tool: str | None = None,
+        cache_resource_uri: str | None = None,
     ):
         self.transport = transport
         self.results: list[MCPTestResult] = []
@@ -472,6 +473,7 @@ class MCPSecurityTests:
         self.cache_invalidation = cache_invalidation
         self.cache_verify = cache_verify
         self.cache_forbidden_tool = cache_forbidden_tool
+        self.cache_resource_uri = cache_resource_uri
         self.selected_protocol_version: str | None = None
 
     def _record(self, result: MCPTestResult):
@@ -1066,6 +1068,46 @@ class MCPSecurityTests:
             request_sent={"invalidate": invalidate, "verify": verify,
                           "forbidden_tool": self.cache_forbidden_tool},
             response_received={"invalidation": invalidation_response, "verification": verification_response},
+            elapsed_s=round(time.monotonic() - t0, 3),
+        ))
+
+    def test_mcp_resource_cache_metadata(self):
+        """MCP-RC-009: modern resource reads must declare cache scope and TTL.
+
+        A resource URI is explicitly supplied by the operator. The probe only
+        reads it, so it can verify freshness and sharing policy without causing
+        target-side state changes.
+        """
+        t0 = time.monotonic()
+        if self.simulate:
+            self._record(MCPTestResult(
+                test_id="MCP-RC-009", name="Resource Cache Metadata",
+                category="cache_security", owasp_asi="ASI04", severity=Severity.MEDIUM.value,
+                passed=True, details="[simulate] Compiled modern resources/read cache metadata check",
+                mcp_method="resources/read", elapsed_s=round(time.monotonic() - t0, 3),
+            ))
+            return
+        if not getattr(self.transport, "is_modern", False) or not self.cache_resource_uri:
+            self._record(MCPTestResult(
+                test_id="MCP-RC-009", name="Resource Cache Metadata",
+                category="cache_security", owasp_asi="ASI04", severity=Severity.MEDIUM.value,
+                passed=True,
+                details="Not applicable: requires modern mode and an operator-authorized --cache-resource-uri",
+                mcp_method="resources/read", elapsed_s=round(time.monotonic() - t0, 3),
+            ))
+            return
+        msg = jsonrpc_request("resources/read", {"uri": self.cache_resource_uri})
+        response = self.transport.send(msg)
+        result = response.get("result", {}) if response else {}
+        scope, ttl = result.get("cacheScope"), result.get("ttlMs")
+        passed = scope in {"public", "private"} and isinstance(ttl, int) and ttl >= 0
+        self._record(MCPTestResult(
+            test_id="MCP-RC-009", name="Resource Cache Metadata",
+            category="cache_security", owasp_asi="ASI04", severity=Severity.MEDIUM.value,
+            passed=passed,
+            details=(f"resources/read declares cacheScope={scope!r}, ttlMs={ttl!r}" if passed
+                     else "resources/read omitted valid cacheScope and/or non-negative ttlMs"),
+            mcp_method="resources/read", request_sent=msg, response_received=response,
             elapsed_s=round(time.monotonic() - t0, 3),
         ))
 
@@ -2609,7 +2651,8 @@ class MCPSecurityTests:
                 self.test_mcp_request_state_request_binding,
             ],
             "explicit_handle_isolation": [self.test_mcp_explicit_handle_isolation],
-            "cache_security": [self.test_mcp_cache_scope_metadata, self.test_mcp_cache_revocation],
+            "cache_security": [self.test_mcp_cache_scope_metadata, self.test_mcp_cache_revocation,
+                                self.test_mcp_resource_cache_metadata],
             "capability_negotiation": [
                 self.test_mcp_capability_escalation,
                 self.test_mcp_protocol_version_downgrade,
@@ -2835,6 +2878,7 @@ def main():
     ap.add_argument("--cache-invalidation", help="Authorized JSON-RPC request that revokes a capability and invalidates its cache entry.")
     ap.add_argument("--cache-verify", help="Read-only JSON-RPC request that returns the post-invalidation tools list.")
     ap.add_argument("--cache-forbidden-tool", help="Tool name that must be absent after --cache-invalidation.")
+    ap.add_argument("--cache-resource-uri", help="Operator-authorized resource URI for the read-only cache-metadata probe.")
     ap.add_argument(
         "--protocol-version",
         choices=[MODERN_PROTOCOL_VERSION, AUTO_PROTOCOL_VERSION, DIFFERENTIAL_PROTOCOL_VERSION],
@@ -2998,7 +3042,8 @@ def main():
                                      mrtr_altered_probe=mrtr_altered_probe, handle_create=handle_create,
                                      handle_access=handle_access, handle_attacker_headers=handle_attacker_headers,
                                      cache_invalidation=cache_invalidation, cache_verify=cache_verify,
-                                     cache_forbidden_tool=args.cache_forbidden_tool)
+                                     cache_forbidden_tool=args.cache_forbidden_tool,
+                                     cache_resource_uri=args.cache_resource_uri)
             try:
                 results = suite.run_all(categories=categories)
                 return build_report(
@@ -3039,7 +3084,8 @@ def main():
                                      mrtr_altered_probe=mrtr_altered_probe, handle_create=handle_create,
                                      handle_access=handle_access, handle_attacker_headers=handle_attacker_headers,
                                      cache_invalidation=cache_invalidation, cache_verify=cache_verify,
-                                     cache_forbidden_tool=args.cache_forbidden_tool)
+                                     cache_forbidden_tool=args.cache_forbidden_tool,
+                                     cache_resource_uri=args.cache_resource_uri)
             try:
                 return {"results": suite.run_all(categories=categories)}
             finally:
@@ -3065,7 +3111,8 @@ def main():
                                  mrtr_altered_probe=mrtr_altered_probe, handle_create=handle_create,
                                  handle_access=handle_access, handle_attacker_headers=handle_attacker_headers,
                                  cache_invalidation=cache_invalidation, cache_verify=cache_verify,
-                                 cache_forbidden_tool=args.cache_forbidden_tool)
+                                 cache_forbidden_tool=args.cache_forbidden_tool,
+                                 cache_resource_uri=args.cache_resource_uri)
         conn_error = None
         try:
             results = suite.run_all(categories=categories)

--- a/protocol_tests/schema_resolution.py
+++ b/protocol_tests/schema_resolution.py
@@ -1,0 +1,115 @@
+"""Fail-closed schema-reference policy helpers for A2A and MCP fixtures.
+
+These helpers deliberately do not resolve JSON Schema references.  A consuming
+adapter can use them before handing a schema to a validator to ensure that only
+locally registered, immutable schema bundles are eligible for resolution.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urldefrag
+
+
+@dataclass(frozen=True)
+class RegisteredSchema:
+    """An allowlisted local schema bundle with an immutable content digest."""
+
+    identifier: str
+    document: dict[str, Any]
+    sha256: str
+
+    @classmethod
+    def from_document(cls, identifier: str, document: dict[str, Any]) -> "RegisteredSchema":
+        canonical = json.dumps(document, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        return cls(identifier=identifier, document=document, sha256=hashlib.sha256(canonical).hexdigest())
+
+
+@dataclass(frozen=True)
+class ReferencePolicyResult:
+    """A policy-only result, never the result of remote or filesystem retrieval."""
+
+    allowed: bool
+    reason: str
+    reference: str
+
+
+def _walk_references(value: Any) -> list[str]:
+    """Return every string-valued ``$ref`` from a JSON-compatible document."""
+    refs: list[str] = []
+    if isinstance(value, dict):
+        ref = value.get("$ref")
+        if isinstance(ref, str):
+            refs.append(ref)
+        for child in value.values():
+            refs.extend(_walk_references(child))
+    elif isinstance(value, list):
+        for child in value:
+            refs.extend(_walk_references(child))
+    return refs
+
+
+def check_reference_policy(
+    document: dict[str, Any], registry: dict[str, RegisteredSchema] | None = None
+) -> list[ReferencePolicyResult]:
+    """Evaluate references without fetching network, files, or package registries.
+
+    Local fragments are allowed.  Absolute or relative external identifiers are
+    allowed only when their defragmented identifier is in ``registry`` and the
+    registered bundle still matches its recorded digest.
+    """
+    registry = registry or {}
+    results: list[ReferencePolicyResult] = []
+    for reference in _walk_references(document):
+        identifier, _fragment = urldefrag(reference)
+        if not identifier:
+            results.append(ReferencePolicyResult(True, "local fragment", reference))
+            continue
+        registered = registry.get(identifier)
+        if registered is None:
+            results.append(ReferencePolicyResult(False, "unregistered external reference", reference))
+            continue
+        expected = RegisteredSchema.from_document(registered.identifier, registered.document).sha256
+        if expected != registered.sha256:
+            results.append(ReferencePolicyResult(False, "registered schema digest mismatch", reference))
+            continue
+        results.append(ReferencePolicyResult(True, "allowlisted pinned schema", reference))
+    return results
+
+
+def references_fail_closed(document: dict[str, Any], registry: dict[str, RegisteredSchema] | None = None) -> bool:
+    """True only when every declared reference is local or pinned in the registry."""
+    return all(result.allowed for result in check_reference_policy(document, registry))
+
+
+def field_collisions(payload: dict[str, Any], aliases: dict[str, tuple[str, str]]) -> list[str]:
+    """Identify payloads that provide both documented spellings of one field."""
+    return [
+        semantic_name
+        for semantic_name, (camel_case, snake_case) in aliases.items()
+        if camel_case in payload and snake_case in payload
+    ]
+
+
+def normalize_wire_fields(
+    payload: dict[str, Any], aliases: dict[str, tuple[str, str]]
+) -> dict[str, Any]:
+    """Normalize one documented spelling per field and reject ambiguous duplicates."""
+    collisions = field_collisions(payload, aliases)
+    if collisions:
+        raise ValueError(f"ambiguous equivalent fields: {', '.join(collisions)}")
+    normalized = dict(payload)
+    for semantic_name, (camel_case, snake_case) in aliases.items():
+        if camel_case in normalized:
+            normalized[semantic_name] = normalized.pop(camel_case)
+        elif snake_case in normalized:
+            normalized[semantic_name] = normalized.pop(snake_case)
+    return normalized
+
+
+def validator_differential(boundary_outcomes: dict[str, bool]) -> bool:
+    """Return True when named validation boundaries disagree on a fixture."""
+    return len(set(boundary_outcomes.values())) > 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "agent-security-harness"
 version = "4.9.1"
-description = "553 security tests for AI agent systems - MCP, A2A, L402, x402, UCP/ACP merchant-journey, AP2 mandate + Fireblocks x402 hardening + Visa TAP / Mastercard Agentic Tokens + denial-of-settlement finality, decision governance, AIUC-1 compliance, NIST AI 800-2 aligned"
+description = "560 security tests for AI agent systems - MCP, A2A, L402, x402, UCP/ACP merchant-journey, AP2 mandate + Fireblocks x402 hardening + Visa TAP / Mastercard Agentic Tokens + denial-of-settlement finality, decision governance, AIUC-1 compliance, NIST AI 800-2 aligned"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {text = "Apache-2.0"}
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "agent-security-harness"
 version = "4.9.1"
-description = "561 security tests for AI agent systems - MCP, A2A, L402, x402, UCP/ACP merchant-journey, AP2 mandate + Fireblocks x402 hardening + Visa TAP / Mastercard Agentic Tokens + denial-of-settlement finality, decision governance, AIUC-1 compliance, NIST AI 800-2 aligned"
+description = "562 security tests for AI agent systems - MCP, A2A, L402, x402, UCP/ACP merchant-journey, AP2 mandate + Fireblocks x402 hardening + Visa TAP / Mastercard Agentic Tokens + denial-of-settlement finality, decision governance, AIUC-1 compliance, NIST AI 800-2 aligned"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {text = "Apache-2.0"}
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "agent-security-harness"
 version = "4.9.1"
-description = "560 security tests for AI agent systems - MCP, A2A, L402, x402, UCP/ACP merchant-journey, AP2 mandate + Fireblocks x402 hardening + Visa TAP / Mastercard Agentic Tokens + denial-of-settlement finality, decision governance, AIUC-1 compliance, NIST AI 800-2 aligned"
+description = "561 security tests for AI agent systems - MCP, A2A, L402, x402, UCP/ACP merchant-journey, AP2 mandate + Fireblocks x402 hardening + Visa TAP / Mastercard Agentic Tokens + denial-of-settlement finality, decision governance, AIUC-1 compliance, NIST AI 800-2 aligned"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {text = "Apache-2.0"}
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-mcp-server = ["mcp>=1.0.0"]
+mcp-server = ["mcp>=1.28.1,<2"]
 
 [project.urls]
 Homepage = "https://github.com/msaleme/red-team-blue-team-agent-fabric"
@@ -63,4 +63,4 @@ agent-security = "protocol_tests.cli:main"
 ash = "protocol_tests.cli:main"
 
 [tool.setuptools.packages.find]
-include = ["protocol_tests*", "scripts*"]
+include = ["protocol_tests*", "scripts*", "mcp_server*"]

--- a/testing/test_schema_resolution.py
+++ b/testing/test_schema_resolution.py
@@ -1,0 +1,110 @@
+"""Fixture tests for fail-closed A2A/MCP schema-resolution policy.
+
+The fixtures are protocol-neutral by design: Agent Cards and MCP tool/resource
+schemas both carry JSON Schema documents.  They demonstrate the policy layer
+without making network or filesystem acquisition part of a test run.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from threading import Thread
+from unittest.mock import patch
+
+from protocol_tests.schema_resolution import (
+    RegisteredSchema,
+    check_reference_policy,
+    field_collisions,
+    normalize_wire_fields,
+    references_fail_closed,
+    validator_differential,
+)
+
+
+class _CountingHandler(BaseHTTPRequestHandler):
+    requests = 0
+
+    def do_GET(self):  # noqa: N802 - stdlib handler API
+        type(self).requests += 1
+        self.send_response(200)
+        self.end_headers()
+
+    def log_message(self, *_args):
+        pass
+
+
+class TestSchemaResolutionPolicy(unittest.TestCase):
+    def setUp(self):
+        _CountingHandler.requests = 0
+        self.server = HTTPServer(("127.0.0.1", 0), _CountingHandler)
+        self.thread = Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+        self.base_url = f"http://127.0.0.1:{self.server.server_port}/schema.json"
+
+    def tearDown(self):
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=2)
+
+    def test_unregistered_http_reference_fails_closed_without_contact(self):
+        doc = {"$ref": self.base_url}
+        result = check_reference_policy(doc)
+        self.assertFalse(result[0].allowed)
+        self.assertEqual(result[0].reason, "unregistered external reference")
+        self.assertEqual(_CountingHandler.requests, 0)
+
+    def test_unregistered_file_reference_fails_closed_without_open(self):
+        with tempfile.TemporaryDirectory() as directory:
+            sentinel = Path(directory) / "sentinel.json"
+            sentinel.write_text('{"opened": true}', encoding="utf-8")
+            with patch("builtins.open", side_effect=AssertionError("must not open external ref")):
+                result = check_reference_policy({"$ref": sentinel.as_uri()})
+        self.assertFalse(result[0].allowed)
+        self.assertEqual(result[0].reason, "unregistered external reference")
+
+    def test_local_defs_reference_is_allowed(self):
+        doc = {"$defs": {"value": {"type": "string"}}, "$ref": "#/$defs/value"}
+        self.assertTrue(references_fail_closed(doc))
+
+    def test_registered_reference_requires_matching_digest(self):
+        identifier = "urn:example:schemas:agent-card:1.0.0"
+        bundle = {"$defs": {"capability": {"type": "string"}}}
+        registered = RegisteredSchema.from_document(identifier, bundle)
+        self.assertTrue(references_fail_closed({"$ref": identifier + "#/$defs/capability"}, {identifier: registered}))
+
+    def test_mutated_registered_bundle_fails_closed(self):
+        identifier = "urn:example:schemas:tool:1.0.0"
+        registered = RegisteredSchema.from_document(identifier, {"type": "object"})
+        mutated = RegisteredSchema(identifier, {"type": "string"}, registered.sha256)
+        result = check_reference_policy({"$ref": identifier}, {identifier: mutated})
+        self.assertFalse(result[0].allowed)
+        self.assertEqual(result[0].reason, "registered schema digest mismatch")
+
+    def test_nested_references_are_all_checked(self):
+        doc = {"allOf": [{"$ref": "#/$defs/value"}, {"items": {"$ref": "https://invalid.example/schema"}}]}
+        results = check_reference_policy(doc)
+        self.assertEqual([item.allowed for item in results], [True, False])
+
+
+class TestWireAndValidatorFixtures(unittest.TestCase):
+    aliases = {"task_id": ("taskId", "task_id"), "input_schema": ("inputSchema", "input_schema")}
+
+    def test_equivalent_wire_fields_are_a_collision(self):
+        self.assertEqual(field_collisions({"taskId": "a", "task_id": "b"}, self.aliases), ["task_id"])
+
+    def test_collision_is_rejected_during_normalization(self):
+        with self.assertRaisesRegex(ValueError, "input_schema"):
+            normalize_wire_fields({"inputSchema": {}, "input_schema": {}}, self.aliases)
+
+    def test_one_documented_spelling_normalizes_consistently(self):
+        self.assertEqual(normalize_wire_fields({"taskId": "a"}, self.aliases), {"task_id": "a"})
+        self.assertEqual(normalize_wire_fields({"task_id": "a"}, self.aliases), {"task_id": "a"})
+
+    def test_validator_outcomes_detect_differential(self):
+        self.assertTrue(validator_differential({"gateway": True, "sdk": False, "receiver": True}))
+
+    def test_validator_outcomes_accept_consensus(self):
+        self.assertFalse(validator_differential({"gateway": False, "sdk": False, "receiver": False}))

--- a/testing/test_transport.py
+++ b/testing/test_transport.py
@@ -1,8 +1,24 @@
 #!/usr/bin/env python3
 """Unit tests for MCP transport and JSON-RPC primitives."""
 import json, os, sys, unittest
+from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from protocol_tests.mcp_harness import jsonrpc_request, jsonrpc_notification, MCPTransport, StreamableHTTPTransport
+from protocol_tests.mcp_harness import (
+    AUTO_PROTOCOL_VERSION,
+    build_differential_report,
+    LEGACY_PROTOCOL_VERSION,
+    MODERN_PROTOCOL_VERSION,
+    MCPSecurityTests,
+    _json_path,
+    _replace_handle,
+    MCPTransport,
+    report_has_failure,
+    StreamableHTTPTransport,
+    _header_value,
+    jsonrpc_notification,
+    jsonrpc_request,
+)
 
 
 class TestJSONRPCRequest(unittest.TestCase):
@@ -27,6 +43,261 @@ class TestTransport(unittest.TestCase):
     def test_http_init(self):
         t = StreamableHTTPTransport("http://localhost:8080")
         self.assertEqual(t.url, "http://localhost:8080"); self.assertIsNone(t.session_id)
+
+    def test_modern_request_metadata_and_headers(self):
+        t = StreamableHTTPTransport("http://localhost:8080", protocol_version=MODERN_PROTOCOL_VERSION)
+        request = t._prepare_modern_message(jsonrpc_request("tools/call", {"name": "scan"}))
+        self.assertEqual(request["params"]["_meta"]["io.modelcontextprotocol/protocolVersion"], MODERN_PROTOCOL_VERSION)
+        self.assertIn("io.modelcontextprotocol/clientInfo", request["params"]["_meta"])
+        headers = t._request_headers(request)
+        self.assertEqual(headers["MCP-Protocol-Version"], MODERN_PROTOCOL_VERSION)
+        self.assertEqual(headers["Mcp-Method"], "tools/call")
+        self.assertEqual(headers["Mcp-Name"], "scan")
+        self.assertNotIn("Mcp-Session-Id", headers)
+
+    def test_modern_resource_name_is_mirrored_and_encoded(self):
+        t = StreamableHTTPTransport("http://localhost:8080", protocol_version=MODERN_PROTOCOL_VERSION)
+        request = t._prepare_modern_message(jsonrpc_request("resources/read", {"uri": "file:///你好"}))
+        self.assertTrue(t._request_headers(request)["Mcp-Name"].startswith("=?base64?"))
+
+    def test_header_value_encodes_unsafe_values(self):
+        self.assertEqual(_header_value("safe-value"), "safe-value")
+        self.assertTrue(_header_value(" leading").startswith("=?base64?"))
+        self.assertTrue(_header_value("=?base64?literal?=").startswith("=?base64?"))
+
+    def test_modern_header_override_reaches_security_probe(self):
+        transport = StreamableHTTPTransport("http://localhost:8080", protocol_version=MODERN_PROTOCOL_VERSION)
+        response = MagicMock()
+        response.headers.get.side_effect = lambda key, default=None: "application/json" if key == "Content-Type" else default
+        response.read.return_value = b'{}'
+        response.status = 200
+        with patch("protocol_tests.mcp_harness.urllib.request.urlopen") as urlopen:
+            urlopen.return_value.__enter__.return_value = response
+            transport.send(
+                jsonrpc_request("tools/list", {}),
+                header_overrides={"Mcp-Method": "tools/call", "Mcp-Name": "__mcp_header_probe__"},
+            )
+            request = urlopen.call_args.args[0]
+        headers = {name.lower(): value for name, value in request.header_items()}
+        self.assertEqual(headers["mcp-method"], "tools/call")
+        self.assertEqual(headers["mcp-name"], "__mcp_header_probe__")
+
+    def test_modern_raw_probe_carries_routing_headers(self):
+        t = StreamableHTTPTransport("http://localhost:8080", protocol_version=MODERN_PROTOCOL_VERSION)
+        with patch("urllib.request.urlopen") as urlopen:
+            response = urlopen.return_value.__enter__.return_value
+            response.read.return_value = b"{}"
+            t.send_raw(b"not-json", mcp_method="tools/call", mcp_name="scan")
+        request = urlopen.call_args.args[0]
+        self.assertEqual(request.get_header("Mcp-protocol-version"), MODERN_PROTOCOL_VERSION)
+        self.assertEqual(request.get_header("Mcp-method"), "tools/call")
+        self.assertEqual(request.get_header("Mcp-name"), "scan")
+        self.assertIsNone(request.get_header("Mcp-session-id"))
+
+
+class _AutoTransport(MCPTransport):
+    def __init__(self, modern_response):
+        self.protocol_version = AUTO_PROTOCOL_VERSION
+        self.session_id = None
+        self.modern_response = modern_response
+        self.sent = []
+
+    @property
+    def is_auto(self):
+        return self.protocol_version == AUTO_PROTOCOL_VERSION
+
+    @property
+    def is_modern(self):
+        return self.protocol_version == MODERN_PROTOCOL_VERSION
+
+    def send(self, message):
+        self.sent.append(message)
+        if message["method"] == "server/discover":
+            return self.modern_response
+        if message["method"] == "initialize":
+            return {"result": {"serverInfo": {"name": "legacy"}, "capabilities": {}}}
+        return None
+
+
+class TestProtocolAutoSelection(unittest.TestCase):
+    def test_auto_keeps_modern_when_discovery_succeeds(self):
+        transport = _AutoTransport({"result": {"serverInfo": {"name": "modern"}, "capabilities": {}}})
+        suite = MCPSecurityTests(transport, json_output=True)
+        self.assertTrue(suite.initialize())
+        self.assertEqual(suite.selected_protocol_version, MODERN_PROTOCOL_VERSION)
+        self.assertEqual(transport.protocol_version, MODERN_PROTOCOL_VERSION)
+        self.assertEqual([message["method"] for message in transport.sent], ["server/discover"])
+
+    def test_auto_falls_back_to_legacy_initialization(self):
+        transport = _AutoTransport(None)
+        suite = MCPSecurityTests(transport, json_output=True)
+        self.assertTrue(suite.initialize())
+        self.assertEqual(suite.selected_protocol_version, LEGACY_PROTOCOL_VERSION)
+        self.assertEqual(transport.protocol_version, LEGACY_PROTOCOL_VERSION)
+        self.assertEqual([message["method"] for message in transport.sent], ["server/discover", "initialize", "notifications/initialized"])
+        self.assertIsNone(getattr(suite, "_connection_error", None))
+
+
+class TestDifferentialReport(unittest.TestCase):
+    def test_marks_claim_changes_and_missing_coverage(self):
+        report = build_differential_report(
+            {"results": [{"test_id": "MCP-001", "passed": True}, {"test_id": "MCP-002", "passed": False}]},
+            {"results": [{"test_id": "MCP-001", "passed": True}, {"test_id": "MCP-002", "passed": True}, {"test_id": "MCP-RC-001", "passed": True}]},
+        )
+        claims = {claim["test_id"]: claim for claim in report["claims"]}
+        self.assertEqual(claims["MCP-001"]["status"], "equivalent")
+        self.assertEqual(claims["MCP-002"]["status"], "changed")
+        self.assertEqual(claims["MCP-RC-001"]["status"], "modern_only")
+        self.assertEqual(report["summary"], {"equivalent": 1, "changed": 1, "legacy_only": 0, "modern_only": 1})
+
+    def test_error_only_report_is_a_failure(self):
+        self.assertTrue(report_has_failure({"results": [], "error": "connection refused"}))
+        self.assertFalse(report_has_failure({"results": [{"passed": True}]}))
+
+
+class _MRTRTransport(MCPTransport):
+    is_modern = True
+
+    def __init__(self):
+        self.requests = []
+
+    def send(self, message, **kwargs):
+        self.requests.append(message)
+        if len(self.requests) == 1:
+            return {"result": {"resultType": "input_required", "requestState": "signed-state-A"}}
+        return {"error": {"code": -32020, "message": "HeaderMismatchError"}}
+
+
+class TestMRTRRequestState(unittest.TestCase):
+    def test_tampered_request_state_is_rejected(self):
+        transport = _MRTRTransport()
+        suite = MCPSecurityTests(
+            transport,
+            json_output=True,
+            mrtr_probe={"method": "tools/call", "params": {"name": "approval_probe", "arguments": {}}},
+        )
+        suite.test_mcp_request_state_integrity()
+        self.assertTrue(suite.results[0].passed)
+        retry = transport.requests[1]
+        self.assertNotEqual(retry["params"]["requestState"], "signed-state-A")
+        self.assertEqual(retry["params"]["inputResponses"], {})
+
+    def test_completed_request_state_replay_is_rejected(self):
+        class ReplayTransport(MCPTransport):
+            is_modern = True
+
+            def __init__(self):
+                self.calls = 0
+
+            def send(self, message, **kwargs):
+                self.calls += 1
+                if self.calls == 1:
+                    return {"result": {"resultType": "input_required", "requestState": "single-use-state"}}
+                if self.calls == 2:
+                    return {"result": {"resultType": "complete", "content": []}}
+                return {"error": {"code": -32000, "message": "requestState already consumed"}}
+
+        suite = MCPSecurityTests(
+            ReplayTransport(),
+            json_output=True,
+            mrtr_probe={"method": "tools/call", "params": {"name": "approval_probe", "arguments": {}}},
+            mrtr_input_responses={"approve": {"action": "accept"}},
+        )
+        suite.test_mcp_request_state_replay()
+        self.assertTrue(suite.results[0].passed)
+
+    def test_cross_principal_request_state_is_rejected(self):
+        class PrincipalTransport(MCPTransport):
+            is_modern = True
+
+            def __init__(self):
+                self.headers = None
+                self.calls = 0
+
+            def send(self, message, **kwargs):
+                self.calls += 1
+                if self.calls == 1:
+                    self.headers = kwargs.get("header_overrides")
+                    return {"result": {"resultType": "input_required", "requestState": "principal-bound-state"}}
+                self.headers = kwargs.get("header_overrides")
+                return {"error": {"code": -32000, "message": "principal mismatch"}}
+
+        transport = PrincipalTransport()
+        suite = MCPSecurityTests(
+            transport,
+            json_output=True,
+            mrtr_probe={"method": "tools/call", "params": {"name": "approval_probe", "arguments": {}}},
+            mrtr_input_responses={"approve": {"action": "accept"}},
+            mrtr_attacker_headers={"Authorization": "Bearer attacker"},
+        )
+        suite.test_mcp_request_state_principal_binding()
+        self.assertTrue(suite.results[0].passed)
+        self.assertEqual(transport.headers, {"Authorization": "Bearer attacker"})
+
+    def test_cross_request_request_state_is_rejected(self):
+        class BindingTransport(MCPTransport):
+            is_modern = True
+
+            def __init__(self):
+                self.calls = []
+
+            def send(self, message, **kwargs):
+                self.calls.append(message)
+                if len(self.calls) == 1:
+                    return {"result": {"resultType": "input_required", "requestState": "request-bound-state"}}
+                return {"error": {"code": -32000, "message": "request binding mismatch"}}
+
+        transport = BindingTransport()
+        suite = MCPSecurityTests(
+            transport,
+            json_output=True,
+            mrtr_probe={"method": "tools/call", "params": {"name": "approve_transfer", "arguments": {"amount": 10}}},
+            mrtr_input_responses={"approve": {"action": "accept"}},
+            mrtr_altered_probe={"method": "tools/call", "params": {"name": "approve_transfer", "arguments": {"amount": 1000}}},
+        )
+        suite.test_mcp_request_state_request_binding()
+        self.assertTrue(suite.results[0].passed)
+        self.assertEqual(transport.calls[1]["params"]["arguments"]["amount"], 1000)
+
+
+class TestExplicitHandleIsolation(unittest.TestCase):
+    def test_replaces_handle_and_rejects_cross_principal_access(self):
+        class HandleTransport(MCPTransport):
+            supports_header_overrides = True
+
+            def __init__(self):
+                self.calls = []
+
+            def send(self, message, **kwargs):
+                self.calls.append((message, kwargs))
+                if len(self.calls) == 1:
+                    return {"result": {"basket": {"id": "tenant-a-handle"}}}
+                return {"error": {"code": -32000, "message": "handle not authorized"}}
+
+        transport = HandleTransport()
+        suite = MCPSecurityTests(
+            transport, json_output=True,
+            handle_create={"method": "tools/call", "params": {"name": "create_basket"}, "handlePath": "result.basket.id"},
+            handle_access={"method": "tools/call", "params": {"name": "read_basket", "arguments": {"basket_id": "$HANDLE"}}},
+            handle_attacker_headers={"Authorization": "Bearer tenant-b"},
+        )
+        suite.test_mcp_explicit_handle_isolation()
+        self.assertTrue(suite.results[0].passed)
+        self.assertEqual(transport.calls[1][0]["params"]["arguments"]["basket_id"], "tenant-a-handle")
+        self.assertEqual(transport.calls[1][1]["header_overrides"], {"Authorization": "Bearer tenant-b"})
+        self.assertEqual(_json_path({"a": {"b": 1}}, "a.b"), 1)
+        self.assertEqual(_replace_handle({"x": ["$HANDLE"]}, "h"), {"x": ["h"]})
+
+
+class TestCacheScopeMetadata(unittest.TestCase):
+    def test_modern_listing_requires_scope_and_ttl(self):
+        class CacheTransport(MCPTransport):
+            is_modern = True
+            def send(self, message, **kwargs):
+                return {"result": {"tools": [], "cacheScope": "private", "ttlMs": 5000}}
+        suite = MCPSecurityTests(CacheTransport(), json_output=True)
+        suite.test_mcp_cache_scope_metadata()
+        self.assertTrue(suite.results[0].passed)
 
 
 if __name__ == "__main__":

--- a/testing/test_transport.py
+++ b/testing/test_transport.py
@@ -299,6 +299,20 @@ class TestCacheScopeMetadata(unittest.TestCase):
         suite.test_mcp_cache_scope_metadata()
         self.assertTrue(suite.results[0].passed)
 
+    def test_modern_resource_read_requires_scope_and_ttl(self):
+        class ResourceCacheTransport(MCPTransport):
+            is_modern = True
+
+            def send(self, message, **kwargs):
+                self.message = message
+                return {"result": {"contents": [], "cacheScope": "private", "ttlMs": 5000}}
+
+        transport = ResourceCacheTransport()
+        suite = MCPSecurityTests(transport, json_output=True, cache_resource_uri="file:///approved/status")
+        suite.test_mcp_resource_cache_metadata()
+        self.assertTrue(suite.results[0].passed)
+        self.assertEqual(transport.message["params"], {"uri": "file:///approved/status"})
+
     def test_authorized_revocation_removes_stale_capability(self):
         class CacheRevocationTransport(MCPTransport):
             is_modern = True

--- a/testing/test_transport.py
+++ b/testing/test_transport.py
@@ -169,6 +169,21 @@ class _MRTRTransport(MCPTransport):
 
 
 class TestMRTRRequestState(unittest.TestCase):
+    def test_failed_configured_probe_is_not_marked_not_applicable(self):
+        class FailingTransport(MCPTransport):
+            is_modern = True
+
+            def send(self, message, **kwargs):
+                return {"_error": "connection refused"}
+
+        suite = MCPSecurityTests(
+            FailingTransport(), json_output=True,
+            mrtr_probe={"method": "tools/call", "params": {"name": "approval_probe"}},
+        )
+        suite.test_mcp_request_state_integrity()
+        self.assertFalse(suite.results[0].passed)
+        self.assertIn("failed", suite.results[0].details)
+
     def test_tampered_request_state_is_rejected(self):
         transport = _MRTRTransport()
         suite = MCPSecurityTests(
@@ -261,6 +276,23 @@ class TestMRTRRequestState(unittest.TestCase):
 
 
 class TestExplicitHandleIsolation(unittest.TestCase):
+    def test_failed_handle_create_is_not_marked_not_applicable(self):
+        class FailingHandleTransport(MCPTransport):
+            supports_header_overrides = True
+
+            def send(self, message, **kwargs):
+                return {"error": {"code": -32000, "message": "create failed"}}
+
+        suite = MCPSecurityTests(
+            FailingHandleTransport(), json_output=True,
+            handle_create={"method": "tools/call", "params": {"name": "create_basket"}},
+            handle_access={"method": "tools/call", "params": {"name": "read_basket"}},
+            handle_attacker_headers={"Authorization": "Bearer tenant-b"},
+        )
+        suite.test_mcp_explicit_handle_isolation()
+        self.assertFalse(suite.results[0].passed)
+        self.assertIn("failed", suite.results[0].details)
+
     def test_replaces_handle_and_rejects_cross_principal_access(self):
         class HandleTransport(MCPTransport):
             supports_header_overrides = True
@@ -313,18 +345,40 @@ class TestCacheScopeMetadata(unittest.TestCase):
         self.assertTrue(suite.results[0].passed)
         self.assertEqual(transport.message["params"], {"uri": "file:///approved/status"})
 
+    def test_boolean_ttl_is_not_accepted_as_cache_metadata(self):
+        class BooleanTTLTransport(MCPTransport):
+            is_modern = True
+
+            def send(self, message, **kwargs):
+                return {"result": {"tools": [], "cacheScope": "private", "ttlMs": True}}
+
+        suite = MCPSecurityTests(BooleanTTLTransport(), json_output=True)
+        suite.test_mcp_cache_scope_metadata()
+        self.assertFalse(suite.results[0].passed)
+
+    def test_boolean_ttl_is_not_accepted_for_resources(self):
+        class BooleanResourceTTLTransport(MCPTransport):
+            is_modern = True
+
+            def send(self, message, **kwargs):
+                return {"result": {"contents": [], "cacheScope": "private", "ttlMs": False}}
+
+        suite = MCPSecurityTests(
+            BooleanResourceTTLTransport(), json_output=True, cache_resource_uri="file:///approved/status"
+        )
+        suite.test_mcp_resource_cache_metadata()
+        self.assertFalse(suite.results[0].passed)
+
     def test_authorized_revocation_removes_stale_capability(self):
         class CacheRevocationTransport(MCPTransport):
             is_modern = True
 
-            def __init__(self):
-                self.calls = []
-
             def send(self, message, **kwargs):
-                self.calls.append(message)
+                if message["method"] == "tools/list":
+                    self.tool_reads = getattr(self, "tool_reads", 0) + 1
+                    return {"result": {"tools": ([{"name": "deploy"}] if self.tool_reads == 1 else [{"name": "read_status"}])}}
                 if message["method"] == "admin/revoke-capability":
                     return {"result": {"revoked": "deploy"}}
-                return {"result": {"tools": [{"name": "read_status"}]}}
 
         transport = CacheRevocationTransport()
         suite = MCPSecurityTests(
@@ -335,7 +389,6 @@ class TestCacheScopeMetadata(unittest.TestCase):
         )
         suite.test_mcp_cache_revocation()
         self.assertTrue(suite.results[0].passed)
-        self.assertEqual([call["method"] for call in transport.calls], ["admin/revoke-capability", "tools/list"])
 
     def test_stale_capability_after_revocation_fails(self):
         class StaleCacheTransport(MCPTransport):
@@ -354,6 +407,28 @@ class TestCacheScopeMetadata(unittest.TestCase):
         )
         suite.test_mcp_cache_revocation()
         self.assertFalse(suite.results[0].passed)
+
+    def test_undiscoverable_capability_does_not_pass_revocation(self):
+        class MissingCapabilityTransport(MCPTransport):
+            is_modern = True
+
+            def __init__(self):
+                self.calls = []
+
+            def send(self, message, **kwargs):
+                self.calls.append(message["method"])
+                return {"result": {"tools": [{"name": "read_status"}]}}
+
+        transport = MissingCapabilityTransport()
+        suite = MCPSecurityTests(
+            transport, json_output=True,
+            cache_invalidation={"method": "admin/revoke-capability", "params": {"name": "deploy"}},
+            cache_verify={"method": "tools/list", "params": {}},
+            cache_forbidden_tool="deploy",
+        )
+        suite.test_mcp_cache_revocation()
+        self.assertFalse(suite.results[0].passed)
+        self.assertEqual(transport.calls, ["tools/list"])
 
 
 if __name__ == "__main__":

--- a/testing/test_transport.py
+++ b/testing/test_transport.py
@@ -299,6 +299,48 @@ class TestCacheScopeMetadata(unittest.TestCase):
         suite.test_mcp_cache_scope_metadata()
         self.assertTrue(suite.results[0].passed)
 
+    def test_authorized_revocation_removes_stale_capability(self):
+        class CacheRevocationTransport(MCPTransport):
+            is_modern = True
+
+            def __init__(self):
+                self.calls = []
+
+            def send(self, message, **kwargs):
+                self.calls.append(message)
+                if message["method"] == "admin/revoke-capability":
+                    return {"result": {"revoked": "deploy"}}
+                return {"result": {"tools": [{"name": "read_status"}]}}
+
+        transport = CacheRevocationTransport()
+        suite = MCPSecurityTests(
+            transport, json_output=True,
+            cache_invalidation={"method": "admin/revoke-capability", "params": {"name": "deploy"}},
+            cache_verify={"method": "tools/list", "params": {}},
+            cache_forbidden_tool="deploy",
+        )
+        suite.test_mcp_cache_revocation()
+        self.assertTrue(suite.results[0].passed)
+        self.assertEqual([call["method"] for call in transport.calls], ["admin/revoke-capability", "tools/list"])
+
+    def test_stale_capability_after_revocation_fails(self):
+        class StaleCacheTransport(MCPTransport):
+            is_modern = True
+
+            def send(self, message, **kwargs):
+                if message["method"] == "admin/revoke-capability":
+                    return {"result": {"revoked": "deploy"}}
+                return {"result": {"tools": [{"name": "deploy"}]}}
+
+        suite = MCPSecurityTests(
+            StaleCacheTransport(), json_output=True,
+            cache_invalidation={"method": "admin/revoke-capability", "params": {"name": "deploy"}},
+            cache_verify={"method": "tools/list", "params": {}},
+            cache_forbidden_tool="deploy",
+        )
+        suite.test_mcp_cache_revocation()
+        self.assertFalse(suite.results[0].passed)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add authorized-fixture-only cache invalidation and stale-capability verification
- include passing and failing transport controls
- synchronize the verified test count in package metadata and README

## Validation
- `python3 -m unittest discover -s testing -p "test_*.py"` (181 passed)
- `python3 -m py_compile protocol_tests/mcp_harness.py testing/test_transport.py`
- `ruff check --select F821 protocol_tests/ testing/ scripts/ mcp_server/`

The probe only runs live when all three explicit authorized fixtures are supplied. Otherwise it reports not applicable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large changes to MCP transport and live-test verdict paths; live RC/MRTR/cache probes are fixture-gated but misconfiguration could skew results. Packaging and conformance additions are mostly additive.
> 
> **Overview**
> Extends the MCP harness for **2026-07-28** stateless HTTP: `server/discover`, per-request `_meta` and mirrored routing headers (`Mcp-Method` / `Mcp-Name`), optional **auto** discovery with legacy fallback, and **differential** legacy-vs-modern reports. Adds **MCP-RC-001–009** (header/body binding, MRTR `requestState` integrity/replay/principal/request binding, explicit-handle isolation, cache scope/TTL, **authorized cache revocation** via `--cache-*` fixtures, resource cache metadata) plus CLI flags for opt-in live probes.
> 
> Ships **RCL receipt-claim** portable fixtures (`conformance/receipt-claim/`) with `generate.py` / `verify_fixtures.py`, a **fail-closed schema-resolution** helper and tests, and an **XSR** proposal doc. **CI** installs `[mcp-server]`, verifies wheel install of `mcp_server`, and imports `mcp_server.server`; **FastMCP** uses `instructions` instead of `version`/`description`; **pyproject** pins `mcp` and includes `mcp_server*`. Documented test count moves **553 → 562**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d869e71b198bb9232e2f4bc26914db20b37e3946. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->