### PR TITLE
feat(mcp): add trace context binding probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 [![PyPI version](https://badge.fury.io/py/agent-security-harness.svg)](https://pypi.org/project/agent-security-harness/)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![Apache 2.0 License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/security%20tests-562-green.svg)](#three-layers-of-agent-decision-security)
+[![Tests](https://img.shields.io/badge/security%20tests-563-green.svg)](#three-layers-of-agent-decision-security)
 [![ClawScan](https://img.shields.io/badge/ClawScan-Benign-brightgreen)](https://clawhub.ai/msaleme/agent-security-harness)
 [![Static Analysis](https://img.shields.io/badge/Static%20Analysis-Benign-brightgreen)](https://clawhub.ai/msaleme/agent-security-harness)
 [![VirusTotal](https://img.shields.io/badge/VirusTotal-0%2F92_Clean-brightgreen)](https://www.virustotal.com/gui/url/37318967b56cd3cc1678972ebf0c53dbd37868b67ba3f6891447d53d51767cd2)
 
 **Even if an agent is properly authenticated and authorized, can it still be manipulated into unsafe or policy-violating behavior?**
 
-562 executable security tests across 38 modules (verified 2026-07-22 via `scripts/count_tests.py`). MCP + A2A + L402 + x402 wire-protocol testing, plus UCP/ACP merchant-journey, AP2 mandate-chain, Fireblocks x402 hardening, Visa TAP / Mastercard Agentic Token funding-instrument, and denial-of-settlement finality conformance across the full agentic-payments stack. Decision-layer attack scenarios. One `pip install` away.
+563 executable security tests across 38 modules (verified 2026-07-22 via `scripts/count_tests.py`). MCP + A2A + L402 + x402 wire-protocol testing, plus UCP/ACP merchant-journey, AP2 mandate-chain, Fireblocks x402 hardening, Visa TAP / Mastercard Agentic Token funding-instrument, and denial-of-settlement finality conformance across the full agentic-payments stack. Decision-layer attack scenarios. One `pip install` away.
 
 ```
 $ agent-security test mcp --url http://localhost:8080/mcp
@@ -62,7 +62,7 @@ See [docs/QUICKSTART.md](docs/QUICKSTART.md) for mock server setup, rate limitin
 |---|---|---|---|---|---|
 | **What it does** | Scans installed MCP configs for tool poisoning | YARA + LLM-as-judge for malicious tools | Scans agent configs for MCP/skill security | LLM model vulnerability testing | Active protocol exploitation + decision governance |
 | **Approach** | Static analysis | Static + LLM classification | Config scanning | Model-layer probing | **Wire-protocol adversarial testing** |
-| **MCP coverage** | Tool descriptions, config files | Tool descriptions, YARA rules | Config files | - | **18 tests: real JSON-RPC 2.0 attacks** |
+| **MCP coverage** | Tool descriptions, config files | Tool descriptions, YARA rules | Config files | - | **30 tests: real JSON-RPC 2.0 attacks** |
 | **A2A coverage** | - | - | - | - | **13 tests** |
 | **L402/x402 coverage** | - | - | - | - | **85 tests** |
 | **Merchant journey (UCP/ACP)** | - | - | - | - | **12 tests: agent-profile + cross-merchant cart + delegated checkout** |
@@ -76,7 +76,7 @@ See [docs/QUICKSTART.md](docs/QUICKSTART.md) for mock server setup, rate limitin
 | **Research backing** | - | Cisco blog | - | Papers | **6 DOIs + 3 NIST submissions** |
 | **MCP server mode** | - | - | - | - | **Yes - invoke from any AI agent** |
 | **Statistical testing** | - | - | - | - | **Wilson CIs, multi-trial** |
-| **Total tests** | Pattern matching | YARA rules | Config checks | Model probes | **562 active tests** |
+| **Total tests** | Pattern matching | YARA rules | Config checks | Model probes | **563 active tests** |
 
 **Use both.** Scan with [Invariant MCP-Scan](https://github.com/invariantlabs-ai/mcp-scan) or [Cisco MCP Scanner](https://github.com/cisco-ai-defense/mcp-scanner) for static analysis. Test with this framework for active exploitation. They're complementary layers.
 
@@ -110,7 +110,7 @@ The [constitutional-agent](https://github.com/CognitiveThoughtEngine/constitutio
 | Resource | Link |
 |---|---|
 | Expanded Quick Start | [docs/QUICKSTART.md](docs/QUICKSTART.md) |
-| Full Test Inventory (562 tests) | [docs/TEST-INVENTORY.md](docs/TEST-INVENTORY.md) |
+| Full Test Inventory (563 tests) | [docs/TEST-INVENTORY.md](docs/TEST-INVENTORY.md) |
 | AIUC-1 Crosswalk | [docs/AIUC1-CROSSWALK.md](docs/AIUC1-CROSSWALK.md) |
 | Advanced Capabilities | [docs/ADVANCED.md](docs/ADVANCED.md) |
 | MCP Server | [docs/mcp-server.md](docs/mcp-server.md) |

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 [![PyPI version](https://badge.fury.io/py/agent-security-harness.svg)](https://pypi.org/project/agent-security-harness/)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![Apache 2.0 License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/security%20tests-563-green.svg)](#three-layers-of-agent-decision-security)
+[![Tests](https://img.shields.io/badge/security%20tests-564-green.svg)](#three-layers-of-agent-decision-security)
 [![ClawScan](https://img.shields.io/badge/ClawScan-Benign-brightgreen)](https://clawhub.ai/msaleme/agent-security-harness)
 [![Static Analysis](https://img.shields.io/badge/Static%20Analysis-Benign-brightgreen)](https://clawhub.ai/msaleme/agent-security-harness)
 [![VirusTotal](https://img.shields.io/badge/VirusTotal-0%2F92_Clean-brightgreen)](https://www.virustotal.com/gui/url/37318967b56cd3cc1678972ebf0c53dbd37868b67ba3f6891447d53d51767cd2)
 
 **Even if an agent is properly authenticated and authorized, can it still be manipulated into unsafe or policy-violating behavior?**
 
-563 executable security tests across 38 modules (verified 2026-07-22 via `scripts/count_tests.py`). MCP + A2A + L402 + x402 wire-protocol testing, plus UCP/ACP merchant-journey, AP2 mandate-chain, Fireblocks x402 hardening, Visa TAP / Mastercard Agentic Token funding-instrument, and denial-of-settlement finality conformance across the full agentic-payments stack. Decision-layer attack scenarios. One `pip install` away.
+564 executable security tests across 38 modules (verified 2026-07-22 via `scripts/count_tests.py`). MCP + A2A + L402 + x402 wire-protocol testing, plus UCP/ACP merchant-journey, AP2 mandate-chain, Fireblocks x402 hardening, Visa TAP / Mastercard Agentic Token funding-instrument, and denial-of-settlement finality conformance across the full agentic-payments stack. Decision-layer attack scenarios. One `pip install` away.
 
 ```
 $ agent-security test mcp --url http://localhost:8080/mcp
@@ -62,7 +62,7 @@ See [docs/QUICKSTART.md](docs/QUICKSTART.md) for mock server setup, rate limitin
 |---|---|---|---|---|---|
 | **What it does** | Scans installed MCP configs for tool poisoning | YARA + LLM-as-judge for malicious tools | Scans agent configs for MCP/skill security | LLM model vulnerability testing | Active protocol exploitation + decision governance |
 | **Approach** | Static analysis | Static + LLM classification | Config scanning | Model-layer probing | **Wire-protocol adversarial testing** |
-| **MCP coverage** | Tool descriptions, config files | Tool descriptions, YARA rules | Config files | - | **30 tests: real JSON-RPC 2.0 attacks** |
+| **MCP coverage** | Tool descriptions, config files | Tool descriptions, YARA rules | Config files | - | **31 tests: real JSON-RPC 2.0 attacks** |
 | **A2A coverage** | - | - | - | - | **13 tests** |
 | **L402/x402 coverage** | - | - | - | - | **85 tests** |
 | **Merchant journey (UCP/ACP)** | - | - | - | - | **12 tests: agent-profile + cross-merchant cart + delegated checkout** |
@@ -76,7 +76,7 @@ See [docs/QUICKSTART.md](docs/QUICKSTART.md) for mock server setup, rate limitin
 | **Research backing** | - | Cisco blog | - | Papers | **6 DOIs + 3 NIST submissions** |
 | **MCP server mode** | - | - | - | - | **Yes - invoke from any AI agent** |
 | **Statistical testing** | - | - | - | - | **Wilson CIs, multi-trial** |
-| **Total tests** | Pattern matching | YARA rules | Config checks | Model probes | **563 active tests** |
+| **Total tests** | Pattern matching | YARA rules | Config checks | Model probes | **564 active tests** |
 
 **Use both.** Scan with [Invariant MCP-Scan](https://github.com/invariantlabs-ai/mcp-scan) or [Cisco MCP Scanner](https://github.com/cisco-ai-defense/mcp-scanner) for static analysis. Test with this framework for active exploitation. They're complementary layers.
 
@@ -110,7 +110,7 @@ The [constitutional-agent](https://github.com/CognitiveThoughtEngine/constitutio
 | Resource | Link |
 |---|---|
 | Expanded Quick Start | [docs/QUICKSTART.md](docs/QUICKSTART.md) |
-| Full Test Inventory (563 tests) | [docs/TEST-INVENTORY.md](docs/TEST-INVENTORY.md) |
+| Full Test Inventory (564 tests) | [docs/TEST-INVENTORY.md](docs/TEST-INVENTORY.md) |
 | AIUC-1 Crosswalk | [docs/AIUC1-CROSSWALK.md](docs/AIUC1-CROSSWALK.md) |
 | Advanced Capabilities | [docs/ADVANCED.md](docs/ADVANCED.md) |
 | MCP Server | [docs/mcp-server.md](docs/mcp-server.md) |

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 [![PyPI version](https://badge.fury.io/py/agent-security-harness.svg)](https://pypi.org/project/agent-security-harness/)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![Apache 2.0 License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/security%20tests-564-green.svg)](#three-layers-of-agent-decision-security)
+[![Tests](https://img.shields.io/badge/security%20tests-565-green.svg)](#three-layers-of-agent-decision-security)
 [![ClawScan](https://img.shields.io/badge/ClawScan-Benign-brightgreen)](https://clawhub.ai/msaleme/agent-security-harness)
 [![Static Analysis](https://img.shields.io/badge/Static%20Analysis-Benign-brightgreen)](https://clawhub.ai/msaleme/agent-security-harness)
 [![VirusTotal](https://img.shields.io/badge/VirusTotal-0%2F92_Clean-brightgreen)](https://www.virustotal.com/gui/url/37318967b56cd3cc1678972ebf0c53dbd37868b67ba3f6891447d53d51767cd2)
 
 **Even if an agent is properly authenticated and authorized, can it still be manipulated into unsafe or policy-violating behavior?**
 
-564 executable security tests across 38 modules (verified 2026-07-22 via `scripts/count_tests.py`). MCP + A2A + L402 + x402 wire-protocol testing, plus UCP/ACP merchant-journey, AP2 mandate-chain, Fireblocks x402 hardening, Visa TAP / Mastercard Agentic Token funding-instrument, and denial-of-settlement finality conformance across the full agentic-payments stack. Decision-layer attack scenarios. One `pip install` away.
+565 executable security tests across 38 modules (verified 2026-07-23 via `scripts/count_tests.py`). MCP + A2A + L402 + x402 wire-protocol testing, plus UCP/ACP merchant-journey, AP2 mandate-chain, Fireblocks x402 hardening, Visa TAP / Mastercard Agentic Token funding-instrument, and denial-of-settlement finality conformance across the full agentic-payments stack. Decision-layer attack scenarios. One `pip install` away.
 
 ```
 $ agent-security test mcp --url http://localhost:8080/mcp
@@ -76,7 +76,7 @@ See [docs/QUICKSTART.md](docs/QUICKSTART.md) for mock server setup, rate limitin
 | **Research backing** | - | Cisco blog | - | Papers | **6 DOIs + 3 NIST submissions** |
 | **MCP server mode** | - | - | - | - | **Yes - invoke from any AI agent** |
 | **Statistical testing** | - | - | - | - | **Wilson CIs, multi-trial** |
-| **Total tests** | Pattern matching | YARA rules | Config checks | Model probes | **564 active tests** |
+| **Total tests** | Pattern matching | YARA rules | Config checks | Model probes | **565 active tests** |
 
 **Use both.** Scan with [Invariant MCP-Scan](https://github.com/invariantlabs-ai/mcp-scan) or [Cisco MCP Scanner](https://github.com/cisco-ai-defense/mcp-scanner) for static analysis. Test with this framework for active exploitation. They're complementary layers.
 
@@ -110,7 +110,7 @@ The [constitutional-agent](https://github.com/CognitiveThoughtEngine/constitutio
 | Resource | Link |
 |---|---|
 | Expanded Quick Start | [docs/QUICKSTART.md](docs/QUICKSTART.md) |
-| Full Test Inventory (564 tests) | [docs/TEST-INVENTORY.md](docs/TEST-INVENTORY.md) |
+| Full Test Inventory (565 tests) | [docs/TEST-INVENTORY.md](docs/TEST-INVENTORY.md) |
 | AIUC-1 Crosswalk | [docs/AIUC1-CROSSWALK.md](docs/AIUC1-CROSSWALK.md) |
 | Advanced Capabilities | [docs/ADVANCED.md](docs/ADVANCED.md) |
 | MCP Server | [docs/mcp-server.md](docs/mcp-server.md) |

--- a/docs/TEST-INVENTORY.md
+++ b/docs/TEST-INVENTORY.md
@@ -180,11 +180,11 @@ agent-security test enterprise --platform salesforce --url https://your-org.sale
 ## Test Harness Modules (representative summary)
 
 > This table lists the largest modules; the full harness spans **37 test-bearing
-> modules / 553 tests** (verified 2026-07-12 via `scripts/count_tests.py`).
+> modules / 563 tests** (verified 2026-07-22 via `scripts/count_tests.py`).
 
 | Module | Tests | Layer | Description |
 |---|---|---|---|
-| **MCP Protocol** | 18 | JSON-RPC 2.0 | Anthropic MCP wire-protocol testing |
+| **MCP Protocol** | 30 | JSON-RPC 2.0 | MCP wire-protocol testing, including stateless routing, MRTR, cache, and task-isolation probes |
 | **A2A Protocol** | 13 | JSON-RPC/HTTP | Google Agent-to-Agent communication |
 | **L402 Payment** | 33 | HTTP/Lightning | Bitcoin/Lightning payment flow security (macaroons, preimages, caveats) |
 | **x402 Payment** | 52 | HTTP/USDC | Coinbase/Stripe agent payment protocol (recipient manipulation, session theft, facilitator trust, cross-chain confusion) |

--- a/docs/TEST-INVENTORY.md
+++ b/docs/TEST-INVENTORY.md
@@ -180,11 +180,11 @@ agent-security test enterprise --platform salesforce --url https://your-org.sale
 ## Test Harness Modules (representative summary)
 
 > This table lists the largest modules; the full harness spans **37 test-bearing
-> modules / 563 tests** (verified 2026-07-22 via `scripts/count_tests.py`).
+> modules / 564 tests** (verified 2026-07-22 via `scripts/count_tests.py`).
 
 | Module | Tests | Layer | Description |
 |---|---|---|---|
-| **MCP Protocol** | 30 | JSON-RPC 2.0 | MCP wire-protocol testing, including stateless routing, MRTR, cache, and task-isolation probes |
+| **MCP Protocol** | 31 | JSON-RPC 2.0 | MCP wire-protocol testing, including stateless routing, MRTR, cache, task-isolation, and trace-context probes |
 | **A2A Protocol** | 13 | JSON-RPC/HTTP | Google Agent-to-Agent communication |
 | **L402 Payment** | 33 | HTTP/Lightning | Bitcoin/Lightning payment flow security (macaroons, preimages, caveats) |
 | **x402 Payment** | 52 | HTTP/USDC | Coinbase/Stripe agent payment protocol (recipient manipulation, session theft, facilitator trust, cross-chain confusion) |

--- a/protocol_tests/mcp_harness.py
+++ b/protocol_tests/mcp_harness.py
@@ -483,6 +483,8 @@ class MCPSecurityTests:
         task_create: dict | None = None,
         task_read: dict | None = None,
         task_attacker_headers: dict | None = None,
+        trace_probe: dict | None = None,
+        trace_attacker_headers: dict | None = None,
     ):
         self.transport = transport
         self.results: list[MCPTestResult] = []
@@ -504,6 +506,8 @@ class MCPSecurityTests:
         self.task_create = task_create
         self.task_read = task_read
         self.task_attacker_headers = task_attacker_headers
+        self.trace_probe = trace_probe
+        self.trace_attacker_headers = trace_attacker_headers
         self.selected_protocol_version: str | None = None
 
     def _record(self, result: MCPTestResult):
@@ -1285,6 +1289,54 @@ class MCPSecurityTests:
             mcp_method=read["method"],
             request_sent={"create": create, "cross_principal_read": read},
             response_received=response, elapsed_s=round(time.monotonic() - t0, 3),
+        ))
+
+    def test_mcp_trace_context_request_binding(self):
+        """MCP-RC-011: an authorized request must reject conflicting trace context.
+
+        Trace context is outside JSON-RPC, so a target that uses it for routing
+        must bind it to the authenticated request. This opt-in probe replays only
+        an operator-authorized, read-only fixture with a distinct W3C trace header.
+        It does not claim legacy/modern equivalence or infer a target's tracing model.
+        """
+        t0 = time.monotonic()
+        if self.simulate:
+            self._record(MCPTestResult(
+                test_id="MCP-RC-011", name="Trace Context Request Binding",
+                category="trace_context_binding", owasp_asi="ASI02", severity=Severity.HIGH.value,
+                passed=True, details="[simulate] Compiled conflicting trace-context fixture",
+                mcp_method="authorized fixture",
+                elapsed_s=round(time.monotonic() - t0, 3),
+            ))
+            return
+        if not getattr(self.transport, "is_modern", False):
+            details = "Not applicable: target selected a legacy MCP transport"
+        elif not getattr(self.transport, "supports_header_overrides", False):
+            details = "Not applicable: requires HTTP header overrides for trace-context validation"
+        elif not self.trace_probe or not self.trace_attacker_headers:
+            details = "Not applicable: requires an authorized read-only --trace-probe and --trace-attacker-header"
+        else:
+            probe = jsonrpc_request(
+                self.trace_probe["method"], dict(self.trace_probe.get("params") or {})
+            )
+            response = self.transport.send(probe, header_overrides=self.trace_attacker_headers)
+            rejected = _probe_failed(response)
+            self._record(MCPTestResult(
+                test_id="MCP-RC-011", name="Trace Context Request Binding",
+                category="trace_context_binding", owasp_asi="ASI02", severity=Severity.HIGH.value,
+                passed=rejected,
+                details=("Server rejected a request with conflicting trace context" if rejected
+                         else "Server accepted the authorized request with conflicting trace context"),
+                mcp_method=probe["method"],
+                request_sent={"body": probe, "trace_headers": self.trace_attacker_headers},
+                response_received=response, elapsed_s=round(time.monotonic() - t0, 3),
+            ))
+            return
+        self._record(MCPTestResult(
+            test_id="MCP-RC-011", name="Trace Context Request Binding",
+            category="trace_context_binding", owasp_asi="ASI02", severity=Severity.HIGH.value,
+            passed=True, details=details, mcp_method="authorized fixture",
+            elapsed_s=round(time.monotonic() - t0, 3),
         ))
 
     def test_mcp_tool_description_injection(self):
@@ -2826,6 +2878,7 @@ class MCPSecurityTests:
             "cache_security": [self.test_mcp_cache_scope_metadata, self.test_mcp_cache_revocation,
                                 self.test_mcp_resource_cache_metadata],
             "task_isolation": [self.test_mcp_task_cross_principal_isolation],
+            "trace_context_binding": [self.test_mcp_trace_context_request_binding],
             "capability_negotiation": [
                 self.test_mcp_capability_escalation,
                 self.test_mcp_protocol_version_downgrade,
@@ -3068,6 +3121,16 @@ def main():
         help="Alternate authorized test-principal header for task isolation, key:value.",
     )
     ap.add_argument(
+        "--trace-probe",
+        help=("Operator-authorized read-only JSON-RPC request for trace-context binding. "
+              "Must be used with --trace-attacker-header."),
+    )
+    ap.add_argument(
+        "--trace-attacker-header", action="append", default=[],
+        help=("Conflicting W3C trace-context header for the authorized trace probe, key:value. "
+              "For example Traceparent:00-..."),
+    )
+    ap.add_argument(
         "--protocol-version",
         choices=[MODERN_PROTOCOL_VERSION, AUTO_PROTOCOL_VERSION, DIFFERENTIAL_PROTOCOL_VERSION],
         help=("Use the stateless 2026-07-28 protocol flow, or 'auto' to probe "
@@ -3119,6 +3182,8 @@ def main():
     cache_invalidation = cache_verify = None
     task_create = task_read = None
     task_attacker_headers = {}
+    trace_probe = None
+    trace_attacker_headers = {}
     if args.mrtr_probe:
         try:
             mrtr_probe = json.loads(args.mrtr_probe)
@@ -3216,6 +3281,24 @@ def main():
         (task_create, task_read, task_attacker_headers)
     ):
         ap.error("--task-create, --task-read, and --task-attacker-header must be supplied together")
+    if args.trace_probe:
+        try:
+            trace_probe = json.loads(args.trace_probe)
+        except json.JSONDecodeError as exc:
+            ap.error(f"--trace-probe must be a JSON object: {exc.msg}")
+        if not isinstance(trace_probe, dict) or not isinstance(trace_probe.get("method"), str):
+            ap.error("--trace-probe must be a JSON object with a string 'method'")
+        if "params" in trace_probe and not isinstance(trace_probe["params"], dict):
+            ap.error("--trace-probe 'params' must be a JSON object")
+    for header in args.trace_attacker_header:
+        if ":" not in header:
+            ap.error("--trace-attacker-header must use key:value form")
+        key, value = header.split(":", 1)
+        if not key.strip():
+            ap.error("--trace-attacker-header must include a header name")
+        trace_attacker_headers[key.strip()] = value.strip()
+    if any((trace_probe, trace_attacker_headers)) and not all((trace_probe, trace_attacker_headers)):
+        ap.error("--trace-probe and --trace-attacker-header must be supplied together")
     for header in args.mrtr_attacker_header:
         if ":" not in header:
             ap.error("--mrtr-attacker-header must use key:value form")
@@ -3259,7 +3342,8 @@ def main():
                                      cache_invalidation=cache_invalidation, cache_verify=cache_verify,
                                      cache_forbidden_tool=args.cache_forbidden_tool,
                                      cache_resource_uri=args.cache_resource_uri, task_create=task_create,
-                                     task_read=task_read, task_attacker_headers=task_attacker_headers)
+                                     task_read=task_read, task_attacker_headers=task_attacker_headers,
+                                     trace_probe=trace_probe, trace_attacker_headers=trace_attacker_headers)
             try:
                 results = suite.run_all(categories=categories)
                 return build_report(
@@ -3302,7 +3386,8 @@ def main():
                                      cache_invalidation=cache_invalidation, cache_verify=cache_verify,
                                      cache_forbidden_tool=args.cache_forbidden_tool,
                                      cache_resource_uri=args.cache_resource_uri, task_create=task_create,
-                                     task_read=task_read, task_attacker_headers=task_attacker_headers)
+                                     task_read=task_read, task_attacker_headers=task_attacker_headers,
+                                     trace_probe=trace_probe, trace_attacker_headers=trace_attacker_headers)
             try:
                 return {"results": suite.run_all(categories=categories)}
             finally:
@@ -3330,7 +3415,8 @@ def main():
                                  cache_invalidation=cache_invalidation, cache_verify=cache_verify,
                                  cache_forbidden_tool=args.cache_forbidden_tool,
                                  cache_resource_uri=args.cache_resource_uri, task_create=task_create,
-                                 task_read=task_read, task_attacker_headers=task_attacker_headers)
+                                 task_read=task_read, task_attacker_headers=task_attacker_headers,
+                                 trace_probe=trace_probe, trace_attacker_headers=trace_attacker_headers)
         conn_error = None
         try:
             results = suite.run_all(categories=categories)

--- a/protocol_tests/mcp_harness.py
+++ b/protocol_tests/mcp_harness.py
@@ -121,6 +121,17 @@ def _replace_handle(value: object, handle: str) -> object:
     return value
 
 
+def _replace_task_id(value: object, task_id: str) -> object:
+    """Deep-copy JSON-compatible fixture data while replacing $TASK_ID tokens."""
+    if isinstance(value, str):
+        return value.replace("$TASK_ID", task_id)
+    if isinstance(value, list):
+        return [_replace_task_id(item, task_id) for item in value]
+    if isinstance(value, dict):
+        return {key: _replace_task_id(item, task_id) for key, item in value.items()}
+    return value
+
+
 # ---------------------------------------------------------------------------
 # MCP JSON-RPC 2.0 primitives
 # ---------------------------------------------------------------------------
@@ -269,6 +280,10 @@ class StreamableHTTPTransport(MCPTransport):
                 name = params.get("name", params.get("uri"))
                 if name is not None:
                     headers["Mcp-Name"] = _header_value(name)
+            elif message.get("method") in {"tasks/get", "tasks/update", "tasks/cancel"}:
+                task_id = params.get("taskId")
+                if task_id is not None:
+                    headers["Mcp-Name"] = _header_value(task_id)
         elif self.session_id:
             headers["Mcp-Session-Id"] = self.session_id
         return headers
@@ -465,6 +480,9 @@ class MCPSecurityTests:
         cache_verify: dict | None = None,
         cache_forbidden_tool: str | None = None,
         cache_resource_uri: str | None = None,
+        task_create: dict | None = None,
+        task_read: dict | None = None,
+        task_attacker_headers: dict | None = None,
     ):
         self.transport = transport
         self.results: list[MCPTestResult] = []
@@ -483,6 +501,9 @@ class MCPSecurityTests:
         self.cache_verify = cache_verify
         self.cache_forbidden_tool = cache_forbidden_tool
         self.cache_resource_uri = cache_resource_uri
+        self.task_create = task_create
+        self.task_read = task_read
+        self.task_attacker_headers = task_attacker_headers
         self.selected_protocol_version: str | None = None
 
     def _record(self, result: MCPTestResult):
@@ -1183,6 +1204,89 @@ class MCPSecurityTests:
             elapsed_s=round(time.monotonic() - t0, 3),
         ))
 
+    def test_mcp_task_cross_principal_isolation(self):
+        """MCP-RC-010: a durable task handle must not cross principals.
+
+        The 2026-07-28-RC Tasks extension requires authentication and
+        authorization checks on every task request. This opt-in probe creates
+        only an operator-authorized task, then attempts a read under a distinct
+        authorized test principal. It never cancels or supplies task input.
+        """
+        t0 = time.monotonic()
+        if self.simulate:
+            self._record(MCPTestResult(
+                test_id="MCP-RC-010", name="Task Cross-Principal Isolation",
+                category="task_isolation", owasp_asi="ASI02", severity=Severity.HIGH.value,
+                passed=True, details="[simulate] Compiled cross-principal task-handle vector",
+                mcp_method="tasks/get", elapsed_s=round(time.monotonic() - t0, 3),
+            ))
+            return
+        if not getattr(self.transport, "is_modern", False):
+            self._record(MCPTestResult(
+                test_id="MCP-RC-010", name="Task Cross-Principal Isolation",
+                category="task_isolation", owasp_asi="ASI02", severity=Severity.HIGH.value,
+                passed=True, details="Not applicable: target selected a legacy MCP transport",
+                mcp_method="tasks/get", elapsed_s=round(time.monotonic() - t0, 3),
+            ))
+            return
+        if not getattr(self.transport, "supports_header_overrides", False):
+            self._record(MCPTestResult(
+                test_id="MCP-RC-010", name="Task Cross-Principal Isolation",
+                category="task_isolation", owasp_asi="ASI02", severity=Severity.HIGH.value,
+                passed=True, details="Not applicable: requires HTTP header overrides for an alternate principal",
+                mcp_method="tasks/get", elapsed_s=round(time.monotonic() - t0, 3),
+            ))
+            return
+        if not self.task_create or not self.task_read or not self.task_attacker_headers:
+            self._record(MCPTestResult(
+                test_id="MCP-RC-010", name="Task Cross-Principal Isolation",
+                category="task_isolation", owasp_asi="ASI02", severity=Severity.HIGH.value,
+                passed=True,
+                details=("Not applicable: requires authorized task-create/read fixtures and "
+                         "--task-attacker-header"),
+                mcp_method="tasks/get", elapsed_s=round(time.monotonic() - t0, 3),
+            ))
+            return
+
+        create = jsonrpc_request(self.task_create["method"], dict(self.task_create.get("params") or {}))
+        created = self.transport.send(create)
+        if _probe_failed(created):
+            self._record(MCPTestResult(
+                test_id="MCP-RC-010", name="Task Cross-Principal Isolation",
+                category="task_isolation", owasp_asi="ASI02", severity=Severity.HIGH.value,
+                passed=False, details="Configured task-create fixture failed before isolation validation",
+                mcp_method=create["method"], request_sent=create, response_received=created,
+                elapsed_s=round(time.monotonic() - t0, 3),
+            ))
+            return
+        task_id = _json_path(created, self.task_create.get("taskIdPath", "result.taskId"))
+        if not isinstance(task_id, str) or not task_id:
+            self._record(MCPTestResult(
+                test_id="MCP-RC-010", name="Task Cross-Principal Isolation",
+                category="task_isolation", owasp_asi="ASI02", severity=Severity.HIGH.value,
+                passed=True,
+                details="Not applicable: create fixture did not return a string task ID at taskIdPath",
+                mcp_method=create["method"], request_sent=create, response_received=created,
+                elapsed_s=round(time.monotonic() - t0, 3),
+            ))
+            return
+        read = jsonrpc_request(
+            self.task_read["method"],
+            _replace_task_id(dict(self.task_read.get("params") or {}), task_id),
+        )
+        response = self.transport.send(read, header_overrides=self.task_attacker_headers)
+        rejected = _probe_failed(response)
+        self._record(MCPTestResult(
+            test_id="MCP-RC-010", name="Task Cross-Principal Isolation",
+            category="task_isolation", owasp_asi="ASI02", severity=Severity.HIGH.value,
+            passed=rejected,
+            details=("Server rejected task access by a different principal" if rejected
+                     else "Server accepted task access by a different principal"),
+            mcp_method=read["method"],
+            request_sent={"create": create, "cross_principal_read": read},
+            response_received=response, elapsed_s=round(time.monotonic() - t0, 3),
+        ))
+
     def test_mcp_tool_description_injection(self):
         """MCP-002: Attempt to register a tool with malicious description via tool call."""
         t0 = time.monotonic()
@@ -1645,15 +1749,11 @@ class MCPSecurityTests:
             ))
             return
 
-        resp_bytes = self.transport.send_raw(batch_json, mcp_method="tools/list")
+        self.transport.send_raw(batch_json, mcp_method="tools/list")
         elapsed = time.monotonic() - t0
 
         # Pass if server either rejected (4xx) or responded within reasonable time
         passed = elapsed < 10.0  # Should handle within 10 seconds
-
-        resp_preview = ""
-        if resp_bytes:
-            resp_preview = resp_bytes[:200].decode("utf-8", errors="replace")
 
         self._record(MCPTestResult(
             test_id="MCP-009",
@@ -2725,6 +2825,7 @@ class MCPSecurityTests:
             "explicit_handle_isolation": [self.test_mcp_explicit_handle_isolation],
             "cache_security": [self.test_mcp_cache_scope_metadata, self.test_mcp_cache_revocation,
                                 self.test_mcp_resource_cache_metadata],
+            "task_isolation": [self.test_mcp_task_cross_principal_isolation],
             "capability_negotiation": [
                 self.test_mcp_capability_escalation,
                 self.test_mcp_protocol_version_downgrade,
@@ -2796,7 +2897,8 @@ class MCPSecurityTests:
                 try:
                     test_fn()
                 except Exception as e:
-                    _eid = re.search(r"([A-Z]{2,}-\d{3})", test_fn.__doc__ or "") ; _eid = _eid.group(1) if _eid else test_fn.__name__
+                    match = re.search(r"([A-Z]{2,}-\d{3})", test_fn.__doc__ or "")
+                    _eid = match.group(1) if match else test_fn.__name__
                     if not self.json_output:
                         print(f"  ERROR ⚠️  {_eid}: {e}")
                     self.results.append(MCPTestResult(
@@ -2952,6 +3054,20 @@ def main():
     ap.add_argument("--cache-forbidden-tool", help="Tool name that must be absent after --cache-invalidation.")
     ap.add_argument("--cache-resource-uri", help="Operator-authorized resource URI for the read-only cache-metadata probe.")
     ap.add_argument(
+        "--task-create",
+        help=("Authorized JSON-RPC request that creates a harmless task. Include optional "
+              "taskIdPath (default result.taskId) for the returned durable task handle."),
+    )
+    ap.add_argument(
+        "--task-read",
+        help=("Read-only JSON-RPC request for that task. Use $TASK_ID in params as the "
+              "created task-handle placeholder (for example tasks/get with taskId)."),
+    )
+    ap.add_argument(
+        "--task-attacker-header", action="append", default=[],
+        help="Alternate authorized test-principal header for task isolation, key:value.",
+    )
+    ap.add_argument(
         "--protocol-version",
         choices=[MODERN_PROTOCOL_VERSION, AUTO_PROTOCOL_VERSION, DIFFERENTIAL_PROTOCOL_VERSION],
         help=("Use the stateless 2026-07-28 protocol flow, or 'auto' to probe "
@@ -3001,6 +3117,8 @@ def main():
     handle_create = handle_access = None
     handle_attacker_headers = {}
     cache_invalidation = cache_verify = None
+    task_create = task_read = None
+    task_attacker_headers = {}
     if args.mrtr_probe:
         try:
             mrtr_probe = json.loads(args.mrtr_probe)
@@ -3073,6 +3191,31 @@ def main():
         (cache_invalidation, cache_verify, args.cache_forbidden_tool)
     ):
         ap.error("--cache-invalidation, --cache-verify, and --cache-forbidden-tool must be supplied together")
+    for option, raw in (("--task-create", args.task_create), ("--task-read", args.task_read)):
+        if raw:
+            try:
+                parsed = json.loads(raw)
+            except json.JSONDecodeError as exc:
+                ap.error(f"{option} must be a JSON object: {exc.msg}")
+            if not isinstance(parsed, dict) or not isinstance(parsed.get("method"), str):
+                ap.error(f"{option} must be a JSON object with a string 'method'")
+            if "params" in parsed and not isinstance(parsed["params"], dict):
+                ap.error(f"{option} 'params' must be a JSON object")
+            if option == "--task-create":
+                task_create = parsed
+            else:
+                task_read = parsed
+    for header in args.task_attacker_header:
+        if ":" not in header:
+            ap.error("--task-attacker-header must use key:value form")
+        key, value = header.split(":", 1)
+        if not key.strip():
+            ap.error("--task-attacker-header must include a header name")
+        task_attacker_headers[key.strip()] = value.strip()
+    if any((task_create, task_read, task_attacker_headers)) and not all(
+        (task_create, task_read, task_attacker_headers)
+    ):
+        ap.error("--task-create, --task-read, and --task-attacker-header must be supplied together")
     for header in args.mrtr_attacker_header:
         if ":" not in header:
             ap.error("--mrtr-attacker-header must use key:value form")
@@ -3115,7 +3258,8 @@ def main():
                                      handle_access=handle_access, handle_attacker_headers=handle_attacker_headers,
                                      cache_invalidation=cache_invalidation, cache_verify=cache_verify,
                                      cache_forbidden_tool=args.cache_forbidden_tool,
-                                     cache_resource_uri=args.cache_resource_uri)
+                                     cache_resource_uri=args.cache_resource_uri, task_create=task_create,
+                                     task_read=task_read, task_attacker_headers=task_attacker_headers)
             try:
                 results = suite.run_all(categories=categories)
                 return build_report(
@@ -3157,7 +3301,8 @@ def main():
                                      handle_access=handle_access, handle_attacker_headers=handle_attacker_headers,
                                      cache_invalidation=cache_invalidation, cache_verify=cache_verify,
                                      cache_forbidden_tool=args.cache_forbidden_tool,
-                                     cache_resource_uri=args.cache_resource_uri)
+                                     cache_resource_uri=args.cache_resource_uri, task_create=task_create,
+                                     task_read=task_read, task_attacker_headers=task_attacker_headers)
             try:
                 return {"results": suite.run_all(categories=categories)}
             finally:
@@ -3184,7 +3329,8 @@ def main():
                                  handle_access=handle_access, handle_attacker_headers=handle_attacker_headers,
                                  cache_invalidation=cache_invalidation, cache_verify=cache_verify,
                                  cache_forbidden_tool=args.cache_forbidden_tool,
-                                 cache_resource_uri=args.cache_resource_uri)
+                                 cache_resource_uri=args.cache_resource_uri, task_create=task_create,
+                                 task_read=task_read, task_attacker_headers=task_attacker_headers)
         conn_error = None
         try:
             results = suite.run_all(categories=categories)

--- a/protocol_tests/mcp_harness.py
+++ b/protocol_tests/mcp_harness.py
@@ -132,6 +132,15 @@ def _replace_task_id(value: object, task_id: str) -> object:
     return value
 
 
+def _redact_sensitive_headers(headers: dict[str, str]) -> dict[str, str]:
+    """Keep credential-bearing probe headers out of evidence records."""
+    sensitive = {"authorization", "cookie", "proxy-authorization"}
+    return {
+        key: "[REDACTED]" if key.lower() in sensitive else value
+        for key, value in headers.items()
+    }
+
+
 # ---------------------------------------------------------------------------
 # MCP JSON-RPC 2.0 primitives
 # ---------------------------------------------------------------------------
@@ -485,6 +494,8 @@ class MCPSecurityTests:
         task_attacker_headers: dict | None = None,
         trace_probe: dict | None = None,
         trace_attacker_headers: dict | None = None,
+        issuer_probe: dict | None = None,
+        issuer_attacker_headers: dict | None = None,
     ):
         self.transport = transport
         self.results: list[MCPTestResult] = []
@@ -508,6 +519,8 @@ class MCPSecurityTests:
         self.task_attacker_headers = task_attacker_headers
         self.trace_probe = trace_probe
         self.trace_attacker_headers = trace_attacker_headers
+        self.issuer_probe = issuer_probe
+        self.issuer_attacker_headers = issuer_attacker_headers
         self.selected_protocol_version: str | None = None
 
     def _record(self, result: MCPTestResult):
@@ -1335,6 +1348,52 @@ class MCPSecurityTests:
         self._record(MCPTestResult(
             test_id="MCP-RC-011", name="Trace Context Request Binding",
             category="trace_context_binding", owasp_asi="ASI02", severity=Severity.HIGH.value,
+            passed=True, details=details, mcp_method="authorized fixture",
+            elapsed_s=round(time.monotonic() - t0, 3),
+        ))
+
+    def test_mcp_oauth_issuer_binding(self):
+        """MCP-RC-012: an authorized fixture must reject a credential from another issuer.
+
+        This opt-in probe requires two operator-authorized test credentials with
+        distinct issuers. It exercises only a read-only JSON-RPC fixture and does
+        not infer token validation behavior beyond the observed target boundary.
+        Credential-bearing headers are redacted from the evidence record.
+        """
+        t0 = time.monotonic()
+        if self.simulate:
+            self._record(MCPTestResult(
+                test_id="MCP-RC-012", name="OAuth Issuer Request Binding",
+                category="oauth_issuer_binding", owasp_asi="ASI02", severity=Severity.HIGH.value,
+                passed=True, details="[simulate] Compiled alternate-issuer authorized-fixture vector",
+                mcp_method="authorized fixture", elapsed_s=round(time.monotonic() - t0, 3),
+            ))
+            return
+        if not getattr(self.transport, "supports_header_overrides", False):
+            details = "Not applicable: requires HTTP header overrides for an alternate issuer credential"
+        elif not self.issuer_probe or not self.issuer_attacker_headers:
+            details = ("Not applicable: requires an authorized read-only --issuer-probe and "
+                       "--issuer-attacker-header")
+        else:
+            probe = jsonrpc_request(
+                self.issuer_probe["method"], dict(self.issuer_probe.get("params") or {})
+            )
+            response = self.transport.send(probe, header_overrides=self.issuer_attacker_headers)
+            rejected = _probe_failed(response)
+            self._record(MCPTestResult(
+                test_id="MCP-RC-012", name="OAuth Issuer Request Binding",
+                category="oauth_issuer_binding", owasp_asi="ASI02", severity=Severity.HIGH.value,
+                passed=rejected,
+                details=("Server rejected the authorized fixture under an alternate issuer credential" if rejected
+                         else "Server accepted the authorized fixture under an alternate issuer credential"),
+                mcp_method=probe["method"],
+                request_sent={"body": probe, "alternate_issuer_headers": _redact_sensitive_headers(self.issuer_attacker_headers)},
+                response_received=response, elapsed_s=round(time.monotonic() - t0, 3),
+            ))
+            return
+        self._record(MCPTestResult(
+            test_id="MCP-RC-012", name="OAuth Issuer Request Binding",
+            category="oauth_issuer_binding", owasp_asi="ASI02", severity=Severity.HIGH.value,
             passed=True, details=details, mcp_method="authorized fixture",
             elapsed_s=round(time.monotonic() - t0, 3),
         ))
@@ -2879,6 +2938,7 @@ class MCPSecurityTests:
                                 self.test_mcp_resource_cache_metadata],
             "task_isolation": [self.test_mcp_task_cross_principal_isolation],
             "trace_context_binding": [self.test_mcp_trace_context_request_binding],
+            "oauth_issuer_binding": [self.test_mcp_oauth_issuer_binding],
             "capability_negotiation": [
                 self.test_mcp_capability_escalation,
                 self.test_mcp_protocol_version_downgrade,
@@ -3131,6 +3191,16 @@ def main():
               "For example Traceparent:00-..."),
     )
     ap.add_argument(
+        "--issuer-probe",
+        help=("Operator-authorized read-only JSON-RPC request for OAuth issuer binding. "
+              "Must be used with --issuer-attacker-header."),
+    )
+    ap.add_argument(
+        "--issuer-attacker-header", action="append", default=[],
+        help=("Credential/header override from a distinct, operator-authorized test issuer, key:value. "
+              "It is redacted from reports."),
+    )
+    ap.add_argument(
         "--protocol-version",
         choices=[MODERN_PROTOCOL_VERSION, AUTO_PROTOCOL_VERSION, DIFFERENTIAL_PROTOCOL_VERSION],
         help=("Use the stateless 2026-07-28 protocol flow, or 'auto' to probe "
@@ -3184,6 +3254,8 @@ def main():
     task_attacker_headers = {}
     trace_probe = None
     trace_attacker_headers = {}
+    issuer_probe = None
+    issuer_attacker_headers = {}
     if args.mrtr_probe:
         try:
             mrtr_probe = json.loads(args.mrtr_probe)
@@ -3299,6 +3371,24 @@ def main():
         trace_attacker_headers[key.strip()] = value.strip()
     if any((trace_probe, trace_attacker_headers)) and not all((trace_probe, trace_attacker_headers)):
         ap.error("--trace-probe and --trace-attacker-header must be supplied together")
+    if args.issuer_probe:
+        try:
+            issuer_probe = json.loads(args.issuer_probe)
+        except json.JSONDecodeError as exc:
+            ap.error(f"--issuer-probe must be a JSON object: {exc.msg}")
+        if not isinstance(issuer_probe, dict) or not isinstance(issuer_probe.get("method"), str):
+            ap.error("--issuer-probe must be a JSON object with a string 'method'")
+        if "params" in issuer_probe and not isinstance(issuer_probe["params"], dict):
+            ap.error("--issuer-probe 'params' must be a JSON object")
+    for header in args.issuer_attacker_header:
+        if ":" not in header:
+            ap.error("--issuer-attacker-header must use key:value form")
+        key, value = header.split(":", 1)
+        if not key.strip():
+            ap.error("--issuer-attacker-header must include a header name")
+        issuer_attacker_headers[key.strip()] = value.strip()
+    if any((issuer_probe, issuer_attacker_headers)) and not all((issuer_probe, issuer_attacker_headers)):
+        ap.error("--issuer-probe and --issuer-attacker-header must be supplied together")
     for header in args.mrtr_attacker_header:
         if ":" not in header:
             ap.error("--mrtr-attacker-header must use key:value form")
@@ -3343,7 +3433,8 @@ def main():
                                      cache_forbidden_tool=args.cache_forbidden_tool,
                                      cache_resource_uri=args.cache_resource_uri, task_create=task_create,
                                      task_read=task_read, task_attacker_headers=task_attacker_headers,
-                                     trace_probe=trace_probe, trace_attacker_headers=trace_attacker_headers)
+                                     trace_probe=trace_probe, trace_attacker_headers=trace_attacker_headers,
+                                     issuer_probe=issuer_probe, issuer_attacker_headers=issuer_attacker_headers)
             try:
                 results = suite.run_all(categories=categories)
                 return build_report(
@@ -3387,7 +3478,8 @@ def main():
                                      cache_forbidden_tool=args.cache_forbidden_tool,
                                      cache_resource_uri=args.cache_resource_uri, task_create=task_create,
                                      task_read=task_read, task_attacker_headers=task_attacker_headers,
-                                     trace_probe=trace_probe, trace_attacker_headers=trace_attacker_headers)
+                                     trace_probe=trace_probe, trace_attacker_headers=trace_attacker_headers,
+                                     issuer_probe=issuer_probe, issuer_attacker_headers=issuer_attacker_headers)
             try:
                 return {"results": suite.run_all(categories=categories)}
             finally:
@@ -3416,7 +3508,8 @@ def main():
                                  cache_forbidden_tool=args.cache_forbidden_tool,
                                  cache_resource_uri=args.cache_resource_uri, task_create=task_create,
                                  task_read=task_read, task_attacker_headers=task_attacker_headers,
-                                 trace_probe=trace_probe, trace_attacker_headers=trace_attacker_headers)
+                                 trace_probe=trace_probe, trace_attacker_headers=trace_attacker_headers,
+                                 issuer_probe=issuer_probe, issuer_attacker_headers=issuer_attacker_headers)
         conn_error = None
         try:
             results = suite.run_all(categories=categories)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "agent-security-harness"
 version = "4.9.1"
-description = "562 security tests for AI agent systems - MCP, A2A, L402, x402, UCP/ACP merchant-journey, AP2 mandate + Fireblocks x402 hardening + Visa TAP / Mastercard Agentic Tokens + denial-of-settlement finality, decision governance, AIUC-1 compliance, NIST AI 800-2 aligned"
+description = "563 security tests for AI agent systems - MCP, A2A, L402, x402, UCP/ACP merchant-journey, AP2 mandate + Fireblocks x402 hardening + Visa TAP / Mastercard Agentic Tokens + denial-of-settlement finality, decision governance, AIUC-1 compliance, NIST AI 800-2 aligned"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {text = "Apache-2.0"}
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "agent-security-harness"
 version = "4.9.1"
-description = "564 security tests for AI agent systems - MCP, A2A, L402, x402, UCP/ACP merchant-journey, AP2 mandate + Fireblocks x402 hardening + Visa TAP / Mastercard Agentic Tokens + denial-of-settlement finality, decision governance, AIUC-1 compliance, NIST AI 800-2 aligned"
+description = "565 security tests for AI agent systems - MCP, A2A, L402, x402, UCP/ACP merchant-journey, AP2 mandate + Fireblocks x402 hardening + Visa TAP / Mastercard Agentic Tokens + denial-of-settlement finality, decision governance, AIUC-1 compliance, NIST AI 800-2 aligned"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {text = "Apache-2.0"}
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "agent-security-harness"
 version = "4.9.1"
-description = "563 security tests for AI agent systems - MCP, A2A, L402, x402, UCP/ACP merchant-journey, AP2 mandate + Fireblocks x402 hardening + Visa TAP / Mastercard Agentic Tokens + denial-of-settlement finality, decision governance, AIUC-1 compliance, NIST AI 800-2 aligned"
+description = "564 security tests for AI agent systems - MCP, A2A, L402, x402, UCP/ACP merchant-journey, AP2 mandate + Fireblocks x402 hardening + Visa TAP / Mastercard Agentic Tokens + denial-of-settlement finality, decision governance, AIUC-1 compliance, NIST AI 800-2 aligned"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {text = "Apache-2.0"}
 requires-python = ">=3.10"

--- a/testing/mock_mcp_server.py
+++ b/testing/mock_mcp_server.py
@@ -13,7 +13,7 @@ import json
 import http.server
 import socketserver
 import sys
-from typing import Dict, Any, Optional
+from typing import Any, Dict
 
 
 class MockMCPHandler(http.server.BaseHTTPRequestHandler):
@@ -260,6 +260,12 @@ class MockMCPHandler(http.server.BaseHTTPRequestHandler):
         print(f"[{self.address_string()}] {format % args}")
 
 
+class ReusableTCPServer(socketserver.TCPServer):
+    """Permit the integration fixture to restart without a TIME_WAIT delay."""
+
+    allow_reuse_address = True
+
+
 def run_server(port: int = 8402):
     """Run the mock MCP server"""
     print(f"Starting Mock MCP Server on http://localhost:{port}")
@@ -268,7 +274,7 @@ def run_server(port: int = 8402):
     print("Press Ctrl+C to stop")
     print()
     
-    with socketserver.TCPServer(("localhost", port), MockMCPHandler) as httpd:
+    with ReusableTCPServer(("localhost", port), MockMCPHandler) as httpd:
         try:
             httpd.serve_forever()
         except KeyboardInterrupt:

--- a/testing/test_transport.py
+++ b/testing/test_transport.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 """Unit tests for MCP transport and JSON-RPC primitives."""
-import json, os, sys, unittest
+import json
+import os
+import sys
+import unittest
 from unittest.mock import MagicMock, patch
-from unittest.mock import patch
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from protocol_tests.mcp_harness import (
     AUTO_PROTOCOL_VERSION,
@@ -12,6 +14,7 @@ from protocol_tests.mcp_harness import (
     MCPSecurityTests,
     _json_path,
     _replace_handle,
+    _replace_task_id,
     MCPTransport,
     report_has_failure,
     StreamableHTTPTransport,
@@ -24,7 +27,9 @@ from protocol_tests.mcp_harness import (
 class TestJSONRPCRequest(unittest.TestCase):
     def test_structure(self):
         msg = jsonrpc_request("tools/list")
-        self.assertEqual(msg["jsonrpc"], "2.0"); self.assertEqual(msg["method"], "tools/list"); self.assertIn("id", msg)
+        self.assertEqual(msg["jsonrpc"], "2.0")
+        self.assertEqual(msg["method"], "tools/list")
+        self.assertIn("id", msg)
     def test_params(self): self.assertEqual(jsonrpc_request("x", {"k":"v"})["params"], {"k":"v"})
     def test_custom_id(self): self.assertEqual(jsonrpc_request("x", id="abc")["id"], "abc")
     def test_none_params(self): self.assertNotIn("params", jsonrpc_request("x", params=None))
@@ -38,11 +43,13 @@ class TestJSONRPCNotification(unittest.TestCase):
 
 class TestTransport(unittest.TestCase):
     def test_send_not_impl(self):
-        with self.assertRaises(NotImplementedError): MCPTransport().send({})
+        with self.assertRaises(NotImplementedError):
+            MCPTransport().send({})
     def test_close_noop(self): MCPTransport().close()
     def test_http_init(self):
         t = StreamableHTTPTransport("http://localhost:8080")
-        self.assertEqual(t.url, "http://localhost:8080"); self.assertIsNone(t.session_id)
+        self.assertEqual(t.url, "http://localhost:8080")
+        self.assertIsNone(t.session_id)
 
     def test_modern_request_metadata_and_headers(self):
         t = StreamableHTTPTransport("http://localhost:8080", protocol_version=MODERN_PROTOCOL_VERSION)
@@ -59,6 +66,13 @@ class TestTransport(unittest.TestCase):
         t = StreamableHTTPTransport("http://localhost:8080", protocol_version=MODERN_PROTOCOL_VERSION)
         request = t._prepare_modern_message(jsonrpc_request("resources/read", {"uri": "file:///你好"}))
         self.assertTrue(t._request_headers(request)["Mcp-Name"].startswith("=?base64?"))
+
+    def test_modern_task_id_is_mirrored_as_routing_name(self):
+        t = StreamableHTTPTransport("http://localhost:8080", protocol_version=MODERN_PROTOCOL_VERSION)
+        request = t._prepare_modern_message(jsonrpc_request("tasks/get", {"taskId": "tenant-a/task-42"}))
+        headers = t._request_headers(request)
+        self.assertEqual(headers["Mcp-Method"], "tasks/get")
+        self.assertEqual(headers["Mcp-Name"], "tenant-a/task-42")
 
     def test_header_value_encodes_unsafe_values(self):
         self.assertEqual(_header_value("safe-value"), "safe-value")
@@ -319,6 +333,72 @@ class TestExplicitHandleIsolation(unittest.TestCase):
         self.assertEqual(transport.calls[1][1]["header_overrides"], {"Authorization": "Bearer tenant-b"})
         self.assertEqual(_json_path({"a": {"b": 1}}, "a.b"), 1)
         self.assertEqual(_replace_handle({"x": ["$HANDLE"]}, "h"), {"x": ["h"]})
+
+
+class TestTaskIsolation(unittest.TestCase):
+    def test_failed_task_create_is_not_marked_not_applicable(self):
+        class FailingTaskTransport(MCPTransport):
+            is_modern = True
+            supports_header_overrides = True
+
+            def send(self, message, **kwargs):
+                return {"error": {"code": -32000, "message": "task create failed"}}
+
+        suite = MCPSecurityTests(
+            FailingTaskTransport(), json_output=True,
+            task_create={"method": "tools/call", "params": {"name": "create_test_task"}},
+            task_read={"method": "tasks/get", "params": {"taskId": "$TASK_ID"}},
+            task_attacker_headers={"Authorization": "Bearer tenant-b"},
+        )
+        suite.test_mcp_task_cross_principal_isolation()
+        self.assertFalse(suite.results[0].passed)
+        self.assertIn("failed", suite.results[0].details)
+
+    def test_cross_principal_task_read_is_rejected_and_task_id_is_replaced(self):
+        class TaskTransport(MCPTransport):
+            is_modern = True
+            supports_header_overrides = True
+
+            def __init__(self):
+                self.calls = []
+
+            def send(self, message, **kwargs):
+                self.calls.append((message, kwargs))
+                if len(self.calls) == 1:
+                    return {"result": {"taskId": "tenant-a-task"}}
+                return {"error": {"code": -32001, "message": "task not authorized"}}
+
+        transport = TaskTransport()
+        suite = MCPSecurityTests(
+            transport, json_output=True,
+            task_create={"method": "tools/call", "params": {"name": "create_test_task"}},
+            task_read={"method": "tasks/get", "params": {"taskId": "$TASK_ID"}},
+            task_attacker_headers={"Authorization": "Bearer tenant-b"},
+        )
+        suite.test_mcp_task_cross_principal_isolation()
+        self.assertTrue(suite.results[0].passed)
+        self.assertEqual(transport.calls[1][0]["params"]["taskId"], "tenant-a-task")
+        self.assertEqual(transport.calls[1][1]["header_overrides"], {"Authorization": "Bearer tenant-b"})
+        self.assertEqual(_replace_task_id({"task": "$TASK_ID"}, "task-1"), {"task": "task-1"})
+
+    def test_cross_principal_task_read_that_succeeds_fails(self):
+        class LeakyTaskTransport(MCPTransport):
+            is_modern = True
+            supports_header_overrides = True
+
+            def send(self, message, **kwargs):
+                if message["method"] == "tools/call":
+                    return {"result": {"taskId": "tenant-a-task"}}
+                return {"result": {"taskId": "tenant-a-task", "status": "working"}}
+
+        suite = MCPSecurityTests(
+            LeakyTaskTransport(), json_output=True,
+            task_create={"method": "tools/call", "params": {"name": "create_test_task"}},
+            task_read={"method": "tasks/get", "params": {"taskId": "$TASK_ID"}},
+            task_attacker_headers={"Authorization": "Bearer tenant-b"},
+        )
+        suite.test_mcp_task_cross_principal_isolation()
+        self.assertFalse(suite.results[0].passed)
 
 
 class TestCacheScopeMetadata(unittest.TestCase):

--- a/testing/test_transport.py
+++ b/testing/test_transport.py
@@ -401,6 +401,47 @@ class TestTaskIsolation(unittest.TestCase):
         self.assertFalse(suite.results[0].passed)
 
 
+class TestTraceContextBinding(unittest.TestCase):
+    def test_conflicting_trace_context_is_rejected(self):
+        class TraceTransport(MCPTransport):
+            is_modern = True
+            supports_header_overrides = True
+
+            def __init__(self):
+                self.calls = []
+
+            def send(self, message, **kwargs):
+                self.calls.append((message, kwargs))
+                return {"error": {"code": -32001, "message": "trace context mismatch"}}
+
+        transport = TraceTransport()
+        trace_header = {"Traceparent": "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01"}
+        suite = MCPSecurityTests(
+            transport, json_output=True,
+            trace_probe={"method": "tools/list", "params": {}},
+            trace_attacker_headers=trace_header,
+        )
+        suite.test_mcp_trace_context_request_binding()
+        self.assertTrue(suite.results[0].passed)
+        self.assertEqual(transport.calls[0][1]["header_overrides"], trace_header)
+
+    def test_trace_probe_success_is_a_failure(self):
+        class LeakyTraceTransport(MCPTransport):
+            is_modern = True
+            supports_header_overrides = True
+
+            def send(self, message, **kwargs):
+                return {"result": {"tools": []}}
+
+        suite = MCPSecurityTests(
+            LeakyTraceTransport(), json_output=True,
+            trace_probe={"method": "tools/list", "params": {}},
+            trace_attacker_headers={"Traceparent": "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01"},
+        )
+        suite.test_mcp_trace_context_request_binding()
+        self.assertFalse(suite.results[0].passed)
+
+
 class TestCacheScopeMetadata(unittest.TestCase):
     def test_modern_listing_requires_scope_and_ttl(self):
         class CacheTransport(MCPTransport):

--- a/testing/test_transport.py
+++ b/testing/test_transport.py
@@ -442,6 +442,54 @@ class TestTraceContextBinding(unittest.TestCase):
         self.assertFalse(suite.results[0].passed)
 
 
+class TestOAuthIssuerBinding(unittest.TestCase):
+    def test_alternate_issuer_is_rejected_and_credential_is_redacted(self):
+        class IssuerTransport(MCPTransport):
+            supports_header_overrides = True
+
+            def __init__(self):
+                self.calls = []
+
+            def send(self, message, **kwargs):
+                self.calls.append((message, kwargs))
+                return {"error": {"code": -32001, "message": "issuer mismatch"}}
+
+        transport = IssuerTransport()
+        headers = {"Authorization": "Bearer synthetic-other-issuer", "X-Test-Issuer": "issuer-b"}
+        suite = MCPSecurityTests(
+            transport, json_output=True,
+            issuer_probe={"method": "tools/list", "params": {}},
+            issuer_attacker_headers=headers,
+        )
+        suite.test_mcp_oauth_issuer_binding()
+        self.assertTrue(suite.results[0].passed)
+        self.assertEqual(transport.calls[0][1]["header_overrides"], headers)
+        evidence_headers = suite.results[0].request_sent["alternate_issuer_headers"]
+        self.assertEqual(evidence_headers["Authorization"], "[REDACTED]")
+        self.assertEqual(evidence_headers["X-Test-Issuer"], "issuer-b")
+
+    def test_alternate_issuer_acceptance_is_a_failure(self):
+        class LeakyIssuerTransport(MCPTransport):
+            supports_header_overrides = True
+
+            def send(self, message, **kwargs):
+                return {"result": {"tools": []}}
+
+        suite = MCPSecurityTests(
+            LeakyIssuerTransport(), json_output=True,
+            issuer_probe={"method": "tools/list", "params": {}},
+            issuer_attacker_headers={"Authorization": "Bearer synthetic-other-issuer"},
+        )
+        suite.test_mcp_oauth_issuer_binding()
+        self.assertFalse(suite.results[0].passed)
+
+    def test_missing_authorized_fixture_is_not_applicable(self):
+        suite = MCPSecurityTests(MCPTransport(), json_output=True)
+        suite.test_mcp_oauth_issuer_binding()
+        self.assertTrue(suite.results[0].passed)
+        self.assertIn("Not applicable", suite.results[0].details)
+
+
 class TestCacheScopeMetadata(unittest.TestCase):
     def test_modern_listing_requires_scope_and_ttl(self):
         class CacheTransport(MCPTransport):


### PR DESCRIPTION
## Summary
- adds opt-in MCP-RC-011 to detect an authorized read-only JSON-RPC fixture accepted under conflicting W3C trace context
- keeps the probe scoped to explicitly supplied fixtures and avoids claiming legacy/modern equivalence
- updates verified test inventory to 564

## Validation
- `python3 -m unittest testing.test_transport` (39 passed)
- `python3 -m protocol_tests.mcp_harness --simulate --categories trace_context_binding --json`
- `ruff check protocol_tests/mcp_harness.py testing/test_transport.py`
- `python3 scripts/count_tests.py` (564 unique IDs)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New probes exercise cross-principal access and credential/header overrides on live endpoints; behavior is opt-in and credentials are redacted in reports, but misconfigured fixtures could still send real tokens to targets.
> 
> **Overview**
> Expands the **MCP protocol harness** with three operator-configured security probes aligned to modern MCP routing and auth boundaries: **MCP-RC-010** (durable task handles must not be readable under a different principal), **MCP-RC-011** (authorized read-only fixtures must fail when replayed with conflicting W3C trace context), and **MCP-RC-012** (same fixture must reject credentials from an alternate issuer, with **Authorization/Cookie redacted** in evidence).
> 
> Wires new categories into the suite runner and adds matching **CLI flags** (`--task-*`, `--trace-*`, `--issuer-*`) with paired-fixture validation. **Modern transport** now mirrors `taskId` into `Mcp-Name` for `tasks/get|update|cancel`, and helpers add `$TASK_ID` substitution plus sensitive-header redaction.
> 
> **README**, **TEST-INVENTORY**, and **pyproject** descriptions update MCP coverage to **31 tests** and total harness count to **565**; **mock MCP server** uses `allow_reuse_address` for faster fixture restarts; **unit tests** cover the new probe pass/fail and N/A paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3293513511166e3cb7d907da71475f29368d5e43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->