### PR TITLE
fix(mcp): configure HTTP bind settings on FastMCP construction

### DIFF
--- a/mcp_server/__main__.py
+++ b/mcp_server/__main__.py
@@ -64,8 +64,8 @@ def main() -> None:
             file=sys.stderr,
         )
 
-    server = create_server(api_key=args.api_key)
-    run_server(server, transport=args.transport, host=args.host, port=args.port)
+    server = create_server(api_key=args.api_key, host=args.host, port=args.port)
+    run_server(server, transport=args.transport)
 
 
 if __name__ == "__main__":

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -152,7 +152,12 @@ def _validate_url_input(url: str) -> dict | None:
 # ---------------------------------------------------------------------------
 
 
-def create_server(api_key: str | None = None) -> FastMCP:
+def create_server(
+    api_key: str | None = None,
+    *,
+    host: str = "127.0.0.1",
+    port: int = 8400,
+) -> FastMCP:
     """Create and configure the MCP server with all tools registered."""
     global _api_key
     _api_key = api_key
@@ -163,6 +168,8 @@ def create_server(api_key: str | None = None) -> FastMCP:
             "Security testing tools for AI agent systems. "
             "553 tests across MCP, A2A, L402, x402, and identity protocols."
         ),
+        host=host,
+        port=port,
     )
 
     # ------------------------------------------------------------------
@@ -628,12 +635,12 @@ def _infer_severity(prefix: str) -> str:
 # Server runner
 # ---------------------------------------------------------------------------
 
-def run_server(mcp: FastMCP, transport: str = "stdio", host: str = "127.0.0.1", port: int = 8400) -> None:
+def run_server(mcp: FastMCP, transport: str = "stdio") -> None:
     """Start the MCP server with the specified transport."""
     if transport == "stdio":
         mcp.run(transport="stdio")
     elif transport == "http":
-        mcp.run(transport="streamable-http", host=host, port=port)
+        mcp.run(transport="streamable-http")
     else:
         print(f"Unknown transport: {transport}", file=sys.stderr)
         sys.exit(1)

--- a/tests/test_mcp_server_runtime.py
+++ b/tests/test_mcp_server_runtime.py
@@ -1,0 +1,20 @@
+"""Regression coverage for MCP SDK runtime configuration."""
+
+from unittest.mock import Mock
+
+from mcp_server.server import create_server, run_server
+
+
+def test_create_server_passes_http_bind_settings_to_fastmcp() -> None:
+    server = create_server(host="127.0.0.1", port=18400)
+
+    assert server.settings.host == "127.0.0.1"
+    assert server.settings.port == 18400
+
+
+def test_http_runner_uses_current_fastmcp_run_signature() -> None:
+    server = Mock()
+
+    run_server(server, transport="http")
+
+    server.run.assert_called_once_with(transport="streamable-http")


### PR DESCRIPTION
Summary: configure Streamable HTTP host and port when constructing FastMCP for MCP 1.28.1, retain a transport-only FastMCP.run call, and add regression coverage. Verification: pytest tests plus testing: 329 passed and 69 subtests passed. A fresh isolated mcp-server install completed loopback /mcp initialize and tools/list with HTTP 200, protocol 2025-03-26, five tools, and no schema refs. Ruff reports eight pre-existing findings in mcp_server/server.py, unchanged from main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized MCP server startup/API alignment with no auth or data-path changes; defaults preserve prior loopback:8400 behavior.
> 
> **Overview**
> **Streamable HTTP bind address and port** are now set when building `FastMCP` in `create_server` (`host`/`port` kwargs), and the CLI passes `--host` / `--port` into that factory instead of into `run_server`.
> 
> **`run_server`** no longer accepts `host`/`port`; for HTTP it only calls `mcp.run(transport="streamable-http")`, matching the current MCP SDK expectation that listen settings live on the server instance.
> 
> Adds **`tests/test_mcp_server_runtime.py`** to assert `FastMCP.settings` receives bind values and that the HTTP runner uses the transport-only `run` signature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56f34d4a08d6771dfe803acc8ed65803b4f794c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->