### PR TITLE
docs(receipt-claim): align README + VS-R04 report with the payment-receipt note

### DIFF
--- a/conformance/receipt-claim/README.md
+++ b/conformance/receipt-claim/README.md
@@ -9,10 +9,10 @@ These are generated from this repo's own claim-level verifier ([`protocol_tests/
 An action receipt decomposes into four separately assessable properties, and signing supports only the first:
 
 ```
-integrity/provenance | authorization | occurrence | check (execution + integrity)
+content authentication/integrity | authorization | occurrence | check (execution + integrity)
 ```
 
-Evidence for the last three must be attested by **distinct trust domains** (authorization authority, execution/settlement authority, independent checker authority), never by the receipt emitter, which the threat model permits to lie. The emitter can validly re-sign its own envelope; it cannot forge another authority's attestation (Ed25519, one keypair per domain, verifier holds only the public keys).
+Content authentication/integrity is what the envelope signature establishes; attribution to a claimed authority additionally depends on trustworthy key-to-identity binding and key custody. Strong evidence for the last three properties must be **bound to the receipt and anchored in the authorities competent to establish them** (the authorization authority, the execution/settlement authority, and an independent checker). Where those roles share an operator, the resulting concentration of trust should be explicit; in all cases the receipt emitter's unsupported self-assertion is insufficient, and the threat model permits the emitter to lie. The emitter can validly re-sign its own envelope; it cannot forge another authority's attestation (Ed25519, one keypair per domain, verifier holds only the public keys).
 
 ## Contents
 

--- a/reports/round_26/VS-R04-receipt-claim-evidence.md
+++ b/reports/round_26/VS-R04-receipt-claim-evidence.md
@@ -2,9 +2,9 @@
 
 - **Round:** VS-R04 (reports/round_26)
 - **Date:** 2026-07-17
-- **Module:** `protocol_tests/receipt_claim_harness.py` (RCL-001..008)
+- **Module:** `protocol_tests/receipt_claim_harness.py` (RCL-001..011)
 - **Artifact:** `vsr04-receipt-claim-evidence.json`
-- **Method:** offline, stdlib-only (HMAC-SHA256 models the envelope signature and each authority's attestation). Deterministic; independently recomputable.
+- **Method:** offline, stdlib-only. Envelope and per-authority attestations use Ed25519 signatures (RFC 8032, pure-stdlib `_ed25519.py`), one keypair per trust domain, verifier holding only the public keys. Deterministic; independently recomputable.
 
 ## The property demonstrated
 


### PR DESCRIPTION
Documentation-alignment only — **no code, fixture, verifier, or evidence-JSON change**. Verifier behavior and all RCL outputs are unchanged; this fixes prose that had drifted from the artifacts.

## Changes
- **`conformance/receipt-claim/README.md`**
  - Property 1 relabeled `integrity/provenance` → **`content authentication/integrity`** (a signature establishes content-to-key binding; attribution to a claimed authority additionally depends on key-to-identity binding and custody).
  - Replaced the absolute *"attested by distinct trust domains … never by the receipt emitter"* with the bounded framing: evidence must be **anchored in the authorities competent to establish it**; where those roles **share an operator**, the trust concentration should be explicit; the emitter's unsupported self-assertion is insufficient. (The Ed25519 threat-model point is retained.)
- **`reports/round_26/VS-R04-receipt-claim-evidence.md`**
  - Method line corrected: said `HMAC-SHA256`, but the harness and evidence JSON have used **Ed25519** since `4c29023`. The evidence JSON `crypto` field is authoritative.
  - Module line `RCL-001..008` → `RCL-001..011` (matches the actual vector set).

## Why
These artifacts back a forthcoming Zenodo note on claim-level testing of agent-payment receipts. External review flagged the README overstatements and the stale HMAC line as a paper↔artifact contradiction. This makes the public artifacts internally consistent and consistent with the note.

## Merge note
Please merge with a **merge commit or tag this commit** rather than squashing — the resulting SHA is cited as the frozen supplementary-artifact reference in the Zenodo deposit, so a stable hash matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only edits to README and an internal evidence report; no runtime, crypto, or conformance behavior changes.
> 
> **Overview**
> **Documentation-only** alignment for receipt-claim conformance prose and the VS-R04 evidence report—no verifier, fixture, or evidence JSON changes.
> 
> In **`conformance/receipt-claim/README.md`**, the first receipt property is relabeled from *integrity/provenance* to **content authentication/integrity**, with a short note that envelope signatures bind content to keys while authority attribution also depends on key-to-identity binding and custody. The trust-model paragraph is tightened: evidence for authorization, occurrence, and check must be **bound to the receipt and anchored in competent authorities**, with explicit mention when roles share an operator; the prior absolute “never by the emitter” wording is replaced by this bounded framing (Ed25519 threat model unchanged).
> 
> In **`reports/round_26/VS-R04-receipt-claim-evidence.md`**, the **Method** line now states **Ed25519** attestations instead of the stale **HMAC-SHA256** description, matching the harness and `vsr04-receipt-claim-evidence.json`. The module scope is updated from **RCL-001..008** to **RCL-001..011** to match the full vector set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1f555a2dcd4ebf891d43b5412ad22a3978bdae4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->