### PR TITLE
docs(receipt-claim): finish prose alignment (harness, test, report)

### DIFF
--- a/protocol_tests/receipt_claim_harness.py
+++ b/protocol_tests/receipt_claim_harness.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Receipt Claim-Level Verification Harness (RCL-001..RCL-008).
+"""Receipt Claim-Level Verification Harness (RCL-001..RCL-011).
 
 The point this suite makes executable: a **format-valid, correctly signed
 receipt** can still be **claim-invalid**, and a claim-level verifier must reject
@@ -8,10 +8,15 @@ it on semantic grounds even though envelope-signature verification succeeds.
 An action receipt is decomposed into four separately assessable properties;
 signing supports only the first:
 
-    integrity/provenance | occurrence | authorization | check execution+integrity
+    content authentication/integrity | occurrence | authorization | check execution+integrity
 
-Evidence for the other three must be attested by *distinct trust domains*, not by
-the receipt emitter (which the threat model permits to lie):
+Content authentication/integrity is what the envelope signature establishes;
+attribution to a claimed authority additionally depends on trustworthy
+key-to-identity binding and key custody. Evidence for the other three properties
+must be bound to the receipt and anchored in the authorities competent to
+establish them; where those roles share an operator the trust concentration
+should be explicit, and the receipt emitter's unsupported self-assertion is
+insufficient (the threat model permits the emitter to lie):
 
     emitter        — signs the receipt envelope
     checker auth   — attests a check ran (id/version/policy/input digest, output)
@@ -23,9 +28,12 @@ authority, fresh, and bound to this action. Each negative vector below builds a
 receipt whose *envelope signature verifies* but whose claims are missing, stale,
 substituted, replayed, or bound to the wrong thing; the verifier must reject it.
 
-Attestations use Ed25519 signatures (RFC 8032, pure-stdlib reference in
-``_ed25519.py``) with a distinct keypair per trust domain; the verifier holds
-only the public keys, so one authority cannot forge another's attestation.
+Envelope and per-authority attestations use Ed25519 (RFC 8032, pure-stdlib
+reference in ``_ed25519.py``) with one deterministic test keypair per modeled
+authority. The verification path consults only the corresponding public keys.
+Under that modeled key separation an emitter can re-sign its envelope but cannot
+produce another authority's attestation. (This is an in-process model of key
+separation, not operational key custody.)
 
 Usage:
     python -m protocol_tests.receipt_claim_harness --simulate

--- a/reports/round_26/VS-R04-receipt-claim-evidence.md
+++ b/reports/round_26/VS-R04-receipt-claim-evidence.md
@@ -8,7 +8,7 @@
 
 ## The property demonstrated
 
-A **format-valid, correctly signed receipt** can still be **claim-invalid**. For each negative vector the receipt's *envelope signature verifies*, yet the claim-level verifier rejects it on semantic grounds, each for its own distinct reason. This is the executable form of the four-property receipt decomposition: signing supports integrity/provenance only; occurrence, authorization, and check-integrity require attestations from distinct trust domains (checker, authorization, execution/settlement), not from the receipt emitter.
+A **format-valid, correctly signed receipt** can still be **claim-invalid**. For each negative vector the receipt's *envelope signature verifies*, yet the claim-level verifier rejects it on semantic grounds, each for its own distinct reason. This is the executable form of the four-property receipt decomposition: signing supports content authentication/integrity only; occurrence, authorization, and check-integrity require evidence anchored in the authorities competent to establish them (checker, authorization, execution/settlement). Where those roles share an operator the trust concentration should be explicit, and the receipt emitter's unsupported self-assertion is insufficient.
 
 | Test | Negative vector | Envelope valid | Claim verdict |
 |---|---|---|---|
@@ -44,4 +44,4 @@ python3 -m unittest testing.test_receipt_claim
 
 ## Significance
 
-This closes the gap the position note (Section 4/8) identified as its central missing experiment: it shows the claim-level verifier rejecting validly-signed-but-claim-invalid receipts, turning the four-property distinction from prose into executable evidence.
+This instantiates the concrete experiment the position note (Section 4/8) proposed: it shows the claim-level verifier rejecting validly-signed-but-claim-invalid receipts, turning the four-property distinction from prose into executable evidence.

--- a/testing/test_receipt_claim.py
+++ b/testing/test_receipt_claim.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""Receipt claim-level verification (RCP-001..RCP-008).
+"""Receipt claim-level verification (RCL-001..RCL-011).
 
 The property under test: a format-valid receipt whose *envelope signature
 verifies* must still be rejected when its claims are not semantically supported
-by the correct trust domain. Each negative asserts BOTH that the envelope is
-valid AND that the claim-level verdict is reject; the control asserts accept.
+by the competent authority. Each negative asserts BOTH that the envelope is
+valid AND that the claim-level verdict is reject; the controls assert accept.
 """
 import os
 import sys


### PR DESCRIPTION
Follow-up to #262. Documentation/comment-only — **no code, fixture, verifier, or evidence-JSON change**; harness reruns 11/11.

Aligns the remaining cited artifacts with the payment-receipt note (a final external review found #262 fixed the README but missed these):

- **`protocol_tests/receipt_claim_harness.py`** — docstring `RCL-001..008` → `RCL-001..011`; property 1 `integrity/provenance` → `content authentication/integrity`; `distinct trust domains` → bounded "competent authorities / shared-operator concentration"; crypto described as an **in-process model of key separation** (deterministic test keypair per modeled authority), not operational key custody.
- **`testing/test_receipt_claim.py`** — docstring `RCP-001..RCP-008` → `RCL-001..RCL-011` (wrong prefix + stale range).
- **`reports/round_26/VS-R04-receipt-claim-evidence.md`** — `integrity/provenance` / `distinct trust domains` → bounded language; `closes the gap / central missing experiment` → "instantiates the concrete experiment the position note proposed."

Backs the forthcoming Zenodo note; a new frozen tag will pin the merge for the deposit's supplementary reference. Please **merge with a merge commit** (not squash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and markdown-only edits with no runtime, verifier, or test logic changes.
> 
> **Overview**
> Follow-up documentation pass so cited receipt-claim artifacts match the payment-receipt note terminology (#262 left these out).
> 
> **Harness and test module docstrings** now reference **RCL-001..RCL-011** (fixing stale **RCL-008** / **RCP-001..RCP-008** ranges). Property 1 is described as **content authentication/integrity** rather than **integrity/provenance**, with clearer bounds on key binding/custody, competent authorities, and shared-operator trust concentration. Ed25519 is framed as a **deterministic in-process key-separation model**, not operational custody. The unit test docstring uses **competent authority** and plural **controls**.
> 
> **VS-R04 evidence report** uses the same bounded trust language and reframes significance from “closes the gap / central missing experiment” to **instantiating the concrete experiment** proposed in the position note.
> 
> No executable behavior, fixtures, or evidence JSON changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6b7184e0d205672463f7f3284571e9e6a3e797d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->