### PR TITLE
docs(readme): cite the payment-receipt Zenodo note (21535452)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ See [docs/QUICKSTART.md](docs/QUICKSTART.md) for mock server setup, rate limitin
 | **APT simulation** | - | - | - | - | **GTG-1002 (17 tests)** |
 | **Jailbreak/over-refusal** | - | - | - | Yes | **50 tests (25 + 25 FPR)** |
 | **AIUC-1 certification** | - | - | - | - | **Maps to 19 of 20 testable requirements** (2026-Q1/Q2 set; [Q3 delta](docs/AIUC1-CROSSWALK.md)) |
-| **Research backing** | - | Cisco blog | - | Papers | **6 DOIs + 3 NIST submissions** |
+| **Research backing** | - | Cisco blog | - | Papers | **7 DOIs + 3 NIST submissions** |
 | **MCP server mode** | - | - | - | - | **Yes - invoke from any AI agent** |
 | **Statistical testing** | - | - | - | - | **Wilson CIs, multi-trial** |
 | **Total tests** | Pattern matching | YARA rules | Config checks | Model probes | **565 active tests** |
@@ -84,7 +84,7 @@ See [docs/QUICKSTART.md](docs/QUICKSTART.md) for mock server setup, rate limitin
 
 ## Research
 
-Six public preprints and notes deposited on Zenodo (not represented as peer-reviewed publications) and three NIST submissions underpin the methodology:
+Seven public preprints and notes deposited on Zenodo (not represented as peer-reviewed publications) and three NIST submissions underpin the methodology:
 
 | Publication | DOI |
 |---|---|
@@ -94,6 +94,7 @@ Six public preprints and notes deposited on Zenodo (not represented as peer-revi
 | **Normalization of Deviance in Autonomous Agent Systems** — Foundational research on behavioral drift patterns | [10.5281/zenodo.15105866](https://doi.org/10.5281/zenodo.15105866) |
 | **Cognitive Style Governance for Multi-Agent Deployments** — Governance mechanisms for managing cognitive style across multi-agent systems | [10.5281/zenodo.15106553](https://doi.org/10.5281/zenodo.15106553) |
 | **Claim-Level Negative Testing for Agent-Governance Evidence** — Receipt-claim decomposition; the RCL-001..011 receipt-verification module in this harness | [10.5281/zenodo.21418701](https://doi.org/10.5281/zenodo.21418701) |
+| **Signing Is Not Authorization: Claim-Level Negative Vectors for Agent-Payment Receipts** — payment-authority application of the receipt-claim decomposition; RCL-001..011 under adversarial payment receipts | [10.5281/zenodo.21535452](https://doi.org/10.5281/zenodo.21535452) |
 
 ---
 


### PR DESCRIPTION
Adds the newly published Zenodo note **"Signing Is Not Authorization: Claim-Level Negative Vectors for Agent-Payment Receipts"** (concept DOI `10.5281/zenodo.21535452`, `isDerivedFrom` the parent `21418701`) to the Research table, and bumps the DOI count 6 → 7 in the comparison table and section intro. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README edits with no runtime, security, or dependency impact.
> 
> **Overview**
> Updates **README** research citations only: the comparison table and Research section intro now say **7 DOIs** (was 6).
> 
> Adds a **Research** table row for **"Signing Is Not Authorization: Claim-Level Negative Vectors for Agent-Payment Receipts"** (`10.5281/zenodo.21535452`), framed as the payment-authority follow-on to the existing claim-level negative testing note and its link to **RCL-001..011** under adversarial payment receipts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d372671fcfaa97ec6bd7faa734d160b80dec3b6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->