### PR TITLE
fix(mcp): make auto fallback protocol-error aware

### DIFF
--- a/protocol_tests/mcp_harness.py
+++ b/protocol_tests/mcp_harness.py
@@ -100,6 +100,20 @@ def _sanitize_url(url: str) -> str:
     return url
 
 
+def _is_unsupported_protocol_version_error(response: object) -> bool:
+    """Return whether an HTTP discovery response rejects the modern version.
+
+    The 2026-07-28 RC reserves JSON-RPC code -32022 for
+    ``UnsupportedProtocolVersionError``.  In auto mode that is an explicit
+    modern-protocol response, not evidence of a legacy server, so falling back
+    to ``initialize`` would violate the stateless negotiation path.
+    """
+    if not isinstance(response, dict) or response.get("_status") != 400:
+        return False
+    error = response.get("error")
+    return isinstance(error, dict) and error.get("code") == -32022
+
+
 def _json_path(value: object, path: str) -> object | None:
     """Resolve a simple dotted path in a JSON result for opt-in test fixtures."""
     current = value
@@ -340,7 +354,16 @@ class StreamableHTTPTransport(MCPTransport):
                 body = e.read().decode("utf-8")
             except Exception:
                 pass
-            return {"_error": True, "_status": e.code, "_body": body[:500]}
+            # HTTP transports surface JSON-RPC errors in a non-2xx body. Keep
+            # the parsed body so auto negotiation can distinguish an explicit
+            # modern version rejection from a legacy-server probe failure.
+            try:
+                parsed = _strip_server_sentinels(json.loads(body)) if body else {}
+            except (TypeError, ValueError):
+                parsed = {}
+            if not isinstance(parsed, dict):
+                parsed = {}
+            return {**parsed, "_error": True, "_status": e.code, "_body": body[:500]}
         except Exception as e:
             return {"_error": True, "_exception": str(e)}
 
@@ -545,6 +568,12 @@ class MCPSecurityTests:
             if self._discover_modern_server(quiet=True):
                 self.selected_protocol_version = MODERN_PROTOCOL_VERSION
                 return True
+            if _is_unsupported_protocol_version_error(
+                getattr(self, "_modern_discovery_response", None)
+            ):
+                # A recognized modern error is authoritative: do not send the
+                # removed legacy handshake to a stateless server.
+                return False
             self.transport.protocol_version = LEGACY_PROTOCOL_VERSION
             self.transport.session_id = None
         if getattr(self.transport, "is_modern", False):
@@ -625,6 +654,7 @@ class MCPSecurityTests:
         """Discover capabilities without creating a protocol-level session."""
         msg = jsonrpc_request("server/discover", {})
         resp = self.transport.send(msg)
+        self._modern_discovery_response = resp
         if resp and "result" in resp:
             result = resp["result"]
             self.server_info = result.get("serverInfo", {})

--- a/testing/test_transport.py
+++ b/testing/test_transport.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 """Unit tests for MCP transport and JSON-RPC primitives."""
 import json
+import io
 import os
 import sys
 import unittest
+import urllib.error
 from unittest.mock import MagicMock, patch
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from protocol_tests.mcp_harness import (
@@ -15,6 +17,7 @@ from protocol_tests.mcp_harness import (
     _json_path,
     _replace_handle,
     _replace_task_id,
+    _is_unsupported_protocol_version_error,
     MCPTransport,
     report_has_failure,
     StreamableHTTPTransport,
@@ -108,6 +111,18 @@ class TestTransport(unittest.TestCase):
         self.assertEqual(request.get_header("Mcp-name"), "scan")
         self.assertIsNone(request.get_header("Mcp-session-id"))
 
+    def test_http_error_preserves_jsonrpc_protocol_error(self):
+        transport = StreamableHTTPTransport("http://localhost:8080", protocol_version=MODERN_PROTOCOL_VERSION)
+        error_body = b'{"jsonrpc":"2.0","id":"discover","error":{"code":-32022,"message":"UnsupportedProtocolVersionError"}}'
+        http_error = urllib.error.HTTPError(
+            "http://localhost:8080", 400, "Bad Request", {}, io.BytesIO(error_body)
+        )
+        with patch("protocol_tests.mcp_harness.urllib.request.urlopen", side_effect=http_error):
+            response = transport.send(jsonrpc_request("server/discover", {}))
+        self.assertEqual(response["_status"], 400)
+        self.assertEqual(response["error"]["code"], -32022)
+        self.assertTrue(_is_unsupported_protocol_version_error(response))
+
 
 class _AutoTransport(MCPTransport):
     def __init__(self, modern_response):
@@ -150,6 +165,16 @@ class TestProtocolAutoSelection(unittest.TestCase):
         self.assertEqual(transport.protocol_version, LEGACY_PROTOCOL_VERSION)
         self.assertEqual([message["method"] for message in transport.sent], ["server/discover", "initialize", "notifications/initialized"])
         self.assertIsNone(getattr(suite, "_connection_error", None))
+
+    def test_auto_does_not_fallback_after_modern_version_rejection(self):
+        transport = _AutoTransport({
+            "_status": 400,
+            "error": {"code": -32022, "message": "UnsupportedProtocolVersionError"},
+        })
+        suite = MCPSecurityTests(transport, json_output=True)
+        self.assertFalse(suite.initialize())
+        self.assertEqual(transport.protocol_version, MODERN_PROTOCOL_VERSION)
+        self.assertEqual([message["method"] for message in transport.sent], ["server/discover"])
 
 
 class TestDifferentialReport(unittest.TestCase):


### PR DESCRIPTION
## Summary
- preserve JSON-RPC bodies returned with HTTP errors
- recognize the RC UnsupportedProtocolVersionError code (-32022) during server/discover
- do not send the removed legacy handshake after that recognized modern error

## Validation
- python3 -m pytest testing/test_transport.py -q (44 passed)

Scope: local RC-oriented negotiation coverage only. This does not claim final MCP v2 compatibility or external interoperability.