### PR TITLE
docs: reconcile test count to 565/38 + fix HRAO-E Wilson CI

### DIFF
--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -101,7 +101,7 @@ Full taxonomy: [PAYMENT-ATTACK-TAXONOMY.md](PAYMENT-ATTACK-TAXONOMY.md)
 
 ## External Validation
 
-- **HRAO-E Assessment (Mar 28, 2026):** 146 tests, 97.9% pass rate, Wilson 95% CI [0.943, 0.994]. 100% pass on jailbreak (25 tests), GTG-1002 full APT campaign (17 tests), harmful output AIUC-1 (10 tests), and advanced polymorphic attacks (10 tests).
+- **HRAO-E Assessment (Mar 28, 2026):** 143 of 146 tests passing (97.9%), Wilson 95% CI [0.941, 0.993]. 100% pass on jailbreak (25 tests), GTG-1002 full APT campaign (17 tests), harmful output AIUC-1 (10 tests), and advanced polymorphic attacks (10 tests).
 - **DrCookies84 independent validation** against live production infrastructure, confirmed in [AutoGen #7432](https://github.com/microsoft/autogen/discussions/7432).
 - **NULL AI (Anhul / DrCookies84) -- v3.6.0 (Mar 24, 2026):**
   - Return channel 8/8 (100%), Capability profile 9/10 (90%), Jailbreak 25/25 (100%), Provenance 15/15 (100%), Advanced attacks 10/10 (100%), Incident response 8/8 (100%), Harmful output 6/10 (expected partial: closed network), CBRN 6/8 (expected partial: closed network)

--- a/docs/TEST-INVENTORY.md
+++ b/docs/TEST-INVENTORY.md
@@ -1,11 +1,12 @@
 # Test Inventory
 
-**553 security tests across 37 modules** (verified 2026-07-12 by `scripts/count_tests.py`)
+**565 security tests across 38 modules** on `main` (verified 2026-07-24 by `scripts/count_tests.py`)
 
-> **Canonical figures (verified 2026-07-12).** Package `agent-security-harness`
-> v4.9.1. 553 test IDs across 37 test-bearing modules in `protocol_tests/`
-> (files with no `test_id` — CLI, helpers, telemetry, registry — are not
-> counted as modules). Wire protocols: 4 (MCP, A2A, L402, x402). AIUC-1: 19 of
+> **Canonical figures (verified 2026-07-24).** Main branch: 565 test IDs across
+> 38 test-bearing modules in `protocol_tests/` (files with no `test_id` — CLI,
+> helpers, telemetry, registry — are not counted as modules). The latest PyPI
+> release, `agent-security-harness` v4.9.1, ships 540; `main` is ahead of the
+> last release. Wire protocols: 4 (MCP, A2A, L402, x402). AIUC-1: 19 of
 > 20 testable requirements (95%). Research: 5 public Zenodo preprints (not
 > peer-reviewed) + 3 NIST submissions. Regenerate with `python
 > scripts/count_tests.py`. Per-module counts below are reconciled to this run;
@@ -179,8 +180,8 @@ agent-security test enterprise --platform salesforce --url https://your-org.sale
 
 ## Test Harness Modules (representative summary)
 
-> This table lists the largest modules; the full harness spans **37 test-bearing
-> modules / 564 tests** (verified 2026-07-22 via `scripts/count_tests.py`).
+> This table lists the largest modules; the full harness spans **38 test-bearing
+> modules / 565 tests** on `main` (verified 2026-07-24 via `scripts/count_tests.py`).
 
 | Module | Tests | Layer | Description |
 |---|---|---|---|


### PR DESCRIPTION
Docs-only reconciliation flagged by external review of the OWASP registration.

- **TEST-INVENTORY.md**: was internally inconsistent (`553 tests / 37 modules` in the header, `564 tests` in the module summary). Synced to **565 tests / 38 modules on `main`** (matches `scripts/count_tests.py`, verified 2026-07-24) and notes that the latest PyPI release v4.9.1 ships 540 (main is ahead of the last release).
- **ADVANCED.md**: HRAO-E Wilson 95% CI corrected `[0.943, 0.994]` → `[0.941, 0.993]` (the correct Wilson score interval for 143/146) and states 143 of 146 passing explicitly.

No test or code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only factual corrections with no code, tests, or runtime behavior changes.
> 
> **Overview**
> Documentation-only updates for OWASP registration and external review accuracy.
> 
> **`TEST-INVENTORY.md`** aligns conflicting inventory numbers to **565 tests / 38 modules on `main`** (2026-07-24, `scripts/count_tests.py`) in the header, canonical block, and module summary. It also clarifies that PyPI **`agent-security-harness` v4.9.1** still ships **540** tests, so `main` is ahead of the last release.
> 
> **`ADVANCED.md`** corrects the HRAO-E Wilson 95% CI from `[0.943, 0.994]` to **`[0.941, 0.993]`** for **143 of 146** passing at 97.9%.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a01f07c96d6cbf66d5d16cc7f244a7b69e20c6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->