### PR TITLE
fix(mcp): keep task IDs out of standard name header

### DIFF
--- a/mcp_server/__main__.py
+++ b/mcp_server/__main__.py
@@ -64,8 +64,8 @@ def main() -> None:
             file=sys.stderr,
         )
 
-    server = create_server(api_key=args.api_key)
-    run_server(server, transport=args.transport, host=args.host, port=args.port)
+    server = create_server(api_key=args.api_key, host=args.host, port=args.port)
+    run_server(server, transport=args.transport)
 
 
 if __name__ == "__main__":

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -152,7 +152,12 @@ def _validate_url_input(url: str) -> dict | None:
 # ---------------------------------------------------------------------------
 
 
-def create_server(api_key: str | None = None) -> FastMCP:
+def create_server(
+    api_key: str | None = None,
+    *,
+    host: str = "127.0.0.1",
+    port: int = 8400,
+) -> FastMCP:
     """Create and configure the MCP server with all tools registered."""
     global _api_key
     _api_key = api_key
@@ -163,6 +168,8 @@ def create_server(api_key: str | None = None) -> FastMCP:
             "Security testing tools for AI agent systems. "
             "553 tests across MCP, A2A, L402, x402, and identity protocols."
         ),
+        host=host,
+        port=port,
     )
 
     # ------------------------------------------------------------------
@@ -628,12 +635,12 @@ def _infer_severity(prefix: str) -> str:
 # Server runner
 # ---------------------------------------------------------------------------
 
-def run_server(mcp: FastMCP, transport: str = "stdio", host: str = "127.0.0.1", port: int = 8400) -> None:
+def run_server(mcp: FastMCP, transport: str = "stdio") -> None:
     """Start the MCP server with the specified transport."""
     if transport == "stdio":
         mcp.run(transport="stdio")
     elif transport == "http":
-        mcp.run(transport="streamable-http", host=host, port=port)
+        mcp.run(transport="streamable-http")
     else:
         print(f"Unknown transport: {transport}", file=sys.stderr)
         sys.exit(1)

--- a/protocol_tests/mcp_harness.py
+++ b/protocol_tests/mcp_harness.py
@@ -289,10 +289,6 @@ class StreamableHTTPTransport(MCPTransport):
                 name = params.get("name", params.get("uri"))
                 if name is not None:
                     headers["Mcp-Name"] = _header_value(name)
-            elif message.get("method") in {"tasks/get", "tasks/update", "tasks/cancel"}:
-                task_id = params.get("taskId")
-                if task_id is not None:
-                    headers["Mcp-Name"] = _header_value(task_id)
         elif self.session_id:
             headers["Mcp-Session-Id"] = self.session_id
         return headers

--- a/testing/test_transport.py
+++ b/testing/test_transport.py
@@ -67,12 +67,13 @@ class TestTransport(unittest.TestCase):
         request = t._prepare_modern_message(jsonrpc_request("resources/read", {"uri": "file:///你好"}))
         self.assertTrue(t._request_headers(request)["Mcp-Name"].startswith("=?base64?"))
 
-    def test_modern_task_id_is_mirrored_as_routing_name(self):
+    def test_modern_task_id_stays_in_body_not_standard_name_header(self):
         t = StreamableHTTPTransport("http://localhost:8080", protocol_version=MODERN_PROTOCOL_VERSION)
         request = t._prepare_modern_message(jsonrpc_request("tasks/get", {"taskId": "tenant-a/task-42"}))
         headers = t._request_headers(request)
         self.assertEqual(headers["Mcp-Method"], "tasks/get")
-        self.assertEqual(headers["Mcp-Name"], "tenant-a/task-42")
+        self.assertEqual(request["params"]["taskId"], "tenant-a/task-42")
+        self.assertNotIn("Mcp-Name", headers)
 
     def test_header_value_encodes_unsafe_values(self):
         self.assertEqual(_header_value("safe-value"), "safe-value")

--- a/tests/test_mcp_server_runtime.py
+++ b/tests/test_mcp_server_runtime.py
@@ -1,0 +1,20 @@
+"""Regression coverage for MCP SDK runtime configuration."""
+
+from unittest.mock import Mock
+
+from mcp_server.server import create_server, run_server
+
+
+def test_create_server_passes_http_bind_settings_to_fastmcp() -> None:
+    server = create_server(host="127.0.0.1", port=18400)
+
+    assert server.settings.host == "127.0.0.1"
+    assert server.settings.port == 18400
+
+
+def test_http_runner_uses_current_fastmcp_run_signature() -> None:
+    server = Mock()
+
+    run_server(server, transport="http")
+
+    server.run.assert_called_once_with(transport="streamable-http")


### PR DESCRIPTION
## Summary
- stop mirroring `tasks/*` `taskId` values into the standard `Mcp-Name` header
- retain task identity in the JSON-RPC body
- add a regression that asserts the header is absent for task requests

## Verification
- `python3 -m pytest testing/test_transport.py testing/test_integration.py -q` (46 passed, 6 subtests passed)
- `python3 -m ruff check protocol_tests/mcp_harness.py testing/test_transport.py`

## Boundary
This aligns the standard transport path with the 2026-07-28 RC header mapping. It is not a final-wire or external interoperability claim.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted harness transport and MCP server wiring changes with regression tests; no auth or data-path changes.
> 
> **Overview**
> Aligns **2026-07-28** stateless Streamable HTTP with the RC: **`tasks/*` `taskId` is no longer copied into `Mcp-Name`**—only `tools/call`, `resources/read`, and `prompts/get` still mirror name/URI into that header. Task identity stays in the JSON-RPC body; transport tests now assert **`Mcp-Name` is absent** for `tasks/get`.
> 
> Separately fixes **HTTP MCP server startup** against the current FastMCP API: **`host`/`port` are set on `FastMCP` at creation** (`create_server`) instead of on `run()`, and **`run_server` only passes `transport="streamable-http"`**. New runtime tests lock in `server.settings` and the `run()` signature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1920e37c95f60d556a2695a93247dca7c3f254bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->