### PR TITLE
fix(mcp): recognize RC unsupported-version code

### DIFF
--- a/protocol_tests/mcp_harness.py
+++ b/protocol_tests/mcp_harness.py
@@ -103,7 +103,7 @@ def _sanitize_url(url: str) -> str:
 def _is_unsupported_protocol_version_error(response: object) -> bool:
     """Return whether an HTTP discovery response rejects the modern version.
 
-    The 2026-07-28 RC reserves JSON-RPC code -32022 for
+    The 2026-07-28 RC reserves JSON-RPC code -32004 for
     ``UnsupportedProtocolVersionError``.  In auto mode that is an explicit
     modern-protocol response, not evidence of a legacy server, so falling back
     to ``initialize`` would violate the stateless negotiation path.
@@ -111,7 +111,7 @@ def _is_unsupported_protocol_version_error(response: object) -> bool:
     if not isinstance(response, dict) or response.get("_status") != 400:
         return False
     error = response.get("error")
-    return isinstance(error, dict) and error.get("code") == -32022
+    return isinstance(error, dict) and error.get("code") == -32004
 
 
 def _json_path(value: object, path: str) -> object | None:

--- a/testing/test_transport.py
+++ b/testing/test_transport.py
@@ -114,14 +114,14 @@ class TestTransport(unittest.TestCase):
 
     def test_http_error_preserves_jsonrpc_protocol_error(self):
         transport = StreamableHTTPTransport("http://localhost:8080", protocol_version=MODERN_PROTOCOL_VERSION)
-        error_body = b'{"jsonrpc":"2.0","id":"discover","error":{"code":-32022,"message":"UnsupportedProtocolVersionError"}}'
+        error_body = b'{"jsonrpc":"2.0","id":"discover","error":{"code":-32004,"message":"Unsupported protocol version","data":{"supported":["2026-07-28"],"requested":"1900-01-01"}}}'
         http_error = urllib.error.HTTPError(
             "http://localhost:8080", 400, "Bad Request", {}, io.BytesIO(error_body)
         )
         with patch("protocol_tests.mcp_harness.urllib.request.urlopen", side_effect=http_error):
             response = transport.send(jsonrpc_request("server/discover", {}))
         self.assertEqual(response["_status"], 400)
-        self.assertEqual(response["error"]["code"], -32022)
+        self.assertEqual(response["error"]["code"], -32004)
         self.assertTrue(_is_unsupported_protocol_version_error(response))
 
 
@@ -170,7 +170,7 @@ class TestProtocolAutoSelection(unittest.TestCase):
     def test_auto_does_not_fallback_after_modern_version_rejection(self):
         transport = _AutoTransport({
             "_status": 400,
-            "error": {"code": -32022, "message": "UnsupportedProtocolVersionError"},
+            "error": {"code": -32004, "message": "Unsupported protocol version", "data": {"supported": ["2026-07-28"], "requested": "1900-01-01"}},
         })
         suite = MCPSecurityTests(transport, json_output=True)
         self.assertFalse(suite.initialize())


### PR DESCRIPTION
## Summary
- align `UnsupportedProtocolVersionError` recognition with the 2026-07-28 RC JSON-RPC code `-32004`
- exercise the RC error payload including `data.supported` and `data.requested`
- preserve the no-legacy-fallback guard for a modern version rejection

## Verification
- `python3 -m pytest testing/test_transport.py testing/test_integration.py -q` (48 passed, 6 subtests passed)
- `python3 -m ruff check protocol_tests/mcp_harness.py testing/test_transport.py`

## Boundary
RC-source alignment only. This does not implement version-retry selection and is not a final-wire or external interoperability claim.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test harness and protocol-negotiation helper only; no production auth or data-path changes.
> 
> **Overview**
> Aligns MCP harness detection of **unsupported protocol version** with the **2026-07-28 RC**: `_is_unsupported_protocol_version_error` now matches JSON-RPC code **`-32004`** instead of **`-32022`**, with the docstring updated accordingly.
> 
> Transport tests use the RC error shape (message plus `data.supported` / `data.requested`) for HTTP 400 discovery failures and for auto-mode negotiation. **Auto** still treats this as an explicit modern rejection and does **not** fall back to legacy `initialize`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea85bdf42065fe31a8d6358899e193974c4e951f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->