### PR TITLE
release: v4.10.0 (565 tests / 38 modules)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.10.0] - 2026-07-24
+
 ### Fixed
 
 - **MCP-020 oracle corrected: a persistent origin id no longer authorizes a
@@ -29,6 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   schemes regardless of determinism. AP2-014 reclassified normative N -> I
   (inferred: standard payment-security practice, not mapped to a cited AP2
   clause). Test count unchanged (AP2-014 retained).
+- **MCP transport/runtime hardening.** Require supported MCP SDK versions (#256); fail closed on cache
+  and probe fixtures; correct HTTP bind settings on FastMCP construction; stop legacy fallback after a
+  modern version error; keep task IDs out of the standard name header.
 
 ### Added
 
@@ -70,6 +75,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   snapshots or an origin-bound (legitimately versioned) update. MCP-019 + MCP-020
   form the composition + runtime tool-poisoning evidence pair.
 - Test count 540 → 542 (MCP Protocol module 18 → 20).
+- **MCP hardening probes: issuer / trace-context / task-principal / cache.** OAuth issuer-binding and
+  trace-context-binding probes, a task-principal isolation probe, and resource-cache probes
+  (cache-metadata validation, cache revocation, fail-closed resolution) — each fails closed on a missing
+  or unverifiable binding.
+- **MCP 2026-07-28 stateless security profile (#257).** Coverage for the stateless MCP transport profile.
+- Test count 553 → 565 (MCP hardening probes + stateless profile).
 
 ## [4.9.1] - 2026-07-10
 

--- a/protocol_tests/mcp_harness.py
+++ b/protocol_tests/mcp_harness.py
@@ -66,7 +66,7 @@ LEGACY_PROTOCOL_VERSION = "2025-03-26"
 MODERN_PROTOCOL_VERSION = "2026-07-28"
 AUTO_PROTOCOL_VERSION = "auto"
 DIFFERENTIAL_PROTOCOL_VERSION = "differential"
-HARNESS_CLIENT_INFO = {"name": "agent-security-harness", "version": "4.9.1"}
+HARNESS_CLIENT_INFO = {"name": "agent-security-harness", "version": "4.10.0"}
 
 
 def _header_value(value: object) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-security-harness"
-version = "4.9.1"
+version = "4.10.0"
 description = "565 security tests for AI agent systems - MCP, A2A, L402, x402, UCP/ACP merchant-journey, AP2 mandate + Fireblocks x402 hardening + Visa TAP / Mastercard Agentic Tokens + denial-of-settlement finality, decision governance, AIUC-1 compliance, NIST AI 800-2 aligned"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
Prepares the v4.10.0 release so PyPI (currently v4.9.1 = 540 tests) catches up to `main` (565).

**Version:** 4.9.1 → 4.10.0 (`pyproject.toml` + hardcoded `mcp_harness.py` `HARNESS_CLIENT_INFO`).

**CHANGELOG:** rolled `[Unreleased]` → `[4.10.0] - 2026-07-24`, adding entries for the previously-undocumented work that took the suite 553 → 565 (MCP issuer/trace-context/task-principal/cache probes; #257 stateless profile; #256 SDK floor + HTTP/runtime fixes). Already-documented: MCP-019/020, RCL-001..011, AP2-014.

⚠️ **PREP ONLY.** Review the derived changelog entries, then merge and cut the GitHub Release (tag `v4.10.0`) to trigger the OIDC PyPI publish. Please **do not squash** (keep the signed commit citable). The release cut is the maintainer action; this PR does not publish anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and version metadata only; no behavioral code changes in the diff. Release tagging/publish is the operational step, not a runtime risk.
> 
> **Overview**
> **Release prep** so PyPI can ship **v4.10.0** with the suite already at **565 tests** on `main` (PyPI was still on **4.9.1** / 540).
> 
> Bumps **`agent-security-harness`** from **4.9.1 → 4.10.0** in `pyproject.toml` and aligns MCP client metadata in `mcp_harness.py` (`HARNESS_CLIENT_INFO`). **CHANGELOG** adds **`[4.10.0] - 2026-07-24`**, rolling prior unreleased notes and documenting the **553 → 565** delta: MCP issuer/trace-context/task-principal/cache hardening probes, **#257** stateless **2026-07-28** profile, and **#256** SDK/runtime fixes—alongside already-listed MCP-019/020, RCL, AP2-014, and MCP-020/AP2-014 oracle fixes.
> 
> No new harness logic in this diff; merge and tag **`v4.10.0`** to trigger publish (per PR description).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 660abd2564fc3fd29f460487b2880055c366ad20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->