### PR TITLE
test(mcp): assert per-request capabilities metadata

### DIFF
--- a/testing/test_transport.py
+++ b/testing/test_transport.py
@@ -59,6 +59,7 @@ class TestTransport(unittest.TestCase):
         request = t._prepare_modern_message(jsonrpc_request("tools/call", {"name": "scan"}))
         self.assertEqual(request["params"]["_meta"]["io.modelcontextprotocol/protocolVersion"], MODERN_PROTOCOL_VERSION)
         self.assertIn("io.modelcontextprotocol/clientInfo", request["params"]["_meta"])
+        self.assertEqual(request["params"]["_meta"]["io.modelcontextprotocol/clientCapabilities"], {})
         headers = t._request_headers(request)
         self.assertEqual(headers["MCP-Protocol-Version"], MODERN_PROTOCOL_VERSION)
         self.assertEqual(headers["Mcp-Method"], "tools/call")


### PR DESCRIPTION
Adds an RC-envelope regression that asserts every modern request carries an explicit empty `io.modelcontextprotocol/clientCapabilities` object. The RC declares this per-request field required; `{}` means no optional capabilities. Local verification: 46 tests plus 6 subtests and Ruff passed. This is RC-source alignment only, not final-wire or external interoperability evidence.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no runtime or security behavior modifications.
> 
> **Overview**
> Adds a regression assertion in **`test_modern_request_metadata_and_headers`** so modern MCP requests built via **`_prepare_modern_message`** include **`params._meta["io.modelcontextprotocol/clientCapabilities"]`** as an explicit empty object **`{}`**, matching RC requirements that the field be present on every request (empty object = no optional capabilities).
> 
> No production transport or harness logic changes in this diff—test-only RC envelope alignment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4feb14d3cbe864dbfff9029353af743208a5a4f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->