### PR TITLE
docs(strategy): refresh test count, flag cookbook-coverage risk tradeoff

### DIFF
--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -10,7 +10,7 @@
 | 4 | Multi-protocol coverage (MCP+A2A+L402+x402) | Y | Y | N | Y | Temporary (6-12 mo) |
 | 5 | AIUC-1 compliance mapping + evidence generation | Y | Y | N | Y | Temporary (1 release cycle) |
 | 6 | Attestation registry/schema | Y | Y | N | Partial | Temporary → sustained if standardized |
-| 7 | Test corpus depth (553 tests) | Y | Y | N | Y | Temporary (velocity-dependent) |
+| 7 | Test corpus depth (595 tests) | Y | Y | N | Y | Temporary (velocity-dependent) |
 | 8 | Decision governance framing ("WHO vs HOW") | Y | N | N | Partial | Parity |
 | 9 | Community contributions | Y | N | N | Partial | Parity |
 | 10 | Open source (Apache 2.0) | Y | N | N | Y | Parity |
@@ -37,6 +37,8 @@ The three moves that convert temporary → sustained:
 ### Existential risk
 
 Not a competitor — tier collapse. If Snyk adds behavioral testing to their scanner, or Anthropic builds security into MCP, the standalone category narrows. Counter: become the verification layer regulated industries require regardless of platform.
+
+A sharper version of this risk shows up whenever coverage is built directly against an Anthropic-published reference pattern (e.g. the July 2026 additions testing tool search, programmatic tool calling, prompt caching, and extended thinking — all lifted from Anthropic's own Claude Cookbook recipes). That's a legitimate first-mover move — no other tool tests these primitives yet — but it's also the most Anthropic-copyable slice of the whole corpus: the moment Anthropic ships native guardrails for its own reference patterns, that specific coverage collapses fastest, not slowest. Treat cookbook-derived modules as a rotating leading edge, not a durable moat — the moat is being first and staying current, not the modules themselves.
 
 ### Industry attractiveness
 


### PR DESCRIPTION
## Summary

- Row 7 test corpus count was stale (553 → 595, current canonical count per `scripts/count_tests.py`).
- Added a paragraph under "Existential risk" naming the tradeoff in building coverage directly against Anthropic's own Claude Cookbook reference patterns (tool search, PTC, prompt caching, extended thinking — added in #271): legitimate first-mover coverage, but also the most Anthropic-copyable slice of the corpus, since native guardrails for Anthropic's own patterns would collapse that coverage fastest, not slowest.

## Test plan

Docs-only change, no code/test impact.


---
_Generated by [Claude Code](https://claude.ai/code/session_01B38zFouRKYbhHXB6oRRGAb)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to strategic narrative and metrics; no runtime, security, or data-handling code changes.
> 
> **Overview**
> Updates **`docs/STRATEGY.md`** so the VRIO table reflects the current test corpus size (**553 → 595**).
> 
> Under **Existential risk**, adds a paragraph that coverage tied to **Anthropic Claude Cookbook** patterns (tool search, PTC, prompt caching, extended thinking) is valuable first-mover work but also the slice most vulnerable if Anthropic ships native guardrails—positioning those modules as a **rotating leading edge**, not a durable moat.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c70a8af7d5b212cf58a8a732acaa84c4a07429dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->