### PR TITLE
Fix stale test count in SKILL.md, add regression guard (553→595)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-security-harness
-description: 553 executable security tests for AI agent systems — MCP, A2A, L402, x402 wire-protocol testing, decision governance, AIUC-1 compliance, NIST AI 800-2 aligned.
+description: 595 executable security tests for AI agent systems — MCP, A2A, L402, x402 wire-protocol testing, decision governance, AIUC-1 compliance, NIST AI 800-2 aligned.
 license: Apache-2.0
 metadata:
   source: "https://github.com/msaleme/red-team-blue-team-agent-fabric"
@@ -22,7 +22,7 @@ metadata:
 
 # Agent Security Harness
 
-553 executable security tests for AI agent systems. MCP + A2A + L402 + x402 wire-protocol testing. Decision-layer attack scenarios. AIUC-1 compliance mapping. One `pip install` away.
+595 executable security tests for AI agent systems. MCP + A2A + L402 + x402 wire-protocol testing. Decision-layer attack scenarios. AIUC-1 compliance mapping. One `pip install` away.
 
 ## Purpose
 

--- a/testing/test_code_quality.py
+++ b/testing/test_code_quality.py
@@ -109,6 +109,12 @@ class TestRegTestCount(unittest.TestCase):
         prose = re.findall(r'\*\*(\d+)\s+executable security tests\*\*', readme)
         if badges: self.assertEqual(badges[0], count)
         if prose: self.assertEqual(prose[0], count)
+    def test_skill_md(self):
+        count = self._canonical_count()
+        with open(os.path.join(REPO_ROOT, "SKILL.md")) as f: skill = f.read()
+        mentions = re.findall(r'(\d+)\s+executable security tests', skill)
+        self.assertTrue(mentions, "SKILL.md must mention test count")
+        for m in mentions: self.assertEqual(m, count)
 
 
 class TestRegPassFail(unittest.TestCase):


### PR DESCRIPTION
## Summary

- `SKILL.md`'s frontmatter `description` and body prose both cited 553 executable security tests — stale (canonical count is 595 per `scripts/count_tests.py`) and undetected because `TestRegTestCount` only checked `README.md`/`pyproject.toml`, not `SKILL.md`.
- Fixed both occurrences and added `test_skill_md` to `testing/test_code_quality.py::TestRegTestCount` so this class of drift is caught going forward, matching the existing `test_pyproject`/`test_readme` pattern.

## Test plan

- [x] `python3 -m pytest testing/ -q` — 311 passed (was 310; +1 new regression test), 73 subtests passed
- [x] Confirmed the new `test_skill_md` check follows the same canonical-count-comparison pattern as the existing README/pyproject checks


---
_Generated by [Claude Code](https://claude.ai/code/session_01B38zFouRKYbhHXB6oRRGAb)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only count fix plus a non-runtime regression test; no product or security logic changes.
> 
> **Overview**
> Updates **`SKILL.md`** so both the frontmatter `description` and body prose say **595** executable security tests instead of the stale **553**, aligned with the canonical count from `scripts/count_tests.py`.
> 
> Adds **`test_skill_md`** under `TestRegTestCount` in `testing/test_code_quality.py`, mirroring the existing README/pyproject checks so future drift in `SKILL.md` fails CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d5c764562f7f41647edceed3991947249b4c77d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->