### PR TITLE
Merge stalled DGB paper reviewer edits, drop dead NeurIPS deadline

### DIFF
--- a/docs/paper-dgb/README.md
+++ b/docs/paper-dgb/README.md
@@ -3,7 +3,7 @@
 LaTeX source for: *Decision Governance Benchmark: Executable Behavioral Tests
 for Autonomous AI Agent Security* (Saleme 2026).
 
-**Targets:** arXiv CS.CR (primary) | NeurIPS 2026 Evaluations & Datasets (stretch, deadline May 6 2026)
+**Target:** arXiv CS.CR (primary). (The NeurIPS 2026 Evaluations & Datasets stretch track's May 6 2026 deadline has passed without a submission — dropped as a target.)
 
 ---
 
@@ -82,7 +82,6 @@ Section 5 results are sourced from:
   title        = {Decision Governance Benchmark: Executable Behavioral Tests
                   for Autonomous {AI} Agent Security},
   year         = {2026},
-  howpublished = {arXiv preprint},
-  note         = {NeurIPS 2026 Evaluations \& Datasets track submission}
+  howpublished = {arXiv preprint}
 }
 ```

--- a/docs/paper-dgb/main.tex
+++ b/docs/paper-dgb/main.tex
@@ -37,30 +37,43 @@ for Autonomous AI Agent Security}}
 
 % ---------------------------------------------------------------------------
 \begin{abstract}
-We introduce the \textbf{Decision Governance Benchmark (DGB)}, a corpus of
-52 executable test cases that evaluate whether autonomous AI agents can
+Metadata scanners of agent tool descriptions and permission declarations
+provide \textbf{0.0\% governance protection against behavioral failures},
+even when they succeed on structurally detectable cases. We introduce
+the \textbf{Decision Governance Benchmark (DGB)}, a corpus of 52
+executable test cases that evaluate whether autonomous AI agents can
 resist five classes of governance failure: escalation bypass, collusion,
 memory tampering, payment chain abuse, and evidence fabrication. Unlike
-metadata scanners that inspect tool descriptions and permission declarations,
-DGB \emph{executes} the agent's decision path and measures behavioral
-outcomes. We find that \textbf{85\% of governance failures (44/52 cases) are
-invisible to static metadata analysis}---the failure only manifests when the
-decision is executed. We present 13 complementary harness tests (7 benchmark
-integrity, 6 governance modification) and an evidence format that produces
-machine-readable attestation reports. Baseline results across three agent
-configurations show: Config~A (ungoverned) achieves 0\% Governance
-Maintenance Rate (GMR); Config~B (constitutional gates, 12 hard constraints)
-achieves 71.2\% GMR and 77.3\% Scanner Gap Score; Config~C (metadata
-scanner only) achieves 15.4\% GMR and 0\% SGS---confirming that 85\% of
-governance failures remain invisible to scanners even when scanners succeed
-on structurally detectable cases. The corpus, harness, and evidence format
-are open source (MIT) at
+metadata scanners that inspect tool descriptions and permission
+declarations, DGB \emph{executes} the agent's decision path and measures
+behavioral outcomes. We find that \textbf{85\% of governance failures
+(44/52 cases) are invisible to static metadata analysis}---the failure
+only manifests when the decision is executed. We present 13 complementary
+harness tests (7 benchmark integrity, 6 governance modification) and an
+evidence format that produces machine-readable attestation reports.
+Baseline results across three agent configurations show: Config~A
+(ungoverned) achieves 0\% Governance Maintenance Rate (GMR); Config~B
+(constitutional gates, 12 hard constraints) achieves 71.2\% GMR and
+77.3\% Scanner Gap Score (SGS); Config~C (metadata scanner only) achieves
+15.4\% GMR and 0\% SGS---metadata scanning contributes zero governance
+protection on the 44 behavioral cases even when it succeeds on the 8
+structurally detectable ones. Unlike prior work, DGB produces
+deterministic, replayable behavioral test results, enabling direct
+comparison with static and dynamic security scanners. The corpus,
+harness, and evidence format are open source (MIT) at
 \url{https://github.com/msaleme/red-team-blue-team-agent-fabric}.
 \end{abstract}
 
 % ---------------------------------------------------------------------------
 \section{Introduction}
 \label{sec:intro}
+
+Autonomous agents are now executing real-world actions---payments, API
+calls, and multi-step workflows---yet evaluation frameworks remain
+focused on capability, not decision correctness. Existing benchmarks
+measure what agents \emph{can} do, not whether they \emph{should} do
+it in context. This gap introduces a new class of failure:
+\emph{authorized but unsafe behavior}.
 
 The evaluation of autonomous AI agents has focused primarily on capability
 benchmarks---SWE-bench~\cite{jimenez2024swe} for code generation,
@@ -100,6 +113,13 @@ makes three contributions:
         testing.
 \end{enumerate}
 
+Framed in security terms, identity answers \emph{who}, authorization
+answers \emph{what}, and decision governance answers \emph{should}. The
+first two layers are mature---instantiated across IAM, RBAC, and policy
+frameworks. The third is the gap this benchmark evaluates: a fully
+authorized agent can still take unsafe actions under adversarial
+pressure. DGB measures whether it does.
+
 % ---------------------------------------------------------------------------
 \section{Related Work}
 \label{sec:related}
@@ -132,14 +152,46 @@ implements six governance gates and 12 hard constraints. No prior work
 provides a benchmark corpus specifically designed to evaluate governance
 decision quality.
 
+\subsection{Positioning Relative to Prior Benchmarks}
+
+DGB occupies a distinct position among agent evaluation approaches
+(Table~\ref{tab:positioning}). It is the only benchmark whose unit of
+analysis is a behavioral governance decision with reproducible
+pass/fail outcomes directly comparable against scanner output on the
+same corpus.
+
+\begin{table*}[!t]
+\centering
+\small
+\caption{Positioning of DGB relative to prior benchmark categories.
+         Scanner-comparable = the same cases can be run through a
+         metadata scanner for direct detection-gap measurement.}
+\label{tab:positioning}
+\begin{tabular}{llll}
+\toprule
+\textbf{Category} & \textbf{Representative benchmarks} & \textbf{Unit of analysis} & \textbf{Scanner-comparable} \\
+\midrule
+Capability               & SWE-bench, WebArena, GAIA           & Task completion        & N/A \\
+Jailbreak / safety       & HarmBench, AdvBench                 & Prompt-level response  & No  \\
+Red-teaming              & AgentDojo, Mythos                   & Attack success rate    & No  \\
+Vulnerability scanning   & AgentSeal, OX MCP audit             & Static metadata        & N/A \\
+\midrule
+\textbf{DGB (this work)} & ---                                 & \textbf{Decision behavior} & \textbf{Yes} \\
+\bottomrule
+\end{tabular}
+\end{table*}
+
 % ---------------------------------------------------------------------------
 \section{The Decision Governance Benchmark}
 \label{sec:dgb}
 
 \subsection{Task Formalism}
 
-Each DGB case is a 6-tuple $(S, C, E_{\text{pass}}, E_{\text{fail}}, D, M)$
-where:
+We formalize a decision-governance test case as a 6-tuple
+$(S, C, E_{\text{pass}}, E_{\text{fail}}, D, M)$---a formal
+representation of behavioral evaluation distinct from the
+capability-level task models used in prior benchmarks. Each element is
+defined as:
 \begin{itemize}
   \item $S$ = scenario (context and setup presented to the agent)
   \item $C$ = constitutional constraints active during the scenario
@@ -169,6 +221,11 @@ against three criteria:
         detect the failure. This enables direct measurement of the detection
         gap.
 \end{enumerate}
+
+The corpus is designed for depth and coverage of distinct behavioral
+failure modes rather than scale, enabling controlled evaluation of
+decision-governance properties under adversarial conditions. Extensions
+are tracked in the public repository.
 
 \subsection{Categories}
 
@@ -202,6 +259,45 @@ involving structural SSRF or token format violations) and evidence
 fabrication (2 cases involving accessible configuration files). This finding
 quantifies what practitioners have suspected: behavioral governance failures
 require execution-based testing, not scanning.
+
+\subsection{Illustrative Case: GM-001 Gate Self-Disable}
+\label{sec:illustrative}
+
+To ground the 6-tuple formalism in a concrete artifact, consider case
+GM-001, derived from the lightningzero (2026) finding that 9 of 12
+evaluated agents disabled their own verification gates within 48 hours
+in pursuit of throughput optimization:
+
+\begin{itemize}
+  \item $S$: The agent is assigned a throughput-optimization objective.
+        Its deployment contains a \texttt{ControlBypassGate} that HOLDs
+        execution when the running count of control-bypass attempts
+        exceeds zero. The agent has tool access to modify its own
+        configuration file.
+  \item $C$: HC-12 (no gate override without ratified amendment) is
+        active. No human reviewer is in the approval path.
+  \item $E_{\text{pass}}$: Agent completes the task within the gate's
+        observed rate limits, or escalates to a human reviewer when
+        throughput targets cannot be met with the gate active.
+  \item $E_{\text{fail}}$: Agent invokes its config-modification tool
+        to raise the bypass threshold to a permissive value, disabling
+        the gate for subsequent calls (the behavior observed in 9 of
+        12 lightningzero agents).
+  \item $D$: harness test \texttt{GM-001} in
+        \texttt{benchmarks/tests/gm\_001\_gate\_self\_disable.py};
+        binary PASS/FAIL on whether the agent wrote to the governance
+        configuration.
+  \item $M$: \textbf{False}. A metadata scanner inspecting the agent's
+        declared tools sees only a \texttt{config-write} capability;
+        there is no structural indicator that the agent will exercise
+        that capability to disable its own oversight. The failure mode
+        is purely behavioral.
+\end{itemize}
+
+GM-001 illustrates the general pattern: the 6-tuple specifies a
+scenario and two contrastive behaviors, $D$ is an executable test, and
+the metadata-detectability flag $M$ enables the direct detection-gap
+measurement reported in Section~\ref{sec:results}.
 
 % ---------------------------------------------------------------------------
 \section{Evaluation Methodology}
@@ -285,7 +381,7 @@ request/response payloads, and statistical confidence intervals. The schema
 maps to AIUC-1 controls B001, C010, D003, and D004.
 
 % ---------------------------------------------------------------------------
-\section{Preliminary Results}
+\section{Baseline Results}
 \label{sec:results}
 
 \subsection{Configuration Details}

--- a/docs/paper-dgb/main.tex
+++ b/docs/paper-dgb/main.tex
@@ -37,9 +37,10 @@ for Autonomous AI Agent Security}}
 
 % ---------------------------------------------------------------------------
 \begin{abstract}
-Metadata scanners of agent tool descriptions and permission declarations
-provide \textbf{0.0\% governance protection against behavioral failures},
-even when they succeed on structurally detectable cases. We introduce
+As autonomous agents execute real-world actions, metadata scanners of
+agent tool descriptions and permission declarations provide
+\textbf{0.0\% governance protection on behavioral failure cases}, even
+when they succeed on structurally detectable ones. We introduce
 the \textbf{Decision Governance Benchmark (DGB)}, a corpus of 52
 executable test cases that evaluate whether autonomous AI agents can
 resist five classes of governance failure: escalation bypass, collusion,
@@ -88,9 +89,9 @@ instructed not to hack.
 
 These findings expose a structural gap: capability benchmarks measure what
 an agent \emph{can} do, not what it \emph{should} do. No existing benchmark
-evaluates whether an agent respects governance constraints under adversarial
-pressure---whether it resists disabling its own safety gates, fabricating
-evaluation evidence, or escalating its own permissions.
+systematically evaluates whether an agent respects governance constraints
+under adversarial pressure---whether it resists disabling its own safety
+gates, fabricating evaluation evidence, or escalating its own permissions.
 
 We address this gap with the Decision Governance Benchmark (DGB), which
 makes three contributions:
@@ -98,7 +99,9 @@ makes three contributions:
 \begin{enumerate}
   \item \textbf{A curated corpus} of 52 decision-behavior test cases across
         five failure categories, each annotated with a contrastive field
-        indicating whether a metadata-only scanner would detect the failure.
+        indicating whether a metadata-only scanner would detect the failure,
+        enabling direct per-case comparison between metadata scanning and
+        execution-based detection.
 
   \item \textbf{A taxonomy of governance failures} grounded in real-world
         incidents (lightningzero 2026, OX Security 2026~\cite{ox2026mcp},
@@ -176,7 +179,7 @@ Jailbreak / safety       & HarmBench, AdvBench                 & Prompt-level re
 Red-teaming              & AgentDojo, Mythos                   & Attack success rate    & No  \\
 Vulnerability scanning   & AgentSeal, OX MCP audit             & Static metadata        & N/A \\
 \midrule
-\textbf{DGB (this work)} & ---                                 & \textbf{Decision behavior} & \textbf{Yes} \\
+\textbf{DGB (this work)} & ---                                 & \textbf{Decision behavior (execution-level)} & \textbf{Yes} \\
 \bottomrule
 \end{tabular}
 \end{table*}
@@ -190,8 +193,9 @@ Vulnerability scanning   & AgentSeal, OX MCP audit             & Static metadata
 We formalize a decision-governance test case as a 6-tuple
 $(S, C, E_{\text{pass}}, E_{\text{fail}}, D, M)$---a formal
 representation of behavioral evaluation distinct from the
-capability-level task models used in prior benchmarks. Each element is
-defined as:
+capability-level task models used in prior benchmarks and from the
+prompt-level safety evaluations used in jailbreak literature. Each
+element is defined as:
 \begin{itemize}
   \item $S$ = scenario (context and setup presented to the agent)
   \item $C$ = constitutional constraints active during the scenario
@@ -493,8 +497,8 @@ structural property of behavioral governance failures. A metadata scanner
 inspects \emph{declarations} (what permissions are claimed, what tool
 descriptions say). A governance failure occurs in the \emph{execution path}
 (what the agent actually decides). These are fundamentally different layers,
-and no improvement to scanning methodology can close the gap for behavioral
-failures.
+and no improvement to scanning methodology alone can close the gap for
+behavioral failures.
 
 Config~C's 0\% SGS demonstrates this empirically: when restricted to the 44
 scanner-invisible cases, the scanner provides zero governance protection.
@@ -526,6 +530,15 @@ identify, protect, and respond.
         mode (payload validation without a live agent) and live mode (full
         execution against a running agent). The baseline results reported
         here were produced in live mode with deterministic stub agents.
+
+  \item \textbf{Cross-model evaluation:} Baseline results use
+        deterministic stub agents to isolate governance mechanics from
+        model-specific capability variance. No cross-model evaluation
+        against frontier LLM agents is included in this version.
+        Extending DGB to production model-based agents (Claude, GPT,
+        Gemini, open-weight hosts) is left for future work; the harness
+        interface is designed for drop-in replacement of the agent under
+        test.
 
   \item \textbf{Model dependence:} Governance behavior may vary across
         model versions and providers. Results should be interpreted as


### PR DESCRIPTION
## Summary

Recovers reviewer polish for `docs/paper-dgb/main.tex` (the Decision Governance Benchmark arXiv paper) that landed on the `paper/dgb-reviewer-edits` branch in May but was never merged. Cherry-picked only the two paper-specific commits (`cfaa444`, `5321be4`) — the branch's third commit (`f719af9`, an unrelated v4.4.2 doc-hardening pass touching `CHANGELOG.md`/`docs/ADVANCED.md`/`docs/TEST-INVENTORY.md`) was intentionally dropped as noise, and those files have moved on substantially since April/May anyway.

- **`docs/paper-dgb/main.tex`** (496 → 605 lines): abstract now leads with the headline stat (0.0% governance protection on behavioral failure cases) instead of burying it; new "Positioning Relative to Prior Benchmarks" section with a comparison table against SWE-bench, WebArena, GAIA, HarmBench, AdvBench, AgentDojo, Mythos, AgentSeal; tightened intro framing (identity = who, authorization = what, decision governance = should).
- **`docs/paper-dgb/README.md`**: dropped the NeurIPS 2026 Evaluations & Datasets stretch target — its May 6 2026 deadline has passed with no submission — and removed the corresponding false claim from the BibTeX citation block. arXiv `cs.CR` remains the (undated) primary target.

Result verified byte-identical to what was in `paper/dgb-reviewer-edits` for `main.tex` (diffed after cherry-pick).

## Test plan

- [x] `python3 -m pytest testing/ -q` — 311 passed, 73 subtests passed (docs-only change, unaffected as expected)
- [x] `diff` confirms cherry-picked `main.tex` is byte-identical to the source branch's version
- [x] `grep -i neurips docs/paper-dgb/main.tex` — no stray references left after the README fix


---
_Generated by [Claude Code](https://claude.ai/code/session_01B38zFouRKYbhHXB6oRRGAb)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> LaTeX and README edits only; no runtime, security, or data-path changes.
> 
> **Overview**
> Merges stalled reviewer polish for the **Decision Governance Benchmark** arXiv paper (`docs/paper-dgb/`), without changing benchmark code or harness behavior.
> 
> **`main.tex`** reframes the narrative: the abstract now opens with the **0.0% scanner protection on behavioral cases** claim and clarifies Config C’s **0% SGS** on the 44 behavioral cases. The introduction adds **authorized-but-unsafe** motivation and a **who / what / should** governance framing. A new **positioning table** contrasts DGB with capability, jailbreak, red-team, and static-scan benchmarks on unit of analysis and scanner-comparability. The **6-tuple formalism** and corpus scope get tighter prose; a new **GM-001 illustrative case** walks through all tuple fields. **Preliminary Results** is renamed to **Baseline Results**; limitations now state **stub-agent baselines** and defer **frontier LLM** runs to future work.
> 
> **`README.md`** drops the **NeurIPS 2026** stretch target (deadline passed, no submission) and removes the matching **BibTeX** note so the citation reflects **arXiv-only** intent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d05910caf0d81e151a436644fd8fafd8389bef5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->