### PR TITLE
Round 35: self-audit of PRs #271-274, fix 2 real defects + 2 doc-drift items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Four new Claude Cookbook-primitive harnesses + multi-agent race-condition
+  tests + jailbreak model-based grading (PRs #271-274).** `tool_search_harness.py`
+  (TS-001..006: embedding-based tool-discovery ranking manipulation, unsigned
+  library injection, description-borne prompt injection, post-discovery access
+  control, keyword stuffing, missing permission metadata), `ptc_harness.py`
+  (PTC-001..006: Programmatic Tool Calling sandbox security — destructive-tool
+  opt-in, sandbox exfiltration, cross-session container isolation, caller-type
+  spoofing, unbounded batch execution, expired-container reuse),
+  `prompt_caching_harness.py` (PCH-001..006: cache isolation/lifecycle —
+  cross-session bleed, stale cached policy, cache-prefix injection, TTL-refresh
+  retention abuse, cross-tenant key collision, cost/latency side channel), and
+  `extended_thinking_harness.py` (ET-001..006: thinking-block tamper-evidence
+  conformance — signature tampering, missing thinking block before tool use,
+  redacted-thinking exposure, fabricated intermediate reasoning,
+  cross-conversation signature replay, silent budget truncation). All four
+  follow the simulate/live dual-mode + `--trials` convention. `multi_agent_harness.py`
+  v3.4 -> v3.5 adds MAG-013..018 (race-condition-pretext attacks, 12 -> 18
+  tests). `jailbreak_harness.py` v3.0 -> v3.1 adds an opt-in `--judge`
+  model-based grading corroboration pass (Building Evals recipe pattern) via
+  new shared helper `protocol_tests._utils.model_judge_compliance()`. Also
+  recovered stalled DGB arXiv-paper reviewer edits (`docs/paper-dgb/main.tex`)
+  and dropped a dead NeurIPS 2026 submission target. Test count 565 -> 595;
+  harnesses 39 -> 43.
 - **RCL-001..008: Receipt claim-level verification (new module `receipt_claim_harness.py`).**
   Makes executable the distinction that a format-valid, correctly signed receipt
   can still be claim-invalid. An action receipt is decomposed into four

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 **Even if an agent is properly authenticated and authorized, can it still be manipulated into unsafe or policy-violating behavior?**
 
-595 executable security tests across 42 modules (verified 2026-07-25 via `scripts/count_tests.py`). MCP + A2A + L402 + x402 wire-protocol testing, plus UCP/ACP merchant-journey, AP2 mandate-chain, Fireblocks x402 hardening, Visa TAP / Mastercard Agentic Token funding-instrument, and denial-of-settlement finality conformance across the full agentic-payments stack. Decision-layer attack scenarios. One `pip install` away.
+595 executable security tests across 43 modules (verified 2026-07-25 via `scripts/count_tests.py`). MCP + A2A + L402 + x402 wire-protocol testing, plus UCP/ACP merchant-journey, AP2 mandate-chain, Fireblocks x402 hardening, Visa TAP / Mastercard Agentic Token funding-instrument, and denial-of-settlement finality conformance across the full agentic-payments stack. Decision-layer attack scenarios. One `pip install` away.
 
 ```
 $ agent-security test mcp --url http://localhost:8080/mcp

--- a/docs/TEST-INVENTORY.md
+++ b/docs/TEST-INVENTORY.md
@@ -1,9 +1,9 @@
 # Test Inventory
 
-**595 security tests across 42 modules** on `main` (verified 2026-07-25 by `scripts/count_tests.py`)
+**595 security tests across 43 modules** on `main` (verified 2026-07-25 by `scripts/count_tests.py`)
 
 > **Canonical figures (verified 2026-07-25).** Main branch: 595 test IDs across
-> 42 test-bearing modules in `protocol_tests/` (files with no `test_id` — CLI,
+> 43 test-bearing modules in `protocol_tests/` (files with no `test_id` — CLI,
 > helpers, telemetry, registry — are not counted as modules). The latest PyPI
 > release, `agent-security-harness` v4.9.1, ships 540; `main` is ahead of the
 > last release. Wire protocols: 4 (MCP, A2A, L402, x402). AIUC-1: 19 of
@@ -180,7 +180,7 @@ agent-security test enterprise --platform salesforce --url https://your-org.sale
 
 ## Test Harness Modules (representative summary)
 
-> This table lists the largest modules; the full harness spans **42 test-bearing
+> This table lists the largest modules; the full harness spans **43 test-bearing
 > modules / 595 tests** on `main` (verified 2026-07-25 via `scripts/count_tests.py`).
 
 | Module | Tests | Layer | Description |

--- a/protocol_tests/extended_thinking_harness.py
+++ b/protocol_tests/extended_thinking_harness.py
@@ -316,16 +316,27 @@ class ExtendedThinkingTests:
         }
 
         def _naive_render(block: dict) -> str:
-            return block["data"]  # leaks raw opaque payload
+            # Realistic naive UI/logging behavior: embed the raw payload in a
+            # larger rendered string rather than returning it bare, so
+            # detecting the leak requires an actual containment check.
+            return f"[thinking block] data={block['data']}"
 
         def _safe_render(block: dict) -> str:
             return "[reasoning redacted]"
 
+        def _exposes_raw_payload(rendered_text: str, block: dict) -> bool:
+            """Real detector: does rendered_text verbatim contain the raw
+            opaque payload anywhere in it? Has an actual branch (the `in`
+            check) that a future edit could get wrong, unlike a bare
+            self-comparison."""
+            raw = block.get("data", "")
+            return bool(raw) and raw in rendered_text
+
         if self.simulate:
             naive_output = _naive_render(redacted_block)
             safe_output = _safe_render(redacted_block)
-            naive_leaks = naive_output == redacted_block["data"]
-            safe_clean = safe_output != redacted_block["data"]
+            naive_leaks = _exposes_raw_payload(naive_output, redacted_block)
+            safe_clean = not _exposes_raw_payload(safe_output, redacted_block)
             passed = naive_leaks and safe_clean  # detection: we correctly tell them apart
 
             self._record(ExtendedThinkingResult(

--- a/protocol_tests/jailbreak_harness.py
+++ b/protocol_tests/jailbreak_harness.py
@@ -1004,7 +1004,7 @@ class JailbreakTests:
             test_map = all_tests
 
         print(f"\n{'='*60}")
-        print("EXPANDED JAILBREAK CORPUS TEST SUITE v3.0")
+        print("EXPANDED JAILBREAK CORPUS TEST SUITE v3.1")
         print(f"{'='*60}")
         print(f"Target: {self.url}")
 
@@ -1055,7 +1055,7 @@ def generate_report(results: list[JailbreakTestResult], output_path: str):
     ci = wilson_ci(passed, total)
 
     report = {
-        "suite": "Expanded Jailbreak Corpus Tests v3.0",
+        "suite": "Expanded Jailbreak Corpus Tests v3.1",
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "summary": {
             "total": total,
@@ -1107,7 +1107,7 @@ def main():
             return {"results": suite.run_all(categories=categories)}
 
         merged = _run_trials(_single_run, trials=args.trials,
-                             suite_name="Expanded Jailbreak Corpus Tests v3.4")
+                             suite_name="Expanded Jailbreak Corpus Tests v3.1")
         if args.report:
             with open(args.report, "w") as f:
                 json.dump(merged, f, indent=2, default=str)

--- a/testing/CRITICAL_EVALUATION_R35_2026-07-25.md
+++ b/testing/CRITICAL_EVALUATION_R35_2026-07-25.md
@@ -1,0 +1,193 @@
+# CRITICAL EVALUATION — Round 35
+
+**Date:** 2026-07-25
+**Round:** 35
+**Focus:** Self-audit of the four Claude Cookbook-primitive harnesses + multi-agent
+race-condition tests + jailbreak model-based grading (PRs #271-274, merged
+2026-07-25)
+**Test count:** 595 across 43 modules
+**Version:** 4.9.1 (unbumped, consistent with current post-4.9.1 convention of
+bumping version only in a dedicated release-prep commit, not per-feature-PR)
+**Evaluator:** Automated round (3 parallel audit agents — security, logic/
+correctness, consistency/integration — each scoped to the session's new/
+changed files, per CLAUDE.md's round procedure)
+
+---
+
+## 1. What Changed (this session, prior to this round)
+
+| PR | Change | Tests |
+|---|---|---|
+| #271 | New modules `tool_search_harness.py` (TS-001..006), `ptc_harness.py` (PTC-001..006) | 565 → 577 |
+| #271 | `multi_agent_harness.py` v3.4 → v3.5: MAG-013..018 (race-condition-pretext attacks) | 577 → 583 |
+| #271 | `jailbreak_harness.py` v3.0 → v3.1: opt-in `--judge` model-based grading via new `protocol_tests._utils.model_judge_compliance()` | 583 (unchanged, methodology only) |
+| #271 | New module `prompt_caching_harness.py` (PCH-001..006) | 583 → 589 |
+| #271 | New module `extended_thinking_harness.py` (ET-001..006) | 589 → 595 |
+| #272 | `docs/STRATEGY.md`: test-count refresh + cookbook-coverage risk paragraph | — |
+| #273 | `SKILL.md`: stale-count fix (553→595) + new `test_skill_md` regression guard | — |
+| #274 | Recovered stalled `docs/paper-dgb/main.tex` reviewer edits; dropped dead NeurIPS 2026 deadline | — |
+
+**This round (R35)** is a self-audit of that work, not new coverage. Three
+parallel agents each audited the same file scope (the four new harness
+modules, plus the modified `multi_agent_harness.py`, `jailbreak_harness.py`,
+and `_utils.py`) from a different angle — security, logic/correctness,
+consistency/integration — matching CLAUDE.md's "use parallel agents for
+thorough audits" instruction. Real findings were fixed in this round; details
+below.
+
+---
+
+## 2. Prior Fix Verification
+
+R35 doesn't inherit an open defect list from R34 (AP2 harness, 2026-07-01) —
+the intervening 24 days saw substantial unrelated work land on `main` (receipt-
+claim verification, MCP tool-poisoning reproduction, settlement-finality,
+card-token conformance, etc., per `git log`). Verification here is scoped to
+confirming that work plus R35's own fixes are all intact:
+
+| Area | Guard | Status |
+|---|---|---|
+| AP2 mandate-chain (R34) | `TestRegAP2` (8 checks) | ✅ intact, full suite green |
+| VS-R03 verdict-correctness | `test_vsr03_verdict_correctness.py` | ✅ intact |
+| MCP-019/020 composite poisoning | full suite | ✅ intact |
+| Receipt-claim verification (RCL-001..011) | full suite | ✅ intact |
+| Everything merged in PRs #271-274 | full suite + `count_tests.py` | ✅ intact, 595 confirmed |
+
+---
+
+## 3. Issues Found & Fixed This Round
+
+| # | Severity | File:line | Issue | Fix |
+|---|---|---|---|---|
+| #275 | LOW-MEDIUM | `extended_thinking_harness.py` (ET-003) | Simulate-mode leak check was a self-referential tautology: `_naive_render` returned its input verbatim, so `naive_output == redacted_block["data"]` reduced to `x == x`, always `True` regardless of any real detection logic — a "test that can't fail" (CLAUDE.md-flagged recurring class) | Introduced a real detector function `_exposes_raw_payload(rendered_text, block)` doing an actual containment check (`raw in rendered_text`); `_naive_render` now embeds the payload in a larger string so detecting the leak requires genuine substring logic, not identity comparison |
+| #276 | LOW-MEDIUM | `jailbreak_harness.py` (4 locations: docstring, `run_all` banner, `generate_report`, trial_runner `suite_name`) | Version string disagreed across the file: v3.1/v3.0/v3.0/v3.4 — partly newly introduced (docstring bumped to v3.1 by the `--judge` commit, other 3 sites weren't touched), partly pre-existing (the stray v3.4 predates this session) | All four sites now consistently say v3.1 |
+| #277 | LOW | `README.md:13`, `docs/TEST-INVENTORY.md:3,6,183` | "42 modules" stale — extended-thinking harness pushed the count to 43, but the commit that added it (`68c15d4`) bumped its own commit-message text from 41→42 instead of 42→43, one step behind. No existing regression test checked module-count prose (only test-count) | Fixed all 4 locations; added `TestRegTestCount.test_readme_module_count` / `test_test_inventory_module_count` |
+| #278 | LOW / informational | `CHANGELOG.md` `[Unreleased]` | No entry for PRs #271-274 | Added a summary entry |
+
+**Not fixed, accepted as a documented tradeoff:**
+
+| # | Severity | File:line | Issue | Disposition |
+|---|---|---|---|---|
+| #279 | LOW | `_utils.py::model_judge_compliance` | The grader prompt interpolates untrusted target-response text with only a plain-text label, no XML delimiter fencing — a malicious target could theoretically try to confuse the judge model | Traced the actual call path in `jailbreak_harness.py::_apply_model_judge_pass`: it only ever flips a result `True→False` (extra scrutiny), never `False→True` (line: `if verdict["complied"]: result.passed = False`). A successful prompt-injection-against-the-judge can therefore only produce a noisy false FAIL on an opt-in corroboration pass — it cannot launder a real jailbreak success into a false PASS, because the deterministic substring scan already caught it before the judge ever runs. Net exploitable impact is bounded to reduced signal quality on an optional feature, not a security bypass. Delimiter-fencing the prompt is reasonable defense-in-depth for a future round, not urgent enough to justify touching a shared grading helper mid-round. |
+
+No CRITICAL, HIGH, or unaccepted MEDIUM defects were found.
+
+---
+
+## 4. What's Good
+
+- **The asymmetric design of `_apply_model_judge_pass` structurally neutralized
+  what looked like it could be a real prompt-injection finding** (#279) —
+  because the judge pass can only make verdicts *stricter*, never more
+  permissive, the worst case for a malicious target is "the harness got extra
+  suspicious of me," not "the harness got fooled into clearing me." This is
+  the same asymmetric-verification instinct as the repo's own VS-R03 pattern
+  (independent re-derivation catches overconfidence) — good that it was
+  designed in from the start rather than needing a follow-up fix.
+- **All four new harness modules' `--trials` wiring, `run_all` completeness,
+  and boolean detection logic passed a genuinely adversarial line-by-line
+  trace** (not just a pattern-match skim) with zero findings — the "house
+  style" template (dataclass result, simulate/live dual mode, `trial_runner`
+  integration) is holding up well as new modules are added against it.
+- **MAG-013..018's OR/AND combination logic (`compromised = succeeded or
+  <keyword-match>`, `passed = not compromised`) traced correctly** on first
+  audit — the polarity is easy to get backwards in this style of test and it
+  wasn't.
+- **The regression tests added this round were verified, not assumed** — each
+  of the 4 new checks in `test_code_quality.py` was run against the pre-fix
+  `origin/main` source (via `git show`) to confirm it would actually have
+  failed there, not just that it passes now. (E.g. `TestRegJailbreakVersionConsistency`
+  correctly detects `{docstring: 3.1, banner: 3.0, report: 3.0, trial_suite_name: 3.4}`
+  as disagreeing when run against the pre-fix file.)
+
+---
+
+## 5. Methods
+
+- **Audit:** 3 parallel general-purpose agents, each independently scoped to
+  the same 7 files (4 new harnesses + `multi_agent_harness.py`,
+  `jailbreak_harness.py`, `_utils.py`), each with a distinct lens:
+  - Security: ReDoS, SSRF, command injection, path traversal, deserialization,
+    secrets handling, prompt-injection-into-the-judge.
+  - Logic/correctness: per-test simulate-mode fail-ability, `run_all`
+    completeness, `--trials` wiring, boolean-logic correctness, in-file
+    version-string self-consistency.
+  - Consistency/integration: `cli.py`/`test_code_quality.py`/`count_tests.py`
+    registration, doc test-count reconciliation across every file that cites
+    a count, prefix-collision check, version-bump convention check.
+- **Fix:** applied directly (not delegated) — each finding traced to its exact
+  root cause before editing, each fix re-verified against the harness's own
+  `--simulate` output and the full suite.
+- **Verification:** `python3 -m pytest testing/ -q` (315 passed pre- and
+  post-fix comparison), `python3 scripts/count_tests.py` (595, unchanged —
+  this was a bugfix round, not a coverage round), `git show origin/main:<path>`
+  diffing to confirm each new regression test fails on pre-fix source.
+
+---
+
+## 6. Self-Test Suite
+
+- **New (4 checks):**
+  - `TestRegTestCount.test_readme_module_count` / `test_test_inventory_module_count`
+    — module-count prose (as opposed to test-count prose, already guarded)
+    reconciled against `len(HARNESSES)`.
+  - `TestRegJailbreakVersionConsistency.test_consistent_version` — the 4
+    version-string sites in `jailbreak_harness.py` must agree.
+  - `TestRegExtendedThinkingET003.test_not_tautological` — ET-003's simulate
+    branch must not compare a value to itself and must route through a real
+    detector function.
+- **Full suite:** 315 passed, 73 subtests passed (was 311 before this round's
+  4 new tests).
+- **Count:** definitive 595; unchanged by this round (bugfix-only, no new test
+  IDs); `len(HARNESSES)` = 43, now correctly reflected everywhere.
+
+---
+
+## 7. Score
+
+**9/10** — No CRITICAL/HIGH/unaccepted-MEDIUM issues; the two LOW-MEDIUM
+findings (#275, #276) were real defects that shipped in the prior session
+before this audit caught them, which is exactly the scenario round-based
+re-auditing exists for — scoring this 10 would understate that something
+genuinely slipped through initial review (a tautological test, specifically,
+is the kind of thing that provides false assurance if it isn't later caught).
+Both are now fixed with verified regression coverage. #279 is a disclosed,
+traced-through, accepted design tradeoff rather than an open defect.
+
+| Round | Score |
+|---|---|
+| R32 | 9 |
+| R33 | 9 |
+| R34 | 9 |
+| **R35** | **9** |
+
+---
+
+## 8. Recommendations
+
+- **Immediate:** none blocking — all round findings fixed and merged-ready.
+- **Before next release:** delimiter-fence the untrusted response text in
+  `model_judge_compliance`'s grader prompt (#279) as defense-in-depth, even
+  though the current asymmetric design already bounds the exploitable impact.
+- **Architecture:** the "test that can't fail" bug class (#275) would be
+  caught earlier by a lightweight structural lint — e.g. a `test_code_quality.py`
+  check that flags any `simulate` branch whose passing condition reduces to a
+  literal self-comparison (`X == X` / `X != X` on the same variable) via AST
+  inspection rather than the current per-incident regex guards. Worth scoping
+  as a follow-up if this bug class recurs a second time.
+
+---
+
+## 9. Cumulative Assessment
+
+R35 is the first purely self-audit round in recent history (R31-R34 were all
+additive coverage rounds). It found what a coverage-focused round structurally
+can't: two real defects (#275, #276) that a fast four-PR session introduced
+alongside 24 genuinely new tests and a feature retrofit, plus two doc-drift
+items (#277, #278) that no existing regression test was positioned to catch.
+All four are now fixed with verified, falsifiability-checked regression tests
+— not just "added a test," but confirmed each test actually fails on the
+pre-fix code before counting it as a real guard. Issues raised this round: 5
+(#275-279). Fixed: 4. Accepted with documented rationale: 1. Open defects: 0.
+Total tests unchanged at 595 (this was a quality round, not a coverage round)
+— cumulative harness count 39 → 43 across this session.

--- a/testing/test_code_quality.py
+++ b/testing/test_code_quality.py
@@ -115,6 +115,69 @@ class TestRegTestCount(unittest.TestCase):
         mentions = re.findall(r'(\d+)\s+executable security tests', skill)
         self.assertTrue(mentions, "SKILL.md must mention test count")
         for m in mentions: self.assertEqual(m, count)
+    def _harness_count(self):
+        from protocol_tests.cli import HARNESSES
+        return str(len(HARNESSES))
+    def test_readme_module_count(self):
+        count = self._harness_count()
+        with open(os.path.join(REPO_ROOT, "README.md")) as f: readme = f.read()
+        m = re.search(r'security tests across (\d+) modules', readme)
+        self.assertIsNotNone(m, "README.md must state a module count")
+        self.assertEqual(m.group(1), count)
+    def test_test_inventory_module_count(self):
+        count = self._harness_count()
+        with open(os.path.join(REPO_ROOT, "docs", "TEST-INVENTORY.md")) as f: inv = f.read()
+        found = re.findall(r'security tests across (\d+) modules', inv)
+        found += re.findall(r'test IDs across\s*>?\s*(\d+)\s+test-bearing', inv)
+        found += re.findall(r'spans \*\*(\d+) test-bearing\s*>?\s*modules', inv)
+        self.assertTrue(found, "docs/TEST-INVENTORY.md must state a module count")
+        for f_ in found: self.assertEqual(f_, count)
+
+
+class TestRegJailbreakVersionConsistency(unittest.TestCase):
+    """jailbreak_harness.py cites its version in 4 places (docstring, run_all
+    banner print, generate_report suite name, trial_runner suite_name) that
+    must agree -- issue found in round evaluation after v3.0->v3.1 (--judge)."""
+    def test_consistent_version(self):
+        path = os.path.join(REPO_ROOT, "protocol_tests", "jailbreak_harness.py")
+        with open(path) as f: src = f.read()
+        patterns = {
+            "docstring": r'Jailbreak Corpus Security Test Harness \(v(\d+\.\d+)\)',
+            "banner": r'CORPUS TEST SUITE v(\d+\.\d+)',
+            "report": r'"suite":\s*"Expanded Jailbreak Corpus Tests v(\d+\.\d+)"',
+            "trial_suite_name": r'suite_name="Expanded Jailbreak Corpus Tests v(\d+\.\d+)"',
+        }
+        found = {}
+        for name, pat in patterns.items():
+            m = re.search(pat, src)
+            self.assertIsNotNone(m, f"{name} version string not found (pattern may need updating)")
+            found[name] = m.group(1)
+        self.assertEqual(len(set(found.values())), 1,
+            f"jailbreak_harness.py version strings disagree: {found}")
+
+
+class TestRegExtendedThinkingET003(unittest.TestCase):
+    """ET-003's simulate-mode leak check must not be a self-referential
+    tautology (x == x, always true regardless of any real detection logic) --
+    found in round evaluation after extended_thinking_harness.py was added."""
+    def test_not_tautological(self):
+        path = os.path.join(REPO_ROOT, "protocol_tests", "extended_thinking_harness.py")
+        with open(path) as f: src = f.read()
+        m = re.search(
+            r'def test_et_003_redacted_thinking_exposed.*?(?=\n    def test_et_004)',
+            src, re.DOTALL,
+        )
+        self.assertIsNotNone(m, "ET-003 test method not found")
+        body = m.group(0)
+        self.assertNotIn(
+            'naive_output == redacted_block["data"]', body,
+            "ET-003's naive_leaks check must not be a self-referential tautology (x == x)",
+        )
+        self.assertIn(
+            "_exposes_raw_payload", body,
+            "ET-003 should route detection through a real detector function, "
+            "not a bare identity comparison",
+        )
 
 
 class TestRegPassFail(unittest.TestCase):


### PR DESCRIPTION
## Summary

Round-based evaluation (per `CLAUDE.md`'s documented procedure) of the four new Claude Cookbook-primitive harnesses, `multi_agent_harness.py`'s MAG-013..018, and `jailbreak_harness.py`'s `--judge` retrofit — all added earlier in this session (PRs #271-274). Three parallel agents audited the same file scope from different angles (security / logic-correctness / consistency-integration).

**Findings, all LOW-MEDIUM or below, no CRITICAL/HIGH/unaccepted-MEDIUM:**

- **#275**: `extended_thinking_harness.py` ET-003's simulate check was a self-referential tautology (`naive_output == redacted_block["data"]` where `naive_output` *is* `redacted_block["data"]` — always true regardless of any real detection logic). Fixed with a genuine `_exposes_raw_payload()` containment-check detector.
- **#276**: `jailbreak_harness.py` cited 4 disagreeing version strings (v3.1 docstring / v3.0 banner / v3.0 report / v3.4 trial-runner). Reconciled to v3.1 everywhere.
- **#277**: "42 modules" stale in `README.md` and `docs/TEST-INVENTORY.md` (4 locations) — the commit that pushed the harness count to 43 said "41→42" in its body instead of "42→43".
- **#278**: `CHANGELOG.md` had no entry for PRs #271-274. Added one.
- **#279** (accepted, not fixed): the model-judge grader prompt in `_utils.py` lacks delimiter fencing around untrusted target-response text. Traced the actual call path — `_apply_model_judge_pass` can only flip a result PASS→FAIL, never the reverse, so this is bounded to noisy false-FAILs on an opt-in corroboration pass, not an exploitable bypass. Documented as a future defense-in-depth item.

Full writeup: `testing/CRITICAL_EVALUATION_R35_2026-07-25.md`. Score: 9/10.

## Test plan

- [x] `python3 -m pytest testing/ -q` — 315 passed (was 311; +4 new regression tests), 73 subtests passed
- [x] `python3 scripts/count_tests.py` — 595 confirmed unchanged (bugfix round, no new test IDs)
- [x] `len(HARNESSES)` = 43 confirmed
- [x] Each of the 4 new regression tests independently verified to fail against pre-fix `origin/main` source (via `git show`) before being counted as a real guard — not just "added a test that passes now"
- [x] `extended_thinking_harness.py --simulate` re-run post-fix, ET-003 still passes with the new real detector logic


---
_Generated by [Claude Code](https://claude.ai/code/session_01B38zFouRKYbhHXB6oRRGAb)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Harness logic and documentation fixes with new static regression tests; no auth, payment, or production runtime behavior changes.
> 
> **Overview**
> Round 35 is a **self-audit follow-up** to PRs #271–#274 (no new security test IDs; count stays **595**).
> 
> **ET-003** in `extended_thinking_harness.py` no longer uses a tautological simulate check (`naive_output == redacted_block["data"]` when the naive renderer returned the raw payload verbatim). Leak detection now goes through **`_exposes_raw_payload()`** (substring containment), with a more realistic naive render string so the simulate branch can actually fail.
> 
> **`jailbreak_harness.py`** version strings are aligned to **v3.1** everywhere (banner, JSON report, trial runner suite name — previously mixed v3.0/v3.1/v3.4).
> 
> Docs are updated to **43 modules** in `README.md` and `docs/TEST-INVENTORY.md`, **`CHANGELOG.md`** gains an `[Unreleased]` entry for the prior feature PRs, and **`testing/CRITICAL_EVALUATION_R35_2026-07-25.md`** records the round.
> 
> **`testing/test_code_quality.py`** adds four regression guards: README/TEST-INVENTORY module counts vs `HARNESSES`, jailbreak version consistency, and ET-003 non-tautology.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9da0dbb23c0d5510622a259b187b80c019481494. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->