### PR TITLE
gitignore: exclude LaTeX build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,14 @@ november-meeting-extracted.txt
 !package.json
 !pyproject.json
 !schemas/*.json
+
+# LaTeX build artifacts (docs/paper-dgb/ -- source of truth is main.tex +
+# references.bib; compiled output is regenerated locally per its README)
+*.aux
+*.bbl
+*.blg
+*.out
+*.fls
+*.fdb_latexmk
+*.synctex.gz
+*.pdf


### PR DESCRIPTION
## Summary

Compiling `docs/paper-dgb/main.tex` locally (e.g. to review the paper as a PDF) leaves `.aux`/`.bbl`/`.blg`/`.out`/`main.pdf` in the working tree. These are regenerable from `main.tex` + `references.bib` per `docs/paper-dgb/README.md`'s documented compile steps, not source — excluded them so they don't show up as untracked files.

## Test plan

Trivial `.gitignore`-only change, no code/test impact.


---
_Generated by [Claude Code](https://claude.ai/code/session_01B38zFouRKYbhHXB6oRRGAb)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> `.gitignore`-only change with no runtime or test impact; the only caveat is the broad `*.pdf` pattern if the repo later needs to commit PDFs outside existing tracked files.
> 
> **Overview**
> Adds a **LaTeX build artifacts** section to `.gitignore` so local compiles of `docs/paper-dgb/` (e.g. `main.pdf`, `.aux`, `.bbl`, `.blg`, `.out`, and related latexmk/synctex files) no longer appear as untracked noise. The comment notes that **`main.tex` + `references.bib`** remain the source of truth per that folder’s README.
> 
> **Note:** `*.pdf` is ignored repo-wide, not only under `docs/paper-dgb/`—any new PDFs elsewhere would also be excluded unless already tracked or negated with a `!` rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b2374cf48d6ea62f1175c7f3bb4f9f61d555f84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->