### PR TITLE
docs(paper-dgb): round-2 reviewer feedback (9.1/10 review)

### DIFF
--- a/docs/paper-dgb/main.tex
+++ b/docs/paper-dgb/main.tex
@@ -324,6 +324,39 @@ fabrication (2 cases involving accessible configuration files). This finding
 quantifies what practitioners have suspected: behavioral governance failures
 require execution-based testing, not scanning.
 
+\begin{figure}[h]
+\centering
+\resizebox{\linewidth}{!}{%
+\begin{tikzpicture}[
+    node distance=5mm and 6mm,
+    box/.style={draw, rounded corners, align=center, font=\small,
+                minimum height=7mm},
+    root/.style={box, minimum width=2.8cm},
+    leaf/.style={box, minimum width=2.8cm},
+    arr/.style={-{Latex[length=2mm]}, thick}
+  ]
+  \node[root] (all) {52 DGB Cases};
+  \node[leaf, below left=8mm and 0mm of all]  (beh)  {44 Behavioral (85\%)\\scanner-invisible ($M{=}$False)};
+  \node[leaf, below right=8mm and 0mm of all] (struc){8 Structural (15\%)\\scanner-detectable ($M{=}$True)};
+  \node[leaf, below=of beh, fill=gray!12]  (behd) {Execution: detects all 44\\Scanner: detects 0};
+  \node[leaf, below=of struc, fill=gray!12] (strucd){Execution: detects all 8\\Scanner: detects all 8};
+
+  \draw[arr] (all) -- (beh);
+  \draw[arr] (all) -- (struc);
+  \draw[arr] (beh) -- (behd);
+  \draw[arr] (struc) -- (strucd);
+\end{tikzpicture}%
+}
+\caption{The 85\% scanner detection gap. Execution-based testing observes
+         every case by construction (Section~\ref{sec:dgb}, criterion~2);
+         metadata scanning observes only the 8 structurally detectable
+         cases. This is a detectability claim (can the method observe the
+         failure at all), distinct from the governance-maintenance results
+         (does the agent avoid the failure) reported in
+         Section~\ref{sec:results}.}
+\label{fig:gap}
+\end{figure}
+
 \subsection{Illustrative Case: GM-001 Gate Self-Disable}
 \label{sec:illustrative}
 
@@ -513,6 +546,24 @@ detection gap: the scanner's 15.4\% GMR is entirely explained by the 8
 scanner-detectable cases; it contributes zero governance protection on the
 44 behavioral cases.
 
+\subsection{Statistical Significance of the Detection Gap}
+\label{sec:significance}
+
+Config~B and Config~C are evaluated on the identical 52 cases, so the two
+configurations' outcomes are paired, not independent, observations---the
+correct test is McNemar's, not a two-sample test such as Fisher's exact
+test or a $\chi^2$ test of independence, both of which assume independent
+samples. Of the 52 cases, execution-based governance (Config~B) succeeds
+where scanning (Config~C) fails on 34 cases, scanning succeeds where
+execution fails on 5, and both agree (concordant) on 13. McNemar's exact
+binomial test on the 39 discordant pairs
+gives $p \approx 2.4\times10^{-6}$~\cite{mcnemar1947}, rejecting the null
+hypothesis that the two methods detect governance failures at equal rates.
+The direction and magnitude of the asymmetry (34 vs.\ 5) indicate the
+methods are not interchangeable: execution-based testing detects failures
+scanning structurally cannot see, at a rate scanning's occasional
+execution-invisible advantages (the 5 cases) do not offset.
+
 \subsection{Per-Category Breakdown}
 
 \begin{table}[h]
@@ -556,10 +607,9 @@ signals: OS-level permission inheritance, prompt injection role reassignment,
 and recursive cost inflation. The gate abstraction cannot block what it
 cannot observe.
 
-Payment chain is the weakest category (50\%) because 4/10 cases are
-protocol-layer controls that sit below the governance gate abstraction.
-This is not a limitation of the evaluated governance implementation---it
-reflects an accurate categorization of the governance layer boundary.
+Payment chain's weakness (50\%) is a special case of the infrastructure-scope
+pattern above: 4 of its 10 cases are protocol-layer controls (L402/x402
+enforcement, SSRF) below the gate abstraction, not a gap in gate logic.
 
 % ---------------------------------------------------------------------------
 \section{Discussion}
@@ -707,16 +757,17 @@ We presented the Decision Governance Benchmark (DGB). To our knowledge, we
 are unaware of a prior benchmark corpus specifically designed to evaluate
 whether autonomous AI agents resist governance failures. Our key
 finding---that 85\% of governance failures are invisible to metadata-only
-scanners---provides evidence that execution-based testing is a
-\emph{necessary complement} to static analysis for agent security
-evaluation.
+scanners, a gap that is statistically significant
+(McNemar's exact test, $p \approx 2.4\times10^{-6}$,
+Section~\ref{sec:significance})---indicates that execution-based
+evaluation measures a different security property than metadata scanning,
+not merely a more thorough version of the same property.
 
-Baseline results show a 71.2\% GMR for constitutional governance (Config~B)
-versus 0\% for ungoverned agents (Config~A). Of the 28.8\% failure rate for
-Config~B, the majority (12/15 cases) require infrastructure-layer controls
-outside governance gate scope, not improvements to the gate logic itself.
-The evaluated governance implementation catches 77.3\% of scanner-invisible
-cases that reach the decision layer.
+A governed configuration achieves a 71.2\% GMR versus 0\% for ungoverned
+agents. Of the resulting 28.8\% failure rate, the majority (12/15 cases)
+require infrastructure-layer controls outside governance gate scope, not
+improvements to the gate logic itself; that configuration catches 77.3\% of
+scanner-invisible cases that reach the decision layer.
 
 The corpus, harness, and evidence format are open source (MIT). Contributions
 are welcome via the public repository.

--- a/docs/paper-dgb/references.bib
+++ b/docs/paper-dgb/references.bib
@@ -160,3 +160,15 @@
   year         = {2001},
   doi          = {10.1214/ss/1009213286}
 }
+
+@article{mcnemar1947,
+  author       = {McNemar, Quinn},
+  title        = {Note on the Sampling Error of the Difference between
+                  Correlated Proportions or Percentages},
+  journal      = {Psychometrika},
+  volume       = {12},
+  number       = {2},
+  pages        = {153--157},
+  year         = {1947},
+  doi          = {10.1007/BF02295996}
+}


### PR DESCRIPTION
## Summary

Second external review round (8.7 → 9.1/10 after the first round of fixes). Addressed the four concrete remaining items plus a narrative-balance pass. Skipped the "evaluate frontier agents" item from the reviewer's "if I had one month" list — that's genuine new research scope (live API evaluation across multiple providers), not a docs edit, and is flagged separately for a standalone decision rather than folded in here.

1. **McNemar's exact test** (new §5.3 "Statistical Significance of the Detection Gap"): computed for real on the paired per-case data in `benchmarks/evaluation_results.json` — n=52, 34 discordant cases favor execution-based testing vs. 5 favoring scanning, **p ≈ 2.4×10⁻⁶**. Deliberately used McNemar's rather than the reviewer's suggested Fisher's exact/χ²: those assume independent samples, but Config B and Config C are evaluated on the *identical* 52 cases (paired design), which McNemar's is the statistically correct test for. Cross-validated the exact binomial p-value two independent ways before using it. New citation: McNemar 1947 (*Psychometrika*).
2. **Second figure**: the 85% detection-gap funnel (52 cases → 44 behavioral / 8 structural → execution detects all / scanner detects only the structural half).
3. **Two exact sentence rewrites**, per the reviewer's own suggested wording.
4. **Config B narrative trim**: cut a sentence that restated the payment-chain weakness near-verbatim twice in adjacent sections, generalized two conclusion mentions from "constitutional governance (Config B)" to "a governed configuration."

## Test plan

- [x] `pdflatex` ×2 + `bibtex` ×1 — compiles cleanly, 11 pages, **zero** undefined references (checked final pass explicitly)
- [x] Overfull-hbox warning set verified **byte-identical** (via `diff`) to the pre-this-session baseline — the first draft of the new figure introduced one new overflow, fixed with `\resizebox` and reverified
- [x] McNemar's p-value cross-validated two independent ways (direct binomial sum + symmetric-distribution shortcut) before use
- [x] `python3 -m pytest testing/ -q` — 315 passed, unaffected
- [x] `git status` confirms build artifacts stayed gitignored


---
_Generated by [Claude Code](https://claude.ai/code/session_01B38zFouRKYbhHXB6oRRGAb)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> LaTeX and bibliography changes only; no benchmark harness, evaluation logic, or runtime code paths are modified.
> 
> **Overview**
> Addresses second-round paper review with **documentation-only** updates to `docs/paper-dgb/main.tex` and `references.bib`.
> 
> Adds a **TikZ figure** (`fig:gap`) that visualizes the 52-case split (44 behavioral vs. 8 structural) and contrasts execution-based detection with scanner-only coverage on each branch.
> 
> Introduces **§5.3 Statistical Significance of the Detection Gap** (`sec:significance`): argues Config B vs. Config C is a **paired** design, applies **McNemar's exact test** on 39 discordant pairs (34 vs. 5), reports **p ≈ 2.4×10⁻⁶**, and cites McNemar (1947). The **conclusion** is rewritten to cite that result and frame execution-based evaluation as measuring a **different security property** than metadata scanning, not a stronger version of the same one.
> 
> Minor narrative edits: payment-chain weakness is folded into the infrastructure-scope error pattern (less duplicate wording), and Config B is described more generically as “a governed configuration” where appropriate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73376a8aa9ed9f5e46f92dd6403436619569aa59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->