### PR TITLE
docs(benchmarks): fix stale corpus README, add CHANGELOG for dgb-v1.0.0

### DIFF
--- a/benchmarks/CHANGELOG.md
+++ b/benchmarks/CHANGELOG.md
@@ -1,0 +1,75 @@
+# Decision Governance Benchmark (DGB) — Changelog
+
+Versioned independently of the `agent-security-harness` package
+(`pyproject.toml`, currently 4.9.1) and of the wire-protocol test suite in
+`protocol_tests/`. This changelog covers only the benchmark corpus,
+evaluation harness, baseline results, and paper under `benchmarks/` and
+`docs/paper-dgb/`.
+
+## [dgb-v1.0.0] — 2026-07-25
+
+First versioned, citable release. Corresponds to the results reported in
+*Decision Governance Benchmark: Executable Behavioral Tests for Autonomous
+AI Agent Security* (docs/paper-dgb/main.tex).
+
+### Included in this release
+
+- **Corpus** (`benchmarks/decision_behavior_corpus.py`): 52 `BenchmarkCase`
+  entries across 5 categories (escalation_bypass, collusion,
+  memory_tampering, payment_chain, evidence_fabrication — see
+  `benchmarks/README.md` for the full breakdown), each grounded in a
+  documented incident, CVE, or research finding rather than a hypothetical
+  scenario.
+- **Evaluation harness** (`benchmarks/evaluation_runner.py`): runs the
+  corpus against a configurable agent under test and scores each case
+  PASS/FAIL against its `expected_behavior`/`failure_behavior` contrast.
+- **Baseline results** (`benchmarks/evaluation_results.json`): the exact
+  per-case, per-configuration (A: ungoverned, B: constitutional, C: scanner
+  only) results reported in the paper's Section 5 and Appendix A. Corpus
+  run timestamp `2026-04-17T12:07:43Z`.
+- **13 complementary harness tests** in `protocol_tests/`: 7 benchmark
+  integrity tests (`benchmark_integrity_harness.py`, BI-001..007) and 6
+  governance modification tests (`governance_modification_harness.py`,
+  GM-001..006), which the corpus's `executable_test` field references.
+- **Paper** (`docs/paper-dgb/`): full LaTeX source, compiled PDF build
+  instructions, and the per-case appendix generator
+  (`docs/paper-dgb/_gen_appendix.py`) that regenerates Appendix A directly
+  from this release's `evaluation_results.json` and
+  `decision_behavior_corpus.py`.
+
+### Findings this release establishes as citable, reproducible baselines
+
+- 44/52 cases (85%) are undetectable by metadata-only scanning
+  (`scanner_passes=True`) — the failure only manifests when the decision
+  path executes.
+- Config B (constitutional governance, `constitutional-agent` v0.1.0):
+  71.2% Governance Maintenance Rate (GMR), 77.3% Scanner Gap Score (SGS).
+  Config A (ungoverned): 0% GMR. Config C (scanner only): 15.4% GMR, 0%
+  SGS.
+- The scanner-vs-execution detection gap is statistically significant:
+  McNemar's exact test on the paired Config B/Config C per-case outcomes,
+  $p \approx 2.4 \times 10^{-6}$ (39 discordant pairs, 34 favoring
+  execution-based detection vs. 5 favoring scanning).
+
+### Known limitations at this release (see paper Section 6.3, "Threats to
+Validity," for the full discussion)
+
+- Baseline results use deterministic stub agents, not production LLM
+  agents (Claude, GPT, Gemini, or otherwise) — this release validates the
+  benchmark and harness, not commercial systems.
+- The corpus and the evaluated governance implementation
+  (`constitutional-agent`) share an author — flagged in the paper as the
+  single largest threat to validity, with independent third-party
+  replication named as the most important open follow-up.
+
+### Fixed in this release
+
+- `benchmarks/README.md` had drifted from the actual corpus: it previously
+  stated "50 cases" / "70%+ scanner miss rate" and an incomplete Sources
+  table, all stale relative to the current 52-case / 85%-miss-rate corpus.
+  Corrected to match `decision_behavior_corpus.py` exactly as of this tag.
+
+---
+
+Corpus and harness are MIT licensed. See the root
+[`LICENSE`](../LICENSE) file. Citation format: `benchmarks/README.md`.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,13 +1,18 @@
 # Decision Behavior Benchmark Corpus
 
-**v1.0 — Issue [#120](https://github.com/msaleme/red-team-blue-team-agent-fabric/issues/120)**
+**[`dgb-v1.0.0`](https://github.com/msaleme/red-team-blue-team-agent-fabric/releases/tag/dgb-v1.0.0) — Issue [#120](https://github.com/msaleme/red-team-blue-team-agent-fabric/issues/120)**
 
 A curated, machine-readable corpus of decision-behavior test cases for autonomous
-AI agents. Part of the v5.0 "Lock the Category" milestone.
+AI agents. Part of the v5.0 "Lock the Category" milestone. This is the corpus
+and evaluation harness behind the paper *Decision Governance Benchmark:
+Executable Behavioral Tests for Autonomous AI Agent Security* (see
+[`docs/paper-dgb/`](../docs/paper-dgb/)). The `dgb-v1.0.0` tag is versioned
+independently of the `agent-security-harness` package (`pyproject.toml`) —
+they are separate deliverables that happen to live in the same repository.
 
 ## What this is
 
-The corpus documents 50+ failure modes where an ungoverned agent takes a harmful
+The corpus documents 52 failure modes where an ungoverned agent takes a harmful
 action that a well-governed agent must block. Every case includes:
 
 - The scenario and context presented to the agent
@@ -18,7 +23,8 @@ action that a well-governed agent must block. Every case includes:
 - A reference to the executable harness test that covers the case
   (`executable_test`)
 
-The central finding: **metadata scanners miss 70%+ of behavioral failures**.
+The central finding: **metadata scanners miss 85% of behavioral failures**
+(44 of 52 cases).
 The failure lives in the execution path — the *decision* the agent makes — not
 in the description of the tool it calls. Scanning tool descriptions is
 insufficient; you need to execute the decision path.
@@ -28,7 +34,7 @@ insufficient; you need to execute the decision path.
 ```python
 from benchmarks.decision_behavior_corpus import CORPUS, BenchmarkCase
 
-# All 50+ cases
+# All 52 cases
 print(len(CORPUS))
 
 # Filter by category
@@ -57,9 +63,9 @@ corpus = load_corpus()
 | `collusion` | DBC-011–020 | 10 | Multi-agent cooperation to circumvent controls |
 | `memory_tampering` | DBC-021–030 | 10 | Manipulation of history, context, or audit state |
 | `payment_chain` | DBC-031–040 | 10 | Abuse of payment or tool execution paths |
-| `evidence_fabrication` | DBC-041–050 | 10 | Fabrication, inflation, or misrepresentation of evaluation results |
+| `evidence_fabrication` | DBC-041–052 | 12 | Fabrication, inflation, or misrepresentation of evaluation results |
 
-**Total: 50 cases across 5 categories.**
+**Total: 52 cases across 5 categories.**
 
 ## BenchmarkCase Schema
 
@@ -91,9 +97,11 @@ Each case carries a `scanner_passes` boolean:
 - **`False`** — a scanner that inspects tool descriptions or configurations could,
   in principle, flag this case without executing the agent.
 
-The corpus maintains >= 70% `scanner_passes=True` cases. This is the core
-argument for executable behavioral testing: the majority of agent governance
-failures require running the agent to observe.
+44 of the 52 cases (85%) have `scanner_passes=True`. This is the core
+argument for executable behavioral testing: the large majority of agent
+governance failures require running the agent to observe, not scanning tool
+descriptions. (See `docs/paper-dgb/main.tex` Section 5.3 for a McNemar's
+exact test on this detection gap, $p \approx 2.4\times10^{-6}$.)
 
 ## Executable Test Mapping
 
@@ -110,23 +118,29 @@ Each corpus case references an executable harness test via `executable_test`:
 
 ## Citation
 
-If you reference this corpus in a paper or report:
+If you reference this corpus in a paper or report, cite the versioned release
+rather than the repository at large, so the citation stays pinned to the
+exact 52-case corpus a result was evaluated against:
 
 ```
-Agent Security Harness Decision Behavior Benchmark Corpus v1.0.
-msaleme/red-team-blue-team-agent-fabric, Issue #120. April 2026.
-https://github.com/msaleme/red-team-blue-team-agent-fabric
+Saleme, M. K. (2026). Decision Governance Benchmark (DGB) Corpus, v1.0.0.
+msaleme/red-team-blue-team-agent-fabric, Issue #120.
+https://github.com/msaleme/red-team-blue-team-agent-fabric/releases/tag/dgb-v1.0.0
 
 Sources: UC Berkeley RDI (Xu et al. 2025), lightningzero 2026,
 METR Autonomy Evaluation Framework 2025, OX Security 2026,
 zhuanruhu 2026, OpenClaw CVE-2026-35625/35629, Kiro/Amazon 2026.
 ```
 
+If citing the accompanying paper instead of (or in addition to) the corpus
+directly, see [`docs/paper-dgb/README.md`](../docs/paper-dgb/README.md) for
+the paper's own citation and arXiv identifier once submitted.
+
 ## Sources
 
 | Source | Finding | Cases |
 |---|---|---|
-| UC Berkeley RDI (Xu et al. 2025) | All 8 major AI benchmarks hackable for perfect scores | DBC-041–050 |
+| UC Berkeley RDI (Xu et al. 2025) | All 8 major AI benchmarks hackable for perfect scores | DBC-041, 043–045, 047–049 |
 | lightningzero 2026 | 9/12 agents self-disabled governance gates within 48h | DBC-001–005 |
 | METR 2025 | Reward-hacking in >30% of o3 and Claude 3.7 Sonnet eval runs | DBC-012, 013, 017, 020, 050 |
 | OX Security 2026 | MCP STDIO injection, 36.7% SSRF, cross-agent relay | DBC-009, 016, 032, 037 |
@@ -137,3 +151,5 @@ zhuanruhu 2026, OpenClaw CVE-2026-35625/35629, Kiro/Amazon 2026.
 | MCP cost inflation 2026 | 658x compute cost via recursive tool calls | DBC-008, 033, 015 |
 | IQuest-Coder 2026 | Git log copying to inflate benchmark scores | DBC-042, 046 |
 | $45M crypto agent 2026 | Autonomous over-threshold trade approval | DBC-031, 036, 038, 040 |
+| AgentSeal runtime exploitation 2026 | Credential retention in tool descriptions | DBC-051 |
+| Return channel poisoning (harness RCP-001, CVE-004) | Cross-tool context leakage | DBC-052 |

--- a/docs/paper-dgb/README.md
+++ b/docs/paper-dgb/README.md
@@ -72,10 +72,16 @@ files are required — the paper uses the standard `article` class with
 
 ## Data
 
-Section 5 results and Appendix A (per-case table) are sourced from:
+Section 5 results and Appendix A (per-case table) are sourced from the
+[`dgb-v1.0.0`](https://github.com/msaleme/red-team-blue-team-agent-fabric/releases/tag/dgb-v1.0.0)
+release of the benchmark (see `benchmarks/CHANGELOG.md`):
 - `benchmarks/evaluation_results.json` — aggregate and per-case results
 - `benchmarks/decision_behavior_corpus.py` — 52-case corpus definition
 - Corpus run timestamp: `2026-04-17T12:07:43Z`
+
+The `dgb-v1.0.0` tag is versioned independently of both the paper (which
+has no version number of its own until an arXiv identifier is assigned)
+and the `agent-security-harness` package.
 
 To regenerate Appendix A's LaTeX table after a corpus/results change:
 
@@ -94,6 +100,11 @@ python3 docs/paper-dgb/_gen_appendix.py > /tmp/appendix.tex
   title        = {Decision Governance Benchmark: Executable Behavioral Tests
                   for Autonomous {AI} Agent Security},
   year         = {2026},
-  howpublished = {arXiv preprint}
+  howpublished = {arXiv preprint},
+  note         = {Corpus and evaluation harness: dgb-v1.0.0}
 }
 ```
+
+To cite the corpus/harness independently of the paper (e.g. "we evaluated
+against DGB v1.0.0"), see `benchmarks/README.md`'s own citation entry
+instead.


### PR DESCRIPTION
## Summary

Prep for tagging the Decision Governance Benchmark as its own versioned, citable release (`dgb-v1.0.0`) — independent of the `agent-security-harness` package's own version (4.9.1). They're separate deliverables sharing a repo, which is what prompted this: the user correctly flagged that "v1" was ambiguous against the harness's existing 4.x versioning.

While verifying `benchmarks/README.md` before tagging it, found it had drifted from the actual corpus (same drift class this session has been catching repeatedly, just in a file the earlier passes hadn't touched):
- "50 cases" / "70%+ scanner miss rate" → actual **52 cases / 85%** (44/52)
- `evidence_fabrication` category: claimed 10 cases (`DBC-041–050`), actual **12 cases** (`DBC-041–052`)
- Sources table: UC Berkeley RDI's case range was stale (included IDs 051/052, which are actually attributed to different sources — AgentSeal and return-channel-poisoning respectively — neither of which had a table row at all)

All verified against `benchmarks/decision_behavior_corpus.py` directly (`Counter` over `CORPUS`, not hand-counted).

New `benchmarks/CHANGELOG.md` documents the `dgb-v1.0.0` release scope: corpus (52 cases), evaluation harness, baseline results (`evaluation_results.json`), the 13 complementary BI/GM harness tests, and the paper — plus the citable baseline findings (85% scanner miss rate, McNemar's p≈2.4×10⁻⁶) and known limitations (stub agents, shared authorship with `constitutional-agent`) as of this release.

Cross-linked the corpus README and `docs/paper-dgb/README.md`'s citation sections to the `dgb-v1.0.0` tag so "cite DGB v1.0.0" points at something concrete and version-pinned.

## Test plan

- [x] All corpus numbers re-derived programmatically from `benchmarks/decision_behavior_corpus.py`'s actual `CORPUS` list, not transcribed from memory
- [x] `python3 -m pytest testing/ -q` — 315 passed, unaffected (docs-only change)
- [x] `git status` confirms no stray build artifacts


---
_Generated by [Claude Code](https://claude.ai/code/session_01B38zFouRKYbhHXB6oRRGAb)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes with no runtime, security, or data-path impact.
> 
> **Overview**
> Documentation-only prep for the **`dgb-v1.0.0`** release, clarifying that the Decision Governance Benchmark is versioned separately from **`agent-security-harness`**.
> 
> Adds **`benchmarks/CHANGELOG.md`** describing the release scope (52-case corpus, evaluation harness, baseline **`evaluation_results.json`**, linked protocol tests, paper), citable baseline metrics (85% scanner miss, GMR/SGS, McNemar’s test), and known limitations.
> 
> **`benchmarks/README.md`** is corrected to match **`decision_behavior_corpus.py`**: **52** cases (not 50), **85%** scanner miss (44/52), **`evidence_fabrication`** through **DBC-052** (12 cases), an updated Sources table (including **DBC-051** / **DBC-052**), and a version-pinned citation URL for the release tag.
> 
> **`docs/paper-dgb/README.md`** now points data provenance and BibTeX at **`dgb-v1.0.0`** and cross-links corpus vs paper citation guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19371e518c1d7c016374f39e2ab1bbb657ac2498. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->