### PR TITLE
release: v4.10.0 (595 tests / 43 modules)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.10.0] - 2026-07-25
+
 ### Fixed
 
 - **MCP-020 oracle corrected: a persistent origin id no longer authorizes a
@@ -29,6 +31,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   schemes regardless of determinism. AP2-014 reclassified normative N -> I
   (inferred: standard payment-security practice, not mapped to a cited AP2
   clause). Test count unchanged (AP2-014 retained).
+- **Round-35 self-audit fixes (PR #275, issues #275-278).** ET-003's
+  simulate check was a self-referential tautology (`x == x`, always true) --
+  fixed with a real `_exposes_raw_payload()` containment-check detector.
+  `jailbreak_harness.py` cited 4 disagreeing version strings across its
+  docstring/banner/report/trial-runner paths -- reconciled to v3.1
+  everywhere. "42 modules" was stale in README.md/TEST-INVENTORY.md (should
+  have been 43). 4 new regression tests added, each verified to actually
+  fail against pre-fix source before being counted as a real guard.
+- **`mcp_harness.py`'s `HARNESS_CLIENT_INFO` had a hardcoded version string**
+  (`"4.9.1"`, literal) that would have drifted out of sync with every future
+  release exactly like this one -- now derived from `protocol_tests.version.get_harness_version()`,
+  the same pyproject.toml-backed source of truth `cli.py` already uses
+  (issue #5 pattern).
+- **`benchmarks/README.md` had drifted from the actual corpus**: stated "50
+  cases" / "70%+ scanner miss rate" against the real 52-case / 85%-miss-rate
+  corpus, with an incomplete Sources table. Corrected while preparing the
+  `dgb-v1.0.0` benchmark release tag (versioned independently of this
+  package).
 
 ### Added
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,8 @@
 cff-version: 1.2.0
 message: "If you cite this work in research, please use this metadata."
 title: "Agent Security Harness"
-abstract: "Multi-protocol agent security testing framework. 540 executable security tests across 37 modules covering MCP, A2A, L402, and x402 wire protocols. Decision-layer attack scenarios, AIUC-1 pre-certification mapping, NIST AI 800-2 aligned."
+version: "4.10.0"
+abstract: "Multi-protocol agent security testing framework. 595 executable security tests across 43 modules covering MCP, A2A, L402, and x402 wire protocols. Decision-layer attack scenarios, AIUC-1 pre-certification mapping, NIST AI 800-2 aligned."
 type: software
 authors:
   - family-names: Saleme
@@ -10,7 +11,7 @@ authors:
 repository-code: "https://github.com/msaleme/red-team-blue-team-agent-fabric"
 url: "https://pypi.org/project/agent-security-harness/"
 license: Apache-2.0
-date-released: "2026-04-25"
+date-released: "2026-07-25"
 keywords:
   - agent-security
   - mcp

--- a/SKILL.md
+++ b/SKILL.md
@@ -4,7 +4,7 @@ description: 595 executable security tests for AI agent systems — MCP, A2A, L4
 license: Apache-2.0
 metadata:
   source: "https://github.com/msaleme/red-team-blue-team-agent-fabric"
-  version: "4.9.1"
+  version: "4.10.0"
   openclaw:
     emoji: "🛡️"
     requires:
@@ -37,7 +37,7 @@ Answer the question every operator needs answered before going to production:
 - **Calendar year:** 2026. CVE references like `CVE-2026-35625` are current-year identifiers, not fabricated. Verify any cited CVE in [NVD](https://nvd.nist.gov/vuln/detail/CVE-2026-35625).
 - **Package origin:** Published to PyPI by `Michael K. Saleme` (ORCID `0009-0003-6736-1900`). Source is public on GitHub. Five public Zenodo preprints (not represented as peer-reviewed publications) back the methodology.
 - **License:** Apache 2.0 (permissive open source). No telemetry, no phone-home.
-- **Versioning:** Semantic. Latest is `4.9.1`; older bundles remain immutable on PyPI for reproducibility.
+- **Versioning:** Semantic. Latest is `4.10.0`; older bundles remain immutable on PyPI for reproducibility.
 
 ## When to use
 

--- a/benchmarks/CHANGELOG.md
+++ b/benchmarks/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Decision Governance Benchmark (DGB) — Changelog
 
 Versioned independently of the `agent-security-harness` package
-(`pyproject.toml`, currently 4.9.1) and of the wire-protocol test suite in
+(`pyproject.toml`, currently 4.10.0) and of the wire-protocol test suite in
 `protocol_tests/`. This changelog covers only the benchmark corpus,
 evaluation harness, baseline results, and paper under `benchmarks/` and
 `docs/paper-dgb/`.

--- a/docs/TEST-INVENTORY.md
+++ b/docs/TEST-INVENTORY.md
@@ -4,9 +4,10 @@
 
 > **Canonical figures (verified 2026-07-25).** Main branch: 595 test IDs across
 > 43 test-bearing modules in `protocol_tests/` (files with no `test_id` — CLI,
-> helpers, telemetry, registry — are not counted as modules). The latest PyPI
-> release, `agent-security-harness` v4.9.1, ships 540; `main` is ahead of the
-> last release. Wire protocols: 4 (MCP, A2A, L402, x402). AIUC-1: 19 of
+> helpers, telemetry, registry — are not counted as modules). `main`'s
+> `pyproject.toml` is at `agent-security-harness` v4.10.0 (595 tests); PyPI
+> itself will show this version once the release is published (see
+> `CHANGELOG.md`). Wire protocols: 4 (MCP, A2A, L402, x402). AIUC-1: 19 of
 > 20 testable requirements (95%). Research: 5 public Zenodo preprints (not
 > peer-reviewed) + 3 NIST submissions. Regenerate with `python
 > scripts/count_tests.py`. Per-module counts below are reconciled to this run;

--- a/protocol_tests/cli.py
+++ b/protocol_tests/cli.py
@@ -172,7 +172,7 @@ def _simulate_harness(harness_name: str, info: dict,
 HARNESSES = {
     "mcp": {
         "module": "protocol_tests.mcp_harness",
-        "description": "MCP wire-protocol security tests (20 tests, JSON-RPC 2.0)",
+        "description": "MCP wire-protocol security tests (32 tests, JSON-RPC 2.0)",
     },
     "mcp-supplychain": {
         "module": "protocol_tests.mcp_supplychain",

--- a/protocol_tests/mcp_harness.py
+++ b/protocol_tests/mcp_harness.py
@@ -58,6 +58,7 @@ from protocol_tests._utils import (
     FORWARD_BRIDGE_PATTERN,
     CREDENTIAL_MATERIAL_PATTERN,
 )
+from protocol_tests.version import get_harness_version
 
 
 # Preserve the harness's existing Streamable HTTP baseline. Dual-era discovery
@@ -66,7 +67,10 @@ LEGACY_PROTOCOL_VERSION = "2025-03-26"
 MODERN_PROTOCOL_VERSION = "2026-07-28"
 AUTO_PROTOCOL_VERSION = "auto"
 DIFFERENTIAL_PROTOCOL_VERSION = "differential"
-HARNESS_CLIENT_INFO = {"name": "agent-security-harness", "version": "4.9.1"}
+# Derived from pyproject.toml (issue #5 pattern) rather than hardcoded, so
+# this can't drift out of sync with the package version the way a literal
+# string previously did.
+HARNESS_CLIENT_INFO = {"name": "agent-security-harness", "version": get_harness_version()}
 
 
 def _header_value(value: object) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-security-harness"
-version = "4.9.1"
+version = "4.10.0"
 description = "595 security tests for AI agent systems - MCP, A2A, L402, x402, UCP/ACP merchant-journey, AP2 mandate + Fireblocks x402 hardening + Visa TAP / Mastercard Agentic Tokens + denial-of-settlement finality, decision governance, AIUC-1 compliance, NIST AI 800-2 aligned"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {text = "Apache-2.0"}

--- a/testing/test_code_quality.py
+++ b/testing/test_code_quality.py
@@ -115,6 +115,16 @@ class TestRegTestCount(unittest.TestCase):
         mentions = re.findall(r'(\d+)\s+executable security tests', skill)
         self.assertTrue(mentions, "SKILL.md must mention test count")
         for m in mentions: self.assertEqual(m, count)
+    def test_cli_total_tests_matches_canonical(self):
+        """cli.py's per-harness description counts (summed by _total_tests(),
+        what `agent-security version` prints) must match the canonical count.
+        Catches a harness module growing (e.g. mcp_harness.py 20->32 tests)
+        without its cli.py HARNESSES description being updated to match --
+        found via round evaluation: 'mcp' still said 20 tests when the
+        module actually had 32, silently undercounting `agent-security
+        version`'s headline number by 12."""
+        from protocol_tests.cli import _total_tests
+        self.assertEqual(str(_total_tests()), self._canonical_count())
     def _harness_count(self):
         from protocol_tests.cli import HARNESSES
         return str(len(HARNESSES))


### PR DESCRIPTION
## Summary

First real version bump since 4.9.1 (2026-07-10) — 30 new tests, 5 new harness modules, and 2 correctness fixes have been sitting on `main` under `[Unreleased]` with only the description-count string bumped, never the version itself. Moves `CHANGELOG.md`'s `[Unreleased]` content to a dated `[4.10.0]` section, bumps `pyproject.toml`, and syncs every place that cites the package version (`SKILL.md`, `CITATION.cff`, `docs/TEST-INVENTORY.md`, `benchmarks/CHANGELOG.md`).

**Context**: this is intentionally timed to land right before publishing the separate `dgb-v1.0.0` benchmark release — that release's publish event will trigger `publish-pypi.yml` (which fires on *any* published release, unfiltered by tag — a known gap, not fixed here per explicit instruction to skip it) and now has a real new version to successfully upload instead of failing on a duplicate 4.9.1.

Two real bugs found and fixed while doing this:

1. **`mcp_harness.py`'s `HARNESS_CLIENT_INFO` had a hardcoded version string** (`"4.9.1"`, literal) sent in the MCP handshake — would have drifted out of sync with this release too. Now derived from `protocol_tests.version.get_harness_version()`, the same source `cli.py` already uses (issue #5 pattern).
2. **`cli.py`'s `mcp` harness description said "20 tests" while the module actually has 32** — stale since a prior merge grew the module without updating this string. Silently undercounted `agent-security version`'s headline number by exactly 12 (583 shown vs. 595 actual). Fixed, and added `TestRegTestCount.test_cli_total_tests_matches_canonical` so this drift class can't recur silently.

Also folds in the round-35 self-audit fixes and the `benchmarks/README.md` corpus-drift fix from this session, since neither had been versioned yet.

## Test plan

- [x] `python3 -m pytest testing/ -q` — 316 passed (was 315; +1 new regression test)
- [x] `python3 scripts/count_tests.py` — 595 confirmed
- [x] New regression test verified to actually fail against pre-fix `origin/main` source (`cli.py`'s old "20 tests" description) before being counted as a real guard
- [x] `python3 -c "from protocol_tests.version import get_harness_version; ..."` and `agent-security version` CLI output both confirmed showing `4.10.0` / `595 tests across 43 modules` end-to-end


---
_Generated by [Claude Code](https://claude.ai/code/session_01B38zFouRKYbhHXB6oRRGAb)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly version and documentation sync plus a small metadata fix and a quality regression test; no changes to security oracle logic in the diff hunk set shown.
> 
> **Overview**
> This PR **releases v4.10.0** by moving `[Unreleased]` changelog content into a dated `[4.10.0]` section, bumping **`pyproject.toml`** to `4.10.0`, and aligning cited figures (595 tests, 43 modules) across **`SKILL.md`**, **`CITATION.cff`**, **`docs/TEST-INVENTORY.md`**, and **`benchmarks/CHANGELOG.md`**.
> 
> **MCP client identity** no longer hardcodes `"4.9.1"` in `HARNESS_CLIENT_INFO`; it uses **`get_harness_version()`** so the version sent in the MCP handshake tracks the package.
> 
> **CLI headline test count** is corrected: the `mcp` harness description now says **32 tests** (was 20), matching the module. **`TestRegTestCount.test_cli_total_tests_matches_canonical`** asserts `_total_tests()` matches the canonical count from `count_tests.py` so per-harness description drift cannot silently under-report `agent-security version` again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4fe68f73e8e41986c18fb60ba3e7a567856e2cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->