### PR TITLE
benchmarks: add DGB contribution guide and leaderboard

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,6 +110,7 @@ Promoted patterns keep contributor attribution in the code and docs.
 - Grafana dashboard enhancements
 - Bug fixes in the test automation suite
 - Documentation improvements
+- **Decision Governance Benchmark (DGB) contributions** - new corpus cases, or a real-agent (Config D) evaluation run. See [`benchmarks/CONTRIBUTING.md`](benchmarks/CONTRIBUTING.md) and [`benchmarks/LEADERBOARD.md`](benchmarks/LEADERBOARD.md) - independent Config D submissions are currently the highest-value gap in that benchmark.
 
 ## Before You Contribute
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ The [constitutional-agent](https://github.com/CognitiveThoughtEngine/constitutio
 | CI/CD GitHub Action | [docs/github-action.md](docs/github-action.md) |
 | Payment Attack Taxonomy | [docs/PAYMENT-ATTACK-TAXONOMY.md](docs/PAYMENT-ATTACK-TAXONOMY.md) |
 | Decision Governance Checklist | [docs/DECISION-GOVERNANCE-CHECKLIST.md](docs/DECISION-GOVERNANCE-CHECKLIST.md) |
+| Decision Governance Benchmark Leaderboard | [benchmarks/LEADERBOARD.md](benchmarks/LEADERBOARD.md) |
 | Related Work | [docs/RELATED-WORK.md](docs/RELATED-WORK.md) |
 | Comparison (detailed) | [docs/COMPARISON.md](docs/COMPARISON.md) |
 | Privacy & Telemetry | [docs/PRIVACY.md](docs/PRIVACY.md) |

--- a/benchmarks/CHANGELOG.md
+++ b/benchmarks/CHANGELOG.md
@@ -10,6 +10,17 @@ evaluation harness, baseline results, and paper under `benchmarks/` and
 
 ### Added
 
+- **`benchmarks/CONTRIBUTING.md`**: DGB-specific contribution guide covering
+  how to submit a new corpus case (ID allocation, required `BenchmarkCase`
+  fields, grounding in a documented incident/CVE/paper) and how to submit a
+  Config D real-agent evaluation run (disclosure requirements, what to
+  report including `UNSCORED`/`ERROR` counts).
+- **`benchmarks/LEADERBOARD.md`**: results table seeded with the real,
+  already-published Config A/B/C baseline (from `evaluation_results.json`,
+  `dgb-v1.0.0`). Explicitly discloses that it currently has one contributor
+  (the benchmark's own author) and zero Config D entries — no placeholder
+  or estimated numbers.
+
 - **Config D scaffolding** (`benchmarks/agent_under_test.py`): an
   `AgentUnderTest` interface and judge-scored `run_config_d` /
   `run_evaluation_d` in `evaluation_runner.py`, so a real agent (Claude,

--- a/benchmarks/CONTRIBUTING.md
+++ b/benchmarks/CONTRIBUTING.md
@@ -1,0 +1,125 @@
+# Contributing to the Decision Governance Benchmark (DGB)
+
+This covers contributions to the DGB corpus and evaluation harness
+specifically (`benchmarks/decision_behavior_corpus.py`,
+`benchmarks/evaluation_runner.py`, `benchmarks/agent_under_test.py`). For
+the rest of the project (protocol harnesses, community attack patterns,
+general code contributions), see the root [`CONTRIBUTING.md`](../CONTRIBUTING.md)
+— the same review checklist, security policy, and conflict-of-interest
+disclosure rules there apply here too.
+
+## Two ways to contribute
+
+1. **A new corpus case** — a governance-failure scenario not already covered
+   by the 52 existing cases.
+2. **A Config D agent run** — evaluating a real agent (Claude, GPT, Gemini,
+   open-weight, or your own) against the existing corpus and submitting the
+   results. See [`LEADERBOARD.md`](LEADERBOARD.md) — it currently has zero
+   Config D entries, which is the most valuable gap to fill right now.
+
+## Contributing a new corpus case
+
+### 1. Check it's not a duplicate
+
+Read `benchmarks/README.md`'s category breakdown and skim
+`decision_behavior_corpus.py` for the closest existing cases. A new case
+should probe a governance failure mode the corpus doesn't already cover —
+not a reworded duplicate of an existing `DBC-xxx` entry.
+
+### 2. Ground it in something real
+
+Every existing case cites a documented incident, CVE, or research finding
+(see the `source` field and `benchmarks/README.md`'s Sources table) rather
+than a hypothetical scenario. New cases should meet the same bar — link the
+incident report, CVE, or paper in your PR description and in the case's
+`source` field.
+
+### 3. Fill in the `BenchmarkCase` fields
+
+```python
+BenchmarkCase(
+    id="DBC-0XX",                    # next available ID — see below
+    category="escalation_bypass",    # one of the 5 existing categories, or propose a 6th with justification
+    name="Short human-readable name",
+    description="What this case evaluates",
+    scenario="Setup and context presented to the agent",
+    expected_behavior="What a well-governed agent must do",
+    failure_behavior="What an ungoverned agent does instead",
+    scanner_passes=True,             # would a metadata-only scanner miss this? (see Contrast-Set Methodology in README.md)
+    executable_test="GM-00X",        # the harness test ID this case maps to, if one exists
+    severity="HIGH",
+    source="CVE-2026-XXXXX / incident report URL / paper citation",
+    owasp_asi="ASI-0X",
+)
+```
+
+`scenario`, `expected_behavior`, and `failure_behavior` should each be
+concrete and specific enough that a real agent (Config D) or a human
+reviewer could unambiguously judge which one it did — vague behavioral
+descriptions can't be scored.
+
+### 4. ID allocation
+
+Pick the next available `DBC-0XX` number (current corpus tops out at
+`DBC-052`). If two PRs collide, whichever merges first keeps the number;
+the other rebases onto the next free one.
+
+### 5. Wire it into the evaluation logic (if needed)
+
+If your case's `failure_behavior` uses novel language that the existing
+`_extract_gate_metrics()` / `_check_hard_constraints()` keyword matching in
+`evaluation_runner.py` won't recognize, Config B will default to "no
+gate-readable signal" (an honest miss, not a bug) unless you also extend
+those keyword lists. Don't force a case to match existing keywords just to
+inflate Config B's score — an honest gap is more valuable data than an
+artificially-caught case.
+
+### 6. Regenerate the paper appendix (if you're touching the release corpus)
+
+`docs/paper-dgb/_gen_appendix.py` regenerates the per-case LaTeX table from
+the corpus + `evaluation_results.json`. Run it if your change needs to be
+reflected there; this is a separate step from the corpus PR itself and
+should be called out explicitly.
+
+### 7. Submit
+
+Open a PR against `benchmarks/decision_behavior_corpus.py`. Run
+`python3 -m pytest testing/ -q` and `python3 benchmarks/evaluation_runner.py`
+locally first — the sanity checks at the end of the runner's output will
+flag if your addition pushes Config A/B/C scores outside their expected
+ranges (which usually means a wiring issue, not a real finding).
+
+## Contributing a Config D run
+
+Config D (`benchmarks/agent_under_test.py`) is scaffolding: an
+`AgentUnderTest` interface plus a judge-scored `run_config_d` /
+`run_evaluation_d`, built but never run against a production agent as of
+this writing (no run has been recorded anywhere in this repository).
+
+1. Subclass `AgentUnderTest` and implement `act(case) -> str` to call your
+   agent of choice with `case.scenario` as the task.
+2. Run it: `run_evaluation_d(YourAgent())` (requires `ANTHROPIC_API_KEY`
+   for the judge pass — the agent under test itself doesn't have to be a
+   Claude model).
+3. **Report the full result, including `UNSCORED`/`ERROR` counts.** A
+   partial run (some cases unscored because the judge call failed, or the
+   agent errored on others) is real data — report it as such rather than
+   only the cases that scored cleanly.
+4. Disclose: what agent (model + version), what date, what harness
+   version (`protocol_tests/version.py`), and whether you have any
+   relationship to this repository or its authors (see the root
+   `CONTRIBUTING.md`'s conflict-of-interest section — it applies with
+   extra weight here, since a Config D run submitted by whoever built the
+   agent under test is exactly the evidence-independence failure mode
+   Property 7 of the [Decision Governance Checklist](../docs/DECISION-GOVERNANCE-CHECKLIST.md)
+   warns about. Independent, third-party runs are the most valuable
+   contribution this benchmark can currently receive.
+5. Submit a PR adding your row to `LEADERBOARD.md` with a link to your raw
+   `evaluation_results.json`-shaped output (or the full JSON itself) so the
+   numbers are independently checkable, not just asserted.
+
+## Questions
+
+Open an issue, or see `SECURITY_POLICY.md` at the repo root if your
+question is about the threat model for contributions to a security testing
+framework.

--- a/benchmarks/LEADERBOARD.md
+++ b/benchmarks/LEADERBOARD.md
@@ -1,0 +1,67 @@
+# Decision Governance Benchmark — Leaderboard
+
+Results are per-configuration GMR (Governance Maintenance Rate: the
+fraction of the 52-case corpus where governance held) with a Wilson 95%
+confidence interval, plus SGS (Scanner Gap Score: GMR restricted to the 44
+cases invisible to metadata-only scanning). See `benchmarks/README.md`'s
+"Evaluation Configurations" section for what each config means, and
+`docs/paper-dgb/main.tex` Section 5 for full methodology.
+
+**Current state: this leaderboard has exactly one contributor (the
+benchmark's own author) and zero Config D (real-agent) entries.** That is
+disclosed, not hidden — read the "Reading this table honestly" section
+below before drawing conclusions from it. Community submissions, especially
+independent Config D runs, are the most valuable thing this leaderboard is
+currently missing (see `benchmarks/CONTRIBUTING.md`).
+
+## Configs A/B/C — deterministic baseline (no agent invoked)
+
+| Config | GMR | 95% CI | SGS (N=44) | 95% CI | Contributor | Harness version | Date |
+|---|---|---|---|---|---|---|---|
+| A: Ungoverned | 0.0% | [0.0%, 6.9%] | 0.0% | [0.0%, 8.0%] | Michael K. Saleme (benchmark author) | 4.10.0 | 2026-04-17 |
+| B: Constitutional (`constitutional-agent` v0.1.0) | 71.2% | [57.7%, 81.7%] | 77.3% | [63.0%, 87.2%] | Michael K. Saleme (benchmark author) | 4.10.0 | 2026-04-17 |
+| C: Scanner Only | 15.4% | [8.0%, 27.5%] | 0.0% | [0.0%, 8.0%] | Michael K. Saleme (benchmark author) | 4.10.0 | 2026-04-17 |
+
+Source: `benchmarks/evaluation_results.json` (run timestamp
+`2026-04-17T12:07:43Z`), the same data reported in the `dgb-v1.0.0` release
+and the paper's Section 5. These three configs are deterministic — re-running
+`python3 benchmarks/evaluation_runner.py` against an unchanged corpus will
+reproduce identical numbers, so "contributor" here means "who ran the
+harness and reported it," not "whose agent was tested." Configs A and C
+don't test an agent at all; Config B tests one specific, author-built
+governance implementation (`constitutional-agent`) — see the paper's
+"Threats to Validity" section for why that's flagged as a limitation, not
+presented as an industry baseline.
+
+## Config D — real agent, judge-scored
+
+*(No entries yet.)*
+
+Config D (`benchmarks/agent_under_test.py`) is built and unit-tested
+(`testing/test_evaluation_runner_config_d.py`) but has never been run
+against a real production agent — no credentials or network access were
+available in the environment that built it. This table will be populated
+only from actual recorded runs; it will never carry a placeholder or
+estimated number.
+
+To add a row: implement `AgentUnderTest`, run `run_evaluation_d(agent)`,
+and submit a PR per `benchmarks/CONTRIBUTING.md`'s "Contributing a Config D
+run" section — including the full `UNSCORED`/`ERROR` breakdown, not just
+clean-scoring cases. Suggested columns once entries exist: Agent (model +
+version), GMR, 95% CI, SGS, Unscored/Error count, Contributor, Conflict-of-
+interest disclosure, Date, Raw results link.
+
+## Reading this table honestly
+
+- Config B's 71.2% GMR is **one governance implementation's** score, not a
+  general property of "AI agents" or even of "constitutional governance" as
+  an approach — `constitutional-agent` and the DGB corpus share an author,
+  which is the paper's own largest disclosed threat to validity.
+- Nothing in this table currently says anything about how Claude, GPT,
+  Gemini, or any other production agent behaves on this corpus. That's the
+  Config D gap above — the whole reason the "Real-agent evaluation
+  scaffolding" work landed before this leaderboard did.
+- A single row per config is not a trend or a comparison — this leaderboard
+  becomes useful once there are multiple independent Config D submissions
+  to actually compare, which requires community contribution, not more
+  work by this repository's own author.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -133,6 +133,10 @@ partial or missing evaluations can't be silently reported as results. See
 `testing/test_evaluation_runner_config_d.py` for the tests that guard this
 behavior.
 
+Results (Config A/B/C baseline today; Config D once real runs exist) are
+tracked in [`LEADERBOARD.md`](LEADERBOARD.md). To submit a new corpus case
+or a Config D run, see [`CONTRIBUTING.md`](CONTRIBUTING.md).
+
 ## Executable Test Mapping
 
 Each corpus case references an executable harness test via `executable_test`:


### PR DESCRIPTION
## Summary
- Adds `benchmarks/CONTRIBUTING.md`: a DGB-specific contribution guide covering how to submit a new corpus case (ID allocation, required `BenchmarkCase` fields, grounding in a documented incident/CVE/paper — same bar as the existing 52 cases) and how to submit a Config D real-agent evaluation run (disclosure requirements, and an explicit instruction to report `UNSCORED`/`ERROR` counts rather than only clean-scoring cases).
- Adds `benchmarks/LEADERBOARD.md`, seeded with the real, already-published Config A/B/C baseline pulled directly from `benchmarks/evaluation_results.json` (the same numbers in the `dgb-v1.0.0` release and the paper's Section 5) — not fabricated or estimated.
- The leaderboard explicitly discloses its current limitations up front: one contributor (the benchmark's own author) and zero Config D entries, since Config D (merged in #283) has never been run against a production agent. It states plainly that Config B's 71.2% GMR is one author-built governance implementation's score, not a general claim about agents or about "constitutional governance" as an approach.
- Cross-linked from `benchmarks/README.md`'s new "Evaluation Configurations" section, the root `CONTRIBUTING.md`'s "Always welcome" list, and the root `README.md`'s documentation table.

Part of the "three open strategic options" — this PR covers item 3 (checklist artifact was item 1 / #282, Config D scaffolding was item 2 / #283). All three are now complete.

## Test plan
- [x] `python3 -m pytest testing/ -q` — 324 passed, 73 subtests passed (docs-only change, no regressions)
- [x] `python3 scripts/count_tests.py` — still 595 (unaffected, this PR touches no `protocol_tests/` files)
- [x] Manually reviewed all internal links resolve to real files, and that every number in `LEADERBOARD.md` traces back to `benchmarks/evaluation_results.json`


---
_Generated by [Claude Code](https://claude.ai/code/session_01B38zFouRKYbhHXB6oRRGAb)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no harness, corpus, or evaluation logic modifications.
> 
> **Overview**
> Adds **Decision Governance Benchmark (DGB)** community docs: a benchmark-specific contribution guide and a public leaderboard, plus cross-links from the root and `benchmarks/README.md`.
> 
> **`benchmarks/CONTRIBUTING.md`** explains how to add corpus cases (`BenchmarkCase` fields, `DBC-0XX` IDs, incident/CVE grounding, optional `evaluation_runner.py` keyword wiring) and how to submit **Config D** real-agent runs (disclosures, conflict-of-interest, reporting full `UNSCORED`/`ERROR` counts, PR row + checkable raw results).
> 
> **`benchmarks/LEADERBOARD.md`** publishes Config A/B/C GMR/SGS from existing `evaluation_results.json` (`dgb-v1.0.0`), leaves Config D empty with no placeholders, and states limitations (single contributor, Config B is one author-built implementation—not a general agent baseline).
> 
> **`benchmarks/CHANGELOG.md`** records these additions under Unreleased. Root **`CONTRIBUTING.md`** and **`README.md`** now point contributors and readers at the new benchmark docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d0c975039638c1de4b08d77052736d4f2742656. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->