### PR TITLE
ci: make the PyPI publish idempotent (skip-existing)

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -50,3 +50,14 @@ jobs:
         uses: pypa/gh-action-pypi-publish@v1.13.0 # Docker-based action requires tag ref, not SHA
         # Uses trusted publishing (OIDC) - no API token needed
         # Configure at: https://pypi.org/manage/project/agent-security-harness/settings/publishing/
+        with:
+          # Make the publish idempotent. A Release whose version is already on
+          # PyPI otherwise fails the job on "file already exists", which is a
+          # red run on a green history for a no-op upload.
+          #
+          # This is not hypothetical: 4.10.0 reached PyPI on 2026-07-25 when the
+          # dgb-v1.0.0 Release fired this workflow against a main tree already
+          # bumped to 4.10.0. Cutting the matching v4.10.0 Release afterwards
+          # would re-upload an existing version and fail. Same hazard applies to
+          # any retroactive tag, re-published Release, or re-run of this job.
+          skip-existing: true


### PR DESCRIPTION
## Problem

`publish-pypi.yml` runs `pypa/gh-action-pypi-publish` with no `skip-existing`. If a Release's version is already on PyPI, the job fails on **"file already exists"** — a red run for what is semantically a no-op upload.

This is currently blocking a real release. `agent-security-harness` **4.10.0** was published to PyPI on `2026-07-25T22:50:14` when the `dgb-v1.0.0` Release fired this workflow against a `main` tree already bumped to 4.10.0 by #281. No `v4.10.0` tag or Release was created at the time, leaving a shipped version with no checkout point, no notes, and no citation anchor.

The `v4.10.0` tag now exists (pointing at `a0d73ba`, the exact commit the published wheel was built from) and the Release notes are staged as a draft — but publishing that draft would re-upload an existing version and fail.

## Change

One `with:` block on the publish step:

```yaml
with:
  skip-existing: true
```

A genuinely new version still uploads. An already-present one is skipped instead of erroring.

## Why it's worth doing rather than accepting one red run

The same hazard applies to any retroactive tag, any re-published Release, and any manual re-run of a partially failed publish job. This removes the whole class, not just the current instance.

## Verification

YAML parses; the step resolves to `pypa/gh-action-pypi-publish@v1.13.0` with `{'skip-existing': True}`; trigger unchanged (`release: types: [published]`). No other step, job, or permission touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow-only change; no application code, credentials, or publish trigger changes beyond making uploads idempotent.
> 
> **Overview**
> The **Publish to PyPI** step in `publish-pypi.yml` now passes **`skip-existing: true`** to `pypa/gh-action-pypi-publish`, so a release whose version is already on PyPI is skipped instead of failing with "file already exists."
> 
> New versions still upload normally; re-runs, retroactive tags, or duplicate release publishes no longer produce a red workflow for a no-op upload. Inline comments document the motivating 4.10.0 case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d39e69d6b4d9884c33a27ee6c3f48ba169d6ab6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->