### PR TITLE
test(mcp): characterize loopback schema reference resolution

### DIFF
--- a/tests/test_mcp_sdk_schema_resolution_boundary.py
+++ b/tests/test_mcp_sdk_schema_resolution_boundary.py
@@ -9,8 +9,8 @@ import pytest
 
 
 mcp = pytest.importorskip("mcp")
-from mcp import types
-from mcp.server.lowlevel import Server
+from mcp import types  # noqa: E402
+from mcp.server.lowlevel import Server  # noqa: E402
 
 
 def test_lowlevel_server_resolves_a_loopback_tool_schema_reference() -> None:
@@ -65,3 +65,45 @@ def test_lowlevel_server_resolves_a_loopback_tool_schema_reference() -> None:
     assert requests == ["/synthetic-schema.json"]
     assert calls == [("probe", {"value": "synthetic"})]
     assert result.root.isError is False
+
+
+def test_lowlevel_server_does_not_invoke_handler_when_loopback_schema_is_missing() -> None:
+    """Characterize the failed-resolution path without any external endpoint."""
+
+    requests: list[str] = []
+    calls: list[tuple[str, dict[str, str]]] = []
+
+    class MissingSchemaHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802 - required by BaseHTTPRequestHandler
+            requests.append(self.path)
+            self.send_error(404)
+
+        def log_message(self, format: str, *args: object) -> None:
+            return
+
+    http = ThreadingHTTPServer(("127.0.0.1", 0), MissingSchemaHandler)
+    thread = threading.Thread(target=http.serve_forever, daemon=True)
+    thread.start()
+    try:
+        schema_url = f"http://127.0.0.1:{http.server_port}/missing-schema.json"
+        server = Server("schema-boundary-probe")
+        server._tool_cache["probe"] = types.Tool(
+            name="probe", description="synthetic local probe", inputSchema={"$ref": schema_url}
+        )
+
+        @server.call_tool()
+        async def call_tool(name: str, arguments: dict[str, str]) -> dict[str, bool]:
+            calls.append((name, arguments))
+            return {"ok": True}
+
+        request = types.CallToolRequest(
+            params=types.CallToolRequestParams(name="probe", arguments={"value": "synthetic"})
+        )
+        result = asyncio.run(server.request_handlers[types.CallToolRequest](request))
+    finally:
+        http.shutdown()
+        http.server_close()
+
+    assert requests == ["/missing-schema.json"]
+    assert calls == []
+    assert result.root.isError is True

--- a/tests/test_mcp_sdk_schema_resolution_boundary.py
+++ b/tests/test_mcp_sdk_schema_resolution_boundary.py
@@ -1,0 +1,67 @@
+"""Controlled receiver-boundary characterization for the optional MCP SDK."""
+
+import asyncio
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+
+mcp = pytest.importorskip("mcp")
+from mcp import types
+from mcp.server.lowlevel import Server
+
+
+def test_lowlevel_server_resolves_a_loopback_tool_schema_reference() -> None:
+    """Document SDK behavior only: a synthetic loopback $ref is retrieved on call."""
+
+    requests: list[str] = []
+    calls: list[tuple[str, dict[str, str]]] = []
+
+    class SchemaHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802 - required by BaseHTTPRequestHandler
+            requests.append(self.path)
+            body = json.dumps(
+                {
+                    "type": "object",
+                    "properties": {"value": {"type": "string"}},
+                    "required": ["value"],
+                    "additionalProperties": False,
+                }
+            ).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/schema+json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format: str, *args: object) -> None:
+            return
+
+    http = ThreadingHTTPServer(("127.0.0.1", 0), SchemaHandler)
+    thread = threading.Thread(target=http.serve_forever, daemon=True)
+    thread.start()
+    try:
+        schema_url = f"http://127.0.0.1:{http.server_port}/synthetic-schema.json"
+        server = Server("schema-boundary-probe")
+        server._tool_cache["probe"] = types.Tool(
+            name="probe", description="synthetic local probe", inputSchema={"$ref": schema_url}
+        )
+
+        @server.call_tool()
+        async def call_tool(name: str, arguments: dict[str, str]) -> dict[str, bool]:
+            calls.append((name, arguments))
+            return {"ok": True}
+
+        request = types.CallToolRequest(
+            params=types.CallToolRequestParams(name="probe", arguments={"value": "synthetic"})
+        )
+        result = asyncio.run(server.request_handlers[types.CallToolRequest](request))
+    finally:
+        http.shutdown()
+        http.server_close()
+
+    assert requests == ["/synthetic-schema.json"]
+    assert calls == [("probe", {"value": "synthetic"})]
+    assert result.root.isError is False

--- a/tests/test_mcp_sdk_schema_resolution_boundary.py
+++ b/tests/test_mcp_sdk_schema_resolution_boundary.py
@@ -7,10 +7,9 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 import pytest
 
-
 mcp = pytest.importorskip("mcp")
-from mcp import types  # noqa: E402
-from mcp.server.lowlevel import Server  # noqa: E402
+from mcp import types
+from mcp.server.lowlevel import Server
 
 
 def test_lowlevel_server_resolves_a_loopback_tool_schema_reference() -> None:
@@ -20,7 +19,7 @@ def test_lowlevel_server_resolves_a_loopback_tool_schema_reference() -> None:
     calls: list[tuple[str, dict[str, str]]] = []
 
     class SchemaHandler(BaseHTTPRequestHandler):
-        def do_GET(self) -> None:  # noqa: N802 - required by BaseHTTPRequestHandler
+        def do_GET(self) -> None:
             requests.append(self.path)
             body = json.dumps(
                 {
@@ -74,7 +73,7 @@ def test_lowlevel_server_does_not_invoke_handler_when_loopback_schema_is_missing
     calls: list[tuple[str, dict[str, str]]] = []
 
     class MissingSchemaHandler(BaseHTTPRequestHandler):
-        def do_GET(self) -> None:  # noqa: N802 - required by BaseHTTPRequestHandler
+        def do_GET(self) -> None:
             requests.append(self.path)
             self.send_error(404)
 
@@ -116,7 +115,7 @@ def test_lowlevel_server_rejects_invalid_arguments_after_loopback_schema_resolut
     calls: list[tuple[str, dict[str, str]]] = []
 
     class SchemaHandler(BaseHTTPRequestHandler):
-        def do_GET(self) -> None:  # noqa: N802 - required by BaseHTTPRequestHandler
+        def do_GET(self) -> None:
             requests.append(self.path)
             body = json.dumps(
                 {
@@ -159,5 +158,52 @@ def test_lowlevel_server_rejects_invalid_arguments_after_loopback_schema_resolut
         http.server_close()
 
     assert requests == ["/synthetic-schema.json"]
+    assert calls == []
+    assert result.root.isError is True
+
+
+def test_lowlevel_server_does_not_invoke_handler_when_loopback_schema_is_malformed() -> None:
+    """Characterize malformed remote-schema handling with a synthetic loopback server."""
+
+    requests: list[str] = []
+    calls: list[tuple[str, dict[str, str]]] = []
+
+    class MalformedSchemaHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            requests.append(self.path)
+            body = b'{"type":"object",'
+            self.send_response(200)
+            self.send_header("Content-Type", "application/schema+json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format: str, *args: object) -> None:
+            return
+
+    http = ThreadingHTTPServer(("127.0.0.1", 0), MalformedSchemaHandler)
+    thread = threading.Thread(target=http.serve_forever, daemon=True)
+    thread.start()
+    try:
+        schema_url = f"http://127.0.0.1:{http.server_port}/malformed-schema.json"
+        server = Server("schema-boundary-probe")
+        server._tool_cache["probe"] = types.Tool(
+            name="probe", description="synthetic local probe", inputSchema={"$ref": schema_url}
+        )
+
+        @server.call_tool()
+        async def call_tool(name: str, arguments: dict[str, str]) -> dict[str, bool]:
+            calls.append((name, arguments))
+            return {"ok": True}
+
+        request = types.CallToolRequest(
+            params=types.CallToolRequestParams(name="probe", arguments={"value": "synthetic"})
+        )
+        result = asyncio.run(server.request_handlers[types.CallToolRequest](request))
+    finally:
+        http.shutdown()
+        http.server_close()
+
+    assert requests == ["/malformed-schema.json"]
     assert calls == []
     assert result.root.isError is True

--- a/tests/test_mcp_sdk_schema_resolution_boundary.py
+++ b/tests/test_mcp_sdk_schema_resolution_boundary.py
@@ -107,3 +107,57 @@ def test_lowlevel_server_does_not_invoke_handler_when_loopback_schema_is_missing
     assert requests == ["/missing-schema.json"]
     assert calls == []
     assert result.root.isError is True
+
+
+def test_lowlevel_server_rejects_invalid_arguments_after_loopback_schema_resolution() -> None:
+    """Show that the resolved synthetic schema governs handler admission."""
+
+    requests: list[str] = []
+    calls: list[tuple[str, dict[str, str]]] = []
+
+    class SchemaHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802 - required by BaseHTTPRequestHandler
+            requests.append(self.path)
+            body = json.dumps(
+                {
+                    "type": "object",
+                    "properties": {"value": {"type": "string"}},
+                    "required": ["value"],
+                    "additionalProperties": False,
+                }
+            ).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/schema+json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format: str, *args: object) -> None:
+            return
+
+    http = ThreadingHTTPServer(("127.0.0.1", 0), SchemaHandler)
+    thread = threading.Thread(target=http.serve_forever, daemon=True)
+    thread.start()
+    try:
+        schema_url = f"http://127.0.0.1:{http.server_port}/synthetic-schema.json"
+        server = Server("schema-boundary-probe")
+        server._tool_cache["probe"] = types.Tool(
+            name="probe", description="synthetic local probe", inputSchema={"$ref": schema_url}
+        )
+
+        @server.call_tool()
+        async def call_tool(name: str, arguments: dict[str, str]) -> dict[str, bool]:
+            calls.append((name, arguments))
+            return {"ok": True}
+
+        request = types.CallToolRequest(
+            params=types.CallToolRequestParams(name="probe", arguments={"wrong": "synthetic"})
+        )
+        result = asyncio.run(server.request_handlers[types.CallToolRequest](request))
+    finally:
+        http.shutdown()
+        http.server_close()
+
+    assert requests == ["/synthetic-schema.json"]
+    assert calls == []
+    assert result.root.isError is True


### PR DESCRIPTION
## Summary
- adds a controlled, loopback-only MCP SDK receiver-boundary regression
- records that the optional SDK resolves a synthetic tool-schema `$ref` during `tools/call` validation

## Evidence boundary
This characterizes local `mcp` SDK behavior only. It is not a gateway, external receiver, vulnerability, or final-wire compatibility claim.

## Verification
- isolated `mcp-server` environment: `pytest tests/test_mcp_sdk_schema_resolution_boundary.py tests/test_mcp_server_runtime.py -q`
- 3 passed
- SDK emitted its own deprecation warning that automatic remote reference retrieval is discouraged and will become an error.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only addition with no production code changes; optional `mcp` dependency is skipped when absent.
> 
> **Overview**
> Adds **`tests/test_mcp_sdk_schema_resolution_boundary.py`**, a loopback-only characterization suite for the optional **`mcp`** lowlevel **`Server`** when a tool’s **`inputSchema`** uses an HTTP **`$ref`**.
> 
> The tests drive **`CallToolRequest`** through the SDK handler with a local **`ThreadingHTTPServer`** and assert: successful fetch + validation runs the tool handler; **404**, **malformed JSON**, and **post-resolution argument mismatch** skip the handler and return **`isError`**. Docstrings stress this documents SDK receiver behavior, not gateway or external security claims.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eef1ef9c18f77488b2cb2fde951c41c19cc3539f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->