### PR TITLE
docs(dgb): update leaderboard and changelog for the measured Config C

### DIFF
--- a/benchmarks/CHANGELOG.md
+++ b/benchmarks/CHANGELOG.md
@@ -8,6 +8,56 @@ evaluation harness, baseline results, and paper under `benchmarks/` and
 
 ## [Unreleased]
 
+### Changed (BREAKING)
+
+- **`BenchmarkCase.scanner_passes` removed; scanner visibility is now derived by
+  measurement.** The field was hand-assigned and never validated — until
+  2026-07-27 the corpus contained no artifact a scanner could read, so the
+  "85% undetectable by metadata-only scanning" headline, Config C, the Scanner
+  Gap Score and the McNemar test all derived from a label rather than a result.
+  Nine of its 52 assignments disagree with measurement. Retired assignments are
+  preserved verbatim as `RETIRED_SCANNER_PASSES_LABELS` so `dgb-v1.0.0` remains
+  reproducible. Use `benchmarks/scanner_derived.py` instead.
+- **`run_config_c()` now executes a scan** over the tool-registry fixtures
+  instead of inverting a boolean. **This supersedes the `dgb-v1.0.0` baseline:**
+  Config C GMR 15.4% → 1.9%, SGS subset N=44 → N=51, detection gap 77.3% → 70.6%.
+  Configs A (0.0%) and B (71.2%) GMR are unchanged.
+- **McNemar re-derived** from the measured results: 36 discordant pairs
+  (36 favouring execution, 0 favouring scanning), p ≈ 2.9e-11, replacing
+  39 pairs / 34 vs 5 / p ≈ 2.4e-6. Only one arm is measured — Configs A and B
+  remain deterministic stub agents.
+
+### Added
+
+- **`benchmarks/tool_fixtures.py`** — tool-registry fixtures for all 52 cases
+  (85 tool entries), authored from each case's `scenario` and `failure_behavior`
+  with `scanner_passes` deliberately not consulted, so scanning them tests the
+  labels rather than restating them. Each fixture records its rationale.
+- **`benchmarks/scanner_derived.py`** — `scanner_detects()` / `scanner_misses()` /
+  `summary()`, deriving visibility by executing `scan_tool_fields()`.
+- **`benchmarks/capability_scanner.py`** — a deterministic capability-rule
+  comparator (7 concept rules plus a cross-tool toxic-flow check). Over the same
+  fixtures it flags 17 of 52 against the regex scanner's 1 — a 17-fold spread that
+  shows the result is a property of the scanner, not of metadata scanning as a class.
+
+### Fixed
+
+- Source attributions across the corpus, paper and bibliography: a BlueRock MCP
+  SSRF finding credited to OX Security; METR's reward-hacking figure; the UC
+  Berkeley RDI byline and benchmark count; two OpenClaw CVE descriptions that did
+  not match their NVD text; and an invalid `CVE-2026-SSRF-MCP` identifier.
+- **Grounding provenance disclosed**: 24 of 52 cases (46%) are grounded wholly or
+  partly in the author's own systems — internal HRAO-E runs (13, run data
+  unpublished), an internal MCP cost-inflation finding (4), and the
+  `agent-security-harness` suites (7). Those are not external corroboration.
+
+### Known open items
+
+- 10 cases whose cited source does not substantiate them; 7 misdescribed cases.
+- `executable_test` does not cover the case for 24 of 52 at the `dgb-v1.0.0` tag.
+- The fixtures, both scanners and the audit share one author. **Independent
+  fixture review is the most valuable outstanding check.**
+
 ### Added
 
 - **`benchmarks/CONTRIBUTING.md`**: DGB-specific contribution guide covering

--- a/benchmarks/LEADERBOARD.md
+++ b/benchmarks/LEADERBOARD.md
@@ -2,7 +2,7 @@
 
 Results are per-configuration GMR (Governance Maintenance Rate: the
 fraction of the 52-case corpus where governance held) with a Wilson 95%
-confidence interval, plus SGS (Scanner Gap Score: GMR restricted to the 44
+confidence interval, plus SGS (Scanner Gap Score: GMR restricted to the 51
 cases invisible to metadata-only scanning). See `benchmarks/README.md`'s
 "Evaluation Configurations" section for what each config means, and
 `docs/paper-dgb/main.tex` Section 5 for full methodology.
@@ -16,11 +16,11 @@ currently missing (see `benchmarks/CONTRIBUTING.md`).
 
 ## Configs A/B/C — deterministic baseline (no agent invoked)
 
-| Config | GMR | 95% CI | SGS (N=44) | 95% CI | Contributor | Harness version | Date |
+| Config | GMR | 95% CI | SGS (N=51) | 95% CI | Contributor | Harness version | Date |
 |---|---|---|---|---|---|---|---|
 | A: Ungoverned | 0.0% | [0.0%, 6.9%] | 0.0% | [0.0%, 8.0%] | Michael K. Saleme (benchmark author) | 4.10.0 | 2026-04-17 |
-| B: Constitutional (`constitutional-agent` v0.1.0) | 71.2% | [57.7%, 81.7%] | 77.3% | [63.0%, 87.2%] | Michael K. Saleme (benchmark author) | 4.10.0 | 2026-04-17 |
-| C: Scanner Only | 15.4% | [8.0%, 27.5%] | 0.0% | [0.0%, 8.0%] | Michael K. Saleme (benchmark author) | 4.10.0 | 2026-04-17 |
+| B: Constitutional (`constitutional-agent` v0.1.0) | 71.2% | [57.7%, 81.7%] | 70.6% | [57.0%, 81.3%] | Michael K. Saleme (benchmark author) | 4.10.0 | 2026-07-28 |
+| C: Scanner Only (**measured**) | 1.9% | [0.3%, 10.1%] | 0.0% | [0.0%, 7.0%] | Michael K. Saleme (benchmark author) | 4.10.0 | 2026-07-28 |
 
 Source: `benchmarks/evaluation_results.json` (run timestamp
 `2026-04-17T12:07:43Z`), the same data reported in the `dgb-v1.0.0` release
@@ -53,6 +53,16 @@ interest disclosure, Date, Raw results link.
 
 ## Reading this table honestly
 
+- **Config C changed on 2026-07-28 and supersedes the `dgb-v1.0.0` figures.** It
+  previously reported 15.4% GMR by inverting a hand-assigned `scanner_passes`
+  field. That field is retired; Config C now executes a pattern-based scanner over
+  the tool-registry fixtures in `benchmarks/tool_fixtures.py` and flags 1 of 52.
+  A capability-rule comparator over the same fixtures flags 17, of which only 2
+  disclose the failure itself. **The number moves with the scanner — cite the
+  scanner and the fixture set alongside it.**
+- **Config C's SGS is structurally zero**, not an empirical finding: Config C passes
+  exactly when the scanner flags, so restricted to unflagged cases it can only
+  score 0.
 - Config B's 71.2% GMR is **one governance implementation's** score, not a
   general property of "AI agents" or even of "constitutional governance" as
   an approach — `constitutional-agent` and the DGB corpus share an author,


### PR DESCRIPTION
Two artifacts were left behind by PRs #291 and #292.

**`benchmarks/LEADERBOARD.md` was still publishing the superseded figures** — Config C 15.4% GMR, SGS N=44, Config B SGS 77.3% — with no indication they had been replaced. Anyone reading the leaderboard would have taken them as current. Now shows the measured values, a supersession note naming the scanner and fixture set, and the caveat that Config C's SGS is structurally zero.

**`benchmarks/CHANGELOG.md` had no Unreleased entry for a breaking change.** `scanner_passes` was removed from a public dataclass with nothing in the changelog. Added an entry covering the retirement, the fixtures, the capability-rule comparator, the re-derived McNemar, the source-attribution fixes, the 46% internal-grounding disclosure, and the known open items.

No code changes; evaluation output unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only documentation; benchmark numbers and harness behavior are unchanged in this PR.
> 
> **Overview**
> Documentation-only follow-up to the measured Config C work: **`benchmarks/LEADERBOARD.md`** now shows the superseded baseline (Config C **1.9%** GMR, SGS **N=51**, Config B SGS **70.6%**) instead of the old **15.4% / N=44 / 77.3%** figures, labels Config C as **measured**, and adds honest-reading notes that the 2026-07-28 numbers replace `dgb-v1.0.0`, that results depend on the scanner + `tool_fixtures.py`, and that Config C’s SGS is **structurally zero**.
> 
> **`benchmarks/CHANGELOG.md`** gains an **[Unreleased]** entry documenting the breaking retirement of `BenchmarkCase.scanner_passes`, measured `run_config_c()`, new fixtures/scanners, re-derived McNemar stats, attribution and grounding disclosures, and known open items—without changing evaluation code or `evaluation_results.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dd39a77c87e647c7ceda02f950277fea58b096b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->