### PR TITLE
fix(dgb): withdraw the 85% headline from the corpus README, fix broken example

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -35,11 +35,26 @@ is the most affected: 9 of its 10 cases derive from a single internal run.
 Those cases are **not** independent corroboration. Read the `source` field before
 citing any individual case as externally evidenced.
 
-The central finding: **metadata scanners miss 85% of behavioral failures**
-(44 of 52 cases).
-The failure lives in the execution path — the *decision* the agent makes — not
-in the description of the tool it calls. Scanning tool descriptions is
-insufficient; you need to execute the decision path.
+**The former "85% (44 of 52)" headline has been withdrawn.** It was a
+hand-assigned label, not a measurement: until 2026-07-27 the corpus contained no
+artifact a scanner could read. See `benchmarks/CHANGELOG.md`.
+
+Measured instead, against the tool-registry fixtures in `tool_fixtures.py`:
+
+| Scanner | Fixtures flagged |
+|---|---|
+| `scan_tool_fields` — 14 regex patterns | **1 / 52** |
+| `capability_scanner.scan_registry` — 7 capability concepts | **17 / 52** |
+
+Of the 17, two disclose the abusive behaviour in the registry text, one exposes a
+toxic capability combination, and fourteen indicate only that a risky capability
+is present. **Any "% undetectable" figure depends on the scanner, the fixture
+set, and what qualifies as detection** — it is not a property of metadata
+scanning in the abstract. Cite all three alongside it.
+
+The failure ordinarily lives in the execution path — the *decision* the agent
+makes — not in the description of the tool it calls. Scanning tool descriptions
+did not surface it here; executing the decision path did.
 
 ## Usage
 
@@ -57,8 +72,8 @@ from benchmarks.scanner_derived import scanner_detects, scanner_misses
 scanner_missed  = [c for c in CORPUS if scanner_misses(c.id)]
 scanner_caught  = [c for c in CORPUS if scanner_detects(c.id)]
 
-print(f"Scanner misses {len(scanner_misses)}/{len(CORPUS)} cases "
-      f"({len(scanner_misses)/len(CORPUS)*100:.0f}%)")
+print(f"Scanner does not flag {len(scanner_missed)}/{len(CORPUS)} cases "
+      f"({len(scanner_missed)/len(CORPUS)*100:.0f}%)")
 ```
 
 The corpus is also accessible via the benchmark integrity harness:


### PR DESCRIPTION
Two defects the `scanner_passes` retirement left behind.

**`benchmarks/README.md` still presented the withdrawn number as fact:**

> The central finding: **metadata scanners miss 85% of behavioral failures** (44 of 52 cases).

A reader arriving at the corpus README would take that as current. Replaced with the measured results for both scanners, the 2 / 1 / 14 signal taxonomy, and the statement that any percentage depends on the scanner, the fixture set, and what qualifies as detection.

**The revised usage example was broken.** It bound `scanner_missed` but printed `len(scanner_misses)` — the imported function. That raises `TypeError`. Verified the corrected example runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to the benchmarks README with no runtime, security, or data-handling impact.
> 
> **Overview**
> **Withdraws the old “metadata scanners miss 85% (44/52)” claim** in `benchmarks/README.md` and replaces it with measured counts from `tool_fixtures.py`: regex `scan_tool_fields` flags **1/52**, `capability_scanner.scan_registry` flags **17/52**, plus a short breakdown (2 disclose abuse in text, 1 toxic combo, 14 risky-capability-only) and a note that any “% undetectable” depends on scanner, fixtures, and detection definition (with pointer to `benchmarks/CHANGELOG.md`).
> 
> **Fixes the usage example** so the print line uses `len(scanner_missed)` (the list built from `scanner_misses(c.id)`) instead of `len(scanner_misses)`, which would raise `TypeError`. Wording shifts from “Scanner misses” to “Scanner does not flag” for consistency with the revised framing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f51e8e03fa8477ba6e9c57d6e0053e390c384fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->