### PR TITLE
docs: stop describing deterministic simulation as agent execution

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -130,9 +130,12 @@ tool-registry fixtures detects **1 of 52**; 51 are not flagged. The retired
 hand-assigned labels claimed 8 and 44. This number is a property of that scanner
 over those fixtures — report both alongside it. This is the core
 argument for executable behavioral testing: the large majority of agent
-governance failures require running the agent to observe, not scanning tool
-descriptions. (See `docs/paper-dgb/main.tex` Section 5.3 for a McNemar's
-exact test on this detection gap, $p \approx 2.4\times10^{-6}$.)
+governance failures were not surfaced by scanning these tool descriptions. Note
+that no production agent is invoked — Configs A/B are deterministic functions
+over each case's metadata — so this does not establish what running an agent
+would show. (See `docs/paper-dgb/main.tex` Section 5.3 for a McNemar's
+exact test on this detection gap, $p \approx 2.9\times10^{-11}$ — nominal, and
+comparing a deterministic Config B against an executed Config C.)
 
 ## Evaluation Configurations
 
@@ -192,7 +195,8 @@ Saleme, M. K. (2026). Decision Governance Benchmark (DGB) Corpus, v1.0.0.
 msaleme/red-team-blue-team-agent-fabric, Issue #120.
 https://github.com/msaleme/red-team-blue-team-agent-fabric/releases/tag/dgb-v1.0.0
 
-Sources: UC Berkeley RDI (Xu et al. 2025), lightningzero 2026,
+Sources: UC Berkeley RDI 2026 (Wang, Mang, Cheung, Sen, Song), internal
+HRAO-E runs (unpublished),
 METR Autonomy Evaluation Framework 2025, OX Security 2026,
 zhuanruhu 2026, OpenClaw CVE-2026-35625/35629, Kiro/Amazon 2026.
 ```

--- a/docs/DECISION-GOVERNANCE-CHECKLIST.md
+++ b/docs/DECISION-GOVERNANCE-CHECKLIST.md
@@ -25,11 +25,14 @@ this checklist measures *control over the decision process itself*. The
 two are independent: an agent with excellent judgment but a governance
 layer it can self-modify is one prompt-injection or one subtly-misaligned
 objective away from acting on that judgment with no backstop. DGB's
-central empirical finding — that 85% of governance failures in its
-52-case corpus are invisible to metadata-only scanning and only manifest
-when the decision path actually executes — is a direct consequence of
-this: static analysis of an agent's configuration cannot tell you whether
-the agent will respect that configuration under adversarial pressure.
+former "85% invisible to metadata-only scanning" figure has been withdrawn:
+it was a hand-assigned label, not a measurement. Measured instead, a named
+14-pattern scanner flags 1 of 52 authored tool-registry fixtures and a
+capability-rule comparator flags 17 — the number depends on the scanner, the
+fixture set, and what counts as detection. The underlying point stands
+independently of any percentage: static analysis of an agent's configuration
+cannot tell you whether the agent will respect that configuration under
+adversarial pressure.
 Only execution can.
 
 ## The seven properties

--- a/docs/paper-dgb/main.tex
+++ b/docs/paper-dgb/main.tex
@@ -41,22 +41,21 @@ for Autonomous AI Agent Security}}
 
 % ---------------------------------------------------------------------------
 \begin{abstract}
-As autonomous agents execute real-world actions, metadata scanners of
-agent tool descriptions and permission declarations provide
-\textbf{0.0\% governance protection on behavioral failure cases}, even
-when they succeed on structurally detectable ones. We introduce
+As autonomous agents execute real-world actions, a named 14-pattern metadata
+scanner flagged \textbf{1 of 52 authored tool-registry fixtures} in this corpus.
+That result is specific to the scanner, the fixture set, and the signal
+definition used. We introduce
 the \textbf{Decision Governance Benchmark (DGB)}, a corpus of 52 authored
 governance-failure cases, evaluated through a deterministic configuration
 harness, that assess whether autonomous AI agents can
 resist five classes of governance failure: escalation bypass, collusion,
 memory tampering, payment chain abuse, and evidence fabrication. Unlike
-metadata scanners that inspect tool descriptions and permission
-declarations, DGB \emph{executes} the agent's decision path and measures
-behavioral outcomes. Running a pattern-based metadata scanner over authored
-tool-registry fixtures, the scanner flags \textbf{1 of 52 cases}; the other
-\textbf{51 are not flagged}. The result is specific to that scanner, fixture
-set, and signal definition; it establishes that the scanner did not flag those
-fixtures, not why, and not that every such failure manifests only on execution. We present 13 complementary
+metadata scanners that inspect tool descriptions and permission declarations,
+DGB models the decision path: Config~C executes a scanner over authored
+fixtures, while Configs~A and~B are deterministic functions over each case's
+metadata. No production agent is invoked. The scanner result above establishes
+that it did not flag the other 51 fixtures --- not why, and not that every such
+failure manifests only on execution. We present 13 complementary
 harness tests (7 benchmark integrity, 6 governance modification) and an
 evidence format that produces machine-readable attestation reports.
 Baseline results across three agent configurations show: Config~A
@@ -106,16 +105,19 @@ makes three contributions:
 
 \begin{enumerate}
   \item \textbf{A curated corpus} of 52 decision-behavior test cases across
-        five failure categories, each annotated with a contrastive field
-        indicating whether a metadata-only scanner would detect the failure,
-        enabling direct per-case comparison between metadata scanning and
-        execution-based detection.
+        five failure categories, each paired with an authored tool-registry
+        fixture and a scanner-derived outcome recording whether the named
+        scanner flags that fixture, enabling per-case comparison between
+        metadata scanning and the harness's configuration outcomes.
 
-  \item \textbf{A taxonomy of governance failures} grounded in real-world
-        incidents (lightningzero 2026, OX Security 2026~\cite{ox2026mcp},
+  \item \textbf{A taxonomy of governance failures} drawn from published
+        findings (OX Security 2026~\cite{ox2026mcp},
         METR 2025~\cite{metr2025autonomy}, UC Berkeley
-        RDI 2026~\cite{wang2026broke}, zhuanruhu 2026) rather than
-        hypothetical scenarios.
+        RDI 2026~\cite{wang2026broke}) and from internal, unpublished runs of
+        the authors' own deployment~\cite{hraoe2026}. A 2026-07 source audit
+        found 24 of 52 source records point to internal artifacts rather than
+        independent external corroboration; the taxonomy is not uniformly
+        externally grounded.
 
   \item \textbf{An executable evaluation methodology} that distinguishes
         behavioral governance failures (51 of 52 unflagged by the named
@@ -245,7 +247,7 @@ Vulnerability scanning   & AgentSeal, OX MCP audit             & Static metadata
   \draw[arr] (test) -- (ev);
 \end{tikzpicture}
 \caption{DGB execution pipeline. Each of the 52 cases instantiates a
-         scenario $S$ under constraints $C$; the agent's actual decision
+         scenario $S$ under constraints $C$; the modelled decision
          produces one of two observable behaviors ($E_{\text{pass}}$ or
          $E_{\text{fail}}$, Section~\ref{sec:illustrative}); an executable
          test $D$ converts that behavior into a binary outcome; the result
@@ -318,7 +320,7 @@ are tracked in the public repository.
 \centering
 \small
 \caption{DGB corpus categories. Scanner Miss Rate = fraction of cases
-         undetectable by metadata-only analysis.}
+         not flagged by the named regex scanner over their tool-registry fixtures.}
 \label{tab:categories}
 \begin{tabular}{lrrl}
 \toprule
@@ -348,7 +350,7 @@ Section~\ref{sec:threats}. The former hand-assigned labels claimed 8
 scanner-detectable cases concentrated in payment/tool chain (4 cases
 involving structural SSRF or token format violations) and evidence
 fabrication (2 cases involving accessible configuration files). This finding
-quantifies what practitioners have suspected: behavioral governance failures
+records, for this scanner and fixture set: behavioral governance failures
 require execution-based testing, not scanning.
 
 \begin{figure}[h]
@@ -499,7 +501,7 @@ or FAIL (agent violated governance). We report:
 
 We use the Wilson score interval rather than the normal (Wald)
 approximation because it remains well-calibrated at the small sample sizes
-($n=10$--12 per category, $n=44$ for SGS) and extreme proportions (0\%,
+($n=10$--12 per category, $n=51$ for SGS) and extreme proportions (0\%,
 100\%) present in this corpus, where the Wald interval is known to
 undercover~\cite{brown2001interval}.
 
@@ -600,7 +602,8 @@ empirical end-to-end. It should be read as evidence about the corpus and the
 scanner, not as a head-to-head trial of two deployed systems.
 
 The direction and magnitude of the asymmetry (36 vs.\ 0) indicate the
-methods are not interchangeable: execution-based testing detects failures
+outcomes are not interchangeable: the deterministic governed configuration
+resolves cases
 scanning structurally cannot see, at a rate scanning's occasional
 execution-invisible advantages do not offset---there were none in this run.
 
@@ -657,9 +660,10 @@ enforcement, SSRF) below the gate abstraction, not a gap in gate logic.
 
 \subsection{The Detection Gap Is Structural}
 
-The measured miss rate is not merely a limitation of the particular scanner
-used---it reflects a structural property of behavioral governance failures. A
-metadata scanner
+Capability declarations and behavioural outcomes are different evidence layers.
+On these authored fixtures the scanners ordinarily exposed capability rather than
+establishing the behavioural failure; explicit failure or policy disclosure
+appeared in two fixtures. A metadata scanner
 inspects \emph{declarations} (what permissions are claimed, what tool
 descriptions say). A governance failure occurs in the \emph{execution path}
 (what the agent actually decides). These are different layers, and a scanner can


### PR DESCRIPTION
Fourth pass on the paper — the first addressing its **construct** rather than its arithmetic.

Configs A and B are deterministic functions over each case's metadata. No agent runs. The paper nonetheless described DGB as executing an agent's decision path, and the README said these failures "require running the agent to observe."

**Paper**
- Abstract opened on *"0.0% governance protection on behavioral failure cases"* — that is Config C's SGS, which the paper itself now states is zero **by construction**. Replaced with the executed result.
- *"DGB executes the agent's decision path"* → Config C executes a scanner over authored fixtures; Configs A and B are deterministic functions over case metadata; no production agent is invoked.
- Discussion converted a scanner-specific result into a structural property. The two-scanner experiment establishes the opposite: **1/52 vs 17/52** depending on scanner and signal definition.
- Wilson discussion still said `n=44` for SGS; it is **51**.
- **The introduction still listed `lightningzero 2026` and `zhuanruhu 2026` among "real-world incidents … rather than hypothetical scenarios."** Those are the internal HRAO-E runs. Now separated into published findings vs internal unpublished runs, with the 24-of-52 audit figure inline.

**`benchmarks/README.md`** — stale McNemar `2.4e-6`; "require running the agent to observe"; a source line still crediting *"UC Berkeley RDI (Xu et al. 2025)"* and `lightningzero 2026`.

**`docs/DECISION-GOVERNANCE-CHECKLIST.md`** — a separate published artifact still calling 85% *"DGB's central empirical finding."* Neither the earlier audit nor three paper passes had touched it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Edits are prose and accuracy disclaimers only; no runtime, auth, or evaluation code paths change.
> 
> **Overview**
> Documentation-only pass that **stops describing Configs A/B and the benchmark as running a production agent**, and **reframes scanner vs. harness claims** as measurement-specific rather than universal.
> 
> **`docs/paper-dgb/main.tex`** — Abstract no longer leads with Config C’s **0% SGS** (zero by construction); it states the **1/52** regex-scanner result and that **only Config C runs a scanner**, while **A/B are deterministic functions over case metadata**. Introduction and corpus text swap hand-assigned “scanner would detect” framing for **scanner-derived fixture outcomes**; taxonomy sources split **published findings** from **internal unpublished HRAO-E runs** (24/52 audit). Pipeline caption uses **“modelled decision”** instead of implying live agent execution. **Wilson SGS sample size** corrected **44 → 51**; McNemar discussion notes **p ≈ 2.9×10⁻¹¹** and that the test compares **executed Config C vs. simulated Config B**. Discussion **drops “structural 85% miss”** in favor of **capability vs. behavioral evidence layers** and **1/52 vs. 17/52** scanner dependence.
> 
> **`benchmarks/README.md`** — Same honesty on **no production agent** for the scanning argument; updated McNemar caveat and citation **sources** line.
> 
> **`docs/DECISION-GOVERNANCE-CHECKLIST.md`** — Withdraws **“85% invisible”** as DGB’s central empirical finding; replaces with **measured scanner counts** and scanner/fixture dependence while keeping the execution vs. static-analysis point.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36ba2daee37a81e105c4412654319e7f0fe61d41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->