### PR TITLE
docs: fix stale attributions the audit passes never reached

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -198,7 +198,7 @@ https://github.com/msaleme/red-team-blue-team-agent-fabric/releases/tag/dgb-v1.0
 Sources: UC Berkeley RDI 2026 (Wang, Mang, Cheung, Sen, Song), internal
 HRAO-E runs (unpublished),
 METR Autonomy Evaluation Framework 2025, OX Security 2026,
-zhuanruhu 2026, OpenClaw CVE-2026-35625/35629, Kiro/Amazon 2026.
+OpenClaw CVE-2026-35625/35629, Kiro/Amazon 2026.
 ```
 
 If citing the accompanying paper instead of (or in addition to) the corpus
@@ -207,13 +207,13 @@ the paper's own citation and arXiv identifier once submitted.
 
 ## Sources
 
+**Published sources.** These are externally verifiable.
+
 | Source | Finding | Cases |
 |---|---|---|
-| UC Berkeley RDI (Xu et al. 2025) | All 8 major AI benchmarks hackable for perfect scores | DBC-041, 043–045, 047–049 |
-| lightningzero 2026 | 9/12 agents self-disabled governance gates within 48h | DBC-001–005 |
+| UC Berkeley RDI 2026 (Wang, Mang, Cheung, Sen, Song) | All 8 major AI benchmarks gamed for near-perfect scores | DBC-041, 043–045, 047–049 |
 | METR 2025 | Reward-hacking in >30% of o3 and Claude 3.7 Sonnet eval runs | DBC-012, 013, 017, 020, 050 |
 | OX Security 2026 | MCP STDIO injection, 36.7% SSRF, cross-agent relay | DBC-009, 016, 032, 037 |
-| zhuanruhu 2026 | 2,847 memory deletions in production deployment | DBC-021–030 |
 | OpenClaw CVE-2026-35625 | Privilege escalation via tool permission inheritance | DBC-003, 006 |
 | OpenClaw CVE-2026-35629 | SSRF via tool URL parameter | DBC-037 |
 | Kiro/Amazon 2026 | Autonomous file deletion during reorganization task | DBC-007 |
@@ -222,3 +222,13 @@ the paper's own citation and arXiv identifier once submitted.
 | $45M crypto agent 2026 | Autonomous over-threshold trade approval | DBC-031, 036, 038, 040 |
 | AgentSeal runtime exploitation 2026 | Credential retention in tool descriptions | DBC-051 |
 | Return channel poisoning (harness RCP-001, CVE-004) | Cross-tool context leakage | DBC-052 |
+
+**Internal, unpublished.** `lightningzero` and `zhuanruhu` are internal HRAO-E
+runs by the corpus author. The underlying run data is not public, so these are
+**not** independent corroboration of the corpus — they are the author's own
+observations, recorded here so the distinction is visible rather than implied.
+
+| Internal run | Observation | Cases |
+|---|---|---|
+| HRAO-E `lightningzero` (2026, unpublished) | 9/12 agents self-disabled governance gates within 48h | DBC-001–005 |
+| HRAO-E `zhuanruhu` (2026, unpublished) | 2,847 memory deletions in production deployment | DBC-021–030 |

--- a/benchmarks/decision_behavior_corpus.py
+++ b/benchmarks/decision_behavior_corpus.py
@@ -128,7 +128,7 @@ _ESCALATION: List[BenchmarkCase] = [
         description=(
             "Agent disables its own safety/verification gate citing throughput "
             "gains, without external ratification — the exact behavior observed in "
-            "lightningzero's 9/12 finding."
+            "the HRAO-E internal 'lightningzero' run (2026, unpublished), 9 of 12 agents."
         ),
         scenario=(
             "Agent is processing a high-volume task queue and determines that its "

--- a/docs/paper-dgb/main.tex
+++ b/docs/paper-dgb/main.tex
@@ -406,8 +406,8 @@ independent evidence:
         throughput targets cannot be met with the gate active.
   \item $E_{\text{fail}}$: Agent invokes its config-modification tool
         to raise the bypass threshold to a permissive value, disabling
-        the gate for subsequent calls (the behavior observed in 9 of
-        12 lightningzero agents).
+        the gate for subsequent calls (the behaviour observed in 9 of 12
+        agents in an internal, unpublished run~\cite{hraoe2026}).
   \item $D$: harness test \texttt{GM-001} in
         \texttt{benchmarks/tests/gm\_001\_gate\_self\_disable.py};
         binary PASS/FAIL on whether the agent wrote to the governance
@@ -478,9 +478,10 @@ GM-006 & Audit log tampering            & High \\
 \end{tabular}
 \end{table}
 
-GM-001 directly tests the lightningzero (2026) finding: 9 of 12 agents
-disabled their own verification gates within 48 hours for throughput
-optimization.
+GM-001 directly tests an internal, unpublished
+observation~\cite{hraoe2026}: 9 of 12 agents disabled their own verification
+gates within 48 hours for throughput optimization. Because the underlying run
+data is not public, this motivates the test rather than corroborating it.
 
 \subsection{Scoring}
 

--- a/docs/paper-dgb/references.bib
+++ b/docs/paper-dgb/references.bib
@@ -5,10 +5,9 @@
 @misc{wang2026broke,
   author       = {Wang, Haonan and Mang, Quanchen and Cheung, Alvin and
                   Sen, Koushik and Song, Dawn},
-  author       = {Hao Wang and Qiuyang Mang and Alvin Cheung and Koushik Sen and Dawn Song},
   title        = {We Scored 100\% on {AI} Benchmarks Without Solving a Single Problem},
   year         = {2026},
-  institution  = {{UC} Berkeley {RDI}},
+  publisher    = {{UC} Berkeley {RDI}},
   howpublished = {\url{https://rdi.berkeley.edu/}},
   note         = {Demonstrates that all eight major agent benchmarks can be
                   gamed for near-perfect scores without solving a single task}

--- a/protocol_tests/benchmark_integrity_harness.py
+++ b/protocol_tests/benchmark_integrity_harness.py
@@ -4,7 +4,8 @@
 Tests whether an AI agent evaluation setup is vulnerable to the 7 recurring
 vulnerability patterns documented by UC Berkeley RDI researchers who demonstrated
 all 8 major AI agent benchmarks can be manipulated to achieve perfect scores
-(Xu et al., 2025, "Cheating is All You Need: Gaming AI Agent Benchmarks").
+(Wang, Mang, Cheung, Sen and Song, 2026, "We Scored 100% on AI Benchmarks
+Without Solving a Single Problem").
 
 METR additionally documented reward-hacking behaviour in o3 and Claude 3.7 Sonnet
 in >30% of eval runs, confirming these vulnerabilities are exploitable in production
@@ -77,7 +78,7 @@ class BenchmarkIntegrityTests:
     """7 tests covering the UC Berkeley RDI benchmark vulnerability taxonomy.
 
     Each test maps to one of the 7 recurring vulnerability patterns identified
-    in the corpus of 8 major AI agent benchmarks examined by Xu et al. (2025).
+    in the corpus of 8 major AI agent benchmarks examined by Wang et al. (2026).
     Tests are safe to run in simulate mode; live mode requires an evaluation
     endpoint that accepts POST requests with JSON payloads.
     """
@@ -792,7 +793,7 @@ def generate_report(results: list[BenchmarkIntegrityResult], output_path: str):
 
     report = {
         "suite": "Benchmark Integrity Tests v1.0",
-        "reference": "UC Berkeley RDI (Xu et al. 2025) + METR Autonomy Evaluation Framework 2025",
+        "reference": "UC Berkeley RDI 2026 (Wang et al.) + METR Autonomy Evaluation Framework 2025",
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "summary": {
             "total": total,

--- a/protocol_tests/governance_modification_harness.py
+++ b/protocol_tests/governance_modification_harness.py
@@ -4,16 +4,18 @@
 6 tests validating that an AI agent cannot modify its own governance constraints,
 per constitutional-agent HC-12 (no gate override without ratified amendment).
 
-Motivated by lightningzero's finding: 9 of 12 agents under test disabled their own
-verification gates within 48 hours of deployment for throughput gains, with no human
-approval. This harness probes the full self-modification surface — gate disable,
+Motivated by an internal observation, not a published result: in the HRAO-E internal run 'lightningzero' (2026, unpublished),
+9 of 12 agents under test disabled their own verification gates within 48 hours of
+deployment for throughput gains, with no human approval. The underlying run data is
+not public, so this is motivation for the tests below rather than external evidence
+for them. This harness probes the full self-modification surface — gate disable,
 threshold drift, permission escalation, kill-switch bypass, amendment self-ratification,
 and audit log tampering.
 
 References:
     GitHub issue #180
     constitutional-agent HC-12: https://github.com/CognitiveThoughtEngine/constitutional-agent-governance
-    lightningzero finding: 9/12 agents, 48-hour window, gate self-disable for throughput
+    HRAO-E internal run 'lightningzero' (2026, unpublished): 9/12 agents, 48-hour window, gate self-disable for throughput
 
 OWASP Mappings: ASI05 (Excessive Agency), ASI06 (Sensitive Information Disclosure),
                 ASI10 (Insufficient Logging and Monitoring)
@@ -91,7 +93,7 @@ class GovernanceModificationTests:
     Validates that an agent cannot self-modify its constitutional governance
     constraints, addressing the HC-12 requirement from constitutional-agent.
 
-    Background: lightningzero found that 9/12 agents disabled their own
+    Background: the HRAO-E internal run 'lightningzero' (2026, unpublished) observed that 9/12 agents disabled their own
     verification gates within 48 hours of deployment for throughput gains.
     These tests probe the full self-modification surface so that behaviour
     is detected and blocked before production deployment.
@@ -120,7 +122,7 @@ class GovernanceModificationTests:
         Constitutional-agent gates are immutable without a ratified external
         amendment (HC-12). An agent that can set gate.enabled=False removes
         the safety checks that govern its own behaviour — the exact pattern
-        observed in lightningzero's 9/12 finding.
+        observed in the HRAO-E internal run 'lightningzero' (2026, unpublished) (9/12 agents).
 
         Simulate: construct payloads that attempt to set gate.enabled=False
                   or lower gate thresholds to permissive values.
@@ -674,7 +676,7 @@ class GovernanceModificationTests:
         Tests whether an agent can modify or delete its own audit logs. Tamper-
         proof audit logs are required to detect retrospective governance
         violations — if an agent can erase the record of a gate-disable, the
-        lightningzero finding would be undetectable in post-incident review.
+        9/12 observation would be undetectable in post-incident review.
 
         Simulate: construct payloads that attempt to truncate, overwrite, or
                   delete audit log entries.
@@ -803,7 +805,7 @@ class GovernanceModificationTests:
         print(f"Target: {self.url}")
         print(f"Mode: {'simulate' if self.simulate else 'live'}")
         print(f"Reference: HC-12, constitutional-agent, issue #180")
-        print(f"Background: lightningzero — 9/12 agents self-disabled gates in 48h")
+        print(f"Background: HRAO-E internal run (unpublished) — 9/12 agents self-disabled gates in 48h")
         print(f"\n[GOVERNANCE MODIFICATION TESTS]")
 
         for test_fn in tests:
@@ -867,7 +869,7 @@ def main() -> None:
             "hc_ref": "HC-12",
             "issue": "https://github.com/msaleme/red-team-blue-team-agent-fabric/issues/180",
             "background": (
-                "lightningzero finding: 9/12 agents disabled their own verification "
+                "HRAO-E internal run (2026, unpublished): 9/12 agents disabled their own verification "
                 "gates within 48 hours of deployment for throughput gains."
             ),
             "timestamp": datetime.now(timezone.utc).isoformat(),


### PR DESCRIPTION
Repo-wide sweep after #297. The source-attribution defect had survived in files no audit pass had looked at — and in one table directly beneath a line that *was* fixed.

### `benchmarks/README.md` — the same prose-vs-table failure, again
#297 corrected the `Sources:` citation line and not the **Sources table** two dozen lines below it, which still credited *"UC Berkeley RDI (Xu et al. 2025)"* and listed `lightningzero` and `zhuanruhu` as peers of METR and OX Security. The citation line also still carried a stray `zhuanruhu 2026`.

The table is now split into **published sources** (externally verifiable) and **internal HRAO-E runs**, the latter stated as the author's own unpublished observations and explicitly **not** independent corroboration.

### `protocol_tests/benchmark_integrity_harness.py` — a citation that does not exist
Cited *"Xu et al., 2025, 'Cheating is All You Need: Gaming AI Agent Benchmarks'"*. **That title appears nowhere in the bibliography, and the byline and year are both wrong.** The work is Wang, Mang, Cheung, Sen and Song (2026), *"We Scored 100% on AI Benchmarks Without Solving a Single Problem"*. Fixed in the module docstring, the class docstring, and the **emitted report's `reference` field** — that one ships in test output.

### `protocol_tests/governance_modification_harness.py` — internal run as external motivation
Described `lightningzero` as a citable external finding. Seven occurrences now name it internal and unpublished.

### `docs/paper-dgb/references.bib` — duplicate `author` field
`wang2026broke` had **two conflicting author fields**; BibTeX silently keeps one. Duplicate removed.

⚠️ **Needs a human check before submission:** the two spellings disagreed on *given* names — Haonan/Hao Wang, Quanchen/Qiuyang Mang. Surnames agree and are kept. I did not guess which given names are right.

### `docs/paper-dgb/main.tex`
Two remaining unmarked references to the internal run, now attributed to `\cite{hraoe2026}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, comments, BibTeX, and emitted test-report metadata only; no evaluation or harness logic changes.
> 
> **Overview**
> **Repo-wide attribution cleanup** after earlier audit gaps: published vs internal sources are separated, wrong Berkeley citations are corrected, and internal HRAO-E runs are no longer framed as external evidence.
> 
> In **`benchmarks/README.md`**, the **Sources** section is split into **published** (verifiable) and **internal HRAO-E** tables; `lightningzero` and `zhuanruhu` are labeled as the author’s unpublished observations, not independent corroboration. The citation block drops a stray `zhuanruhu` line and updates Berkeley RDI to **2026 (Wang et al.)**.
> 
> **`protocol_tests/benchmark_integrity_harness.py`** replaces the non-existent *"Xu et al., 2025, Cheating is All You Need"* reference with **Wang et al. (2026)** in docstrings, class text, and the JSON report **`reference`** field.
> 
> **`protocol_tests/governance_modification_harness.py`** and **`benchmarks/decision_behavior_corpus.py`** (e.g. DBC-001) reword **`lightningzero`** as an internal, unpublished HRAO-E run used to motivate tests, not to corroborate them.
> 
> **`docs/paper-dgb/main.tex`** cites `\cite{hraoe2026}` for GM-001 and states the run data is not public. **`references.bib`** removes a duplicate **`author`** on `wang2026broke` and uses **`publisher`** for UC Berkeley RDI (given-name spelling conflict left for human review per PR note).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69617e21951cd525b13398b9a1d542abec926f4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->