### PR TITLE
feat(rcl): export receipt-claim vectors as portable oracle fixtures

### DIFF
--- a/fixtures/rcl/README.md
+++ b/fixtures/rcl/README.md
@@ -1,0 +1,111 @@
+# RCL oracle fixtures
+
+Eleven receipt-claim vectors as portable data, for running an independent
+verifier against. Generated from `protocol_tests/receipt_claim_harness.py`.
+
+```bash
+python -m protocol_tests.rcl_fixture_export          # regenerate in place
+python -m protocol_tests.rcl_fixture_export --stdout # print
+```
+
+## What these test
+
+A receipt asserts several different things at once. This set separates them
+into four **claim families**, so a verifier can be checked on each
+independently:
+
+| Family | The claim | Established by |
+|---|---|---|
+| `integrity_provenance` | the artifact has not changed since signing | envelope signature, action digest |
+| `occurrence` | the action actually happened | execution/settlement authority attestation |
+| `authorization` | the action was permitted, with these exact parameters | authorization authority attestation |
+| `check_execution` | the claimed control ran, and passed, over this action's inputs | independent checker attestation |
+
+**Every fixture's envelope signature verifies.** That is the point of the
+set: signature validity establishes that the artifact has not changed since
+it was signed. It does not establish that the action occurred, was
+authorized, or passed the control it claims to have passed.
+
+## How to use it
+
+For each entry, run your verifier over `receipt` and compare with
+`expected.verdict`.
+
+```python
+import json
+data = json.load(open("fixtures/rcl/rcl-oracle-fixtures.v1.json"))
+for f in data["fixtures"]:
+    got = my_verifier(f["receipt"])           # "accept" | "reject"
+    assert got == f["expected"]["verdict"], f["id"]
+```
+
+`expected.claim_family` names which property failed, so a partial
+implementation can score itself per family rather than pass/fail overall.
+
+**Keep the accept cases.** The set is **9 reject and 2 accept**, not eleven
+negatives. A verifier that rejects all eleven has not demonstrated correct
+claim validation, it has demonstrated that it rejects things. `RCL-008` and
+`RCL-009` are what make the other nine mean something.
+
+## Schema
+
+Top level:
+
+| Field | Meaning |
+|---|---|
+| `schema_version` | `"1.0"` |
+| `evaluation_time` | Unix seconds the fixtures were built at. Freshness cases are relative to this, so pass it to your verifier as "now" |
+| `freshness_window_seconds` | how long a checker transcript stays fresh |
+| `signature_algorithm` | Ed25519 (RFC 8032) over JCS-canonicalised JSON |
+| `public_keys` | hex Ed25519 public keys per authority: `emitter`, `checker`, `authz`, `exec`. Enough to verify every signature in the file. No private material is exported |
+| `claim_families` | the four families above |
+| `counts` | `{total, accept, reject}` |
+| `coverage_gaps` | families the verifier enforces that no vector currently exercises |
+| `scope` | see below |
+
+Each fixture:
+
+| Field | Meaning |
+|---|---|
+| `id` | `RCL-001` … `RCL-011` |
+| `name` | one-line description |
+| `envelope_valid` | always `true` |
+| `receipt` | the receipt, as data |
+| `expected.verdict` | `accept` or `reject` |
+| `expected.claim_family` | family that failed; `null` for an accept |
+| `expected.reason` | the reference verifier's reason string |
+
+## Expected values are executed, not asserted
+
+Every `expected` block is produced by running `ClaimLevelVerifier` over the
+built receipt at export time. Nothing hand-writes a verdict or a family;
+`claim_family` comes from the verifier's own rejection-reason prefix.
+
+This matters because a hand-assigned expectation is a label, not a result.
+This project published an audit about exactly that failure in a different
+corpus, where a hand-assigned boolean was inverted and reported as a
+measurement (`benchmarks/CHANGELOG.md`).
+
+Output is byte-stable: keys are derived from fixed seeds and
+`evaluation_time` is pinned, so regenerating produces an identical file and
+any diff is a real behavioural change. Enforced by
+`tests/test_rcl_fixture_export.py`, which also verifies every signature
+using only the public keys in the file.
+
+## Known coverage gap
+
+`integrity_provenance` is enforced by the verifier but **no current vector
+exercises it** — every vector is envelope-valid by construction, which is
+the property the set was built to isolate. So these fixtures do not test a
+verifier's integrity checking. Declared in `coverage_gaps` rather than left
+for a reader to discover.
+
+## Scope
+
+These vectors establish **whether a receipt supports its asserted claims.**
+They do not establish that any particular implementation produces defective
+receipts. If they are used as oracle cases, that distinction is worth
+preserving in how results are described.
+
+The vectors, the reference verifier, and this packaging share one author.
+Independent evaluation design and reproduction are the outstanding checks.

--- a/protocol_tests/rcl_fixture_export.py
+++ b/protocol_tests/rcl_fixture_export.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Export the RCL receipt-claim vectors as portable oracle fixtures.
+
+Why this exists
+---------------
+``receipt_claim_harness.py`` reports *outcomes*: it builds each receipt in
+code, verifies it, and prints a pass/fail line whose verdict lives as prose
+inside a ``details`` string. That is adequate as an evidence report and
+unusable as a fixture: an outside implementation cannot consume it without
+reimplementing the builders.
+
+This module emits the same eleven vectors as data, so a third party can run
+their own verifier against them and compare.
+
+Derived, not asserted
+---------------------
+Every expected value in the output is produced by **executing**
+``ClaimLevelVerifier`` over the built receipt. Nothing here hand-writes an
+expected verdict or claim family. A hand-assigned expectation would be a
+label, not a result, and this project has already published one audit about
+what happens when those two are confused (see ``benchmarks/CHANGELOG.md``).
+
+The ``claim_family`` field is taken from the verifier's own rejection reason
+prefix, which is where the verifier already records which property failed.
+
+Determinism
+-----------
+Signing keys are derived from fixed seeds and the evaluation time is pinned
+(``EVALUATION_TIME``), so the emitted JSON is byte-stable across runs and
+machines. ``tests/test_rcl_fixture_export.py`` enforces that.
+
+Only public keys are exported. The seeds stay in the harness; these fixtures
+are for verification, not for minting new receipts.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from protocol_tests import receipt_claim_harness as H
+
+SCHEMA_VERSION = "1.0"
+
+# Pinned so the output is reproducible. Matches ReceiptClaimTests.now.
+EVALUATION_TIME = 1_750_000_000
+
+# The four families the decomposition defines. `integrity_provenance` is
+# declared and enforced by the verifier but is NOT exercised by any current
+# vector -- see `coverage_gaps` in the emitted file. Stated rather than
+# quietly omitted.
+CLAIM_FAMILIES = [
+    "integrity_provenance",
+    "occurrence",
+    "authorization",
+    "check_execution",
+]
+
+# The verifier prefixes each rejection reason with the property that failed.
+_REASON_PREFIX_TO_FAMILY = {
+    "integrity": "integrity_provenance",
+    "occurrence": "occurrence",
+    "authorization": "authorization",
+    "check": "check_execution",
+}
+
+
+def _family_from_reason(reason: str) -> str | None:
+    """Map a verifier reason onto a claim family. None for an accept."""
+    prefix = reason.split(":", 1)[0].strip()
+    return _REASON_PREFIX_TO_FAMILY.get(prefix)
+
+
+def _case(verifier, test_id: str, name: str, receipt: dict) -> dict:
+    outcome = verifier.verify(receipt)
+    envelope_valid = verifier.verify_envelope(receipt)
+    family = _family_from_reason(outcome.reason) if outcome.verdict == "reject" else None
+    return {
+        "id": test_id,
+        "name": name,
+        # Every vector's envelope signature verifies. That is the whole point:
+        # signature validity does not establish the substantive claims.
+        "envelope_valid": envelope_valid,
+        "receipt": receipt,
+        "expected": {
+            "verdict": outcome.verdict,
+            "claim_family": family,
+            "reason": outcome.reason,
+        },
+    }
+
+
+def build_fixture_set(now: int = EVALUATION_TIME) -> dict:
+    """Build the full fixture set by executing the verifier over each vector."""
+    v = H.ClaimLevelVerifier(now)
+    fixtures: list[dict] = []
+
+    for test_id, name, builder in H.NEGATIVES:
+        fixtures.append(_case(v, test_id, name, builder(now)))
+
+    fixtures.append(
+        _case(v, "RCL-008", "Fully-supported receipt accepted (control)",
+              H.build_valid_receipt(now))
+    )
+    fixtures.append(
+        _case(v, "RCL-009", "Wired MCP-019 check (clean) accepted",
+              H.build_tool_context_receipt(now, H._CLEAN_TOOLS))
+    )
+    fixtures.append(
+        _case(v, "RCL-010", "Wired MCP-019 check (composite found) rejected",
+              H.build_tool_context_receipt(now, H._SHARELOCK_TOOLS))
+    )
+    fixtures.append(
+        _case(v, "RCL-011", "Wired MCP-019 check bound to wrong tool set rejected",
+              H.build_tool_context_receipt(now, H._CLEAN_TOOLS,
+                                           action_tools=H._SHARELOCK_TOOLS))
+    )
+
+    accepts = [f for f in fixtures if f["expected"]["verdict"] == "accept"]
+    rejects = [f for f in fixtures if f["expected"]["verdict"] == "reject"]
+    exercised = {f["expected"]["claim_family"] for f in rejects}
+    gaps = [fam for fam in CLAIM_FAMILIES if fam not in exercised]
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_by": "protocol_tests/rcl_fixture_export.py",
+        "source_module": "protocol_tests/receipt_claim_harness.py",
+        "evaluation_time": now,
+        "freshness_window_seconds": H.FRESHNESS_WINDOW,
+        "signature_algorithm": "Ed25519 (RFC 8032) over JCS-canonicalised JSON",
+        "public_keys": {k: v.hex() for k, v in H.PUBKEYS.items()},
+        "claim_families": CLAIM_FAMILIES,
+        "counts": {
+            "total": len(fixtures),
+            "accept": len(accepts),
+            "reject": len(rejects),
+        },
+        "coverage_gaps": {
+            "families_with_no_negative_vector": gaps,
+            "note": (
+                "The decomposition defines four claim families. Families listed "
+                "here are enforced by the verifier but have no negative vector "
+                "in this set, so these fixtures do not exercise them."
+            ),
+        },
+        "scope": (
+            "These vectors establish whether a receipt supports its asserted "
+            "claims. They do not establish that any particular implementation "
+            "produces defective receipts."
+        ),
+        "usage": (
+            "For each fixture, run your verifier over `receipt` and compare "
+            "against `expected.verdict`. Retain the accept cases: a verifier "
+            "that rejects every fixture has not demonstrated correct claim "
+            "validation."
+        ),
+        "fixtures": fixtures,
+    }
+
+
+DEFAULT_OUTPUT = Path("fixtures/rcl/rcl-oracle-fixtures.v1.json")
+
+
+def serialise(data: dict) -> str:
+    return json.dumps(data, indent=2, sort_keys=False) + "\n"
+
+
+def main() -> None:
+    import argparse
+
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("-o", "--output", type=Path, default=DEFAULT_OUTPUT)
+    ap.add_argument("--stdout", action="store_true", help="print instead of writing")
+    args = ap.parse_args()
+
+    data = build_fixture_set()
+    text = serialise(data)
+
+    if args.stdout:
+        print(text, end="")
+        return
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(text, encoding="utf-8")
+    c = data["counts"]
+    print(f"wrote {args.output} - {c['total']} fixtures "
+          f"({c['accept']} accept, {c['reject']} reject)")
+    gaps = data["coverage_gaps"]["families_with_no_negative_vector"]
+    if gaps:
+        print(f"coverage gap: no negative vector for {', '.join(gaps)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_rcl_fixture_export.py
+++ b/tests/test_rcl_fixture_export.py
@@ -1,0 +1,94 @@
+"""Regression tests for the exported RCL oracle fixtures.
+
+The point of the fixture file is that somebody else can use it. These tests
+check the properties that claim depends on:
+
+1. it regenerates byte-identically (so a diff means a real change);
+2. it is self-contained -- every signature verifies using only the public
+   keys inside the file, with no import from the harness;
+3. the accept cases survive (a fixture set of only negatives lets a
+   reject-everything verifier score full marks);
+4. no private seed material leaks into it.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from protocol_tests import rcl_fixture_export as X
+
+FIXTURE_PATH = Path("fixtures/rcl/rcl-oracle-fixtures.v1.json")
+
+
+@pytest.fixture(scope="module")
+def committed() -> dict:
+    if not FIXTURE_PATH.exists():
+        pytest.skip(f"{FIXTURE_PATH} not generated")
+    return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+def test_regenerates_byte_identically(committed):
+    """A diff in the committed file must mean a real behavioural change."""
+    assert X.serialise(X.build_fixture_set()) == FIXTURE_PATH.read_text(encoding="utf-8")
+
+
+def test_counts_are_nine_reject_two_accept(committed):
+    verdicts = [f["expected"]["verdict"] for f in committed["fixtures"]]
+    assert len(verdicts) == 11
+    assert verdicts.count("accept") == 2, "the positive controls must survive export"
+    assert verdicts.count("reject") == 9
+
+
+def test_accept_controls_present_by_id(committed):
+    accepts = {f["id"] for f in committed["fixtures"]
+               if f["expected"]["verdict"] == "accept"}
+    assert accepts == {"RCL-008", "RCL-009"}
+
+
+def test_every_envelope_signature_is_valid(committed):
+    """Each vector is envelope-valid; only the substantive claims differ."""
+    assert all(f["envelope_valid"] for f in committed["fixtures"])
+
+
+def test_fixtures_are_self_contained_for_an_outside_verifier(committed):
+    """Verify every envelope signature using ONLY the file's own public keys.
+
+    This is the property that makes the export useful to a third party: no
+    reference to the harness, its seeds, or its builders.
+    """
+    from protocol_tests.receipt_claim_harness import _ed25519, _jcs
+
+    emitter_pub = bytes.fromhex(committed["public_keys"]["emitter"])
+    for f in committed["fixtures"]:
+        receipt = f["receipt"]
+        body = {k: v for k, v in receipt.items() if k != "envelope_sig"}
+        sig = bytes.fromhex(receipt["envelope_sig"])
+        assert _ed25519.verify(emitter_pub, _jcs(body), sig), \
+            f"{f['id']} envelope signature did not verify from the exported public key"
+
+
+def test_claim_family_is_set_for_every_rejection(committed):
+    for f in committed["fixtures"]:
+        exp = f["expected"]
+        if exp["verdict"] == "reject":
+            assert exp["claim_family"] in committed["claim_families"], f["id"]
+        else:
+            assert exp["claim_family"] is None, f["id"]
+
+
+def test_declared_coverage_gap_is_accurate(committed):
+    """The file claims integrity_provenance has no negative vector. Check it."""
+    exercised = {f["expected"]["claim_family"] for f in committed["fixtures"]
+                 if f["expected"]["verdict"] == "reject"}
+    declared = set(committed["coverage_gaps"]["families_with_no_negative_vector"])
+    assert declared == set(committed["claim_families"]) - exercised
+
+
+def test_no_private_key_material_exported(committed):
+    raw = FIXTURE_PATH.read_text(encoding="utf-8")
+    assert "_SEEDS" not in raw
+    assert "secret" not in raw.lower()
+    assert set(committed["public_keys"]) == {"emitter", "checker", "authz", "exec"}


### PR DESCRIPTION
Shenghan Zheng (Dartmouth, AgentThread) proposed the RCL vectors as oracle cases for their L5 audit/provenance adapter tests. This packages them so that is actually possible.

Today `receipt_claim_harness.py` builds each receipt **in code** and records the verdict as **prose inside a `details` string**. Fine as an evidence report; unusable as a fixture, since an outside implementation would have to reimplement the builders.

## What's here
- `protocol_tests/rcl_fixture_export.py` — emits all eleven vectors as data
- `fixtures/rcl/rcl-oracle-fixtures.v1.json` — the generated set
- `fixtures/rcl/README.md` — schema and usage
- `tests/test_rcl_fixture_export.py` — 8 regression tests

## Expected values are executed, not asserted
Every expected verdict and claim family comes from running `ClaimLevelVerifier` over the built receipt at export time. `claim_family` is taken from the verifier's own rejection-reason prefix. Nothing hand-writes an expectation — a hand-assigned expectation is a label, not a result, and this repo already published an audit about confusing those two.

## Properties enforced by test, not by claim
| Property | Test |
|---|---|
| Regenerates byte-identically | `test_regenerates_byte_identically` |
| **Every signature verifies from the file's own public keys** | `test_fixtures_are_self_contained_for_an_outside_verifier` |
| 9 reject + 2 accept | `test_counts_are_nine_reject_two_accept` |
| No private key material exported | `test_no_private_key_material_exported` |
| Declared coverage gap is accurate | `test_declared_coverage_gap_is_accurate` |

## Two things stated rather than hidden
**The composition is 9 reject + 2 accept, not eleven negatives.** RCL-008 and RCL-009 stop a reject-everything verifier scoring full marks. Guarded by test and by the README.

**`integrity_provenance` has no negative vector.** The verifier enforces it, but every vector is envelope-valid by construction — that is the property the set exists to isolate. Declared in `coverage_gaps` in the file itself.

## Scope
Carried in the artifact: these vectors establish whether a receipt supports its asserted claims. They do **not** establish that AgentThread, or any implementation, produces defective receipts.

The vectors, the reference verifier, and this packaging share one author. Independent evaluation design and reproduction remain the outstanding checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and documentation tooling around existing harness vectors; no production runtime or auth paths changed, with only public keys in the artifact.
> 
> **Overview**
> **Packages the existing RCL receipt-claim harness vectors as portable oracle data** so external implementations can verify receipts against fixed inputs instead of reimplementing in-code builders and parsing prose `details` strings.
> 
> Adds `protocol_tests/rcl_fixture_export.py`, which builds all eleven cases from `receipt_claim_harness`, runs `ClaimLevelVerifier` at export time for every `expected` field (verdict, `claim_family` from rejection-reason prefix, reason), pins `evaluation_time` for byte-stable JSON, exports only public keys, and records metadata (`claim_families`, `coverage_gaps` for `integrity_provenance`, scope/usage). Documents schema and usage in `fixtures/rcl/README.md`.
> 
> Adds `tests/test_rcl_fixture_export.py` to enforce byte-identical regeneration, 9 reject / 2 accept (`RCL-008`, `RCL-009`), envelope validity, self-contained Ed25519 verification from exported keys, accurate coverage gaps, and no leaked private material.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f916bda7b47815c71be2856adad003c2a239ef36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->