### PR TITLE
test(mcp): lock Streamable HTTP input boundary

### DIFF
--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -188,6 +188,12 @@ def create_server(
             dict with keys: grade, tests_passed, tests_run, results,
             recommendation, scan_time, target_url, timestamp.
         """
+        # Test-only execution witness for the public Streamable HTTP boundary
+        # regression. It is inert unless an isolated test supplies a path.
+        handler_marker = os.environ.get("MCP_TEST_SCAN_HANDLER_MARKER")
+        if handler_marker:
+            Path(handler_marker).touch()
+
         # Rate limit per-client (#109): key on URL as client identifier
         # since MCP tool calls don't carry a client_id in context.
         # This ensures different clients scanning different targets aren't blocked.

--- a/tests/test_mcp_server_streamable_http_boundary.py
+++ b/tests/test_mcp_server_streamable_http_boundary.py
@@ -1,0 +1,94 @@
+"""Released-SDK Streamable HTTP input-validation characterization.
+
+This loopback-only regression deliberately tests the bundled server through the
+public Streamable HTTP client, rather than the SDK's in-memory ``Client``.
+It records the server-side tool-schema boundary only.  It does not establish
+gateway behavior, external receiver behavior, or final-wire conformance.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+import subprocess
+import sys
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+mcp = pytest.importorskip("mcp")
+from mcp import ClientSession  # noqa: E402
+from mcp.client.streamable_http import streamable_http_client  # noqa: E402
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _free_loopback_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        listener.bind(("127.0.0.1", 0))
+        return int(listener.getsockname()[1])
+
+
+def _wait_for_listener(port: int) -> None:
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as connection:
+            connection.settimeout(0.2)
+            if connection.connect_ex(("127.0.0.1", port)) == 0:
+                return
+        time.sleep(0.1)
+    raise AssertionError("bundled MCP server did not bind its loopback port")
+
+
+@contextmanager
+def _streamable_server() -> Iterator[str]:
+    port = _free_loopback_port()
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "mcp_server",
+            "--transport",
+            "http",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+        ],
+        cwd=REPO_ROOT,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        _wait_for_listener(port)
+        yield f"http://127.0.0.1:{port}/mcp"
+    finally:
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=5)
+
+
+def test_streamable_http_rejects_invalid_tool_arguments_before_handler_execution() -> None:
+    """The bundled v2 server rejects a missing required ``url`` at its tool boundary."""
+
+    async def call_invalid_tool(endpoint: str):
+        async with streamable_http_client(endpoint) as streams:
+            async with ClientSession(*streams) as session:
+                await session.initialize()
+                return await session.call_tool("scan_mcp_server", {"wrong": "synthetic"})
+
+    with _streamable_server() as endpoint:
+        result = asyncio.run(call_invalid_tool(endpoint))
+
+    assert result.is_error is True
+    assert len(result.content) == 1
+    assert result.content[0].type == "text"
+    assert "url" in result.content[0].text
+    assert "Field required" in result.content[0].text

--- a/tests/test_mcp_server_streamable_http_boundary.py
+++ b/tests/test_mcp_server_streamable_http_boundary.py
@@ -9,6 +9,7 @@ gateway behavior, external receiver behavior, or final-wire conformance.
 from __future__ import annotations
 
 import asyncio
+import os
 import socket
 import subprocess
 import sys
@@ -45,8 +46,10 @@ def _wait_for_listener(port: int) -> None:
 
 
 @contextmanager
-def _streamable_server() -> Iterator[str]:
+def _streamable_server(handler_marker: Path) -> Iterator[str]:
     port = _free_loopback_port()
+    environment = os.environ.copy()
+    environment["MCP_TEST_SCAN_HANDLER_MARKER"] = str(handler_marker)
     process = subprocess.Popen(
         [
             sys.executable,
@@ -60,6 +63,7 @@ def _streamable_server() -> Iterator[str]:
             str(port),
         ],
         cwd=REPO_ROOT,
+        env=environment,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
@@ -75,7 +79,7 @@ def _streamable_server() -> Iterator[str]:
             process.wait(timeout=5)
 
 
-def test_streamable_http_rejects_invalid_tool_arguments_before_handler_execution() -> None:
+def test_streamable_http_rejects_invalid_tool_arguments_before_handler_execution(tmp_path: Path) -> None:
     """The bundled v2 server rejects a missing required ``url`` at its tool boundary."""
 
     async def call_invalid_tool(endpoint: str):
@@ -84,7 +88,8 @@ def test_streamable_http_rejects_invalid_tool_arguments_before_handler_execution
                 await session.initialize()
                 return await session.call_tool("scan_mcp_server", {"wrong": "synthetic"})
 
-    with _streamable_server() as endpoint:
+    handler_marker = tmp_path / "scan-handler-invoked"
+    with _streamable_server(handler_marker) as endpoint:
         result = asyncio.run(call_invalid_tool(endpoint))
 
     assert result.is_error is True
@@ -92,3 +97,4 @@ def test_streamable_http_rejects_invalid_tool_arguments_before_handler_execution
     assert result.content[0].type == "text"
     assert "url" in result.content[0].text
     assert "Field required" in result.content[0].text
+    assert not handler_marker.exists()


### PR DESCRIPTION
## Summary
- add a loopback-only released-SDK v2 Streamable HTTP regression
- verify the bundled server rejects missing required tool input before handler execution

## Verification
- fresh `mcp==2.0.0` environment: 7 focused tests passed

## Scope
This is a bundled-server local transport characterization only. It makes no claim about gateways, external receivers, vulnerabilities, or final-wire conformance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scope is test infrastructure plus a few inert lines in `scan_mcp_server` gated on an env var; no auth, SSRF, or scan logic changes in normal operation.
> 
> **Overview**
> Locks in **Streamable HTTP tool input validation** for the bundled MCP server by exercising the real released SDK client against a loopback HTTP transport, not the in-memory test client.
> 
> A new regression starts `mcp_server` on `127.0.0.1`, calls `scan_mcp_server` with a wrong argument shape (missing required `url`), and expects an error response mentioning **Field required** for `url`. The test also asserts the **`scan_mcp_server` handler never ran**.
> 
> To detect handler execution, **`scan_mcp_server`** gains a test-only hook: when `MCP_TEST_SCAN_HANDLER_MARKER` is set, the handler touches that path at entry. Normal deployments leave the variable unset, so behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2072aecf629be6b4e46013c627055265000988f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->