### PR TITLE
fix: name the RCL fixture signing encoding accurately (not JCS)

### DIFF
--- a/fixtures/rcl/README.md
+++ b/fixtures/rcl/README.md
@@ -56,7 +56,7 @@ Top level:
 | `schema_version` | `"1.0"` |
 | `evaluation_time` | Unix seconds the fixtures were built at. Freshness cases are relative to this, so pass it to your verifier as "now" |
 | `freshness_window_seconds` | how long a checker transcript stays fresh |
-| `signature_algorithm` | Ed25519 (RFC 8032) over JCS-canonicalised JSON |
+| `signature_algorithm` | Ed25519 (RFC 8032) over **sorted compact JSON**, not JCS. The signing payload is `json.dumps(obj, sort_keys=True, separators=(",", ":"))` encoded UTF-8. It coincides with JCS (RFC 8785) for the ASCII-only, integer-valued payloads in this corpus, but diverges on number canonicalisation and non-ASCII escaping. Verify with the encoding named in the field, not with JCS |
 | `public_keys` | hex Ed25519 public keys per authority: `emitter`, `checker`, `authz`, `exec`. Enough to verify every signature in the file. No private material is exported |
 | `key_material` | states plainly that these are test authorities, not trust anchors |
 | `claim_families` | the four families above |

--- a/fixtures/rcl/rcl-oracle-fixtures.v1.json
+++ b/fixtures/rcl/rcl-oracle-fixtures.v1.json
@@ -4,7 +4,7 @@
   "source_module": "protocol_tests/receipt_claim_harness.py",
   "evaluation_time": 1750000000,
   "freshness_window_seconds": 300,
-  "signature_algorithm": "Ed25519 (RFC 8032) over JCS-canonicalised JSON",
+  "signature_algorithm": "Ed25519 (RFC 8032) over sorted compact JSON: json.dumps(obj, sort_keys=True, separators=(',', ':')) encoded UTF-8. This is NOT JCS (RFC 8785). It coincides with JCS for the ASCII-only, integer-valued payloads in this corpus, which is why a JCS verifier reproduces these signatures, but it diverges on number canonicalisation (1.0 stays '1.0' rather than '1') and on non-ASCII escaping (Python escapes to \\uXXXX; JCS emits raw UTF-8). Verify with the encoding named here, not with JCS, if a future corpus carries non-ASCII strings or non-integer numbers.",
   "public_keys": {
     "emitter": "0c00eff6ec5a14a61947baa64aa5af0ef32c8bb0af2c1c12ddc5d68d35200000",
     "checker": "73164cba8603b8f71cbcf087c5067c3dad1f995c992a6b795466d758ea6d4ff2",
@@ -27,7 +27,8 @@
     "families_with_no_negative_vector": [
       "integrity_provenance"
     ],
-    "note": "The decomposition defines four claim families. Families listed here are enforced by the verifier but have no negative vector in this set, so these fixtures do not exercise them."
+    "note": "The decomposition defines four claim families. Families listed here are enforced by the verifier but have no negative vector in this set, so these fixtures do not exercise them.",
+    "temporal_vectors_not_exercised": "Freshness is exercised only in the stale direction (RCL-003, a transcript older than the freshness window). This set contains no future-dated checker timestamp, so it does not establish how a verifier treats a check attested ahead of evaluation_time."
   },
   "scope": "These vectors establish whether a receipt supports its asserted claims. They do not establish that any particular implementation produces defective receipts.",
   "usage": "For each fixture, run your verifier over `receipt` and compare against `expected.verdict`. Retain the accept cases: a verifier that rejects every fixture has not demonstrated correct claim validation.",

--- a/protocol_tests/rcl_fixture_export.py
+++ b/protocol_tests/rcl_fixture_export.py
@@ -127,7 +127,17 @@ def build_fixture_set(now: int = EVALUATION_TIME) -> dict:
         "source_module": "protocol_tests/receipt_claim_harness.py",
         "evaluation_time": now,
         "freshness_window_seconds": H.FRESHNESS_WINDOW,
-        "signature_algorithm": "Ed25519 (RFC 8032) over JCS-canonicalised JSON",
+        "signature_algorithm": (
+            "Ed25519 (RFC 8032) over sorted compact JSON: "
+            "json.dumps(obj, sort_keys=True, separators=(',', ':')) encoded "
+            "UTF-8. This is NOT JCS (RFC 8785). It coincides with JCS for the "
+            "ASCII-only, integer-valued payloads in this corpus, which is why "
+            "a JCS verifier reproduces these signatures, but it diverges on "
+            "number canonicalisation (1.0 stays '1.0' rather than '1') and on "
+            "non-ASCII escaping (Python escapes to \\uXXXX; JCS emits raw "
+            "UTF-8). Verify with the encoding named here, not with JCS, if a "
+            "future corpus carries non-ASCII strings or non-integer numbers."
+        ),
         "public_keys": {k: v.hex() for k, v in H.PUBKEYS.items()},
         "key_material": (
             "Test authorities only, never a real trust anchor. Public keys are "
@@ -149,6 +159,13 @@ def build_fixture_set(now: int = EVALUATION_TIME) -> dict:
                 "The decomposition defines four claim families. Families listed "
                 "here are enforced by the verifier but have no negative vector "
                 "in this set, so these fixtures do not exercise them."
+            ),
+            "temporal_vectors_not_exercised": (
+                "Freshness is exercised only in the stale direction (RCL-003, "
+                "a transcript older than the freshness window). This set "
+                "contains no future-dated checker timestamp, so it does not "
+                "establish how a verifier treats a check attested ahead of "
+                "evaluation_time."
             ),
         },
         "scope": (


### PR DESCRIPTION
Closes the technical correction promised in #304.

## Origin

An external reproducibility report (#304, VrtxOmega) wrote a separate Node verifier, replayed the pinned corpus, and matched **11/11** verdicts, claim families, and reason strings. They explicitly declined to claim full RFC 8785 conformance. **They were right to decline, and the fixture's own label was the thing at fault.**

## The defect

`signature_algorithm` claimed `"Ed25519 (RFC 8032) over JCS-canonicalised JSON"`. The signing payload is actually produced by `receipt_claim_harness.py:62`:

```python
json.dumps(obj, sort_keys=True, separators=(",", ":")).encode("utf-8")
```

That is sorted compact JSON, **not** JCS. They coincide for the ASCII-only, integer-valued payloads in this corpus, which is why a JCS verifier reproduces these signatures today. They diverge on:

| | this encoder | RFC 8785 |
|---|---|---|
| number canonicalisation | `1.0` | `1` |
| non-ASCII | `"caf\u00e9"` | `"café"` |

A verifier canonicalising per RFC 8785 against a **future** corpus carrying non-ASCII strings or non-integer numbers would have hit a signature mismatch with no way to tell whether the fixture or their verifier was wrong. That is the failure this prevents.

## Also declared

A second limit the same report identified: freshness is exercised only in the **stale** direction (`RCL-003`), so the set does not establish how a verifier treats a check attested *ahead of* `evaluation_time`.

## The corpus itself is unchanged

Verified programmatically, not asserted:

```
fixtures identical : True
counts identical   : True
pubkeys identical  : True
changed top keys   : ['signature_algorithm', 'coverage_gaps']
```

No verdict, receipt, or signature moved.

## Hash change is expected and bounded

```
before  0bc47dab20d1c45100f5525a1798fd84df3fd979d1febb2b5fc1c5a69846befb
after   4164151383605d9d68230d81cc9ae1dd31eb5cfb3fb1348289abf71ee64773ea
```

The file's self-description changed, so its hash changed. **The before hash remains valid at the commit #304 pinned (`5e25bc6`), which is immutable — that report stays reproducible exactly as written.** Nothing in the repo pins the old hash (checked).

## Tests

- `tests/test_rcl_fixture_export.py`: **9 passed**
- rcl/receipt suite: **16 passed + 7 subtests**
- `ruff check`: clean
- `tests/test_mcp_server_runtime.py` errors on a missing optional `mcp` extra — **identical on pristine main**, unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and fixture metadata only; no verifier or signing logic changes, so external reproducibility of vectors is preserved aside from the updated file hash from revised top-level fields.
> 
> **Overview**
> Corrects **mislabeled** RCL oracle fixture metadata: `signature_algorithm` no longer claims JCS (RFC 8785) and instead names the real signing payload—**Ed25519 over Python sorted compact JSON** (`json.dumps(..., sort_keys=True, separators=(",", ":"))` UTF-8)—including where that encoding **differs** from JCS (numbers, non-ASCII).
> 
> The exporter (`rcl_fixture_export.py`), regenerated `rcl-oracle-fixtures.v1.json`, and `fixtures/rcl/README.md` stay aligned on that wording. **`coverage_gaps`** also gains **`temporal_vectors_not_exercised`**, noting freshness is only tested for **stale** checker timestamps (e.g. RCL-003), not future-dated checks relative to `evaluation_time`.
> 
> **Receipt bodies, signatures, verdicts, and public keys are unchanged**; only self-description fields (and thus the fixture file hash) move.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 385b7c28bc29f923bab46ee620b006ddfdbabb4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->