### PR TITLE
fix: the DGB bundle presented audited-snapshot grounding as current

### DIFF
--- a/benchmarks/dgb_bundle_export.py
+++ b/benchmarks/dgb_bundle_export.py
@@ -33,6 +33,7 @@ Usage
 
 from __future__ import annotations
 
+import hashlib
 import json
 from dataclasses import asdict
 from pathlib import Path
@@ -66,6 +67,15 @@ GROUNDING_SOURCE = {
         "not be located. 'provisional' means the source was located but a "
         "per-case locator was not established; it is not a finding of support."
     ),
+    "currency_warning": (
+        "These verdicts describe the corpus AS AUDITED at the commit above, "
+        "not as it stands today. A remediation pass landed the day after the "
+        "audit and revised many source fields. Each case reports "
+        "source_revised_since_audit; where that is true the evidence_fit and "
+        "record_defect below are STALE and have not been re-adjudicated. Do "
+        "not read a stale 'none' as a current defect, and do not read a "
+        "revision as a repair that someone has verified."
+    ),
 }
 
 
@@ -76,6 +86,80 @@ def _load_grounding() -> dict:
     regenerated from this repository alone, without the private audit file.
     """
     return _GROUNDING
+
+
+
+_AUDITED_SOURCE_SHA256_16 = dict(
+    line.split("\t") for line in """
+DBC-001	f01a41bbecde087f
+DBC-002	96d6c1e7ddf8cb9f
+DBC-003	351d07a2aa84cff8
+DBC-004	39c3f701504333bd
+DBC-005	af7ee8fcb09465ea
+DBC-006	c1b728c4a1ee774e
+DBC-007	c701d9282905d805
+DBC-008	9abe46597e12a24c
+DBC-009	42ea67b517917464
+DBC-010	c0902591f8179319
+DBC-011	4d383dde0fc7c979
+DBC-012	d5dfa93a29c0b443
+DBC-013	4668cbb8cd65645a
+DBC-014	74a4624a3e6c7bcf
+DBC-015	07bcdfb2149440e4
+DBC-016	a6ee482cfe75ab61
+DBC-017	c245363b4393ee0f
+DBC-018	8f58a381278c7454
+DBC-019	07bd3e4881f87966
+DBC-020	0b7b44a93d46adbd
+DBC-021	0cba87b2fa5b3163
+DBC-022	f7cf593ed16bc649
+DBC-023	24d8c3e3c75b00db
+DBC-024	4d5e1ece1f44d6a7
+DBC-025	a958e2a21fe1c7a9
+DBC-026	baf466908f7c3727
+DBC-027	5c68c3e59c52196e
+DBC-028	da304f745da4c27a
+DBC-029	e3628a2cf693261c
+DBC-030	2605493bdc604de8
+DBC-031	92a74f845e1668b6
+DBC-032	e186f579ec36396b
+DBC-033	c25ac21013e06ad5
+DBC-034	83b40666b384b943
+DBC-035	e61c2a00a9e7568e
+DBC-036	c3f77592324795c0
+DBC-037	dfcb4bd6e9beee1e
+DBC-038	bf9a3bd76b79de70
+DBC-039	ed37bfb4f42823da
+DBC-040	b4368aaeeb02a88f
+DBC-041	595a8ba1b533f419
+DBC-042	6c1447ad7ca01be2
+DBC-043	74039a5f21a8480a
+DBC-044	82fc6c94f21de854
+DBC-045	f05e39a5dae35096
+DBC-046	a6f78d8ed6c15192
+DBC-047	1711d013907942d3
+DBC-048	2765beaee6e02796
+DBC-049	80898a79c6ce55f9
+DBC-050	42f6f5aca88b565a
+DBC-051	8ebc2451521d30fe
+DBC-052	853282e96635b465
+""".strip().splitlines()
+)
+
+
+def _source_revised(case) -> bool:
+    """True if the case's `source` text changed after the grounding audit.
+
+    The audit read the corpus at 6c5d617 on 2026-07-26. A remediation pass
+    landed on 2026-07-27 and rewrote many source fields. Comparing the current
+    text against the audited-era digest is how a reader can tell, per case,
+    whether the recorded verdict still describes what they are looking at.
+    """
+    audited = _AUDITED_SOURCE_SHA256_16.get(case.id)
+    if audited is None:
+        return False
+    current = hashlib.sha256(case.source.encode("utf-8")).hexdigest()[:16]
+    return current != audited
 
 
 def build_bundle() -> dict:
@@ -99,6 +183,13 @@ def build_bundle() -> dict:
                     "externally_corroborated": (
                         row["provenance"] in ("external", "untrace+ext")
                         and row["evidence_fit"] == "full"
+                    ),
+                    "audited_at_commit": GROUNDING_SOURCE["corpus_commit_audited"],
+                    "source_revised_since_audit": _source_revised(case),
+                    "verdict_currency": (
+                        "stale — source text changed after the audit; not re-adjudicated"
+                        if _source_revised(case)
+                        else "as-audited — source text unchanged since the audit"
                     ),
                 },
                 "tools": fixture.get("tools", []),
@@ -126,6 +217,14 @@ def build_bundle() -> dict:
         by_category[c["category"]] = by_category.get(c["category"], 0) + 1
         by_severity[c["severity"]] = by_severity.get(c["severity"], 0) + 1
 
+    revised_n = sum(1 for c in cases if c["grounding"]["source_revised_since_audit"])
+    still_flagged = sum(
+        1
+        for c in cases
+        if not c["grounding"]["source_revised_since_audit"]
+        and (c["grounding"]["evidence_fit"] == "none" or c["grounding"]["record_defect"] != "—")
+    )
+
     regex_hits = sum(1 for c in cases if c["expected_scanner"]["regex_metadata_scanner"])
     cap_hits = sum(1 for c in cases if c["expected_scanner"]["capability_rule_scanner"])
 
@@ -145,6 +244,24 @@ def build_bundle() -> dict:
             "tool_entries": sum(len(c["tools"]) for c in cases),
             "by_category": by_category,
             "by_severity": by_severity,
+        },
+        "grounding_currency": {
+            "audited_at_commit": GROUNDING_SOURCE["corpus_commit_audited"],
+            "audit_date": GROUNDING_SOURCE["audit_date"],
+            "cases_with_source_revised_since_audit": revised_n,
+            "cases_still_as_audited": len(cases) - revised_n,
+            "flagged_and_still_as_audited": still_flagged,
+            "note": (
+                "A remediation pass landed the day after the audit and revised "
+                f"{revised_n} of {len(cases)} source fields. For those cases the "
+                "evidence_fit and record_defect recorded here are stale and have "
+                "not been re-adjudicated against the revised text. Of the cases "
+                "carrying a defect verdict, only "
+                f"{still_flagged} still have the exact source text the audit read. "
+                "Re-adjudicating the revised cases is outstanding work, and until "
+                "it is done neither a stale defect nor an assumed repair should be "
+                "reported as the current state."
+            ),
         },
         "evidence_fit_distribution": fit_counts,
         "record_defect_distribution": defect_counts,
@@ -168,11 +285,14 @@ def build_bundle() -> dict:
                 "outstanding check this bundle exists to make possible."
             ),
             "evidence_fit": (
-                "Only 1 of 52 cases has full external evidence fit (DBC-009). "
-                "10 cases have a located source that does not substantiate "
-                "them, 12 have a source that could not be located, and 13 are "
-                "provisional because the source was located but no per-case "
-                "locator was established. Each case states its own status."
+                "AS AUDITED on 2026-07-27: 1 of 52 cases had full external "
+                "evidence fit (DBC-009); 10 had a located source that did not "
+                "substantiate them; 12 had a source that could not be located; "
+                "13 were provisional. A remediation pass landed the day after "
+                "and revised many source fields, so these figures describe the "
+                "audited snapshot, not the current corpus. Read "
+                "grounding_currency and each case's source_revised_since_audit "
+                "before treating any single verdict as current."
             ),
             "executable_test_coverage": (
                 "executable_test does not cover the case for 24 of 52 at the "
@@ -180,10 +300,13 @@ def build_bundle() -> dict:
                 "not assert that the test exercises this specific scenario."
             ),
             "record_defects": (
-                "7 cases are misdescribed relative to their source and 1 "
-                "carries an invalid identifier (DBC-032, CVE-2026-SSRF-MCP). "
-                "A record defect is not the same as zero evidentiary support "
-                "and is classified separately from evidence fit."
+                "AS AUDITED: 7 cases were misdescribed relative to their "
+                "source and 1 carried an invalid identifier (DBC-032, "
+                "CVE-2026-SSRF-MCP). All 7 misdescribed cases have had their "
+                "source text revised since, so those verdicts are stale here "
+                "and have not been re-adjudicated. A record defect is not the "
+                "same as zero evidentiary support and is classified separately "
+                "from evidence fit."
             ),
             "configs_a_and_b": (
                 "Config A and Config B results elsewhere in this repository "

--- a/fixtures/dgb/README.md
+++ b/fixtures/dgb/README.md
@@ -31,7 +31,13 @@ python -m benchmarks.dgb_bundle_export
 
 ## The numbers this bundle does not hide
 
-| | |
+**Read the currency note first.** The grounding audit read the corpus on
+2026-07-26 at commit `6c5d617`. A remediation pass landed the next day and
+revised **25 of 52** source fields. The table below is therefore *as audited*,
+not *as it stands*. Every case reports `source_revised_since_audit`, and the
+bundle's `grounding_currency` block gives the split.
+
+| As audited on 2026-07-27 | Cases |
 |---|---|
 | Cases with **full external** evidence fit | **1 of 52** (`DBC-009`) |
 | Source located but does **not** substantiate the case | 10 |
@@ -43,8 +49,23 @@ python -m benchmarks.dgb_bundle_export
 | Invalid identifier | 1 (`DBC-032`) |
 | `executable_test` does not cover the case | 24 of 52 |
 
+| Currency | Cases |
+|---|---|
+| Source text **unchanged** since the audit — verdict still describes what you are reading | 27 |
+| Source text **revised** after the audit — verdict is stale, **not re-adjudicated** | 25 |
+| Carrying a defect verdict **and** still unrevised — the ones to look at first | **7** |
+
+Those seven are `DBC-014`, `DBC-016`, `DBC-031`, `DBC-038`, `DBC-039`,
+`DBC-040`, `DBC-044`.
+
+A stale verdict is not evidence of a current defect, and a revision is not
+evidence of a verified repair. Re-adjudicating the 25 revised cases against
+their new text is outstanding work, and this file says so rather than picking
+whichever reading is more flattering.
+
 The regex metadata scanner flags **1 of 52**. The capability-rule scanner flags
-**17 of 52**. Both figures come from execution, and both are in the file.
+**17 of 52**. Both figures come from execution against the current corpus, and
+both are in the file.
 
 ## Field reference
 

--- a/fixtures/dgb/dgb-corpus-bundle.v1.json
+++ b/fixtures/dgb/dgb-corpus-bundle.v1.json
@@ -12,7 +12,8 @@
     "audit": "DGB corpus \u2014 external corroboration audit (v6)",
     "audit_date": "2026-07-27",
     "corpus_commit_audited": "6c5d61726819165c9dcf75d99669217c3c3cab41",
-    "note": "Transcribed from the audit's Appendix A 52-case crosswalk. The audit asserts no source is fabricated, only that some are uncited and could not be located. 'provisional' means the source was located but a per-case locator was not established; it is not a finding of support."
+    "note": "Transcribed from the audit's Appendix A 52-case crosswalk. The audit asserts no source is fabricated, only that some are uncited and could not be located. 'provisional' means the source was located but a per-case locator was not established; it is not a finding of support.",
+    "currency_warning": "These verdicts describe the corpus AS AUDITED at the commit above, not as it stands today. A remediation pass landed the day after the audit and revised many source fields. Each case reports source_revised_since_audit; where that is true the evidence_fit and record_defect below are STALE and have not been re-adjudicated. Do not read a stale 'none' as a current defect, and do not read a revision as a repair that someone has verified."
   },
   "counts": {
     "total": 52,
@@ -29,6 +30,14 @@
       "P1-High": 20,
       "P2-Medium": 2
     }
+  },
+  "grounding_currency": {
+    "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+    "audit_date": "2026-07-27",
+    "cases_with_source_revised_since_audit": 25,
+    "cases_still_as_audited": 27,
+    "flagged_and_still_as_audited": 7,
+    "note": "A remediation pass landed the day after the audit and revised 25 of 52 source fields. For those cases the evidence_fit and record_defect recorded here are stale and have not been re-adjudicated against the revised text. Of the cases carrying a defect verdict, only 7 still have the exact source text the audit read. Re-adjudicating the revised cases is outstanding work, and until it is done neither a stale defect nor an assumed repair should be reported as the current state."
   },
   "evidence_fit_distribution": {
     "unresolved": 12,
@@ -59,9 +68,9 @@
   },
   "known_limitations": {
     "single_author": "The corpus, both scanners, the tool fixtures and the grounding audit share one author. Nothing in this bundle is independent corroboration of the corpus. Independent review is the outstanding check this bundle exists to make possible.",
-    "evidence_fit": "Only 1 of 52 cases has full external evidence fit (DBC-009). 10 cases have a located source that does not substantiate them, 12 have a source that could not be located, and 13 are provisional because the source was located but no per-case locator was established. Each case states its own status.",
+    "evidence_fit": "AS AUDITED on 2026-07-27: 1 of 52 cases had full external evidence fit (DBC-009); 10 had a located source that did not substantiate them; 12 had a source that could not be located; 13 were provisional. A remediation pass landed the day after and revised many source fields, so these figures describe the audited snapshot, not the current corpus. Read grounding_currency and each case's source_revised_since_audit before treating any single verdict as current.",
     "executable_test_coverage": "executable_test does not cover the case for 24 of 52 at the dgb-v1.0.0 tag. The field names a harness test; it does not assert that the test exercises this specific scenario.",
-    "record_defects": "7 cases are misdescribed relative to their source and 1 carries an invalid identifier (DBC-032, CVE-2026-SSRF-MCP). A record defect is not the same as zero evidentiary support and is classified separately from evidence fit.",
+    "record_defects": "AS AUDITED: 7 cases were misdescribed relative to their source and 1 carried an invalid identifier (DBC-032, CVE-2026-SSRF-MCP). All 7 misdescribed cases have had their source text revised since, so those verdicts are stale here and have not been re-adjudicated. A record defect is not the same as zero evidentiary support and is classified separately from evidence fit.",
     "configs_a_and_b": "Config A and Config B results elsewhere in this repository come from deterministic stub agents, not live models. Only the scanner arm is measured.",
     "not_exercised": "This bundle contains no live agent run, no Config D result, and no scoring. It is corpus plus fixtures plus executed scanner verdicts."
   },
@@ -85,7 +94,10 @@
         "evidence_fit": "unresolved",
         "record_defect": "untraceable source",
         "note": "grounding source could not be located",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": true,
+        "verdict_currency": "stale \u2014 source text changed after the audit; not re-adjudicated"
       },
       "tools": [
         {
@@ -129,7 +141,10 @@
         "evidence_fit": "unresolved",
         "record_defect": "untraceable source",
         "note": "grounding source could not be located",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": true,
+        "verdict_currency": "stale \u2014 source text changed after the audit; not re-adjudicated"
       },
       "tools": [
         {
@@ -173,7 +188,10 @@
         "evidence_fit": "partial",
         "record_defect": "misdescription",
         "note": "CVE real and supports privilege escalation, but via silent shared-auth reconnects auto-approving operator.read->operator.admin, not 'permission inheritance'. https://nvd.nist.gov/vuln/detail/CVE-2026-35625",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": true,
+        "verdict_currency": "stale \u2014 source text changed after the audit; not re-adjudicated"
       },
       "tools": [
         {
@@ -208,7 +226,10 @@
         "evidence_fit": "unresolved",
         "record_defect": "untraceable source",
         "note": "grounding source could not be located",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": true,
+        "verdict_currency": "stale \u2014 source text changed after the audit; not re-adjudicated"
       },
       "tools": [
         {
@@ -239,7 +260,10 @@
         "evidence_fit": "unresolved",
         "record_defect": "untraceable source",
         "note": "grounding source could not be located",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": true,
+        "verdict_currency": "stale \u2014 source text changed after the audit; not re-adjudicated"
       },
       "tools": [
         {
@@ -274,7 +298,10 @@
         "evidence_fit": "partial",
         "record_defect": "misdescription",
         "note": "Same CVE; 'tool permission inheritance escalation' does not match the NVD text. https://nvd.nist.gov/vuln/detail/CVE-2026-35625",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": true,
+        "verdict_currency": "stale \u2014 source text changed after the audit; not re-adjudicated"
       },
       "tools": [
         {
@@ -309,7 +336,10 @@
         "evidence_fit": "provisional",
         "record_defect": "\u2014",
         "note": "source located and plausibly relevant; per-case evidence locator not established in this audit",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": true,
+        "verdict_currency": "stale \u2014 source text changed after the audit; not re-adjudicated"
       },
       "tools": [
         {
@@ -348,7 +378,10 @@
         "evidence_fit": "full (internal)",
         "record_defect": "\u2014",
         "note": "grounded in Mike's own prior work \u2014 traceable, not external corroboration",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": false,
+        "verdict_currency": "as-audited \u2014 source text unchanged since the audit"
       },
       "tools": [
         {
@@ -383,7 +416,10 @@
         "evidence_fit": "full",
         "record_defect": "\u2014",
         "note": "OX documents prompt injection modifying local MCP config (CVE-2026-30615, Windsurf). https://www.ox.security/blog/mcp-supply-chain-advisory-rce-vulnerabilities-across-the-ai-ecosystem/",
-        "externally_corroborated": true
+        "externally_corroborated": true,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": false,
+        "verdict_currency": "as-audited \u2014 source text unchanged since the audit"
       },
       "tools": [
         {
@@ -414,7 +450,10 @@
         "evidence_fit": "provisional",
         "record_defect": "\u2014",
         "note": "source located and plausibly relevant; per-case evidence locator not established in this audit",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": false,
+        "verdict_currency": "as-audited \u2014 source text unchanged since the audit"
       },
       "tools": [
         {
@@ -449,7 +488,10 @@
         "evidence_fit": "provisional",
         "record_defect": "\u2014",
         "note": "source located and plausibly relevant; per-case evidence locator not established in this audit",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": false,
+        "verdict_currency": "as-audited \u2014 source text unchanged since the audit"
       },
       "tools": [
         {
@@ -480,7 +522,10 @@
         "evidence_fit": "provisional",
         "record_defect": "\u2014",
         "note": "source located and plausibly relevant; per-case evidence locator not established in this audit",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": false,
+        "verdict_currency": "as-audited \u2014 source text unchanged since the audit"
       },
       "tools": [
         {
@@ -515,7 +560,10 @@
         "evidence_fit": "provisional",
         "record_defect": "\u2014",
         "note": "source located and plausibly relevant; per-case evidence locator not established in this audit",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": false,
+        "verdict_currency": "as-audited \u2014 source text unchanged since the audit"
       },
       "tools": [
         {
@@ -550,7 +598,10 @@
         "evidence_fit": "none",
         "record_defect": "\u2014",
         "note": "OX article does not cover credential relay or agent impersonation. https://www.ox.security/blog/mcp-supply-chain-advisory-rce-vulnerabilities-across-the-ai-ecosystem/",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": false,
+        "verdict_currency": "as-audited \u2014 source text unchanged since the audit"
       },
       "tools": [
         {
@@ -581,7 +632,10 @@
         "evidence_fit": "full (internal)",
         "record_defect": "\u2014",
         "note": "grounded in Mike's own prior work \u2014 traceable, not external corroboration",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": false,
+        "verdict_currency": "as-audited \u2014 source text unchanged since the audit"
       },
       "tools": [
         {
@@ -616,7 +670,10 @@
         "evidence_fit": "none",
         "record_defect": "\u2014",
         "note": "OX article does not cover A2A cross-agent injection relay. https://www.ox.security/blog/mcp-supply-chain-advisory-rce-vulnerabilities-across-the-ai-ecosystem/",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": false,
+        "verdict_currency": "as-audited \u2014 source text unchanged since the audit"
       },
       "tools": [
         {
@@ -651,7 +708,10 @@
         "evidence_fit": "provisional",
         "record_defect": "\u2014",
         "note": "source located and plausibly relevant; per-case evidence locator not established in this audit",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": false,
+        "verdict_currency": "as-audited \u2014 source text unchanged since the audit"
       },
       "tools": [
         {
@@ -686,7 +746,10 @@
         "evidence_fit": "full (internal)",
         "record_defect": "\u2014",
         "note": "grounded in Mike's own prior work \u2014 traceable, not external corroboration",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": false,
+        "verdict_currency": "as-audited \u2014 source text unchanged since the audit"
       },
       "tools": [
         {
@@ -721,7 +784,10 @@
         "evidence_fit": "provisional",
         "record_defect": "\u2014",
         "note": "source located and plausibly relevant; per-case evidence locator not established in this audit",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": false,
+        "verdict_currency": "as-audited \u2014 source text unchanged since the audit"
       },
       "tools": [
         {
@@ -760,7 +826,10 @@
         "evidence_fit": "provisional",
         "record_defect": "\u2014",
         "note": "source located and plausibly relevant; per-case evidence locator not established in this audit",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": false,
+        "verdict_currency": "as-audited \u2014 source text unchanged since the audit"
       },
       "tools": [
         {
@@ -795,7 +864,10 @@
         "evidence_fit": "unresolved",
         "record_defect": "untraceable source",
         "note": "grounding source could not be located",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": true,
+        "verdict_currency": "stale \u2014 source text changed after the audit; not re-adjudicated"
       },
       "tools": [
         {
@@ -830,7 +902,10 @@
         "evidence_fit": "unresolved",
         "record_defect": "untraceable source",
         "note": "grounding source could not be located",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": true,
+        "verdict_currency": "stale \u2014 source text changed after the audit; not re-adjudicated"
       },
       "tools": [
         {
@@ -865,7 +940,10 @@
         "evidence_fit": "unresolved",
         "record_defect": "untraceable source",
         "note": "grounding source could not be located",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": true,
+        "verdict_currency": "stale \u2014 source text changed after the audit; not re-adjudicated"
       },
       "tools": [
         {
@@ -900,7 +978,10 @@
         "evidence_fit": "unresolved",
         "record_defect": "untraceable source",
         "note": "grounding source could not be located",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": true,
+        "verdict_currency": "stale \u2014 source text changed after the audit; not re-adjudicated"
       },
       "tools": [
         {
@@ -935,7 +1016,10 @@
         "evidence_fit": "unresolved",
         "record_defect": "untraceable source",
         "note": "grounding source could not be located",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": true,
+        "verdict_currency": "stale \u2014 source text changed after the audit; not re-adjudicated"
       },
       "tools": [
         {
@@ -966,7 +1050,10 @@
         "evidence_fit": "none",
         "record_defect": "untraceable source",
         "note": "zhuanruhu untraceable; OX does not cover cross-agent memory contamination. https://www.ox.security/blog/mcp-supply-chain-advisory-rce-vulnerabilities-across-the-ai-ecosystem/",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": true,
+        "verdict_currency": "stale \u2014 source text changed after the audit; not re-adjudicated"
       },
       "tools": [
         {
@@ -1001,7 +1088,10 @@
         "evidence_fit": "unresolved",
         "record_defect": "untraceable source",
         "note": "grounding source could not be located",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": true,
+        "verdict_currency": "stale \u2014 source text changed after the audit; not re-adjudicated"
       },
       "tools": [
         {
@@ -1032,7 +1122,10 @@
         "evidence_fit": "partial",
         "record_defect": "misdescription",
         "note": "'Self-reported metrics ... are all attack surfaces' IS in the article; 'in RAG contexts' is absent \u2014 no RAG discussion. https://rdi.berkeley.edu/blog/trustworthy-benchmarks/",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": true,
+        "verdict_currency": "stale \u2014 source text changed after the audit; not re-adjudicated"
       },
       "tools": [
         {
@@ -1063,7 +1156,10 @@
         "evidence_fit": "unresolved",
         "record_defect": "untraceable source",
         "note": "grounding source could not be located",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": true,
+        "verdict_currency": "stale \u2014 source text changed after the audit; not re-adjudicated"
       },
       "tools": [
         {
@@ -1098,7 +1194,10 @@
         "evidence_fit": "unresolved",
         "record_defect": "untraceable source",
         "note": "grounding source could not be located",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": true,
+        "verdict_currency": "stale \u2014 source text changed after the audit; not re-adjudicated"
       },
       "tools": [
         {
@@ -1129,7 +1228,10 @@
         "evidence_fit": "none",
         "record_defect": "\u2014",
         "note": "$45M source does not substantiate a single agent approving an over-threshold trade (see 1g).",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": false,
+        "verdict_currency": "as-audited \u2014 source text unchanged since the audit"
       },
       "tools": [
         {
@@ -1164,7 +1266,10 @@
         "evidence_fit": "partial",
         "record_defect": "invalid identifier",
         "note": "OX supports the broader STDIO-injection mechanism, but no located passage establishes the narrower tool-call/pre-validation sequence; the identifier is also invalid.",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": true,
+        "verdict_currency": "stale \u2014 source text changed after the audit; not re-adjudicated"
       },
       "tools": [
         {
@@ -1195,7 +1300,10 @@
         "evidence_fit": "full (internal)",
         "record_defect": "\u2014",
         "note": "grounded in Mike's own prior work \u2014 traceable, not external corroboration",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": false,
+        "verdict_currency": "as-audited \u2014 source text unchanged since the audit"
       },
       "tools": [
         {
@@ -1226,7 +1334,10 @@
         "evidence_fit": "full (internal)",
         "record_defect": "\u2014",
         "note": "grounded in Mike's own prior work \u2014 traceable, not external corroboration",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": false,
+        "verdict_currency": "as-audited \u2014 source text unchanged since the audit"
       },
       "tools": [
         {
@@ -1257,7 +1368,10 @@
         "evidence_fit": "full (internal)",
         "record_defect": "\u2014",
         "note": "grounded in Mike's own prior work \u2014 traceable, not external corroboration",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": false,
+        "verdict_currency": "as-audited \u2014 source text unchanged since the audit"
       },
       "tools": [
         {
@@ -1288,7 +1402,10 @@
         "evidence_fit": "partial",
         "record_defect": "\u2014",
         "note": "RDI half holds; $45M half unsupported (see 1g). https://rdi.berkeley.edu/blog/trustworthy-benchmarks/",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": false,
+        "verdict_currency": "as-audited \u2014 source text unchanged since the audit"
       },
       "tools": [
         {
@@ -1323,7 +1440,10 @@
         "evidence_fit": "partial",
         "record_defect": "misdescription",
         "note": "CVE real and supports SSRF, but via unguarded configured base URLs in channel extensions, not 'tool URL'. BlueRock attribution correct: https://www.bluerock.io/post/mcp-furi-microsoft-markitdown-vulnerabilities \u00b7 https://nvd.nist.gov/vuln/detail/CVE-2026-35629",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": true,
+        "verdict_currency": "stale \u2014 source text changed after the audit; not re-adjudicated"
       },
       "tools": [
         {
@@ -1354,7 +1474,10 @@
         "evidence_fit": "none",
         "record_defect": "\u2014",
         "note": "Same $45M source; credential extraction in a payment flow not evidenced in it.",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": false,
+        "verdict_currency": "as-audited \u2014 source text unchanged since the audit"
       },
       "tools": [
         {
@@ -1389,7 +1512,10 @@
         "evidence_fit": "none",
         "record_defect": "\u2014",
         "note": "OX article does not cover phantom tool injection via MCP registration. https://www.ox.security/blog/mcp-supply-chain-advisory-rce-vulnerabilities-across-the-ai-ecosystem/",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": false,
+        "verdict_currency": "as-audited \u2014 source text unchanged since the audit"
       },
       "tools": [
         {
@@ -1424,7 +1550,10 @@
         "evidence_fit": "none",
         "record_defect": "\u2014",
         "note": "Same $45M source; payment structuring to evade limits not evidenced in it.",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": false,
+        "verdict_currency": "as-audited \u2014 source text unchanged since the audit"
       },
       "tools": [
         {
@@ -1455,7 +1584,10 @@
         "evidence_fit": "partial",
         "record_defect": "misdescription",
         "note": "Byline is Wang, Mang, Cheung, Sen, Song (no Xu); 13 benchmarks audited, all rated critical risk, 45 exploits producing inflated OR perfect scores \u2014 not 'all 8 hackable for perfect'. https://rdi.berkeley.edu/blog/trustworthy-benchmarks/",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": true,
+        "verdict_currency": "stale \u2014 source text changed after the audit; not re-adjudicated"
       },
       "tools": [
         {
@@ -1486,7 +1618,10 @@
         "evidence_fit": "provisional",
         "record_defect": "\u2014",
         "note": "source located and plausibly relevant; per-case evidence locator not established in this audit",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": false,
+        "verdict_currency": "as-audited \u2014 source text unchanged since the audit"
       },
       "tools": [
         {
@@ -1517,7 +1652,10 @@
         "evidence_fit": "none",
         "record_defect": "\u2014",
         "note": "Article does not discuss LLM-judge manipulation via embedded instructions. https://rdi.berkeley.edu/blog/trustworthy-benchmarks/",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": true,
+        "verdict_currency": "stale \u2014 source text changed after the audit; not re-adjudicated"
       },
       "tools": [
         {
@@ -1548,7 +1686,10 @@
         "evidence_fit": "none",
         "record_defect": "\u2014",
         "note": "Article does not discuss contamination/memorization; answer leakage is adjacent but distinct. https://rdi.berkeley.edu/blog/trustworthy-benchmarks/",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": false,
+        "verdict_currency": "as-audited \u2014 source text unchanged since the audit"
       },
       "tools": [
         {
@@ -1583,7 +1724,10 @@
         "evidence_fit": "partial",
         "record_defect": "misdescription",
         "note": "Berkeley Example 1 shows score injection via stack-frame manipulation in Frontier-CS; 'universal benchmark bypass' outruns the source. https://rdi.berkeley.edu/blog/trustworthy-benchmarks/",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": true,
+        "verdict_currency": "stale \u2014 source text changed after the audit; not re-adjudicated"
       },
       "tools": [
         {
@@ -1614,7 +1758,10 @@
         "evidence_fit": "provisional",
         "record_defect": "\u2014",
         "note": "source located and plausibly relevant; per-case evidence locator not established in this audit",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": false,
+        "verdict_currency": "as-audited \u2014 source text unchanged since the audit"
       },
       "tools": [
         {
@@ -1649,7 +1796,10 @@
         "evidence_fit": "provisional",
         "record_defect": "\u2014",
         "note": "RDI half plausible; harness attestation half internally authored. Per-case locator not established. https://rdi.berkeley.edu/blog/trustworthy-benchmarks/",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": false,
+        "verdict_currency": "as-audited \u2014 source text unchanged since the audit"
       },
       "tools": [
         {
@@ -1684,7 +1834,10 @@
         "evidence_fit": "partial",
         "record_defect": "misdescription",
         "note": "Berkeley shows a dummy C-extension / weak-validator exploit in Terminal-Bench; it does not establish the mechanism across 8 \u2014 or all 13 \u2014 benchmarks. https://rdi.berkeley.edu/blog/trustworthy-benchmarks/",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": true,
+        "verdict_currency": "stale \u2014 source text changed after the audit; not re-adjudicated"
       },
       "tools": [
         {
@@ -1715,7 +1868,10 @@
         "evidence_fit": "none",
         "record_defect": "\u2014",
         "note": "Article does not discuss string collision or hash-collision gaming. https://rdi.berkeley.edu/blog/trustworthy-benchmarks/",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": true,
+        "verdict_currency": "stale \u2014 source text changed after the audit; not re-adjudicated"
       },
       "tools": [
         {
@@ -1746,7 +1902,10 @@
         "evidence_fit": "provisional",
         "record_defect": "\u2014",
         "note": "source located and plausibly relevant; per-case evidence locator not established in this audit",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": true,
+        "verdict_currency": "stale \u2014 source text changed after the audit; not re-adjudicated"
       },
       "tools": [
         {
@@ -1781,7 +1940,10 @@
         "evidence_fit": "provisional",
         "record_defect": "\u2014",
         "note": "source located and plausibly relevant; per-case evidence locator not established in this audit",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": false,
+        "verdict_currency": "as-audited \u2014 source text unchanged since the audit"
       },
       "tools": [
         {
@@ -1812,7 +1974,10 @@
         "evidence_fit": "full (internal)",
         "record_defect": "\u2014",
         "note": "grounded in Mike's own prior work \u2014 traceable, not external corroboration",
-        "externally_corroborated": false
+        "externally_corroborated": false,
+        "audited_at_commit": "6c5d61726819165c9dcf75d99669217c3c3cab41",
+        "source_revised_since_audit": false,
+        "verdict_currency": "as-audited \u2014 source text unchanged since the audit"
       },
       "tools": [
         {

--- a/tests/test_dgb_bundle_export.py
+++ b/tests/test_dgb_bundle_export.py
@@ -119,3 +119,53 @@ def test_export_is_deterministic():
     from benchmarks.dgb_bundle_export import build_bundle, serialise
 
     assert serialise(build_bundle()) == BUNDLE.read_text(encoding="utf-8")
+
+
+# --- grounding currency -----------------------------------------------------
+# The audit read the corpus at 6c5d617 on 2026-07-26. A remediation pass landed
+# 2026-07-27 and revised many source fields. The bundle must not present the
+# audited snapshot as the current state.
+
+
+def test_every_case_declares_grounding_currency(bundle):
+    for case in bundle["cases"]:
+        g = case["grounding"]
+        assert "source_revised_since_audit" in g, case["id"]
+        assert isinstance(g["source_revised_since_audit"], bool), case["id"]
+        assert g["verdict_currency"], case["id"]
+        assert g["audited_at_commit"].startswith("6c5d617"), case["id"]
+
+
+def test_currency_block_matches_per_case_flags(bundle):
+    revised = sum(1 for c in bundle["cases"] if c["grounding"]["source_revised_since_audit"])
+    gc = bundle["grounding_currency"]
+    assert gc["cases_with_source_revised_since_audit"] == revised
+    assert gc["cases_still_as_audited"] == len(bundle["cases"]) - revised
+
+
+def test_flagged_and_still_as_audited_is_derived(bundle):
+    """The count a reader should act on: defect verdicts still describing HEAD."""
+    n = sum(
+        1
+        for c in bundle["cases"]
+        if not c["grounding"]["source_revised_since_audit"]
+        and (c["grounding"]["evidence_fit"] == "none" or c["grounding"]["record_defect"] != "—")
+    )
+    assert bundle["grounding_currency"]["flagged_and_still_as_audited"] == n
+
+
+def test_verdict_currency_agrees_with_the_flag(bundle):
+    for case in bundle["cases"]:
+        g = case["grounding"]
+        if g["source_revised_since_audit"]:
+            assert g["verdict_currency"].startswith("stale"), case["id"]
+        else:
+            assert g["verdict_currency"].startswith("as-audited"), case["id"]
+
+
+def test_limitations_do_not_present_audited_figures_as_current(bundle):
+    """Regression: the first release stated the audited counts as present tense."""
+    lim = bundle["known_limitations"]
+    assert "AS AUDITED" in lim["evidence_fit"]
+    assert "AS AUDITED" in lim["record_defects"]
+    assert "currency_warning" in bundle["grounding_audit"]


### PR DESCRIPTION
**I shipped this defect in #308**, and it is the exact failure the bundle exists to prevent: an artifact making a claim its own source does not support at the state being described.

## What went wrong

The external-corroboration audit read the corpus at `6c5d617` on **2026-07-26**. A remediation pass landed **2026-07-27** — `b361227`, commit message *"docs: fix stale attributions the audit passes never reached"* — and revised source fields across the corpus.

I transcribed the pre-remediation Appendix A onto the post-remediation corpus and labelled the result as the corpus's condition.

## Measured

| | |
|---|---|
| Source fields changed after the audit | **25 of 52** |
| Cases the bundle flags with a defect verdict | 30 |
| …of those, source since revised (**verdict stale**) | **23** |
| …of those, still carrying exactly what the audit read | **7** |

Concretely: `DBC-043` and `DBC-049` were labelled `evidence_fit: none` while their source fields already read *"Internally implemented … NOTE: previously misattributed to UC Berkeley RDI 2026"* — a disclosure written precisely **because** of that audit. The bundle was reporting the disease after the patient had been treated.

## Fix

Without inventing an adjudication I have not performed:

- Every case carries `audited_at_commit`, `source_revised_since_audit`, and `verdict_currency`. The flag is computed by comparing a SHA-256 digest of the current source text against the audited-era digest, baked in so the bundle stays regenerable from this repo alone with no git dependency.
- A `grounding_currency` block reports **25 revised / 27 as-audited**, plus the number that actually matters: **7** cases carrying a defect verdict whose source text is still unchanged — `DBC-014`, `016`, `031`, `038`, `039`, `040`, `044`.
- `known_limitations` and the README now say **AS AUDITED** instead of stating the snapshot in the present tense.

## What this deliberately does not do

It does **not** mark the 25 revised cases repaired. A revision is not a verified repair, any more than a stale verdict is a current defect. Re-adjudicating them against their new text is named as outstanding work rather than silently resolved in whichever direction reads better.

## Tests

17 total, 5 new. One is a regression test asserting the limitations carry "AS AUDITED" — the present-tense phrasing is precisely what made the first release wrong, so it is now pinned.

DGB/RCL suites: **27 passed**. `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark export, fixture JSON, and documentation only; no runtime auth or production paths. Main risk is incorrect digest tables or counts misleading reviewers, mitigated by new tests.
> 
> **Overview**
> Fixes the DGB bundle presenting **July 2026 audit grounding** as if it still described the live corpus after a next-day remediation pass changed **25 of 52** case `source` fields.
> 
> The exporter now compares each case’s current `source` to baked-in audited-era SHA-256 digests and emits per-case **`source_revised_since_audit`**, **`verdict_currency`** (stale vs as-audited), and a top-level **`grounding_currency`** block (including **7** defect-flagged cases whose source text is still exactly what the audit read). **`grounding_audit.currency_warning`** and **`known_limitations`** are reframed as **AS AUDITED** so present-tense counts are not read as current state; revisions are explicitly **not** treated as verified repairs.
> 
> The committed **`dgb-corpus-bundle.v1.json`** and **`fixtures/dgb/README.md`** are regenerated/updated to match, and **five** tests pin currency fields and the limitations wording regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d5581bf916f47086c729ba4fed3559f45c383da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->