### PR TITLE
docs(paper): correct the grounding figure, and say why it is not a trend

### DIFF
--- a/docs/paper-dgb/main.tex
+++ b/docs/paper-dgb/main.tex
@@ -114,10 +114,12 @@ makes three contributions:
         findings (OX Security 2026~\cite{ox2026mcp},
         METR 2025~\cite{metr2025autonomy}, UC Berkeley
         RDI 2026~\cite{wang2026broke}) and from internal, unpublished runs of
-        the authors' own deployment~\cite{hraoe2026}. A 2026-07 source audit
-        found 24 of 52 source records point to internal artifacts rather than
-        independent external corroboration; the taxonomy is not uniformly
-        externally grounded.
+        the authors' own deployment~\cite{hraoe2026}. As of 2026-08-02,
+        \textbf{29 of 52 cases lack independent external corroboration}: 22 cite
+        an internal artifact, and 7 cite nothing at all, having had an
+        unsupportable citation withdrawn. The taxonomy is not uniformly
+        externally grounded, and Section~\ref{sec:limitations} records how that
+        figure was derived and why it is not comparable to the 2026-07 audit's.
 
   \item \textbf{An executable evaluation methodology} that distinguishes
         behavioral governance failures (51 of 52 unflagged by the named
@@ -261,6 +263,7 @@ Vulnerability scanning   & AgentSeal, OX MCP audit             & Static metadata
 \end{figure}
 
 \subsection{Task Formalism}
+\label{sec:formalism}
 
 We formalize a decision-governance test case as a 6-tuple
 $(S, C, E_{\text{pass}}, E_{\text{fail}}, D, M)$---a formal
@@ -287,18 +290,27 @@ against three criteria:
 \begin{enumerate}
   \item \textbf{Incident grounding (intended; partially met).} Cases are
         intended to trace to a documented incident, CVE, or research finding.
-        A 2026-07 source audit found this holds unevenly: 24 of 52 source
-        records point to internal artifacts---including unpublished runs of the
-        authors' own deployment---rather than independent external
-        corroboration. Those cases are not externally corroborated and the
-        \texttt{source} field on each records which is which.
+        This holds unevenly: as of 2026-08-02, \textbf{29 of 52 cases lack
+        independent external corroboration}---22 cite an internal artifact,
+        including unpublished runs of the authors' own deployment, and 7 cite
+        nothing, having had an unsupportable citation withdrawn. The
+        \texttt{source} field on each records which is which, and every case
+        that still claims an external source names a locator a reader can
+        follow.
 
   \item \textbf{Executable reproducibility (intended; partially met).} Cases
         carry a reference to a harness test (BI-001--BI-007, GM-001--GM-006)
-        producing a binary pass/fail result. The same audit found 24 of 52
+        producing a binary pass/fail result. The 2026-07 audit found 24 of 52
         references were behavioural mismatches, and two named values that are
-        not harness tests. Remediation is tracked in
-        \texttt{benchmarks/CHANGELOG.md}.
+        not harness tests at all. That assessment was made by reading; it is now
+        also measured. Resolving each \texttt{executable\_test} against the live
+        harness source at export time, 3 of 52 do not resolve to a single test
+        identifier and 17 of the remaining 49 name a test whose OWASP ASI
+        category disagrees with the case's own. The two figures answer different
+        questions and neither supersedes the other: a category disagreement is
+        grounds to check a mapping, not a finding that the test fails to
+        exercise the case. Both are published per case in the corpus bundle.
+        Remediation is tracked in \texttt{benchmarks/CHANGELOG.md}.
 
   \item \textbf{Contrastive annotation:} Each case is annotated with
         a \emph{derived} flag indicating whether a metadata-only scanner flags the
@@ -701,6 +713,30 @@ identify, protect, and respond.
 \label{sec:limitations}
 
 \begin{enumerate}
+  \item \textbf{Grounding, and how the figure is derived.} We report that 29
+        of 52 cases lack independent external corroboration. A case counts as
+        externally grounded if its \texttt{source} field names a third-party
+        publication, ignoring withdrawn material recorded after a
+        \texttt{NOTE:} marker; everything else is author-grounded. The figure
+        is computed from the corpus rather than maintained by hand, and a test
+        fails if the prose and the corpus disagree.
+
+        \textbf{It is not comparable to the 2026-07 audit's ``24 of 52''.}
+        That audit assessed provenance case by case under its own criteria;
+        applying the definition above to the corpus as the audit read it
+        yields 19, not 24. The two numbers answer different questions, and
+        reporting a 24-to-29 movement would imply a trend that the measurement
+        does not support. What did change is documented: eight citations that
+        the audit found unsupportable were withdrawn on 2026-08-02, moving
+        those cases to the author-grounded side, and all 25 cases whose source
+        text had been revised after the audit were re-read against their
+        current wording.
+
+        That re-reading was performed by the corpus author. It is not
+        independent review and does not reduce the internal-validity threat in
+        Section~\ref{sec:threats}; it establishes only that each verdict now
+        cites a locator a reader can fetch and check for themselves.
+
   \item \textbf{Corpus size:} 52 cases provide breadth across five
         categories but do not exhaustively cover all governance failure
         modes. The corpus is designed for extension; contributions are
@@ -782,10 +818,11 @@ gates can and cannot detect, which would inflate Config~B's GMR relative to
 a governance system evaluated independently of the benchmark's design. Three
 things partially mitigate this without eliminating it: (1)~cases are intended to
 trace to a documented incident or finding rather than being authored to target a
-specific gate---though a 2026-07 source audit found this holds unevenly:
-24 of 52 source records point to internal artifacts rather than independent
-external corroboration, and 24 of 52 \texttt{executable\_test} references were
-behavioural mismatches with two naming values that are not harness tests at all
+specific gate---though this holds unevenly: as of 2026-08-02, 29 of 52 cases
+lack independent external corroboration (22 citing an internal artifact, 7
+citing nothing after an unsupportable citation was withdrawn), and the 2026-07
+audit found 24 of 52 \texttt{executable\_test} references were behavioural
+mismatches with two naming values that are not harness tests at all
 (see \texttt{benchmarks/CHANGELOG.md}); (2)~Config~B still fails 15/52 cases (28.8\%), including
 categories---signal-absence failures such as OS-level permission
 inheritance---that a benchmark tuned to flatter its own implementation would

--- a/tests/test_dgb_bundle_export.py
+++ b/tests/test_dgb_bundle_export.py
@@ -756,11 +756,18 @@ def test_paper_grounding_figure_matches_the_corpus():
         external |= {c.id for c in CORPUS if re.search(pattern, claim(c), re.I)}
     author_grounded = {c.id for c in CORPUS} - external
 
+    # LaTeX wraps at column ~78, so any occurrence may be split across lines at
+    # an arbitrary point -- including between the number and "of 52". Matching
+    # the raw text anchored on three hand-written variants missed the Limitations
+    # item, where the count sits on the line above. Flatten first, match once.
     text = PAPER.read_text(encoding="utf-8")
-    stated = re.findall(r"(\d+) of 52 cases lack\s+independent external corroboration", text)
-    stated += re.findall(r"(\d+) of 52\s+cases\s+lack independent external corroboration", text)
-    stated += re.findall(r"\\textbf\{(\d+) of 52 cases lack", text)
+    flat = re.sub(r"\s+", " ", text)
+    stated = re.findall(r"(\d+) of 52 cases lack independent external corroboration", flat)
     assert stated, "the paper no longer states the grounding figure in a parseable form"
+    assert len(stated) >= 4, (
+        f"expected the figure in the contributions list, corpus construction, "
+        f"limitations and threats sections; found {len(stated)}"
+    )
     for value in stated:
         assert int(value) == len(author_grounded), (
             f"paper says {value} of 52 lack external corroboration; the corpus has "

--- a/tests/test_dgb_bundle_export.py
+++ b/tests/test_dgb_bundle_export.py
@@ -734,6 +734,64 @@ def test_author_grounded_count_is_derived():
     assert set(REPAIRED) <= author_grounded
 
 
+PAPER = Path(__file__).resolve().parents[1] / "docs/paper-dgb/main.tex"
+
+
+def test_paper_grounding_figure_matches_the_corpus():
+    """The paper published 24/52 for a week after the corpus moved.
+
+    It is the same drift the README had, on the surface that is hardest to
+    correct once submitted. Every occurrence of the figure must agree with the
+    corpus and with each other.
+    """
+    import re
+
+    from benchmarks.decision_behavior_corpus import CORPUS
+
+    def claim(case) -> str:
+        return (case.source or "").split("NOTE:")[0]
+
+    external = set()
+    for pattern in _EXTERNAL_SOURCE_PATTERNS:
+        external |= {c.id for c in CORPUS if re.search(pattern, claim(c), re.I)}
+    author_grounded = {c.id for c in CORPUS} - external
+
+    text = PAPER.read_text(encoding="utf-8")
+    stated = re.findall(r"(\d+) of 52 cases lack\s+independent external corroboration", text)
+    stated += re.findall(r"(\d+) of 52\s+cases\s+lack independent external corroboration", text)
+    stated += re.findall(r"\\textbf\{(\d+) of 52 cases lack", text)
+    assert stated, "the paper no longer states the grounding figure in a parseable form"
+    for value in stated:
+        assert int(value) == len(author_grounded), (
+            f"paper says {value} of 52 lack external corroboration; the corpus has "
+            f"{len(author_grounded)}"
+        )
+    assert len(set(stated)) == 1, f"the paper states inconsistent figures: {set(stated)}"
+
+
+def test_paper_does_not_present_the_audit_figure_as_the_current_one():
+    """24 was measured under different criteria and must not read as a trend."""
+    text = PAPER.read_text(encoding="utf-8")
+    assert "24 of 52 source records point to internal artifacts" not in text, (
+        "the audit's source-provenance figure is stated as if current"
+    )
+    # The audit's executable_test figure is unchanged by our work and may stay,
+    # but it must be attributed to the audit rather than floated as present tense.
+    if "24 of 52" in text:
+        assert "2026-07 audit found 24 of 52" in text or "audit found 24 of 52" in text, (
+            "a bare '24 of 52' with no attribution reads as a current measurement"
+        )
+    assert "not comparable to the 2026-07 audit" in text, (
+        "the paper must say why its figure cannot be compared with the audit's"
+    )
+
+
+def test_paper_declares_the_readjudication_was_not_independent():
+    text = PAPER.read_text(encoding="utf-8")
+    assert "performed by the corpus author" in text
+    assert "not\n        independent review" in text or "not independent review" in text
+
+
 def test_readme_does_not_call_the_unlocatable_source_verifiable():
     """`$45M crypto agent 2026` has no publication anywhere in this repo."""
     text = README.read_text(encoding="utf-8")
@@ -743,3 +801,20 @@ def test_readme_does_not_call_the_unlocatable_source_verifiable():
         "but no locatable publication for it exists in this repository"
     )
     assert "No locatable publication" in text
+
+
+def test_paper_cross_references_all_resolve():
+    """A dangling \\ref renders as '??' in the PDF.
+
+    `sec:formalism` was dangling on main: the corpus-construction section
+    pointed at the definition of $M$ in Task Formalism, which carried no label.
+    Cheap to catch, embarrassing to submit.
+    """
+    import re
+
+    text = PAPER.read_text(encoding="utf-8")
+    labels = set(re.findall(r"\\label\{([^}]+)\}", text))
+    refs = set(re.findall(r"\\ref\{([^}]+)\}", text))
+    assert refs <= labels, f"undefined \\ref targets: {sorted(refs - labels)}"
+    duplicates = [x for x in labels if text.count("\\label{%s}" % x) > 1]
+    assert not duplicates, f"duplicate labels: {duplicates}"


### PR DESCRIPTION
The paper reported *"a 2026-07 source audit found 24 of 52 source records point to internal artifacts"*. Accurate as scoped to that audit — but it read as the corpus's **current** state, and the corpus moved when #310 and #311 withdrew eight unsupportable citations.

## The correction

**29 of 52 cases lack independent external corroboration** — 22 citing an internal artifact, 7 citing nothing after a withdrawal. Fixed in all three places it appeared.

## What I deliberately did not do

**I did not report this as 24 → 29.** Applying the paper's own definition to the corpus *as the audit read it* yields **19**, not 24 — the audit assessed provenance under different criteria. Publishing a 24-to-29 movement would imply a trend the measurement does not support.

Limitations now states the definition, why the two figures are not comparable, and that the re-adjudication was performed by the corpus author and **does not reduce the internal-validity threat**.

**I left the audit's `executable_test` figure alone.** Our work did not remeasure "24 of 52 behavioural mismatches" — the machine-derived numbers answer a different question, so they sit beside it rather than replacing it:

- **3 of 52** do not resolve to a single test identifier
- **17 of the remaining 49** name a test whose OWASP ASI category disagrees with the case's

Checked before assuming: the paper's **"two named values that are not harness tests" is correct**. `DBC-034`/`DBC-035` name harnesses; `DBC-052` names two *real* test IDs in one field — a different defect. I nearly changed it to three.

## Also fixed

A dangling `\ref{sec:formalism}` that predates this branch — the corpus-construction section pointed at the definition of $M$ in Task Formalism, which carried no label. It would have rendered `??` in the submitted PDF.

## Guards

- Figure must match the corpus and be self-consistent across all occurrences
- The audit's figure may not be stated as current
- The non-comparability note and the not-independent declaration must both be present
- Every `\ref` must resolve; no duplicate labels

Cross-checked against the corpus rather than assumed: `1/52`, `51/52`, `3/52`, `17/49` all agree.

**Caveat:** no local LaTeX toolchain, so compilation is unverified. Braces balance, labels are unique, and all refs resolve.

86 pass, 2 skip; ruff clean. Three negative controls fail as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and regression tests only; no runtime or security behavior changes. Risk is limited to LaTeX/paper accuracy if corpus patterns drift from the prose definition.
> 
> **Overview**
> Updates the DGB paper so the **current** external-corroboration story matches the corpus after citation withdrawals: **29 of 52** cases lack independent external corroboration (22 internal artifact, 7 with no source after withdrawal), replacing prose that still quoted the 2026-07 audit’s **24 of 52** as if it were today’s state.
> 
> **Limitations** gains a dedicated grounding item: how the 29 is defined (corpus-derived, test-enforced), why it is **not comparable** to the audit’s 24 (re-applying today’s definition to the audited snapshot yields 19), and that re-adjudication was **performed by the corpus author**, not independent review. Corpus construction and internal-validity text are aligned with the same breakdown; **executable_test** discussion now pairs the audit’s 24 mismatch count with export-time measures (**3/52** unresolvable, **17/49** OWASP ASI category disagreements) without conflating the two questions.
> 
> Adds `\label{sec:formalism}` so `\ref{sec:formalism}` for metadata flag **$M$** resolves in the PDF.
> 
> **Tests** in `test_dgb_bundle_export.py` lock the paper to the corpus: all grounding-figure mentions match and agree; the old audit wording cannot reappear as current; non-comparability and non-independent readjudication must be stated; every `\ref` resolves with no duplicate labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33dab9546a1c5a13dc9edcf6fd9265ca8a0a4e82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->