### PR TITLE
fix(mcp): auto mode downgraded final-spec servers to the legacy handshake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`auto` mode silently downgraded every final-spec server to the legacy
+  handshake.** `_is_unsupported_protocol_version_error` matched only `-32004`,
+  the code the 2026-07-28 *release candidate* used for
+  `UnsupportedProtocolVersion`. The final specification adds an error-code
+  allocation policy — `-32000..-32019` implementation-defined and grandfathered,
+  `-32020..-32099` reserved for the spec — and renumbers the codes introduced in
+  the draft: `HeaderMismatch` `-32001` → `-32020`,
+  `MissingRequiredClientCapability` `-32003` → `-32021`,
+  `UnsupportedProtocolVersion` `-32004` → `-32022`
+  ([changelog, minor change 12](https://modelcontextprotocol.io/specification/2026-07-28/changelog)).
+
+  Against a server built to the final spec the guard returned `False`, `auto`
+  mode read the version rejection as evidence of a legacy server, and sent
+  `initialize` — the handshake the spec removed. The suite then reported on a
+  protocol the server had explicitly refused.
+
+  Both codes are now accepted: `-32022` is the standard, `-32004` is what RC-era
+  servers still emit. The check stays exact rather than matching the reserved
+  range, because `-32020` and `-32021` are adjacent and a range would suppress
+  legacy fallbacks that should happen.
+
+  Shipped in 4.10.0. Every existing fixture pinned the RC code, so the suite
+  stayed green throughout — a test that exercises only the deprecated value
+  cannot detect that the standard one is unhandled.
+
 ## [4.10.0] - 2026-07-25
 
 ### Fixed

--- a/protocol_tests/mcp_harness.py
+++ b/protocol_tests/mcp_harness.py
@@ -104,18 +104,40 @@ def _sanitize_url(url: str) -> str:
     return url
 
 
+# UnsupportedProtocolVersion moved between the release candidate and the final
+# 2026-07-28 specification. The final revision adds an error-code allocation
+# policy -- -32000..-32019 stays implementation-defined and grandfathered,
+# -32020..-32099 is reserved for the spec -- and renumbers the codes introduced
+# in the draft: HeaderMismatch -32001 -> -32020, MissingRequiredClientCapability
+# -32003 -> -32021, UnsupportedProtocolVersion -32004 -> -32022.
+# See the changelog, "Minor changes" item 12:
+# https://modelcontextprotocol.io/specification/2026-07-28/changelog
+#
+# Both are accepted on purpose. -32022 is the standard; -32004 is what RC-era
+# servers still in the wild emit, and treating one of them as "not a version
+# error" is worse than accepting both -- it silently downgrades a stateless
+# probe to a legacy handshake.
+UNSUPPORTED_PROTOCOL_VERSION_CODE = -32022
+UNSUPPORTED_PROTOCOL_VERSION_CODE_RC = -32004
+
+
 def _is_unsupported_protocol_version_error(response: object) -> bool:
     """Return whether an HTTP discovery response rejects the modern version.
 
-    The 2026-07-28 RC reserves JSON-RPC code -32004 for
-    ``UnsupportedProtocolVersionError``.  In auto mode that is an explicit
-    modern-protocol response, not evidence of a legacy server, so falling back
-    to ``initialize`` would violate the stateless negotiation path.
+    In auto mode this is an explicit modern-protocol response, not evidence of a
+    legacy server, so falling back to ``initialize`` would violate the stateless
+    negotiation path. Reading only the RC code made exactly that happen against
+    any server built to the final spec.
     """
     if not isinstance(response, dict) or response.get("_status") != 400:
         return False
     error = response.get("error")
-    return isinstance(error, dict) and error.get("code") == -32004
+    if not isinstance(error, dict):
+        return False
+    return error.get("code") in (
+        UNSUPPORTED_PROTOCOL_VERSION_CODE,
+        UNSUPPORTED_PROTOCOL_VERSION_CODE_RC,
+    )
 
 
 def _json_path(value: object, path: str) -> object | None:

--- a/testing/test_transport.py
+++ b/testing/test_transport.py
@@ -18,6 +18,8 @@ from protocol_tests.mcp_harness import (
     _replace_handle,
     _replace_task_id,
     _is_unsupported_protocol_version_error,
+    UNSUPPORTED_PROTOCOL_VERSION_CODE,
+    UNSUPPORTED_PROTOCOL_VERSION_CODE_RC,
     MCPTransport,
     report_has_failure,
     StreamableHTTPTransport,
@@ -125,6 +127,46 @@ class TestTransport(unittest.TestCase):
         self.assertEqual(response["error"]["code"], -32004)
         self.assertTrue(_is_unsupported_protocol_version_error(response))
 
+    def test_http_error_preserves_final_spec_version_error(self):
+        """The FINAL 2026-07-28 code, which the RC-only tests could not see.
+
+        The spec's error-code allocation policy renumbered
+        UnsupportedProtocolVersion -32004 -> -32022 (changelog, minor change 12).
+        Every fixture here pinned the RC code, so the suite stayed green while
+        the harness mis-read every compliant server. A test that exercises only
+        the deprecated value cannot detect that the standard one is unhandled.
+        """
+        transport = StreamableHTTPTransport("http://localhost:8080", protocol_version=MODERN_PROTOCOL_VERSION)
+        error_body = b'{"jsonrpc":"2.0","id":"discover","error":{"code":-32022,"message":"Unsupported protocol version","data":{"supported":["2026-07-28"],"requested":"1900-01-01"}}}'
+        http_error = urllib.error.HTTPError(
+            "http://localhost:8080", 400, "Bad Request", {}, io.BytesIO(error_body)
+        )
+        with patch("protocol_tests.mcp_harness.urllib.request.urlopen", side_effect=http_error):
+            response = transport.send(jsonrpc_request("server/discover", {}))
+        self.assertEqual(response["_status"], 400)
+        self.assertEqual(response["error"]["code"], -32022)
+        self.assertTrue(_is_unsupported_protocol_version_error(response))
+
+    def test_version_error_codes_are_named_not_inlined(self):
+        """Pin both constants so a future renumber is a deliberate edit."""
+        self.assertEqual(UNSUPPORTED_PROTOCOL_VERSION_CODE, -32022)
+        self.assertEqual(UNSUPPORTED_PROTOCOL_VERSION_CODE_RC, -32004)
+
+    def test_unrelated_server_errors_are_not_version_rejections(self):
+        """-32020..-32099 is spec-reserved; only the version code may match here.
+
+        HeaderMismatch (-32020) and MissingRequiredClientCapability (-32021) sit
+        adjacent to the version code. Widening the check to a range would swallow
+        both and suppress a legacy fallback that should happen.
+        """
+        for code in (-32020, -32021, -32600, -32602, -32000):
+            self.assertFalse(
+                _is_unsupported_protocol_version_error(
+                    {"_status": 400, "error": {"code": code}}
+                ),
+                f"{code} must not be read as a protocol-version rejection",
+            )
+
 
 class _AutoTransport(MCPTransport):
     def __init__(self, modern_response):
@@ -177,6 +219,27 @@ class TestProtocolAutoSelection(unittest.TestCase):
         self.assertFalse(suite.initialize())
         self.assertEqual(transport.protocol_version, MODERN_PROTOCOL_VERSION)
         self.assertEqual([message["method"] for message in transport.sent], ["server/discover"])
+
+    def test_auto_does_not_fallback_on_final_spec_version_rejection(self):
+        """The regression that shipped in v4.10.0.
+
+        Against a server built to the final spec, `_is_unsupported…` returned
+        False, auto mode read the rejection as "this must be a legacy server",
+        and sent `initialize` — silently downgrading a stateless probe to the
+        handshake the spec removed. The suite reported on the wrong protocol.
+        """
+        transport = _AutoTransport({
+            "_status": 400,
+            "error": {"code": -32022, "message": "Unsupported protocol version", "data": {"supported": ["2026-07-28"], "requested": "1900-01-01"}},
+        })
+        suite = MCPSecurityTests(transport, json_output=True)
+        self.assertFalse(suite.initialize())
+        self.assertEqual(transport.protocol_version, MODERN_PROTOCOL_VERSION)
+        self.assertEqual(
+            [message["method"] for message in transport.sent],
+            ["server/discover"],
+            "a final-spec version rejection must not trigger the legacy handshake",
+        )
 
 
 class TestDifferentialReport(unittest.TestCase):


### PR DESCRIPTION
Found while verifying a risk I flagged in a strategic sweep, not by any test.

## The bug

`_is_unsupported_protocol_version_error` matched only **`-32004`** — the code the 2026-07-28 **release candidate** used for `UnsupportedProtocolVersion`.

The final spec added an error-code allocation policy and renumbered the draft codes ([changelog, minor change 12](https://modelcontextprotocol.io/specification/2026-07-28/changelog)):

| Code | RC | Final |
|---|---|---|
| `HeaderMismatch` | `-32001` | `-32020` |
| `MissingRequiredClientCapability` | `-32003` | `-32021` |
| **`UnsupportedProtocolVersion`** | **`-32004`** | **`-32022`** |

`-32000..-32019` stays implementation-defined and grandfathered; `-32020..-32099` is reserved for the spec.

**Against a server built to the final spec the guard returned `False`.** `auto` mode read an explicit version rejection as evidence of a legacy server and sent `initialize` — the handshake the spec removed. The suite then reported on a protocol the server had just refused.

The function's own docstring says falling back here "would violate the stateless negotiation path." It did.

**Shipped in 4.10.0, live on PyPI.**

## Why the suite didn't catch it

Every fixture pinned `-32004`. A test that exercises only the deprecated value cannot detect that the standard one is unhandled — the same shape as a guard that matches formatting instead of meaning.

## The fix

Both codes accepted: `-32022` is the standard, `-32004` is what RC-era servers still emit in the wild. Treating either as "not a version error" is worse than accepting both.

**The check stays exact rather than matching the reserved range.** `-32020` and `-32021` sit adjacent to the version code; a range match would swallow both and suppress legacy fallbacks that should happen. There's a negative control for precisely that tempting wrong fix.

## Verification

- 328 pass in `testing/`, 86 in `tests/`, ruff F821 clean
- Four new tests: the final code end-to-end, the auto-mode non-fallback, both constants pinned, and adjacent reserved codes rejected

Two negative controls, both confirmed to fail:
1. Reverting to the RC-only check → the two final-spec tests fail
2. Widening to the reserved range → the adjacent-codes test fails

## Context

The harness has targeted `2026-07-28` since **2026-07-22** — six days before ratification. That lead is real, and this is its cost: tracking a spec through its RC window means inheriting the RC's provisional decisions. Worth a sweep of anything else pinned during that window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core MCP auto handshake logic; incorrect classification could still mis-route probes, but scope is narrow and well covered by new regression tests.
> 
> **Overview**
> Fixes **`auto` protocol negotiation** so a final **2026-07-28** `UnsupportedProtocolVersion` response is treated as an explicit modern rejection, not a signal to fall back to legacy **`initialize`**.
> 
> `_is_unsupported_protocol_version_error` now matches **`-32022`** (final spec) as well as **`-32004`** (RC-era), via named constants. The check stays **exact**—not a reserved-code range—so adjacent errors like **`-32020`** / **`-32021`** do not block legitimate legacy fallback.
> 
> **CHANGELOG** documents the v4.10.0 regression. **Tests** cover the final error code end-to-end, auto-mode non-fallback on **`-32022`**, constant pinning, and negative cases for unrelated codes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aba3af9a937d56cfc69b5a3e3239e0eafcaa9d1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->