### PR TITLE
release: 4.12.0 — OWASP Agentic v1.1 coverage model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,79 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.12.0] - 2026-08-02
+
+### Added
+
+- **OWASP Agentic AI v1.1 coverage model — T1–T17 from one canonical source.**
+  Supersedes the T1–T15 model shipped in 4.11.0, which was built from the threat-name
+  table. This one is built from the complete publication, *Agentic AI — Threats and
+  Mitigations* v1.1 (December 2025, SHA-256 `65e3bd59f99c411b…`), read directly.
+
+  - `docs/coverage/owasp-agentic-v1.1.yaml` — canonical source of truth.
+  - `docs/OWASP-AGENTIC-V1.1-COVERAGE.md` — complete report, T1–T17.
+  - `docs/OWASP-AGENTIC-T1-T15-SUBMISSION-COVERAGE.md` — filtered to the taxonomy the
+    OWASP Solutions Landscape form presented. A test asserts the two views agree on
+    every shared threat, so the filtered view cannot become a second set of claims.
+  - `docs/coverage/owasp-agentic-v1.1.json` — machine-readable output.
+  - `scripts/generate_owasp_agentic_coverage.py`,
+    `scripts/validate_owasp_agentic_mapping.py`, `tests/test_owasp_agentic_mapping.py`.
+
+  **T1–T17: 13 direct, 2 partial, 2 not evidenced, 88 unique mapped tests.** The T1–T15
+  view is unchanged from 4.11.0 — carried forward, not re-litigated.
+
+  **T16 Insecure Inter-Agent Protocol Abuse → direct.** Version downgrade, capability
+  declaration, task-state transition, undocumented method surface, template context
+  injection and discovery-to-invocation substitution, each with a rejection assertion.
+  Adjudicated on protocol semantics rather than relabelled communication poisoning.
+
+  **T17 Supply Chain Compromise → direct.** Post-scan update substitution, registry hash
+  mismatch, publisher spoofing, signature bypass and skill-update tampering. Adjudicated
+  as distribution and provenance failure, not tool misuse after trusted installation.
+
+- **Scenario-level adjudication.** All 66 named OWASP scenarios: 29 covered, 14 partial,
+  23 not evidenced. Scenario coverage never implies threat completeness — a threat can be
+  `direct` while individual scenarios under it have no test.
+
+- **Mitigation validation as a separate dimension.** 5 validated, 66 guidance-only. A test
+  showing a threat is exercisable says nothing about whether a control works. A validated
+  control must be linked by an evidence record that claims it; validation is never
+  inferred, and a test enforces that.
+
+- Six-step decision path, six mitigation playbooks with 22 paraphrased controls, three
+  example threat models with analogy status, and a 14-row guide-coverage manifest.
+  Evidence classes recorded per record, with `static_preflight` alone unable to establish
+  direct coverage for a behaviourally defined threat.
+
+- CC BY-SA 4.0 attribution, licence link and non-endorsement language in both reports,
+  enforced by the validator.
+
+### Changed
+
+- The 4.11.0 T1–T15 report is retired. `docs/OWASP-AGENTIC-T1-T15-COVERAGE.md` is now a
+  pointer to the two current reports; the published version remains available at the
+  `v4.11.0` tag.
+
+### Fixed
+
+- **The generated coverage JSON was silently dropped by `.gitignore`.** The blanket
+  `*.json` rule matched `docs/coverage/owasp-agentic-v1.1.json`, `git add -A` reported
+  success, and the commit shipped without it. The local suite passed because the file
+  existed on disk; only a fresh checkout could see the difference. Third occurrence of
+  this rule eating a published artifact in this repository — `!docs/coverage/*.json`
+  added alongside the existing `!fixtures/**/*.json` negation.
+
+### Notes
+
+- All three v1.1 source inconsistencies are disclosed, each carrying whether it could be
+  confirmed. Two verified in the source text: the narrative says "five playbooks" while
+  six are enumerated, and Playbook 6 is labelled Step 5 alongside Playbook 5. The third —
+  an introductory claim of four example scenarios against three published families — was
+  **not** located in the extracted text and is recorded as reported-but-unconfirmed rather
+  than asserted. A test pins that verification state.
+- The adjudication was performed by the corpus author and is not independent review.
+- Outstanding: spec PR 3 (control-level test mapping) and PR 4 (T10/T15/T16 gap tests).
+
 ## [4.11.0] - 2026-08-02
 
 ### Added

--- a/docs/OWASP-AGENTIC-T1-T15-SUBMISSION-COVERAGE.md
+++ b/docs/OWASP-AGENTIC-T1-T15-SUBMISSION-COVERAGE.md
@@ -11,7 +11,7 @@
 | Report view | Submission (T1–T15) |
 | Report version | 1.0 |
 | Project | Agent Security Harness |
-| Harness version | `4.11.0` |
+| Harness version | `4.12.0` |
 | Assessed commit | [`093bdae3d97cc9a7f610441a61738a80e648fbd1`](https://github.com/msaleme/red-team-blue-team-agent-fabric/commit/093bdae3d97cc9a7f610441a61738a80e648fbd1) |
 | Assessed at | 2026-08-02T18:30:00Z |
 | Repository tests | 595 (`python scripts/count_tests.py`) |
@@ -579,7 +579,7 @@ Per-test rerun commands are in the `Rerun` column of each evidence table.
 
 | Report | Source | Harness | Commit | Date | Change |
 |---|---|---|---|---|---|
-| 1.0 | v1.1 `65e3bd59f99c` | 4.11.0 | `093bdae3d97c` | 2026-08-02 | Initial T1–T17 adjudication against guide v1.1. |
+| 1.0 | v1.1 `65e3bd59f99c` | 4.12.0 | `093bdae3d97c` | 2026-08-02 | Initial T1–T17 adjudication against guide v1.1. |
 
 A status changes only through a reviewed mapping change.
 

--- a/docs/OWASP-AGENTIC-V1.1-COVERAGE.md
+++ b/docs/OWASP-AGENTIC-V1.1-COVERAGE.md
@@ -9,7 +9,7 @@
 | Report view | Complete (T1–T17) |
 | Report version | 1.0 |
 | Project | Agent Security Harness |
-| Harness version | `4.11.0` |
+| Harness version | `4.12.0` |
 | Assessed commit | [`093bdae3d97cc9a7f610441a61738a80e648fbd1`](https://github.com/msaleme/red-team-blue-team-agent-fabric/commit/093bdae3d97cc9a7f610441a61738a80e648fbd1) |
 | Assessed at | 2026-08-02T18:30:00Z |
 | Repository tests | 595 (`python scripts/count_tests.py`) |
@@ -811,7 +811,7 @@ Recorded for source fidelity, not as criticism of OWASP. Inconsistencies in the 
 
 | Report | Source | Harness | Commit | Date | Change |
 |---|---|---|---|---|---|
-| 1.0 | v1.1 `65e3bd59f99c` | 4.11.0 | `093bdae3d97c` | 2026-08-02 | Initial T1–T17 adjudication against guide v1.1. |
+| 1.0 | v1.1 `65e3bd59f99c` | 4.12.0 | `093bdae3d97c` | 2026-08-02 | Initial T1–T17 adjudication against guide v1.1. |
 
 A status changes only through a reviewed mapping change.
 

--- a/docs/TEST-INVENTORY.md
+++ b/docs/TEST-INVENTORY.md
@@ -7,7 +7,7 @@ See also: **[OWASP Agentic AI v1.1 Threat Coverage Report](OWASP-AGENTIC-V1.1-CO
 > **Canonical figures (verified 2026-07-25).** Main branch: 595 test IDs across
 > 43 test-bearing modules in `protocol_tests/` (files with no `test_id` — CLI,
 > helpers, telemetry, registry — are not counted as modules). `main`'s
-> `pyproject.toml` is at `agent-security-harness` v4.11.0 (595 tests); PyPI
+> `pyproject.toml` is at `agent-security-harness` v4.12.0 (595 tests); PyPI
 > itself will show this version once the release is published (see
 > `CHANGELOG.md`). Wire protocols: 4 (MCP, A2A, L402, x402). AIUC-1: 19 of
 > 20 testable requirements (95%). Research: 5 public Zenodo preprints (not

--- a/docs/coverage/owasp-agentic-v1.1.json
+++ b/docs/coverage/owasp-agentic-v1.1.json
@@ -34,7 +34,7 @@
   "assessment": {
     "project": "Agent Security Harness",
     "repository": "https://github.com/msaleme/red-team-blue-team-agent-fabric",
-    "harness_version": "4.11.0",
+    "harness_version": "4.12.0",
     "git_commit": "093bdae3d97cc9a7f610441a61738a80e648fbd1",
     "assessed_at": "2026-08-02T18:30:00Z",
     "total_repository_tests": 595,

--- a/docs/coverage/owasp-agentic-v1.1.yaml
+++ b/docs/coverage/owasp-agentic-v1.1.yaml
@@ -52,7 +52,7 @@ framework:
 assessment:
   project: Agent Security Harness
   repository: https://github.com/msaleme/red-team-blue-team-agent-fabric
-  harness_version: 4.11.0
+  harness_version: 4.12.0
   git_commit: 093bdae3d97cc9a7f610441a61738a80e648fbd1
   assessed_at: '2026-08-02T18:30:00Z'
   total_repository_tests: 595

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-security-harness"
-version = "4.11.0"
+version = "4.12.0"
 description = "595 security tests for AI agent systems - MCP, A2A, L402, x402, UCP/ACP merchant-journey, AP2 mandate + Fireblocks x402 hardening + Visa TAP / Mastercard Agentic Tokens + denial-of-settlement finality, decision governance, AIUC-1 compliance, NIST AI 800-2 aligned"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
Version bump, changelog and regenerated reports for 4.12.0.

`v4.11.0` was tagged with the T1–T15 model. The v1.1 model supersedes it and is substantial enough to deserve its own number rather than being retro-fitted into a tag that does not contain it.

**T1–T17: 13 direct · 2 partial · 2 not evidenced · 88 unique tests · 66 scenarios adjudicated.**

Verified: 107 `tests/` + 328 `testing/` pass, ruff clean, both reports regenerate byte-identically, version consistent across `pyproject.toml`, the mapping, the test inventory and the changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only release metadata and version strings; no runtime, auth, or test oracle changes in the PR diff.
> 
> **Overview**
> **Release 4.12.0** packages the OWASP Agentic AI v1.1 coverage work under a new semver (superseding the T1–T15–only `v4.11.0` tag) without changing the assessed commit or test corpus.
> 
> `pyproject.toml` and every published coverage artifact now report **`4.12.0`**: `docs/coverage/owasp-agentic-v1.1.yaml` / `.json`, `OWASP-AGENTIC-V1.1-COVERAGE.md`, `OWASP-AGENTIC-T1-T15-SUBMISSION-COVERAGE.md`, and `docs/TEST-INVENTORY.md` (PyPI version line). Report change-history rows are updated accordingly; adjudication figures stay **595 tests**, **88** unique mapped tests (T1–T17 view), same `093bdae3`.
> 
> `CHANGELOG.md` gains a **[4.12.0]** section documenting the v1.1 model (canonical YAML, T16/T17 direct coverage, scenario and mitigation dimensions, retired T1–T15-only report pointer, and the `!docs/coverage/*.json` gitignore fix). No harness or test logic appears in this diff—only version alignment and release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f707702772c4991b71084f1fc95ae99289430e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->