### PR TITLE
Docs: add E1-E5 evidence claim taxonomy

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@
 
 **Even if an agent is properly authenticated and authorized, can it still be manipulated into unsafe or policy-violating behavior?**
 
+## Evidence before coverage
+
+Every claim in this project is bounded by the
+[E1-E5 Evidence Class Taxonomy](docs/EVIDENCE-CLASS-TAXONOMY.md): observation,
+runtime characterization, enforcement, persistence/replay resistance, and
+isolation. A result is not promoted beyond what its retained artifact and
+execution record demonstrate. Author-performed mappings and test runs are not
+independent certification.
+
 603 executable security tests across 44 modules (verified 2026-08-02 via `scripts/count_tests.py`). MCP + A2A + L402 + x402 wire-protocol testing, plus UCP/ACP merchant-journey, AP2 mandate-chain, Fireblocks x402 hardening, Visa TAP / Mastercard Agentic Token funding-instrument, and denial-of-settlement finality conformance across the full agentic-payments stack. Decision-layer attack scenarios. One `pip install` away.
 
 **[OWASP Agentic AI v1.1 Threat Coverage Report](docs/OWASP-AGENTIC-V1.1-COVERAGE.md)** — commit-pinned mapping from the full **T1–T17** taxonomy to executable tests: **13 direct, 4 partial, 0 not evidenced**, across 96 mapped tests and 66 named OWASP scenarios. Mitigation-control validation is tracked separately from threat coverage (11 validated, 10 partial, 1 guidance-only), and every gap, evidence class and reproduction command is in the report. ([T1–T15 submission view](docs/OWASP-AGENTIC-T1-T15-SUBMISSION-COVERAGE.md) · [canonical mapping](docs/coverage/owasp-agentic-v1.1.yaml))

--- a/docs/EVIDENCE-CLASS-TAXONOMY.md
+++ b/docs/EVIDENCE-CLASS-TAXONOMY.md
@@ -1,0 +1,40 @@
+# Evidence Class Taxonomy
+
+This taxonomy states what a security or governance artifact permits its author
+to claim. It is intentionally conservative: evidence of a lower level does not
+support language reserved for a higher one.
+
+## Levels
+
+| Level | Evidence required | Permitted claim language | Does not establish |
+| --- | --- | --- | --- |
+| **E1 - Observation** | A versioned artifact, configuration, source record, or documentation snapshot with its identifier and retrieval context. | "The artifact describes…", "The record contains…" | Runtime behavior, control operation, or security effect. |
+| **E2 - Runtime characterization** | A reproducible invocation with environment, inputs, timestamps, and captured result sufficient to characterize the observed execution path. | "Under these conditions, the system returned…", "The run observed…" | That a control enforced a policy, persisted through restart, or isolated a boundary. |
+| **E3 - Enforcement** | E2 evidence plus a recorded decision or transaction at the control point showing an action was allowed, refused, or constrained. | "The control enforced…", "The action was refused at…" | Persistence, replay resistance, or isolation beyond the tested path. |
+| **E4 - Persistence and replay resistance** | E3 evidence plus a replay, restart, recovery, or retained-state check demonstrating that the relevant decision/state survives the claimed lifecycle. | "The decision persisted across…", "The replay was refused…" | Isolation from other principals, tenants, processes, or trust boundaries. |
+| **E5 - Isolation and security boundary** | E4 evidence plus an adversarial boundary test that demonstrates the claimed separation or containment under the stated conditions. | "The boundary isolated…", "The attempted cross-boundary action was contained…" | A universal guarantee outside the tested configuration and threat model. |
+
+Each level subsumes the levels before it. A result may be useful at E1 or E2;
+it must not be described as enforcement, persistence, replay resistance, or
+isolation without the corresponding evidence.
+
+## Required provenance for any class
+
+Every claim should identify the artifact version, method or command, inputs
+that materially affect the result, execution environment, timestamp, and the
+retained output used to support the claim. When a claim concerns a third-party
+system, distinguish author-performed testing from independent verification.
+
+## Claim discipline
+
+- Describe the tested configuration and threat model, not an entire product or
+  protocol.
+- Treat an unreachable target, an incomplete trace, or an ambiguous response as
+  inconclusive.
+- Do not promote an E1/E2 observation into an E3 enforcement claim.
+- Do not promote an E3 result into E4 persistence/replay resistance or E5
+  isolation without the corresponding lifecycle and boundary evidence.
+- Record negative and null results alongside favorable results.
+
+This document is a methodology definition, not a certification framework or a
+claim that every harness result satisfies E5.

--- a/docs/paper-dgb/main.tex
+++ b/docs/paper-dgb/main.tex
@@ -72,6 +72,26 @@ harness, and evidence format are open source (MIT) at
 \end{abstract}
 
 % ---------------------------------------------------------------------------
+\section{Evidence classification}
+\label{sec:evidence-classification}
+
+This paper classifies claims by the evidence retained for them. E1 is an
+artifact or documentation observation; E2 is a reproducible runtime
+characterization; E3 records enforcement at the relevant decision or
+transaction point; E4 additionally demonstrates persistence or replay
+resistance; and E5 additionally demonstrates isolation at a tested security
+boundary. Each level subsumes the preceding levels. Evidence at a lower level
+does not establish a higher-level property. The versioned definition and claim
+language are maintained with the harness at
+\url{https://github.com/msaleme/red-team-blue-team-agent-fabric/blob/main/docs/EVIDENCE-CLASS-TAXONOMY.md}.
+
+Unless a result names its retained artifact, method, inputs that materially
+affect the result, execution environment, and tested configuration, it is an
+incomplete basis for the corresponding claim. Author-performed results are not
+independent certification. This classification describes evidence strength; it
+does not promote every result in this paper to E5.
+
+% ---------------------------------------------------------------------------
 \section{Introduction}
 \label{sec:intro}
 


### PR DESCRIPTION
Adds a versioned E1-E5 evidence taxonomy defining required provenance, permitted claim language, and prohibited inference. Makes it the leading evidence frame in the README and the Decision Governance Benchmark paper. This is a methodology and claim-discipline change, not a certification claim.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only methodology and wording; no executable or security-sensitive code paths are modified.
> 
> **Overview**
> Introduces a versioned **E1–E5 Evidence Class Taxonomy** (`docs/EVIDENCE-CLASS-TAXONOMY.md`) that caps what security and governance claims may say: observation → runtime characterization → enforcement → persistence/replay resistance → isolation. The doc spells out required provenance, permitted wording per level, and rules against upgrading weaker evidence (e.g. E1/E2 → enforcement or isolation).
> 
> The **README** now leads with an **Evidence before coverage** section that points readers at that taxonomy and states that results are not promoted beyond retained artifacts, and that author-performed work is not independent certification.
> 
> The **Decision Governance Benchmark paper** (`docs/paper-dgb/main.tex`) adds an **Evidence classification** section (after the abstract) that adopts the same E1–E5 framing, links to the harness doc, and clarifies that paper results are not all E5.
> 
> This is documentation and claim discipline only—no harness, test, or runtime behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f53c0a8cc464eb3c6450a92c0d2c24f5f3376472. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->