### PR TITLE
docs: bound AIUC-1 crosswalk claims to evidence mapping

### DIFF
--- a/docs/AIUC1-CROSSWALK.md
+++ b/docs/AIUC1-CROSSWALK.md
@@ -1,30 +1,34 @@
-# AIUC-1 Crosswalk: Pre-Certification Testing
+# AIUC-1 Crosswalk: Evidence Mapping
 
-[AIUC-1](https://www.aiuc-1.com) is the first AI agent certification standard, requiring **quarterly independent adversarial testing** to validate agent security, safety, and reliability. Built with MITRE, Cisco, Stanford, MIT, and Google Cloud. This framework provides the technical testing that AIUC-1 certification demands.
+This document maps selected [AIUC-1](https://www.aiuc-1.com) requirements to
+potentially relevant Agent Security Harness tests. It is a research crosswalk,
+not a certification, conformity assessment, or determination that a target
+system meets a requirement. Applicability, sufficiency, independence, and
+conformity must be determined for the specific target and standard version.
 
 > **Standard currency:** this mapping was built against **v2026-Q1** (reviewed March 2026). AIUC-1 now revises quarterly — **Q2 (April 2026)** added MCP/A2A protocol-security and agent-identity controls; **Q3 (released 2026-07-15)** modified 8 requirements / 41 controls. Requirement-level rows below remain valid (renumbering happened at sub-control level), but see the **Q3-2026 Currency Note** near the end of this document before citing this crosswalk against the current standard. Last currency review: 2026-07-16.
 
 ---
 
-## Full AIUC-1 Requirement Mapping (test mappings defined for 19 of 20 testable requirements)
+## Requirement mapping (19 of 20 testable requirements in the 2026-Q1/Q2 set)
 
-### B. Security (100% coverage)
+### B. Security (all listed requirements mapped)
 
 | AIUC-1 Req | Requirement | Our Coverage |
 |---|---|---|
-| **B001** | Third-party adversarial robustness testing | **603 tests** across 4 wire protocols, 44 modules. Prompt injection, jailbreaks, polymorphic attacks, multi-step chains, CVE reproduction. |
+| **B001** | Third-party adversarial robustness testing | Harness test vectors may support evidence collection for prompt injection, jailbreaks, polymorphic attacks, multi-step chains, and CVE reproduction. See the [test inventory](TEST-INVENTORY.md) and run the count script for the current test-ID total. |
 | **B002** | Detect adversarial input | MCP tool injection (MCP-001-010), A2A message spoofing (A2A-001-012), prompt injection via operational data (APP-001-030) |
 | **B005** | Real-time input filtering | Filter bypass via encoding tricks, nested injection, polymorphic payloads, context displacement (ADV-001-010) |
 | **B009** | Limit output over-exposure | Information leakage detection, output exfiltration tests, API key regex scanning |
 
-### D. Reliability (100% coverage)
+### D. Reliability (all listed requirements mapped)
 
 | AIUC-1 Req | Requirement | Our Coverage |
 |---|---|---|
 | **D003** | Restrict unsafe tool calls | MCP capability escalation, unauthorized tool registration, A2A task hijacking, L402/x402 unauthorized payment execution |
 | **D004** | Third-party testing of tool calls | 62 wire-protocol tests (MCP + A2A + L402 + x402) + 83 platform adapter tests across 25 cloud + 20 enterprise platforms |
 
-### C. Safety (67% coverage)
+### C. Safety (mapped subset)
 
 | AIUC-1 Req | Requirement | Our Coverage |
 |---|---|---|
@@ -33,7 +37,7 @@
 | **C010** | Third-party testing for harmful outputs | Adversarial test suite validates whether safety controls hold under attack |
 | **C011** | Third-party testing for out-of-scope outputs | Protocol-level scope violation tests (MCP-003 capability escalation, A2A unauthorized access) |
 
-### A. Data & Privacy (67% of testable requirements)
+### A. Data & Privacy (mapped subset)
 
 | AIUC-1 Req | Requirement | Our Coverage |
 |---|---|---|
@@ -45,10 +49,10 @@
 | AIUC-1 Req | Requirement | Our Coverage |
 |---|---|---|
 | **E004** | Assign accountability | [CSG paper](https://doi.org/10.5281/zenodo.19162104) defines 3-tier governance with explicit accountability. 12 mechanisms, 77 days production evidence. |
-| **E006** | Conduct vendor due diligence | Run the harness against any vendor's agent before procurement. 603 tests as vendor evaluation. |
+| **E006** | Conduct vendor due diligence | A bounded, authorized harness run may contribute technical evidence to a vendor-due-diligence review. It does not replace the review or establish a vendor conclusion on its own. |
 | **E015** | Log model activity | JSON reports with full request/response transcripts serve as audit evidence |
 
-### F. Society (50% coverage)
+### F. Society (mapped subset)
 
 | AIUC-1 Req | Requirement | Our Coverage |
 |---|---|---|
@@ -56,24 +60,22 @@
 
 ---
 
-## AIUC-1 Coverage Summary
+## AIUC-1 Mapping Summary
 
-| Principle | Reqs | Covered | Key Strength |
+| Principle | Reqs | Mapped | Evidence boundary |
 |---|---|---|---|
-| B. Security | 4 | **4 (100%)** | Adversarial robustness testing is our core capability |
-| D. Reliability | 2 | **2 (100%)** | Tool call testing across 4 wire protocols + 45 platforms |
-| C. Safety | 6 | **6 (100%)** | CBRN prevention (F002), harmful output (C003/C004), pre-deployment testing, risk taxonomy |
-| A. Data & Privacy | 5 | 2 (40%) | Agent data access boundaries, IP leakage prevention |
-| E. Accountability | 7 | **5 (71%)** | Incident response (E001-E003), vendor due diligence, audit evidence, CSG governance framework |
-| F. Society | 2 | **2 (100%)** | GTG-1002 APT simulation + CBRN prevention |
+| B. Security | 4 | **4** | Mapping identifies potentially relevant adversarial-testing vectors; it is not evidence of target performance. |
+| D. Reliability | 2 | **2** | Mapping identifies potentially relevant tool-call testing; target configuration and execution evidence remain necessary. |
+| C. Safety | 6 | **6** | Mapping identifies relevant CBRN, harmful-output, pre-deployment, and taxonomy artifacts. |
+| A. Data & Privacy | 5 | 2 | Mapping identifies agent data-access and IP-leakage artifacts. |
+| E. Accountability | 7 | **5** | Mapping identifies incident-response, diligence, and audit-evidence artifacts. |
+| F. Society | 2 | **2** | Mapping identifies GTG-1002 and CBRN-prevention artifacts. |
 
 **Not yet covered (3 requirements):** A001 (input data policy - process requirement), A002 (output data policy - process requirement), E005 (cloud vs on-prem assessment - infrastructure decision). Previously tracked gaps now closed: F002 CBRN prevention ([#34](https://github.com/msaleme/red-team-blue-team-agent-fabric/issues/34) - resolved with `cbrn` + `aiuc1` harnesses), C003/C004 harmful output ([#33](https://github.com/msaleme/red-team-blue-team-agent-fabric/issues/33) - resolved with `harmful-output` + `aiuc1` harnesses), E001-E003 incident response ([#35](https://github.com/msaleme/red-team-blue-team-agent-fabric/issues/35) - resolved with `incident-response` + `aiuc1` harnesses).
 
-> **Note:** "100% coverage" on Security and Reliability means this framework maps to every requirement in those principles. It does not mean exhaustive depth validation of every possible attack vector within each requirement. Coverage indicates breadth of requirement **mapping**, not a conformance or pass-rate result - a mapping file is not evidence that mapped tests passed. Depth depends on target system complexity and test configuration (use `--trials N` for statistical confidence).
+> **Claim boundary:** a mapped test has a documented relationship to a requirement. It does not establish that the test was executed, that a target passed, that testing was independent, or that a target conforms to AIUC-1. Retain the pinned revision, invocation, inputs, environment, timestamps, and output before making a runtime claim; obtain independent review before representing evidence as third-party reviewed.
 
-> **Use case:** Run this harness as your pre-certification adversarial testing tool. AIUC-1 requires quarterly third-party testing (B001, C010, D004). This framework satisfies those requirements with 603 executable tests, JSON audit reports, and statistical confidence intervals aligned to [NIST AI 800-2](https://doi.org/10.6028/NIST.AI.800-2).
->
-> **Want an expert assessment?** [Book an AIUC-1 Readiness Assessment](https://msaleme.github.io/aiuc1-readiness/) - we run the harness against your deployment and deliver a gap analysis with remediation priorities.
+> **Use case:** Use this crosswalk to select potentially relevant tests for an authorized target, run a pinned harness revision, and retain the resulting artifacts for review. The harness can support evidence collection relevant to AIUC-1 requirements. Applicability, sufficiency, independence, and conformity must be determined for the specific target and standard version.
 
 ---
 
@@ -90,11 +92,11 @@ The Q3-2026 quarterly refresh modified 8 requirements and 41 controls ([changelo
 | **B006.3 extended** — sandboxing now covers agent-executed code alongside first-party MCP servers | Runtime/infrastructure control — attestation-level, not test coverage. |
 | **E009 expanded** (+E009.2 anomalous-access alerting) | E-principle rows are complementary/process; no test-coverage claim made or added. |
 
-**Claim discipline:** the "19 of 20 testable requirements" figure is denominated against the **2026-Q1/Q2 requirement set**. Q3 added two requirements scoped to code-generating agents; until the maintainer either maps or formally scopes them out, cite this document as *"pre-certification mapping against AIUC-1 2026-Q1/Q2; Q3-2026 delta reviewed 2026-07-16, two new codegen-scoped requirements pending scope decision."*
+**Claim discipline:** the "19 of 20 testable requirements" figure is denominated against the **2026-Q1/Q2 requirement set**. Q3 added two requirements scoped to code-generating agents; until the maintainer either maps or formally scopes them out, cite this document as *"evidence mapping against AIUC-1 2026-Q1/Q2; Q3-2026 delta reviewed 2026-07-16, two new codegen-scoped requirements pending scope decision."*
 
 ## Standards Alignment
 
-- **AIUC-1 (2026)** - Pre-certification testing for 19 of 20 testable requirements (2026-Q1/Q2 set; Q3-2026 delta — see Currency Note above)
+- **AIUC-1 (2026)** - Evidence mapping for 19 of 20 testable requirements (2026-Q1/Q2 set; Q3-2026 delta — see Currency Note above)
 - **OWASP Top 10 for Agentic Applications (2026)** - Complete ASI01-ASI10 coverage
 - **OWASP LLM Top 10** - LLM01 (Prompt Injection), LLM02, LLM03, LLM04, LLM06, LLM08
 - **NIST AI RMF** - GOVERN, MAP, MEASURE, MANAGE functions covered

--- a/testing/test_code_quality.py
+++ b/testing/test_code_quality.py
@@ -428,10 +428,10 @@ class TestAIUC1Crosswalk(unittest.TestCase):
         content = self._crosswalk()
         self.assertIn("19 of 20", content)
 
-    def test_coverage_summary_exists(self):
-        """Should have a summary table with category-level coverage."""
+    def test_mapping_summary_exists(self):
+        """The crosswalk should summarize the mapped requirements by category."""
         content = self._crosswalk()
-        self.assertIn("Coverage Summary", content)
+        self.assertIn("Mapping Summary", content)
 
     def test_requirement_ids_present(self):
         """AIUC-1 requirement IDs should be referenced (e.g., B001, C010, D004)."""
@@ -440,13 +440,14 @@ class TestAIUC1Crosswalk(unittest.TestCase):
         self.assertGreater(len(req_ids), 10,
                            "Expected 10+ AIUC-1 requirement IDs in crosswalk")
 
-    def test_security_section_claims_100pct(self):
-        """The crosswalk claims 100% coverage of Security (B) requirements."""
+    def test_security_section_states_all_listed_requirements_are_mapped(self):
+        """Security mapping is explicit without implying target conformance."""
         content = self._crosswalk()
-        self.assertIn("Security", content)
+        self.assertIn("Security (all listed requirements mapped)", content)
         self.assertTrue(
-            re.search(r'Security.*?100%', content, re.DOTALL | re.IGNORECASE),
-            "Security section should claim 100% coverage"
+            re.search(r'Mapping identifies.*?not evidence of target performance', content,
+                      re.DOTALL | re.IGNORECASE),
+            "Mapping summary should preserve the target-evidence boundary"
         )
 
     def test_crosswalk_references_real_test_ids(self):


### PR DESCRIPTION
## Summary
- Reframes the AIUC-1 crosswalk as a requirement-to-test evidence mapping.
- Removes the commercial readiness-assessment CTA and unsupported language that the harness itself satisfies third-party requirements.
- Makes the execution, independence, and conformity boundaries explicit.

## Validation
- `python scripts/count_tests.py` reports 603 unique test IDs.
- Verified removed commercial claims and `git diff --check` locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test expectation changes only; no runtime, auth, or harness behavior is modified.
> 
> **Overview**
> Reframes **`docs/AIUC1-CROSSWALK.md`** from pre-certification / coverage language to an **evidence mapping** crosswalk: it documents which harness tests may relate to AIUC-1 requirements and explicitly disclaims certification, conformity, or target pass/fail.
> 
> **Documentation tone and claims:** Section titles and the summary table shift from “coverage” and “100%” to **mapped** requirements and an **evidence boundary** column. **B001** no longer asserts a fixed test count in prose; it points readers to the test inventory and count script. **E006** is scoped to bounded harness runs as *input* to diligence, not a substitute for review. The **claim boundary** and **use case** blocks state that mapping ≠ execution, independence, or conformance, and that artifacts must be retained for runtime claims.
> 
> **Removed / softened:** The commercial **AIUC-1 Readiness Assessment** CTA and wording that the harness **satisfies** third-party AIUC-1 testing requirements. Standards alignment and Q3 currency note now say **evidence mapping** instead of pre-certification testing.
> 
> **Tests:** `TestAIUC1Crosswalk` in **`testing/test_code_quality.py`** expects **Mapping Summary**, the security “all listed requirements mapped” heading, and copy that mapping is **not evidence of target performance**—replacing assertions on “Coverage Summary” and Security **100%** claims.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc48387255e5423d5257350edf23c3e75c4cb373. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->