### PR TITLE
docs: link AIUC-1 Evidence Field Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,15 @@ isolation. A result is not promoted beyond what its retained artifact and
 execution record demonstrate. Author-performed mappings and test runs are not
 independent certification.
 
-For a concise explanation of the distinction between mapped, executed, and
-independently reviewed evidence, see the
-[AIUC-1 Evidence Field Guide](https://msaleme.github.io/aiuc1-readiness/).
+The [AIUC-1 Evidence Field Guide](https://msaleme.github.io/aiuc1-readiness/) is a
+plain-language companion that applies this same taxonomy. It adds one distinction
+the ladder above does not encode: whether evidence is *mapped* (a documented
+requirement relationship), *executed* (a recorded run against a stated target and
+pinned revision), or *independently reviewed* (assessed by a qualified outside
+party). Those describe the status of evidence and are orthogonal to E1-E5, which
+describes its strength. A mapping alone is E1-level material regardless of how many
+requirements it covers. The taxonomy in this repository is canonical; the field
+guide is hosted outside it and is not version-pinned.
 
 603 executable security tests across 44 modules (verified 2026-08-02 via `scripts/count_tests.py`). MCP + A2A + L402 + x402 wire-protocol testing, plus UCP/ACP merchant-journey, AP2 mandate-chain, Fireblocks x402 hardening, Visa TAP / Mastercard Agentic Token funding-instrument, and denial-of-settlement finality conformance across the full agentic-payments stack. Decision-layer attack scenarios. One `pip install` away.
 
@@ -167,7 +173,8 @@ The [constitutional-agent](https://github.com/CognitiveThoughtEngine/constitutio
 | OWASP Agentic v1.1 Coverage (T1–T17) | [docs/OWASP-AGENTIC-V1.1-COVERAGE.md](docs/OWASP-AGENTIC-V1.1-COVERAGE.md) |
 | Canonical coverage mapping (source of truth) | [docs/coverage/owasp-agentic-v1.1.yaml](docs/coverage/owasp-agentic-v1.1.yaml) |
 | Release history & known gaps | [ROADMAP.md](ROADMAP.md) · [CHANGELOG.md](CHANGELOG.md) |
-| AIUC-1 Evidence Field Guide | [msaleme.github.io/aiuc1-readiness](https://msaleme.github.io/aiuc1-readiness/) |
+| E1-E5 Evidence Class Taxonomy (canonical) | [docs/EVIDENCE-CLASS-TAXONOMY.md](docs/EVIDENCE-CLASS-TAXONOMY.md) |
+| AIUC-1 Evidence Field Guide (external, not version-pinned) | [msaleme.github.io/aiuc1-readiness](https://msaleme.github.io/aiuc1-readiness/) |
 | AIUC-1 Crosswalk | [docs/AIUC1-CROSSWALK.md](docs/AIUC1-CROSSWALK.md) |
 | Advanced Capabilities | [docs/ADVANCED.md](docs/ADVANCED.md) |
 | MCP Server | [docs/mcp-server.md](docs/mcp-server.md) |

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ isolation. A result is not promoted beyond what its retained artifact and
 execution record demonstrate. Author-performed mappings and test runs are not
 independent certification.
 
+For a concise explanation of the distinction between mapped, executed, and
+independently reviewed evidence, see the
+[AIUC-1 Evidence Field Guide](https://msaleme.github.io/aiuc1-readiness/).
+
 603 executable security tests across 44 modules (verified 2026-08-02 via `scripts/count_tests.py`). MCP + A2A + L402 + x402 wire-protocol testing, plus UCP/ACP merchant-journey, AP2 mandate-chain, Fireblocks x402 hardening, Visa TAP / Mastercard Agentic Token funding-instrument, and denial-of-settlement finality conformance across the full agentic-payments stack. Decision-layer attack scenarios. One `pip install` away.
 
 **[OWASP Agentic AI v1.1 Threat Coverage Report](docs/OWASP-AGENTIC-V1.1-COVERAGE.md)** — commit-pinned mapping from the full **T1–T17** taxonomy to executable tests: **13 direct, 4 partial, 0 not evidenced**, across 96 mapped tests and 66 named OWASP scenarios. Mitigation-control validation is tracked separately from threat coverage (11 validated, 10 partial, 1 guidance-only), and every gap, evidence class and reproduction command is in the report. ([T1–T15 submission view](docs/OWASP-AGENTIC-T1-T15-SUBMISSION-COVERAGE.md) · [canonical mapping](docs/coverage/owasp-agentic-v1.1.yaml))
@@ -163,6 +167,7 @@ The [constitutional-agent](https://github.com/CognitiveThoughtEngine/constitutio
 | OWASP Agentic v1.1 Coverage (T1–T17) | [docs/OWASP-AGENTIC-V1.1-COVERAGE.md](docs/OWASP-AGENTIC-V1.1-COVERAGE.md) |
 | Canonical coverage mapping (source of truth) | [docs/coverage/owasp-agentic-v1.1.yaml](docs/coverage/owasp-agentic-v1.1.yaml) |
 | Release history & known gaps | [ROADMAP.md](ROADMAP.md) · [CHANGELOG.md](CHANGELOG.md) |
+| AIUC-1 Evidence Field Guide | [msaleme.github.io/aiuc1-readiness](https://msaleme.github.io/aiuc1-readiness/) |
 | AIUC-1 Crosswalk | [docs/AIUC1-CROSSWALK.md](docs/AIUC1-CROSSWALK.md) |
 | Advanced Capabilities | [docs/ADVANCED.md](docs/ADVANCED.md) |
 | MCP Server | [docs/mcp-server.md](docs/mcp-server.md) |

--- a/docs/AIUC1-CROSSWALK.md
+++ b/docs/AIUC1-CROSSWALK.md
@@ -6,6 +6,9 @@ not a certification, conformity assessment, or determination that a target
 system meets a requirement. Applicability, sufficiency, independence, and
 conformity must be determined for the specific target and standard version.
 
+For a shorter explanation of how mapped, executed, and independently reviewed
+evidence differ, see the [AIUC-1 Evidence Field Guide](https://msaleme.github.io/aiuc1-readiness/).
+
 > **Standard currency:** this mapping was built against **v2026-Q1** (reviewed March 2026). AIUC-1 now revises quarterly — **Q2 (April 2026)** added MCP/A2A protocol-security and agent-identity controls; **Q3 (released 2026-07-15)** modified 8 requirements / 41 controls. Requirement-level rows below remain valid (renumbering happened at sub-control level), but see the **Q3-2026 Currency Note** near the end of this document before citing this crosswalk against the current standard. Last currency review: 2026-07-16.
 
 ---

--- a/docs/AIUC1-CROSSWALK.md
+++ b/docs/AIUC1-CROSSWALK.md
@@ -6,8 +6,13 @@ not a certification, conformity assessment, or determination that a target
 system meets a requirement. Applicability, sufficiency, independence, and
 conformity must be determined for the specific target and standard version.
 
-For a shorter explanation of how mapped, executed, and independently reviewed
-evidence differ, see the [AIUC-1 Evidence Field Guide](https://msaleme.github.io/aiuc1-readiness/).
+In the terms of the [AIUC-1 Evidence Field Guide](https://msaleme.github.io/aiuc1-readiness/),
+everything below is **mapped** evidence: a documented requirement relationship, not
+a recorded run against any target and not an independent review. Under the
+[E1-E5 Evidence Class Taxonomy](EVIDENCE-CLASS-TAXONOMY.md) a mapping is E1-level
+material no matter how many requirements it covers. Executed evidence requires a
+stated target and a pinned revision; independent review requires a qualified
+outside party.
 
 > **Standard currency:** this mapping was built against **v2026-Q1** (reviewed March 2026). AIUC-1 now revises quarterly — **Q2 (April 2026)** added MCP/A2A protocol-security and agent-identity controls; **Q3 (released 2026-07-15)** modified 8 requirements / 41 controls. Requirement-level rows below remain valid (renumbering happened at sub-control level), but see the **Q3-2026 Currency Note** near the end of this document before citing this crosswalk against the current standard. Last currency review: 2026-07-16.
 


### PR DESCRIPTION
## Summary
- Adds the AIUC-1 Evidence Field Guide as the plain-language companion to the README evidence boundary and crosswalk.
- Makes the field guide the primary explainer for mapped, executed, and independently reviewed evidence.
- Does not alter test counts or certification boundaries.

## Validation
- `python3 -m pytest testing/test_code_quality.py -q`
- `python3 scripts/count_tests.py`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README and crosswalk text only; no runtime, security, or data-handling code changes.
> 
> **Overview**
> Documentation-only PR that links the external [AIUC-1 Evidence Field Guide](https://msaleme.github.io/aiuc1-readiness/) next to the repo’s canonical E1–E5 taxonomy.
> 
> **README** — Under *Evidence before coverage*, adds a paragraph explaining the field guide as a plain-language companion: it introduces evidence *status* (mapped / executed / independently reviewed) as orthogonal to E1–E5 *strength*, states that mappings stay E1-level, and notes the in-repo taxonomy is canonical while the guide is external and not version-pinned. The Documentation table gains rows for the taxonomy and the field guide.
> 
> **AIUC-1 crosswalk** — Adds an upfront disclaimer that the crosswalk is **mapped** evidence only (not executed runs or independent review), aligned with the field guide and E1 classification.
> 
> No test counts, harness behavior, or certification boundaries are changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fb6e85727fc84593867053adaa3a7cbebf9d8c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->