### PR TITLE
docs: add the I0-I2 independence axis to the evidence taxonomy

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@
 Every claim in this project is bounded by the
 [E1-E5 Evidence Class Taxonomy](docs/EVIDENCE-CLASS-TAXONOMY.md): observation,
 runtime characterization, enforcement, persistence/replay resistance, and
-isolation. A result is not promoted beyond what its retained artifact and
+isolation. A second axis, **I0-I2**, states who produced the oracle:
+self-authored, independently reimplemented, or an independent sensor the target
+does not control. Strength and independence are different properties, so both
+are cited. A result is not promoted beyond what its retained artifact and
 execution record demonstrate. Author-performed mappings and test runs are not
 independent certification.
 

--- a/docs/EVIDENCE-CLASS-TAXONOMY.md
+++ b/docs/EVIDENCE-CLASS-TAXONOMY.md
@@ -38,3 +38,56 @@ system, distinguish author-performed testing from independent verification.
 
 This document is a methodology definition, not a certification framework or a
 claim that every harness result satisfies E5.
+
+## Independence axis (I0-I2)
+
+E1-E5 states how strong a result is. It does not state **who produced the
+oracle**, and that is a separate failure mode. A result can be E5 and still be
+worthless if the check and the thing it checks were derived from the same
+assumption.
+
+| Level | Who produced the oracle | Catches | Does not catch |
+| --- | --- | --- | --- |
+| **I0 - Self-authored** | The same author, and often the same source, as the implementation under test. | Coding errors the author did not intend. | Any assumption the author did not know they were making. |
+| **I1 - Independent implementation** | A second implementation of the same published contract, written by a different party from the specification rather than from the code. | A shared assumption between a check and its implementation. Divergence is the signal; agreement is weak evidence. | A target that misreports its own state. Both implementations read the same channel and will agree while both are wrong. |
+| **I2 - Independent sensor** | A channel the system under test does not author: kernel event log, network capture, hardware trace, out-of-band ledger. | A system whose self-report does not match its behavior. | Nothing about correctness of the specification itself. |
+
+The axis is orthogonal to E1-E5. Cite both: an author-performed enforcement
+result is **E3/I0**, and a separately reimplemented replay of a pinned corpus is
+**E2/I1**. An author-performed E5 is still I0 and is not independent
+verification.
+
+### Why the axis exists
+
+Two measured cases in this repository, both recorded rather than hypothetical.
+
+**I0 failure, 2026-08-02.** The human-oversight module shipped with a guard that
+treated only a transport failure as "no answer." A regression test existed for
+exactly that defect and mocked a transport failure, which was the same
+assumption the implementation made. The oracle and the code were two copies of
+one belief, so the suite stayed green while the defect was live. Measured
+against a live host answering 404, 401, 500, and a JSON-RPC error inside an
+HTTP 200: **20 false passes across four status classes**, and 0 after the fix.
+
+**I1 in practice, 2026-08-01.** A separate Node verifier, written from the
+published contract by a party unknown to the author, replayed the pinned RCL
+oracle corpus and matched 11/11 verdicts (issue #304). The agreement was not the
+useful part. The divergence was: the reimplementation established that the
+artifact declared RFC 8785 JCS canonicalisation while the code emitted
+Python-style sorted compact JSON, encodings that coincide only for ASCII-only,
+integer-valued payloads. That is a defect no I0 test in this repository could
+have surfaced, because every one of them was written against the
+implementation.
+
+### Claim discipline for the axis
+
+- State the I-level next to the E-level. Omitting it defaults the reader to
+  assuming independence that was not established.
+- **I1 agreement is not validation.** Report the divergences found, or state
+  that none were found and that this is weak evidence.
+- Do not describe an I1 cross-evaluation as independent validation,
+  certification, endorsement, or adoption. Preserve the scope the second party
+  set for their own work.
+- This harness holds **no I2 evidence**. It reads protocol responses, which the
+  target emits, so its observations remain inside the boundary a dishonest
+  target controls. Where that limit matters to a claim, say so.


### PR DESCRIPTION
## Summary

E1-E5 states how strong a result is. It does not state **who produced the oracle**, and that is a separate failure mode. This adds an orthogonal **I0-I2** axis and requires both to be cited.

- **I0 self-authored** - the check and the implementation share an author and their assumptions.
- **I1 independent implementation** - a second implementation of the same published contract, written from the specification rather than the code. Divergence is the signal; agreement is weak evidence.
- **I2 independent sensor** - a channel the target does not author. This repository holds none, and now says so on its face.

An author-performed enforcement result is `E3/I0`. A separately reimplemented replay of a pinned corpus is `E2/I1`. An author-performed E5 is still I0.

## Why now

Both grounding cases are measured and already in this repository, not hypothetical.

**I0 failure (2026-08-02).** The HITL guard treated only a transport failure as "no answer," and the regression test written for that exact defect mocked a transport failure, which was the same assumption the implementation made. Measured against a live host: 20 false passes across 404 / 401 / 500 / JSON-RPC-error-inside-200, and 0 after the fix.

**I1 in practice (2026-08-01, #304).** A separate Node verifier replayed the pinned RCL oracle corpus and matched 11/11. The agreement was not the useful part. The reimplementation surfaced that the artifact declared RFC 8785 JCS canonicalisation while the code emitted Python-style sorted compact JSON, encodings that coincide only for ASCII-only integer-valued payloads. No I0 test here could have found it, because all of them were written against the implementation.

This also closes an omission the AIUC-1 field-guide work surfaced in #327: "independently reviewed" was described as a claim state with no place in the taxonomy. It now has one.

## Scope

Preserves the scope the second party set for their own work. I1 is explicitly not independent validation, certification, endorsement, or adoption.

## Validation

- `testing/test_code_quality.py` 60 passed, 38 subtests passed
- `scripts/count_tests.py` 603
- No em dashes in additions. No test count, coverage number, or certification wording changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only methodology and README wording; no runtime, test, or security behavior changes.
> 
> **Overview**
> Adds an **orthogonal I0–I2 axis** alongside E1–E5 so claims cite both evidence strength and **who produced the oracle** (self-authored, independent reimplementation, or independent sensor).
> 
> `docs/EVIDENCE-CLASS-TAXONOMY.md` defines the levels, requires combined labels (e.g. **E3/I0**, **E2/I1**), documents repo-grounded I0 (HITL false passes) and I1 (#304 RCL divergence) examples, and states the harness has **no I2 evidence** because it relies on target-emitted protocol responses. The README **Evidence before coverage** section now introduces I0–I2 and that strength and independence must both be cited.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93b50d8ee190c55742e995452b46826f10302603. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->