### PR TITLE
docs: add restrained release-follow CTA

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@
 
 **Even if an agent is properly authenticated and authorized, can it still be manipulated into unsafe or policy-violating behavior?**
 
+If this evidence discipline is useful in your agent-security work, **star this
+repository to follow releases**.
+
 ## Evidence before coverage
 
 Every claim in this project is bounded by the


### PR DESCRIPTION
## Summary
- add a single, noncommercial star CTA near the README opening
- position it as a way to follow releases, not as a sales or installation prompt

## Validation
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README wording with no code, security, or runtime impact.
> 
> **Overview**
> Inserts a **single, noncommercial CTA** immediately after the README’s opening question, inviting readers who find the evidence discipline useful to **star the repository to follow releases**—framed as release updates, not install or sales.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa1c386ff46fb57638e152ac5f57030b8be68f19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->