### PR TITLE
docs: define assurance evidence-status ladder

### DIFF
--- a/docs/EVIDENCE-CLASS-TAXONOMY.md
+++ b/docs/EVIDENCE-CLASS-TAXONOMY.md
@@ -25,6 +25,24 @@ that materially affect the result, execution environment, timestamp, and the
 retained output used to support the claim. When a claim concerns a third-party
 system, distinguish author-performed testing from independent verification.
 
+## Evidence status
+
+E1-E5 describes the strength of a result and I0-I2 describes the independence
+of its oracle. Neither axis states where an item sits in an assurance workflow.
+Use these status terms separately:
+
+| Status | Establishes | Does not establish |
+| --- | --- | --- |
+| **Mapped** | A documented relationship between an artifact and a requirement. | That the artifact was executed, a target passed, or the relationship is sufficient for a decision. |
+| **Executed** | A recorded run against an identified target from a pinned revision, with relevant inputs and outputs retained. | That the evidence is applicable or sufficient, or that the run was independently reviewed. |
+| **Independently reviewed** | A qualified party assessed whether the evidence was applicable and sufficient for the stated purpose. | Certification, unless the reviewing party is authorized to issue it. |
+| **Certified** | An authorized certification process concluded that applicable requirements were satisfied for a defined scope. | A universal claim outside that scope or standard version. |
+
+These statuses are not interchangeable. A mapping is E1-level material
+regardless of how many requirements it covers. An executed result still needs
+an E-class and I-class, and independent review does not itself issue a
+certificate.
+
 ## Claim discipline
 
 - Describe the tested configuration and threat model, not an entire product or


### PR DESCRIPTION
## Summary\n- add mapped, executed, independently reviewed, and certified as a separate evidence-status ladder\n- preserve the orthogonality of evidence strength (E1-E5) and oracle independence (I0-I2)\n- make the canonical taxonomy support the terminology used by the unpublished LinkedIn draft\n\n## Validation\n- git diff --check\n\nNo public post is included or authorized by this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only taxonomy clarification with no code, security, or data-path changes.
> 
> **Overview**
> **Adds an assurance workflow axis** to `docs/EVIDENCE-CLASS-TAXONOMY.md` without changing the existing **E1–E5** strength or **I0–I2** independence definitions.
> 
> A new **Evidence status** section defines four non-interchangeable stages—**Mapped**, **Executed**, **Independently reviewed**, and **Certified**—each with explicit “establishes / does not establish” boundaries. The text states that **E1–E5** and **I0–I2** do not describe where an item sits in that workflow, and that executed results still need an E-class and I-class while review is not certification.
> 
> This is documentation-only; no harness, tooling, or runtime behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60d32b3bba13a113fe3a9316e7212d9e7fa88d9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->