### PR TITLE
docs: lead the README with what the harness does

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,22 @@
 
 **Even if an agent is properly authenticated and authorized, can it still be manipulated into unsafe or policy-violating behavior?**
 
+603 executable security tests across 44 modules (verified 2026-08-02 via `scripts/count_tests.py`). MCP + A2A + L402 + x402 wire-protocol testing, plus UCP/ACP merchant-journey, AP2 mandate-chain, Fireblocks x402 hardening, Visa TAP / Mastercard Agentic Token funding-instrument, and denial-of-settlement finality conformance across the full agentic-payments stack. Decision-layer attack scenarios. One `pip install` away.
+
+```
+$ agent-security test mcp --url http://localhost:8080/mcp
+Running MCP Protocol Security Tests v4.13.1...
+ MCP-001: Tool List Integrity Check [PASS] (0.234s)
+ MCP-002: Tool Registration via Call Injection [PASS] (0.412s)
+ MCP-003: Capability Escalation via Initialize [FAIL] (0.156s)
+...
+Results: 8/10 passed (80% pass rate) - see report.json
+```
+
+> Illustrative output. A target the harness cannot reach, or that answers without
+> servicing the request, reports **INCONCLUSIVE** — never PASS. See
+> [v4.13.1](CHANGELOG.md) for why that distinction is enforced rather than assumed.
+
 If this evidence discipline is useful in your agent-security work, **star this
 repository to follow releases**.
 
@@ -36,25 +52,9 @@ describes its strength. A mapping alone is E1-level material regardless of how m
 requirements it covers. The taxonomy in this repository is canonical; the field
 guide is hosted outside it and is not version-pinned.
 
-603 executable security tests across 44 modules (verified 2026-08-02 via `scripts/count_tests.py`). MCP + A2A + L402 + x402 wire-protocol testing, plus UCP/ACP merchant-journey, AP2 mandate-chain, Fireblocks x402 hardening, Visa TAP / Mastercard Agentic Token funding-instrument, and denial-of-settlement finality conformance across the full agentic-payments stack. Decision-layer attack scenarios. One `pip install` away.
-
 **[OWASP Agentic AI v1.1 Threat Coverage Report](docs/OWASP-AGENTIC-V1.1-COVERAGE.md)** — commit-pinned mapping from the full **T1–T17** taxonomy to executable tests: **13 direct, 4 partial, 0 not evidenced**, across 96 mapped tests and 66 named OWASP scenarios. Mitigation-control validation is tracked separately from threat coverage (11 validated, 10 partial, 1 guidance-only), and every gap, evidence class and reproduction command is in the report. ([T1–T15 submission view](docs/OWASP-AGENTIC-T1-T15-SUBMISSION-COVERAGE.md) · [canonical mapping](docs/coverage/owasp-agentic-v1.1.yaml))
 
 > Adapted from OWASP *Agentic AI — Threats and Mitigations* v1.1 under [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/). A test-capability report — not a certification, conformance claim, or OWASP endorsement. The adjudication is author-performed and is not independent review.
-
-```
-$ agent-security test mcp --url http://localhost:8080/mcp
-Running MCP Protocol Security Tests v4.13.1...
- MCP-001: Tool List Integrity Check [PASS] (0.234s)
- MCP-002: Tool Registration via Call Injection [PASS] (0.412s)
- MCP-003: Capability Escalation via Initialize [FAIL] (0.156s)
-...
-Results: 8/10 passed (80% pass rate) - see report.json
-```
-
-> Illustrative output. A target the harness cannot reach, or that answers without
-> servicing the request, reports **INCONCLUSIVE** — never PASS. See
-> [v4.13.1](CHANGELOG.md) for why that distinction is enforced rather than assumed.
 
 ## Quick Start
 


### PR DESCRIPTION
## Problem

The README's first screen was eight badges, a rhetorical question, the star CTA, then two dense paragraphs of evidence taxonomy. What the tool actually does — the 603-test summary and the sample run — did not appear until roughly line 39.

A visitor deciding in fifteen seconds needs the *what* before the *epistemology*. This matters right now: the repo is three stars short of the `stars:>25` GitHub discovery gate and has not gained one since 2026-07-24.

## Change

Pure reorder. No wording changes anywhere.

| | Before | After |
|---|---|---|
| 1 | badges, question | badges, question |
| 2 | star CTA | **603 tests / protocol coverage** |
| 3 | Evidence before coverage | **sample run** |
| 4 | AIUC-1 field guide para | **INCONCLUSIVE caveat** |
| 5 | 603 tests / protocol coverage | star CTA |
| 6 | OWASP coverage report | Evidence before coverage |
| 7 | sample run + caveat | OWASP coverage report |

Two deliberate placements:

- **The star CTA now follows the INCONCLUSIVE caveat.** It reads "if this evidence discipline is useful," and the caveat is that discipline demonstrated. The ask lands after the demonstration instead of before it.
- **The OWASP report stays with the evidence section.** Its disclaimer already uses the same claim language ("author-performed and is not independent review"), so the two belong together.

The taxonomy keeps its position immediately after the demo. It is the differentiator, and it is a second-screen argument.

## Verification

- 16 insertions, 16 deletions, line count unchanged at 254 — confirms reorder, not rewrite
- No duplicated blocks: `603 executable security tests` ×1, `Running MCP Protocol Security Tests` ×1
- `#three-layers-of-agent-decision-security` badge anchor still resolves (heading at line 91)
- `testing/test_code_quality.py`: 60 passed, 38 subtests passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only reorder in README.md; no code, config, or behavioral changes.
> 
> **Overview**
> Reorders the **README** intro so visitors see **what the harness does** before the evidence taxonomy and star CTA.
> 
> Right after the opening question, the **603-test / protocol coverage** blurb and the **sample `agent-security test mcp`** run (with the **INCONCLUSIVE** caveat) now appear first. The **star** ask follows that demo; **Evidence before coverage**, the AIUC-1 paragraph, and the **OWASP** report block stay grouped in the evidence section below.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 764037a704ebc165c0c34990f116df71968bc022. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->