### PR TITLE
docs: correct who found what in the I1 grounding case

### DIFF
--- a/docs/EVIDENCE-CLASS-TAXONOMY.md
+++ b/docs/EVIDENCE-CLASS-TAXONOMY.md
@@ -90,12 +90,19 @@ HTTP 200: **20 false passes across four status classes**, and 0 after the fix.
 **I1 in practice, 2026-08-01.** A separate Node verifier, written from the
 published contract by a party unknown to the author, replayed the pinned RCL
 oracle corpus and matched 11/11 verdicts (issue #304). The agreement was not the
-useful part. The divergence was: the reimplementation established that the
-artifact declared RFC 8785 JCS canonicalisation while the code emitted
-Python-style sorted compact JSON, encodings that coincide only for ASCII-only,
-integer-valued payloads. That is a defect no I0 test in this repository could
-have surfaced, because every one of them was written against the
-implementation.
+useful part. The exercise produced two corrections to this repository's own
+artifacts: the fixture declared RFC 8785 JCS canonicalisation while the code
+emitted Python-style sorted compact JSON, encodings that coincide only for
+ASCII-only, integer-valued payloads; and the corpus did not declare that
+freshness was exercised only in the stale direction. Both were fixed in #307.
+
+Who found what is part of the case. The reimplementation did not report the
+canonicalisation mismatch. The author identified it while reviewing the outside
+report, and the reporting party confirmed it. What the exercise supplied was a
+second implementation written from the published contract, which is what made
+the gap between declaration and behaviour legible. Neither correction is one an
+I0 test in this repository could have surfaced, because every one of them was
+written against the implementation.
 
 ### Claim discipline for the axis
 


### PR DESCRIPTION
## The defect

`docs/EVIDENCE-CLASS-TAXONOMY.md` credited the outside reimplementation with finding the canonicalisation defect:

> The divergence was: **the reimplementation established** that the artifact declared RFC 8785 JCS canonicalisation while the code emitted Python-style sorted compact JSON

Issue #304 shows the opposite order:

1. VrtxOmega reported an 11/11 match with no defect claimed
2. You raised the canonicalisation mismatch while reviewing their report
3. VrtxOmega confirmed it — *"I accept both points: the fixture signs Python-style sorted compact JSON, not full RFC 8785 JCS"*

The reimplementation never reported it.

## Why it matters more than a normal wording slip

This sentence sits inside **"Why the axis exists"** — the section that tells a reader what an I1 exercise can and cannot establish. Overstating I1's return there weakens the axis it defines.

It is also the document the AIUC-1 posts link as their single URL, so it is the page a skeptical reader lands on.

`README.md:220` already has it right: *"The exchange also produced two corrections to this repository."* This brings the canonical taxonomy in line with the README.

## Change

The conclusion is unchanged and now rests on an accurate premise: what the exercise supplied was a second implementation written from the published contract, which is what made the gap between declaration and behaviour legible. That claim survives regardless of who noticed first, and no I0 test could have surfaced it, because every one is written against the implementation.

Also records the second correction from the same exchange — the corpus did not declare that freshness was exercised only in the stale direction — and cites #307, where both were fixed.

## Verification

Every claim traced to the issue thread, not to memory of it:

| Claim | Source |
|---|---|
| 11/11 match, no defect claimed in the report | #304 body, "Actual" section |
| Author raised the mismatch | #304 comment, msaleme 2026-08-01T20:22 |
| Reporting party confirmed | #304 comment, VrtxOmega 2026-08-01T22:12 |
| Both corrections merged in #307 | #304 comment, msaleme 2026-08-01T22:30 (`70a38a8`) |
| Second defect is the stale-only freshness gap | same comment, `coverage_gaps.temporal_vectors_not_exercised` |

`testing/test_code_quality.py`: 60 passed, 38 subtests passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording and attribution changes with no runtime or security behavior impact.
> 
> **Overview**
> **Corrects who discovered what** in the **I1 in practice** example in `docs/EVIDENCE-CLASS-TAXONOMY.md`. The text no longer says the outside reimplementation *established* the RFC 8785 JCS vs Python sorted-JSON canonicalisation mismatch; it now states the author spotted that gap while reviewing the #304 report and the reporting party confirmed it, while the independent reimplementation still supplied the second contract-based implementation that made declaration vs behaviour visible.
> 
> The same passage now names **two** repo fixes from that exchange (canonicalisation plus corpus freshness exercised only in the stale direction), cites **#307**, and adds a short **“Who found what is part of the case”** paragraph so the I0/I1 claim-discipline section does not over-credit I1 agreement as defect discovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fb9f86b713f48697a6d150c5f67cb5c21b6f3a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->