### PR TITLE
security: remove fabricated default endpoints and the third-party privacy contact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security — fabricated infrastructure removed
+
+- **The default attestation-registry and telemetry endpoints pointed at domains this
+  project does not own and never did.** `6b6a64c` (2026-03-28, *"feat: add telemetry,
+  privacy policy, and attestation registry"*) introduced three references to
+  infrastructure that was invented rather than provisioned: a registry host, a
+  telemetry host, and a data-protection contact address named in `docs/PRIVACY.md`.
+  None was ever under this project's control. The registry and telemetry hosts resolve
+  to third-party parking addresses and return HTTP 404; the contact domain is a live
+  site operated by someone else.
+
+  **Exposure.** `agent-security publish` posted to the registry default whenever
+  `AGENT_SECURITY_REGISTRY_URL` was unset. The submission carried the user-supplied
+  `server_name`, the stripped report, an Ed25519 public-key fingerprint, and — when
+  provided — the user's **contact email address**. `strip_sensitive_fields()` worked
+  correctly throughout, so target URLs, headers, auth tokens, and request/response
+  bodies never left the machine. The endpoints returned 404, but a 404 means the
+  request arrived: the receiving hosts saw source IP, TLS SNI, and the POST body.
+  Telemetry was opt-in and off by default, so it fired only for users who explicitly
+  enabled it, and sent only module names, test counts, and the harness version.
+  `docs/PRIVACY.md` directed GDPR data-subject requests to the third-party address.
+
+  **Fix — the absence of a default, not a corrected default.**
+  - `AGENT_SECURITY_REGISTRY_URL` is now required. `publish_attestation()` and
+    `verify_attestation()` raise `RegistryNotConfigured` when it is unset. Resolution
+    moved from import time to call time, so importing the module and using
+    `strip_sensitive_fields()` offline still works.
+  - `AGENT_SECURITY_TELEMETRY_URL` is now required. With no endpoint configured
+    telemetry is disabled regardless of opt-in state, and the endpoint check is not
+    overridable by opting in: an opt-in is consent to a destination the operator
+    chose, not to whatever host is compiled in.
+  - Badge URLs derive from the configured registry instead of a hardcoded host.
+  - `docs/PRIVACY.md` now routes data-protection inquiries to the repository issue
+    tracker or the address already published in `SECURITY_POLICY.md`.
+  - `testing/test_no_default_endpoints.py` (12 tests) guards the absence of both
+    defaults and fails if either host or the contact address reappears in shipped
+    source or user-facing documentation.
+
+  **Also corrected: an independence claim.** `docs/attestation-registry.md` described a
+  published attestation as showing a system had been *"independently security-tested"*,
+  and generated a *"Verified by Agent Security Harness"* badge. The publisher ran this
+  harness against their own target, which is **I0** under
+  `docs/EVIDENCE-CLASS-TAXONOMY.md` — the same party produced the oracle and the system
+  under test. The badge label is now *"Tested with Agent Security Harness"*, and the
+  document states what an attestation does not establish.
+
+  This is the second fabricated-external-reference defect found in this repository, after
+  the DOI misattribution recorded below. Both were introduced as plausible-looking detail
+  that no one verified, and both were found by checking whether the referenced thing
+  actually existed.
+
 ### Fixed — documentation accuracy sweep
 
 - **Two DOIs in the README research table belonged to other researchers.**

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -171,12 +171,20 @@ Under GDPR, you have the right to:
 
 Since telemetry is anonymous (no IP addresses retained, no user identifiers), we may not be able to identify your specific data. However, we will make best efforts to honor any request.
 
-To exercise these rights, contact us at **trusted@synapseops.com**. We respond within 30 days.
+To exercise these rights, open an issue at
+[github.com/msaleme/red-team-blue-team-agent-fabric/issues](https://github.com/msaleme/red-team-blue-team-agent-fabric/issues),
+or for anything you would rather not file publicly, email **research@cognitivethoughtengine.com**
+(the address in `SECURITY_POLICY.md`). We respond within 30 days.
+
+In practice there is very little to exercise these rights against: this project now
+operates no telemetry endpoint and no registry, so it receives and stores nothing.
+If you configured your own endpoint, the data is on your infrastructure and this
+project never saw it.
 
 ### Data Controller
 
-**Signal Ops / Michael K. Saleme**
-Contact for data protection inquiries: **trusted@synapseops.com**
+**Michael K. Saleme**
+Contact for data protection inquiries: **research@cognitivethoughtengine.com**
 
 ---
 
@@ -194,6 +202,6 @@ Contact for data protection inquiries: **trusted@synapseops.com**
 
 Questions, concerns, or audit requests:
 
-**trusted@synapseops.com**
+**research@cognitivethoughtengine.com**, or a public issue on the repository.
 
 We respond to privacy inquiries within 48 hours.

--- a/docs/attestation-registry.md
+++ b/docs/attestation-registry.md
@@ -1,10 +1,26 @@
 # Attestation Registry
 
+> ## Status: the public registry is not running
+>
+> **Verified 2026-08-04.** Every `registry.agentsecurity.dev` URL in this document
+> returns HTTP 404 — the publish endpoint, the verify endpoint, and the badge
+> endpoint. The domain resolves; no registry service is answering on it.
+>
+> `agent-security publish` and `agent-security verify` are registered commands and
+> will run. They will not reach a registry. Do not rely on the publish flow, the
+> badge, or the AgentCard reference below.
+>
+> **The only supported path today is a self-hosted registry** via
+> `AGENT_SECURITY_REGISTRY_URL`. See [Self-Hosted Registry](#self-hosted-registry).
+> The server contract is being specified in #333.
+>
+> Everything below describes a client that is implemented and a server that is not.
+
 ## What It Is
 
-The Attestation Registry is a **voluntary, opt-in** public directory where you can prove your MCP server, A2A agent, or payment endpoint passed security testing with Agent Security Harness.
-
-Think of it as a "Verified by Agent Security Harness" badge - a trust signal you can display in your AgentCard, README, or documentation.
+The Attestation Registry is a **voluntary, opt-in** public directory where you can
+record that your MCP server, A2A agent, or payment endpoint was tested with Agent
+Security Harness, and what the run returned.
 
 **Nothing is ever published automatically.** You must explicitly run the publish command.
 
@@ -12,10 +28,21 @@ Think of it as a "Verified by Agent Security Harness" badge - a trust signal you
 
 ## Why Use It
 
-- **Trust signal** - Show users and integrators that your agent/server has been independently security-tested
-- **AgentCard enhancement** - Reference your attestation in A2A Agent Cards for machine-readable trust
-- **CI/CD gating** - Prove that deployments pass security testing before release
-- **Compliance evidence** - Attach attestation IDs to audit documentation
+- **Disclosure** - Show users and integrators that your agent or server was tested with this harness, and what the run returned.
+- **AgentCard enhancement** - Reference your attestation in A2A Agent Cards for machine-readable disclosure
+- **CI/CD gating** - Gate deployments on a recorded harness run
+- **Compliance evidence** - Attach attestation IDs to audit documentation, bounded by the claim discipline below
+
+### What an attestation does not establish
+
+You ran this harness against your own target. Under the
+[Evidence Class Taxonomy](EVIDENCE-CLASS-TAXONOMY.md) that result is **I0**:
+self-authored, because the same party produced the oracle and the system under
+test. Publishing it to a registry records that you published it. It does not make
+it independent, and a registry entry is not a review, a certification, or a
+conformance claim.
+
+Describe an attestation as *tested with*, not as *independently verified*.
 
 ---
 
@@ -55,6 +82,9 @@ print(f"Badge markdown: {result['badge_markdown']}")
 
 ## How to Verify
 
+> **Not usable against the public endpoint**, which returns 404. These commands
+> work against a self-hosted registry set via `AGENT_SECURITY_REGISTRY_URL`.
+
 ### CLI
 
 ```bash
@@ -78,12 +108,17 @@ Visit: `https://registry.agentsecurity.dev/v1/attestation/<registry_id>`
 
 ## How to Delete Your Listing
 
+> **Nothing can currently be listed, so nothing needs deleting.** No public registry
+> is running, and no attestation submitted through the default endpoint was stored.
+> The route below describes the intended policy for a registry that exists.
+
 Your attestation, your decision. To delete:
 
 1. **Email:** Send a deletion request to trusted@synapseops.com with your registry ID
 2. **API:** `DELETE https://registry.agentsecurity.dev/v1/attestation/<registry_id>` (requires signature from your original signing key)
 
-Deletion is permanent and immediate.
+Deletion is intended to be permanent and immediate. A self-hosted registry sets its
+own retention policy; this document does not bind it.
 
 ---
 
@@ -129,7 +164,15 @@ print(json.dumps(cleaned, indent=2))
 
 ## Badge / Embed Code
 
-After publishing, you receive badge embed code:
+> **Not usable.** The badge endpoint returns 404, so every image below renders
+> broken. Kept as the intended format, not as working embed code.
+>
+> When a registry does exist, the badge text must not claim independence. A badge
+> reading "Verified by Agent Security Harness" on a self-run result would present
+> I0 evidence as third-party verification, which is the failure the taxonomy exists
+> to prevent. "Tested with Agent Security Harness" is the accurate wording.
+
+After publishing, you would receive badge embed code:
 
 ### Markdown (for README)
 
@@ -164,17 +207,26 @@ After publishing, you receive badge embed code:
 Attestations are signed with an Ed25519 key generated on first use and stored locally at `~/.agent-security/signing_key.pem`. The public key is at `~/.agent-security/signing_key_pub.pem`.
 
 - The private key never leaves your machine
-- The registry stores your public key fingerprint to verify updates and deletions
 - You can rotate keys, but previously signed attestations will remain linked to the original key
+- A registry is expected to store your public key fingerprint to verify updates and deletions. No public registry currently does, because none is running.
+
+The signing and stripping behaviour is client-side and works today. It is the part
+of this document you can rely on.
 
 ---
 
 ## Self-Hosted Registry
 
-For organizations running their own registry:
+**This is the only supported deployment.** Point the client at a server you control:
 
 ```bash
 export AGENT_SECURITY_REGISTRY_URL=https://your-internal-registry.example.com/v1/attestation
 ```
 
-The registry API is a simple REST interface. Documentation for self-hosting the server component is coming in a future release.
+The client validates that the URL is `https://`, or `http://` for `localhost`,
+`127.0.0.1`, and `::1` during development.
+
+The server contract is not yet published. #333 tracks specifying it, including what
+is submitted, what a submission establishes, and how a third party verifies an entry
+without trusting the registry operator. Until that lands, a self-hosted server has to
+be written against `protocol_tests/attestation_registry.py` directly.

--- a/docs/attestation-registry.md
+++ b/docs/attestation-registry.md
@@ -1,20 +1,22 @@
 # Attestation Registry
 
-> ## Status: the public registry is not running
+> ## Status: this project operates no public registry
 >
-> **Verified 2026-08-04.** Every `registry.agentsecurity.dev` URL in this document
-> returns HTTP 404 — the publish endpoint, the verify endpoint, and the badge
-> endpoint. The domain resolves; no registry service is answering on it.
+> **There is no default endpoint.** `AGENT_SECURITY_REGISTRY_URL` is required.
+> With nothing set, `publish` and `verify` raise `RegistryNotConfigured` rather
+> than contacting anyone.
 >
-> `agent-security publish` and `agent-security verify` are registered commands and
-> will run. They will not reach a registry. Do not rely on the publish flow, the
-> badge, or the AgentCard reference below.
+> Until 2026-08-04 this client defaulted to a host that was never ours. It was
+> fabricated together with the telemetry host and the privacy contact in
+> `6b6a64c` (2026-03-28), and every `publish` run without an override posted a
+> signed attestation, including the optional contact email, to a third party.
+> See `CHANGELOG.md` for the disclosure.
 >
-> **The only supported path today is a self-hosted registry** via
-> `AGENT_SECURITY_REGISTRY_URL`. See [Self-Hosted Registry](#self-hosted-registry).
-> The server contract is being specified in #333.
+> **A registry you control is the only supported deployment.** See
+> [Self-Hosted Registry](#self-hosted-registry). The server contract is being
+> specified in #333.
 >
-> Everything below describes a client that is implemented and a server that is not.
+> Everything below describes a client that is implemented and a server you host.
 
 ## What It Is
 
@@ -82,8 +84,8 @@ print(f"Badge markdown: {result['badge_markdown']}")
 
 ## How to Verify
 
-> **Not usable against the public endpoint**, which returns 404. These commands
-> work against a self-hosted registry set via `AGENT_SECURITY_REGISTRY_URL`.
+> Requires `AGENT_SECURITY_REGISTRY_URL` pointing at a registry you control.
+> Without it these raise `RegistryNotConfigured`.
 
 ### CLI
 
@@ -102,20 +104,19 @@ print(result)
 
 ### Web
 
-Visit: `https://registry.agentsecurity.dev/v1/attestation/<registry_id>`
+Visit: `$AGENT_SECURITY_REGISTRY_URL/<registry_id>`
 
 ---
 
 ## How to Delete Your Listing
 
-> **Nothing can currently be listed, so nothing needs deleting.** No public registry
-> is running, and no attestation submitted through the default endpoint was stored.
-> The route below describes the intended policy for a registry that exists.
+> Applies to a registry you host. This project stores nothing and has nothing to
+> delete.
 
 Your attestation, your decision. To delete:
 
-1. **Email:** Send a deletion request to trusted@synapseops.com with your registry ID
-2. **API:** `DELETE https://registry.agentsecurity.dev/v1/attestation/<registry_id>` (requires signature from your original signing key)
+1. **Operator:** Contact whoever runs the registry you published to
+2. **API:** `DELETE $AGENT_SECURITY_REGISTRY_URL/<registry_id>` (requires signature from your original signing key)
 
 Deletion is intended to be permanent and immediate. A self-hosted registry sets its
 own retention policy; this document does not bind it.
@@ -164,27 +165,28 @@ print(json.dumps(cleaned, indent=2))
 
 ## Badge / Embed Code
 
-> **Not usable.** The badge endpoint returns 404, so every image below renders
-> broken. Kept as the intended format, not as working embed code.
+> Badge URLs are derived from your configured registry, not from any host this
+> project names.
 >
-> When a registry does exist, the badge text must not claim independence. A badge
-> reading "Verified by Agent Security Harness" on a self-run result would present
-> I0 evidence as third-party verification, which is the failure the taxonomy exists
-> to prevent. "Tested with Agent Security Harness" is the accurate wording.
+> The label is **"Tested with"**, not "Verified by". You ran this harness against
+> your own target, so the result is I0 under
+> [EVIDENCE-CLASS-TAXONOMY.md](EVIDENCE-CLASS-TAXONOMY.md). A badge claiming
+> verification would present self-authored evidence as third-party review.
 
-After publishing, you would receive badge embed code:
+After publishing, you receive badge embed code. `<your-registry>` is the scheme and
+host of your configured `AGENT_SECURITY_REGISTRY_URL`:
 
 ### Markdown (for README)
 
 ```markdown
-[![Verified by Agent Security Harness](https://registry.agentsecurity.dev/badge/<id>)](https://registry.agentsecurity.dev/v1/attestation/<id>)
+[![Tested with Agent Security Harness](<your-registry>/badge/<id>)]($AGENT_SECURITY_REGISTRY_URL/<id>)
 ```
 
 ### HTML
 
 ```html
-<a href="https://registry.agentsecurity.dev/v1/attestation/<id>">
-  <img src="https://registry.agentsecurity.dev/badge/<id>" alt="Verified by Agent Security Harness" />
+<a href="$AGENT_SECURITY_REGISTRY_URL/<id>">
+  <img src="<your-registry>/badge/<id>" alt="Tested with Agent Security Harness" />
 </a>
 ```
 
@@ -194,7 +196,7 @@ After publishing, you would receive badge embed code:
 {
   "security_attestation": {
     "framework": "agent-security-harness",
-    "registry_url": "https://registry.agentsecurity.dev/v1/attestation/<id>",
+    "registry_url": "$AGENT_SECURITY_REGISTRY_URL/<id>",
     "verification_hash": "<sha256>"
   }
 }
@@ -208,7 +210,7 @@ Attestations are signed with an Ed25519 key generated on first use and stored lo
 
 - The private key never leaves your machine
 - You can rotate keys, but previously signed attestations will remain linked to the original key
-- A registry is expected to store your public key fingerprint to verify updates and deletions. No public registry currently does, because none is running.
+- A registry you host is expected to store your public key fingerprint to verify updates and deletions
 
 The signing and stripping behaviour is client-side and works today. It is the part
 of this document you can rely on.

--- a/protocol_tests/attestation_registry.py
+++ b/protocol_tests/attestation_registry.py
@@ -24,30 +24,55 @@ from datetime import datetime, timezone
 from pathlib import Path
 from urllib.request import Request, urlopen
 
-# Configurable registry endpoint - override for self-hosted deployments
-_DEFAULT_REGISTRY = "https://registry.agentsecurity.dev/v1/attestation"
-_raw_endpoint = os.environ.get("AGENT_SECURITY_REGISTRY_URL", _DEFAULT_REGISTRY)
+# There is no default registry endpoint, deliberately.
+#
+# Until 2026-08-04 this module defaulted to https://registry.agentsecurity.dev,
+# a domain this project does not own and never did. It was fabricated, along with
+# the telemetry host and the privacy contact, in 6b6a64c (2026-03-28). Every
+# `agent-security publish` run with no override posted a signed attestation --
+# including the optional user-supplied contact email -- to a third party.
+#
+# A security tool must not have a silent default destination. That property is
+# what turned one wrong constant into an exfiltration path, so the fix is the
+# absence of a default rather than a different default.
+#
+# The endpoint resolves at call time, not import time, so that importing this
+# module and using strip_sensitive_fields() offline still works.
 
-# Validate URL format (#124): must be https:// (or http:// for localhost only)
-if _raw_endpoint != _DEFAULT_REGISTRY:
+_REGISTRY_ENV = "AGENT_SECURITY_REGISTRY_URL"
+
+
+class RegistryNotConfigured(RuntimeError):
+    """Raised when a network operation is attempted with no registry configured."""
+
+
+def resolve_registry_endpoint() -> str:
+    """Return the configured registry endpoint, or raise.
+
+    Requires AGENT_SECURITY_REGISTRY_URL. There is no default: see the note above.
+    """
+    raw = os.environ.get(_REGISTRY_ENV, "").strip()
+    if not raw:
+        raise RegistryNotConfigured(
+            f"No attestation registry is configured. Set {_REGISTRY_ENV} to a "
+            f"registry you control.\n"
+            f"This project operates no public registry. See "
+            f"docs/attestation-registry.md and issue #333 for the server contract."
+        )
+
+    # Validate URL format (#124): must be https:// (or http:// for localhost only)
     from urllib.parse import urlparse as _urlparse
 
-    _parsed = _urlparse(_raw_endpoint)
-    if _parsed.scheme == "https":
-        pass  # always allowed
-    elif _parsed.scheme == "http" and _parsed.hostname in ("localhost", "127.0.0.1", "::1"):
-        pass  # http allowed for local development
-    else:
-        raise ValueError(
-            f"AGENT_SECURITY_REGISTRY_URL must use https:// "
-            f"(or http:// for localhost). Got: {_raw_endpoint!r}"
-        )
-    if not _parsed.hostname:
-        raise ValueError(
-            f"AGENT_SECURITY_REGISTRY_URL is not a valid URL: {_raw_endpoint!r}"
-        )
-
-REGISTRY_ENDPOINT = _raw_endpoint
+    parsed = _urlparse(raw)
+    if not parsed.hostname:
+        raise ValueError(f"{_REGISTRY_ENV} is not a valid URL: {raw!r}")
+    if parsed.scheme == "https":
+        return raw
+    if parsed.scheme == "http" and parsed.hostname in ("localhost", "127.0.0.1", "::1"):
+        return raw  # http allowed for local development
+    raise ValueError(
+        f"{_REGISTRY_ENV} must use https:// (or http:// for localhost). Got: {raw!r}"
+    )
 
 _KEY_DIR = Path.home() / ".agent-security"
 _KEY_FILE = _KEY_DIR / "signing_key.pem"
@@ -258,8 +283,10 @@ def publish_attestation(
         ).hexdigest()[:16],
     }
 
+    endpoint = resolve_registry_endpoint()
+
     req = Request(
-        REGISTRY_ENDPOINT,
+        endpoint,
         data=json.dumps(submission).encode(),
         headers={"Content-Type": "application/json"},
         method="POST",
@@ -272,21 +299,29 @@ def publish_attestation(
         raise RuntimeError(f"Failed to publish attestation: {exc}") from exc
 
     registry_id = result.get("id", verification_hash[:12])
-    registry_url = f"{REGISTRY_ENDPOINT}/{registry_id}"
+    registry_url = f"{endpoint}/{registry_id}"
+
+    # Badge URLs derive from the configured registry, never from a hardcoded host.
+    from urllib.parse import urlparse as _urlparse
+
+    _p = _urlparse(endpoint)
+    badge_url = f"{_p.scheme}://{_p.netloc}/badge/{registry_id}"
+
+    # "Tested with", not "Verified by". The publisher ran this harness against
+    # their own target, so the result is I0 under docs/EVIDENCE-CLASS-TAXONOMY.md.
+    # A badge claiming verification would present self-authored evidence as
+    # third-party review.
+    _label = "Tested with Agent Security Harness"
 
     return {
         "registry_id": registry_id,
         "registry_url": registry_url,
         "verification_hash": verification_hash,
-        "badge_markdown": (
-            f"[![Verified by Agent Security Harness]"
-            f"(https://registry.agentsecurity.dev/badge/{registry_id})]"
-            f"({registry_url})"
-        ),
+        "badge_markdown": f"[![{_label}]({badge_url})]({registry_url})",
         "badge_html": (
             f'<a href="{html.escape(registry_url)}">'
-            f'<img src="https://registry.agentsecurity.dev/badge/{html.escape(registry_id)}" '
-            f'alt="Verified by Agent Security Harness" /></a>'
+            f'<img src="{html.escape(badge_url)}" '
+            f'alt="{_label}" /></a>'
         ),
     }
 
@@ -310,7 +345,7 @@ def verify_attestation(registry_id: str) -> dict:
     # Validate registry_id before URL construction (#114)
     _validate_registry_id(registry_id)
 
-    url = f"{REGISTRY_ENDPOINT}/{registry_id}"
+    url = f"{resolve_registry_endpoint()}/{registry_id}"
     req = Request(url, method="GET")
 
     try:

--- a/protocol_tests/telemetry.py
+++ b/protocol_tests/telemetry.py
@@ -14,25 +14,44 @@ from datetime import datetime, timezone
 from pathlib import Path
 from urllib.request import Request, urlopen
 
-# Configurable endpoint -- override for self-hosted deployments
-TELEMETRY_ENDPOINT = os.environ.get(
-    "AGENT_SECURITY_TELEMETRY_URL", "https://telemetry.agentsecurity.dev/v1/event")
+# There is no default telemetry endpoint, deliberately.
+#
+# Until 2026-08-04 this defaulted to https://telemetry.agentsecurity.dev, a domain
+# this project does not own and never did. It was fabricated alongside the registry
+# host and the privacy contact in 6b6a64c (2026-03-28). Telemetry was opt-in and
+# off by default, so this only fired for users who explicitly enabled it -- but for
+# those users it sent module names and test counts to a third party.
+#
+# A security tool must not have a silent default destination. Telemetry is now
+# disabled unless BOTH an opt-in and an endpoint you control are configured.
+TELEMETRY_ENDPOINT = os.environ.get("AGENT_SECURITY_TELEMETRY_URL", "").strip()
 
 _CFG_DIR = Path.home() / ".agent-security"
 _CFG_FILE = _CFG_DIR / "telemetry.json"
 _NOTICE_MARKER = _CFG_DIR / "telemetry-notice-shown"
 _FIRST_RUN_NOTICE = """agent-security-harness: Anonymous usage statistics are OFF by default.
-To help improve the framework: export AGENT_SECURITY_TELEMETRY=on
+This project operates no telemetry endpoint, so opting in alone sends nothing.
+To collect your own: export AGENT_SECURITY_TELEMETRY_URL=<a host you control>
+                    export AGENT_SECURITY_TELEMETRY=on
 Details: docs/PRIVACY.md
 """
 
 def _is_disabled() -> bool:
-    """Check env var and config file. Telemetry is OFF by default (opt-in).
+    """Check endpoint, env var, and config file. Telemetry is OFF by default.
 
-    Telemetry is only enabled when explicitly opted in via:
-    - Environment variable: AGENT_SECURITY_TELEMETRY=on/true/1
-    - Config file: {"enabled": true}
+    Two independent conditions must both hold before anything is sent:
+    - An endpoint is configured via AGENT_SECURITY_TELEMETRY_URL. There is no
+      default, so with nothing set there is nowhere to send and telemetry is off.
+    - The user opted in, via AGENT_SECURITY_TELEMETRY=on/true/1 or a config file
+      containing {"enabled": true}.
+
+    The endpoint check comes first and is not overridable by opting in. An opt-in
+    is consent to share with a destination the operator chose, not consent to
+    share with whatever host happens to be compiled in.
     """
+    if not TELEMETRY_ENDPOINT:
+        return True  # No destination configured: nothing to send anywhere.
+
     # Check config file first - explicit config takes precedence
     try:
         if json.loads(_CFG_FILE.read_text()).get("enabled") is True:

--- a/testing/test_no_default_endpoints.py
+++ b/testing/test_no_default_endpoints.py
@@ -1,0 +1,154 @@
+"""The 2026-08-04 fabricated-infrastructure defect.
+
+Commit 6b6a64c (2026-03-28) shipped three references to infrastructure this
+project does not own and never did:
+
+- ``https://registry.agentsecurity.dev/v1/attestation`` as the default publish target
+- ``https://telemetry.agentsecurity.dev/v1/event`` as the default telemetry target
+- ``trusted@synapseops.com`` as the data-protection contact in docs/PRIVACY.md
+
+Every ``agent-security publish`` run without an override posted a signed
+attestation, including the optional user-supplied contact email, to a third
+party. Telemetry was opt-in and off by default, which bounded that half.
+
+The fix is the *absence* of a default, not a corrected default. These tests guard
+that absence, and guard the two hosts and the contact address from reappearing
+anywhere in the shipped package.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import re
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+# Hosts and addresses that were never ours. Kept as fragments so this file does
+# not itself become a source of the strings when grepped loosely.
+FORBIDDEN = ("agentsecurity" + ".dev", "trusted@" + "synapseops.com")
+
+PACKAGE_DIRS = ("protocol_tests", "mcp_server", "community_modules", "conformance")
+DOC_FILES = ("docs/PRIVACY.md", "docs/attestation-registry.md", "README.md")
+
+
+class TestNoDefaultRegistryEndpoint(unittest.TestCase):
+    def setUp(self) -> None:
+        self.env = patch.dict(os.environ, {}, clear=False)
+        self.env.start()
+        os.environ.pop("AGENT_SECURITY_REGISTRY_URL", None)
+        self.reg = importlib.import_module("protocol_tests.attestation_registry")
+
+    def tearDown(self) -> None:
+        self.env.stop()
+
+    def test_import_succeeds_without_configuration(self) -> None:
+        """Importing must not require an endpoint; strip_sensitive_fields is offline."""
+        importlib.reload(self.reg)
+        cleaned = self.reg.strip_sensitive_fields({"target_url": "http://x", "ok": 1})
+        self.assertNotIn("target_url", cleaned)
+        self.assertEqual(cleaned["ok"], 1)
+
+    def test_resolving_with_no_env_raises_rather_than_defaulting(self) -> None:
+        with self.assertRaises(self.reg.RegistryNotConfigured) as ctx:
+            self.reg.resolve_registry_endpoint()
+        self.assertIn("AGENT_SECURITY_REGISTRY_URL", str(ctx.exception))
+
+    def test_blank_env_is_treated_as_unset(self) -> None:
+        for blank in ("", "   ", "\t"):
+            with patch.dict(os.environ, {"AGENT_SECURITY_REGISTRY_URL": blank}):
+                with self.assertRaises(self.reg.RegistryNotConfigured):
+                    self.reg.resolve_registry_endpoint()
+
+    def test_https_endpoint_is_accepted(self) -> None:
+        with patch.dict(os.environ, {"AGENT_SECURITY_REGISTRY_URL": "https://r.example.com/v1"}):
+            self.assertEqual(self.reg.resolve_registry_endpoint(), "https://r.example.com/v1")
+
+    def test_plain_http_is_refused_except_on_loopback(self) -> None:
+        with patch.dict(os.environ, {"AGENT_SECURITY_REGISTRY_URL": "http://r.example.com/v1"}):
+            with self.assertRaises(ValueError):
+                self.reg.resolve_registry_endpoint()
+        with patch.dict(os.environ, {"AGENT_SECURITY_REGISTRY_URL": "http://localhost:9/v1"}):
+            self.assertEqual(self.reg.resolve_registry_endpoint(), "http://localhost:9/v1")
+
+
+class TestNoDefaultTelemetryEndpoint(unittest.TestCase):
+    def setUp(self) -> None:
+        os.environ.pop("AGENT_SECURITY_TELEMETRY_URL", None)
+        self.tel = importlib.import_module("protocol_tests.telemetry")
+        importlib.reload(self.tel)
+
+    def test_no_endpoint_configured_by_default(self) -> None:
+        self.assertEqual(self.tel.TELEMETRY_ENDPOINT, "")
+
+    def test_disabled_when_no_endpoint_even_if_opted_in(self) -> None:
+        """An opt-in is consent to a destination the operator chose, not to any host."""
+        with patch.dict(os.environ, {"AGENT_SECURITY_TELEMETRY": "on"}):
+            importlib.reload(self.tel)
+            self.assertTrue(self.tel._is_disabled())
+
+    def test_send_is_a_noop_with_no_endpoint(self) -> None:
+        with patch.dict(os.environ, {"AGENT_SECURITY_TELEMETRY": "on"}):
+            importlib.reload(self.tel)
+            with patch.object(self.tel, "_post") as post:
+                self.tel.send_telemetry_event(module="mcp", tests=1, passed=1, failed=0)
+            post.assert_not_called()
+
+    def test_opt_in_plus_endpoint_is_the_only_enabled_path(self) -> None:
+        with patch.dict(
+            os.environ,
+            {"AGENT_SECURITY_TELEMETRY": "on", "AGENT_SECURITY_TELEMETRY_URL": "https://t.example.com/v1"},
+        ):
+            importlib.reload(self.tel)
+            self.assertFalse(self.tel._is_disabled())
+
+
+class TestForbiddenHostsAreGone(unittest.TestCase):
+    """No shipped source or user-facing doc may reference the fabricated hosts."""
+
+    def _scan(self, paths) -> list[str]:
+        hits = []
+        for path in paths:
+            try:
+                text = path.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+            for lineno, line in enumerate(text.splitlines(), 1):
+                stripped = line.strip()
+                # Prose explaining what happened is allowed: a Python comment or a
+                # Markdown blockquote. What is forbidden is a usable reference.
+                if stripped.startswith("#") or stripped.startswith(">"):
+                    continue
+                for bad in FORBIDDEN:
+                    if bad in line:
+                        hits.append(f"{path.relative_to(ROOT)}:{lineno}: {stripped[:90]}")
+        return hits
+
+    def test_no_forbidden_host_in_package_source(self) -> None:
+        files = [p for d in PACKAGE_DIRS for p in (ROOT / d).rglob("*.py") if "__pycache__" not in str(p)]
+        self.assertTrue(files, "no package sources found to scan")
+        self.assertEqual(self._scan(files), [], "fabricated host reintroduced in package source")
+
+    def test_no_forbidden_contact_in_user_facing_docs(self) -> None:
+        files = [ROOT / f for f in DOC_FILES if (ROOT / f).exists()]
+        self.assertTrue(files, "no docs found to scan")
+        self.assertEqual(self._scan(files), [], "fabricated contact or host reintroduced in docs")
+
+
+class TestBadgeDoesNotClaimIndependence(unittest.TestCase):
+    """A self-run harness result is I0. A badge must not say 'Verified by'."""
+
+    def test_badge_label_says_tested_with(self) -> None:
+        src = (ROOT / "protocol_tests" / "attestation_registry.py").read_text()
+        self.assertIn("Tested with Agent Security Harness", src)
+        badge_claims = re.findall(r'Verified by Agent Security Harness', src)
+        self.assertEqual(badge_claims, [], "badge still claims independent verification")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Supersedes the doc-only caveat this branch started as. Confirmed with @msaleme that `agentsecurity.dev` and `trusted@synapseops.com` were never his — they appear to have been fabricated by an agent.

## What was wrong

`6b6a64c` (2026-03-28, *"feat: add telemetry, privacy policy, and attestation registry"*) shipped three references to infrastructure that was invented rather than provisioned:

| Location | Reference | Trigger |
|---|---|---|
| `attestation_registry.py:28` | registry host | `publish` with no override |
| `telemetry.py:19` | telemetry host | opt-in only, off by default |
| `PRIVACY.md` ×3 | data-protection contact | named as the GDPR contact |

Both hosts resolve to third-party parking addresses and return 404. The contact domain is a live site someone else runs.

## Exposure

`agent-security publish` posted the user-supplied `server_name`, the stripped report, an Ed25519 public-key fingerprint, and — when provided — **the user's contact email**.

`strip_sensitive_fields()` worked correctly throughout. Target URLs, headers, auth tokens, and request/response bodies never left the machine.

The endpoints 404, but **a 404 means the request arrived**. The receiving hosts saw source IP, TLS SNI, and the full POST body.

Telemetry was opt-in and off by default — correctly implemented — so that half fired only for users who explicitly enabled it, sending module names, test counts, and the harness version.

## Fix: the absence of a default, not a corrected default

A silent default destination is what turned one wrong constant into an exfiltration path. Repointing at a domain you do own would preserve that property.

- **`AGENT_SECURITY_REGISTRY_URL` required.** `publish_attestation()` / `verify_attestation()` raise `RegistryNotConfigured`. Resolution moved from import time to call time, so importing the module and using `strip_sensitive_fields()` offline still works.
- **`AGENT_SECURITY_TELEMETRY_URL` required.** With no endpoint, telemetry is disabled regardless of opt-in, and that check is **not overridable by opting in** — an opt-in is consent to a destination the operator chose, not to whatever host is compiled in.
- **Badge URLs derive from the configured registry**, not a hardcoded host.
- **`PRIVACY.md`** routes inquiries to the issue tracker or the address already in `SECURITY_POLICY.md`.
- **First-run notice** no longer implies that opting in alone does anything.

## Also fixed on the same surface

The docs claimed a published attestation showed a system had been *"independently security-tested"*, and emitted a *"Verified by Agent Security Harness"* badge. The publisher ran this harness against their own target — **I0** under `EVIDENCE-CLASS-TAXONOMY.md`. Label is now *"Tested with Agent Security Harness"*.

This one survives the 404: if a registry were ever stood up, the badge would have laundered self-authored evidence as third-party verification.

## Regression guard

`testing/test_no_default_endpoints.py`, 12 tests:

- import succeeds unconfigured; `strip_sensitive_fields` works offline
- resolving with no env raises rather than defaulting; blank/whitespace treated as unset
- https accepted, plain http refused except on loopback
- telemetry disabled with no endpoint **even when opted in**; `_post` not called
- opt-in **plus** endpoint is the only enabled path
- neither host nor the contact address appears in shipped source or user-facing docs, outside prose explaining the incident
- badge label does not claim verification

## Verification

Full suite: **373 passed, 73 subtests**. Behavior confirmed with both env vars unset:

```
import ok; strip works: {'keep': 1}
raises as expected: No attestation registry is configured. Set AGENT_SECURITY_RE...
telemetry endpoint: '' | disabled: True
```

`CHANGELOG.md` carries the disclosure under Unreleased, and notes this is the second fabricated-external-reference defect in this repository after the DOI misattribution — both introduced as plausible detail nobody verified, both found by checking whether the referenced thing existed.