### PR TITLE
release: v4.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.14.0] - 2026-08-05
+
+### Breaking
+
+- **`AGENT_SECURITY_REGISTRY_URL` and `AGENT_SECURITY_TELEMETRY_URL` are now required.**
+  Both previously defaulted to hosts this project does not own (see below).
+  `publish_attestation()` and `verify_attestation()` raise `RegistryNotConfigured`
+  when no registry is configured, instead of posting to a default. Telemetry is
+  disabled when no endpoint is set, regardless of opt-in state. Importing
+  `protocol_tests.attestation_registry` and calling `strip_sensitive_fields()`
+  offline is unaffected.
+
 ### Security — fabricated infrastructure removed
 
 - **The default attestation-registry and telemetry endpoints pointed at domains this

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you cite this work in research, please use this metadata."
 title: "Agent Security Harness"
-version: "4.13.1"
+version: "4.14.0"
 abstract: "Multi-protocol agent security testing framework. 603 executable security tests across 44 modules covering MCP, A2A, L402, and x402 wire protocols. Decision-layer attack scenarios, AIUC-1 pre-certification mapping, NIST AI 800-2 aligned."
 type: software
 authors:

--- a/EVALUATION_PROTOCOL.md
+++ b/EVALUATION_PROTOCOL.md
@@ -288,4 +288,4 @@ Per NIST AI 800-2, we distinguish:
 
 _Document version: 1.0_
 _NIST AI 800-2 alignment date: March 21, 2026_
-_Framework version: 4.13.1 (603 tests)_
+_Framework version: 4.14.0 (603 tests)_

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ```
 $ agent-security test mcp --url http://localhost:8080/mcp
-Running MCP Protocol Security Tests v4.13.1...
+Running MCP Protocol Security Tests v4.14.0...
  MCP-001: Tool List Integrity Check [PASS] (0.234s)
  MCP-002: Tool Registration via Call Injection [PASS] (0.412s)
  MCP-003: Capability Escalation via Initialize [FAIL] (0.156s)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -55,6 +55,7 @@ Dates and themes below are reconciled against `CHANGELOG.md`, which is authorita
 | **v4.11–v4.12 — Corpus Currency** | 2026-08-02 | Decision-governance corpus provenance repair, per-case currency tracking, re-adjudication | Shipped |
 | **v4.13.0 — OWASP Agentic v1.1** | 2026-08-02 | T1–T17 commit-pinned coverage mapping, selector tooling, HITL harness (T10/T15) | Shipped |
 | **v4.13.1 — HITL correctness** | 2026-08-02 | All 8 HITL tests could record a verdict against a target that never serviced the request; `_serviced()` guard added | Shipped |
+| **v4.14.0 — Endpoint provenance** | 2026-08-05 | Removed fabricated default registry/telemetry endpoints pointing at domains this project never owned; both env vars now required; attestation independence claim corrected to "tested with" | Shipped |
 | **Next — Standards & Evidence** | — | Reproducible settlement-time payment evidence; methodology paper; schema as a standards-body informational draft | In progress |
 
 **Known gaps, stated rather than deferred.** T16-S1 (consent-flow manipulation) and T10-S1/T10-S3

--- a/docs/OWASP-AGENTIC-T1-T15-SUBMISSION-COVERAGE.md
+++ b/docs/OWASP-AGENTIC-T1-T15-SUBMISSION-COVERAGE.md
@@ -11,7 +11,7 @@
 | Report view | Submission (T1–T15) |
 | Report version | 1.0 |
 | Project | Agent Security Harness |
-| Harness version | `4.13.1` |
+| Harness version | `4.14.0` |
 | Assessed commit | [`19dbfb871d1379a42bbfa22fa06bb2edda58a2c0`](https://github.com/msaleme/red-team-blue-team-agent-fabric/commit/19dbfb871d1379a42bbfa22fa06bb2edda58a2c0) |
 | Assessed at | 2026-08-02T18:30:00Z |
 | Repository tests | 603 (`python scripts/count_tests.py`) |
@@ -724,6 +724,7 @@ Per-test rerun commands are in the `Rerun` column of each evidence table.
 |---|---|---|---|---|---|
 | 1.0 | v1.1 `65e3bd59f99c` | 4.13.0 | `093bdae3d97c` | 2026-08-02 | Initial T1-T17 adjudication against guide v1.1. |
 | 1.1 | v1.1 `65e3bd59f99c` | 4.13.1 | `19dbfb871d13` | 2026-08-03 | Re-pinned after the v4.13.1 HITL correctness fix. No threat, scenario or control verdict changed; the T10/T15 limitations now state the corrected guard. The adjudication itself was performed at the 1.0 commit and was not redone. |
+| 1.2 | v1.1 `65e3bd59f99c` | 4.14.0 | `19dbfb871d13` | 2026-08-05 | Re-pinned to the v4.14.0 release. No threat, scenario or control verdict changed, and no test was added or removed. v4.14.0 removes fabricated default network endpoints and corrects an attestation independence claim; the harness exercises neither. commit and assessed_at are deliberately unchanged from 1.1, because the adjudication was not redone. |
 
 A status changes only through a reviewed mapping change.
 

--- a/docs/OWASP-AGENTIC-V1.1-COVERAGE.md
+++ b/docs/OWASP-AGENTIC-V1.1-COVERAGE.md
@@ -9,7 +9,7 @@
 | Report view | Complete (T1–T17) |
 | Report version | 1.0 |
 | Project | Agent Security Harness |
-| Harness version | `4.13.1` |
+| Harness version | `4.14.0` |
 | Assessed commit | [`19dbfb871d1379a42bbfa22fa06bb2edda58a2c0`](https://github.com/msaleme/red-team-blue-team-agent-fabric/commit/19dbfb871d1379a42bbfa22fa06bb2edda58a2c0) |
 | Assessed at | 2026-08-02T18:30:00Z |
 | Repository tests | 603 (`python scripts/count_tests.py`) |
@@ -973,6 +973,7 @@ Recorded for source fidelity, not as criticism of OWASP. Inconsistencies in the 
 |---|---|---|---|---|---|
 | 1.0 | v1.1 `65e3bd59f99c` | 4.13.0 | `093bdae3d97c` | 2026-08-02 | Initial T1-T17 adjudication against guide v1.1. |
 | 1.1 | v1.1 `65e3bd59f99c` | 4.13.1 | `19dbfb871d13` | 2026-08-03 | Re-pinned after the v4.13.1 HITL correctness fix. No threat, scenario or control verdict changed; the T10/T15 limitations now state the corrected guard. The adjudication itself was performed at the 1.0 commit and was not redone. |
+| 1.2 | v1.1 `65e3bd59f99c` | 4.14.0 | `19dbfb871d13` | 2026-08-05 | Re-pinned to the v4.14.0 release. No threat, scenario or control verdict changed, and no test was added or removed. v4.14.0 removes fabricated default network endpoints and corrects an attestation independence claim; the harness exercises neither. commit and assessed_at are deliberately unchanged from 1.1, because the adjudication was not redone. |
 
 A status changes only through a reviewed mapping change.
 

--- a/docs/TEST-INVENTORY.md
+++ b/docs/TEST-INVENTORY.md
@@ -7,7 +7,7 @@ See also: **[OWASP Agentic AI v1.1 Threat Coverage Report](OWASP-AGENTIC-V1.1-CO
 > **Canonical figures (verified 2026-08-02).** Main branch: 603 test IDs across
 > 44 test-bearing modules in `protocol_tests/` (files with no `test_id` — CLI,
 > helpers, telemetry, registry — are not counted as modules). `main`'s
-> `pyproject.toml` is at `agent-security-harness` v4.13.1 (603 tests); PyPI
+> `pyproject.toml` is at `agent-security-harness` v4.14.0 (603 tests); PyPI
 > itself will show this version once the release is published (see
 > `CHANGELOG.md`). Wire protocols: 4 (MCP, A2A, L402, x402). AIUC-1: 19 of
 > 20 testable requirements (95%). Research: 5 public Zenodo preprints (not

--- a/docs/coverage/owasp-agentic-v1.1.json
+++ b/docs/coverage/owasp-agentic-v1.1.json
@@ -34,7 +34,7 @@
   "assessment": {
     "project": "Agent Security Harness",
     "repository": "https://github.com/msaleme/red-team-blue-team-agent-fabric",
-    "harness_version": "4.13.1",
+    "harness_version": "4.14.0",
     "git_commit": "19dbfb871d1379a42bbfa22fa06bb2edda58a2c0",
     "assessed_at": "2026-08-02T18:30:00Z",
     "reverified_at": "2026-08-03T01:05:00Z",
@@ -52,6 +52,13 @@
         "harness": "4.13.1",
         "date": "2026-08-03",
         "change": "Re-pinned after the v4.13.1 HITL correctness fix. No threat, scenario or control verdict changed; the T10/T15 limitations now state the corrected guard. The adjudication itself was performed at the 1.0 commit and was not redone."
+      },
+      {
+        "report": "1.2",
+        "commit": "19dbfb871d1379a42bbfa22fa06bb2edda58a2c0",
+        "harness": "4.14.0",
+        "date": "2026-08-05",
+        "change": "Re-pinned to the v4.14.0 release. No threat, scenario or control verdict changed, and no test was added or removed. v4.14.0 removes fabricated default network endpoints and corrects an attestation independence claim; the harness exercises neither. commit and assessed_at are deliberately unchanged from 1.1, because the adjudication was not redone."
       }
     ],
     "total_repository_tests": 603,

--- a/docs/coverage/owasp-agentic-v1.1.yaml
+++ b/docs/coverage/owasp-agentic-v1.1.yaml
@@ -52,7 +52,7 @@ framework:
 assessment:
   project: Agent Security Harness
   repository: https://github.com/msaleme/red-team-blue-team-agent-fabric
-  harness_version: 4.13.1
+  harness_version: 4.14.0
   git_commit: 19dbfb871d1379a42bbfa22fa06bb2edda58a2c0
   assessed_at: '2026-08-02T18:30:00Z'
   reverified_at: '2026-08-03T01:05:00Z'
@@ -70,6 +70,15 @@ assessment:
       or control verdict changed; the T10/T15 limitations now state the corrected
       guard. The adjudication itself was performed at the 1.0 commit and was not
       redone.
+  - report: '1.2'
+    commit: 19dbfb871d1379a42bbfa22fa06bb2edda58a2c0
+    harness: 4.14.0
+    date: '2026-08-05'
+    change: Re-pinned to the v4.14.0 release. No threat, scenario or control verdict
+      changed, and no test was added or removed. v4.14.0 removes fabricated default
+      network endpoints and corrects an attestation independence claim; the harness
+      exercises neither. commit and assessed_at are deliberately unchanged from 1.1,
+      because the adjudication was not redone.
 
   total_repository_tests: 603
   total_tests_command: python scripts/count_tests.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-security-harness"
-version = "4.13.1"
+version = "4.14.0"
 description = "603 security tests for AI agent systems - MCP, A2A, L402, x402, UCP/ACP merchant-journey, AP2 mandate + Fireblocks x402 hardening + Visa TAP / Mastercard Agentic Tokens + denial-of-settlement finality, decision governance, AIUC-1 compliance, NIST AI 800-2 aligned"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
Cuts the release for #335. That fix is on `main` but **not on PyPI** — `pip install agent-security-harness` still serves 4.13.1, whose default registry endpoint posts a signed attestation and the user-supplied contact email to a domain this project does not own.

## Breaking

`AGENT_SECURITY_REGISTRY_URL` and `AGENT_SECURITY_TELEMETRY_URL` are now required.

- `publish_attestation()` / `verify_attestation()` raise `RegistryNotConfigured` instead of defaulting
- Telemetry is disabled with no endpoint set, regardless of opt-in
- Importing the module and calling `strip_sensitive_fields()` offline is unaffected

Minor bump rather than patch: a caller relying on the old default now raises.

## Version bumped in current-state locations only

| File | Why |
|---|---|
| `pyproject.toml` | source of truth for `version.py` |
| `CITATION.cff` | citation metadata |
| `EVALUATION_PROTOCOL.md` | "Framework version" footer |
| `docs/TEST-INVENTORY.md` | current-version line |
| `README.md` | illustrative sample banner |

**Deliberately not bumped:** the `Harness version` pins in `docs/OWASP-AGENTIC-V1.1-COVERAGE.md:12` and `docs/OWASP-AGENTIC-T1-T15-SUBMISSION-COVERAGE.md:14`. Those record the version at which coverage was *adjudicated*. Moving them without redoing the adjudication would assert a re-verification that did not happen — the defect class this repo exists to catch, and the same reasoning as the AIUC-1 Q3 currency note.

## Verification

- `scripts/count_tests.py`: **603**, unchanged
- `version.py` resolves to `4.14.0`
- Full suite: **373 passed, 73 subtests**
- `ROADMAP.md` release table gains the v4.14.0 row

## After merge

Tag `v4.14.0` on the merge commit and publish the GitHub Release. `publish-pypi.yml` fires on `release: published` and uses trusted publishing (OIDC), with `skip-existing: true`.

Tag must be cut **after** this merges — a release workflow runs from the tag, so anything merged afterwards is not in that build.