### PR TITLE
docs: lead with pipx, because the documented pip install fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,53 @@ guide is hosted outside it and is not version-pinned.
 ## Quick Start
 
 ```bash
-pip install agent-security-harness
-
-# If 'agent-security' is not found, add ~/.local/bin to your PATH:
-export PATH="$HOME/.local/bin:$PATH"
+pipx install agent-security-harness
 ```
+
+`pipx` is the recommended install because this is a command-line tool. It builds
+an isolated environment and puts `agent-security` on your PATH, with no `sudo`
+and no PATH edits. Get it with `brew install pipx`, `apt install pipx`, or
+`python3 -m pip install --user pipx`.
+
+<details>
+<summary>Installing with pip instead</summary>
+
+Use a virtual environment:
+
+```bash
+python3 -m venv .venv && source .venv/bin/activate
+pip install agent-security-harness
+```
+
+**`pip install agent-security-harness` outside a virtual environment fails on
+most current systems**, including Homebrew Python on macOS and Linux, Debian,
+Ubuntu, and Fedora:
+
+```
+error: externally-managed-environment
+```
+
+Those interpreters ship a [PEP 668](https://peps.python.org/pep-0668/) marker
+that blocks installs into the system environment. `--user` does not bypass it.
+`--break-system-packages` does, and is a bad idea on a Homebrew Python. Use
+`pipx` or a venv.
+
+</details>
+
+<details>
+<summary>Keeping it updated</summary>
+
+```bash
+pipx upgrade agent-security-harness
+```
+
+[topgrade](https://github.com/topgrade-rs/topgrade) picks this up automatically
+through its `pipx` step, or its `pip3` step for a `--user` install. No
+configuration needed.
+
+There is no Homebrew formula for this package.
+
+</details>
 
 ```bash
 # See it work immediately — no server needed:

--- a/SKILL.md
+++ b/SKILL.md
@@ -50,7 +50,7 @@ Answer the question every operator needs answered before going to production:
 ## Quick Start
 
 ```bash
-pip install agent-security-harness
+pipx install agent-security-harness   # pip outside a venv fails on PEP 668 systems
 
 # Simulate immediately — no server needed:
 agent-security test mcp --simulate

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -3,8 +3,27 @@
 ## Installation
 
 ```bash
+pipx install agent-security-harness
+```
+
+`pipx` is recommended for a command-line tool: it builds an isolated environment
+and puts `agent-security` on your PATH. Install it with `brew install pipx`,
+`apt install pipx`, or `python3 -m pip install --user pipx`.
+
+To use pip instead, install into a virtual environment:
+
+```bash
+python3 -m venv .venv && source .venv/bin/activate
 pip install agent-security-harness
 ```
+
+`pip install` outside a virtual environment fails with
+`error: externally-managed-environment` on Homebrew Python, Debian, Ubuntu, and
+Fedora. Those interpreters ship a [PEP 668](https://peps.python.org/pep-0668/)
+marker, and `--user` does not bypass it.
+
+Keep it current with `pipx upgrade agent-security-harness`. `topgrade` handles it
+automatically through its `pipx` step. There is no Homebrew formula.
 
 ## Basic Usage
 
@@ -94,7 +113,7 @@ Use the harness as an MCP tool that any AI agent can call:
 
 ```bash
 # Install with MCP support
-pip install agent-security-harness[mcp-server]
+pipx install "agent-security-harness[mcp-server]"   # or, inside a venv: pip install 'agent-security-harness[mcp-server]'
 
 # stdio mode (for Cursor, Claude Desktop, IDE integration)
 python -m mcp_server
@@ -171,7 +190,7 @@ jobs:
 Or use the CLI directly in any CI system:
 
 ```bash
-pip install agent-security-harness
+pip install agent-security-harness   # fine on an ephemeral CI runner; use pipx or a venv locally
 agent-security test mcp --url http://localhost:8080/mcp --json > report.json
 ```
 

--- a/docs/discord-bot.md
+++ b/docs/discord-bot.md
@@ -134,7 +134,7 @@ docker run -d --env-file .env agent-scan-bot
 The Discord bot runs a quick 5-test subset. For comprehensive testing (100+ tests across MCP, A2A, L402, identity, and more):
 
 ```bash
-pip install agent-security-harness
+pipx install agent-security-harness
 agent-security test mcp --url https://your-server.com/mcp
 ```
 


### PR DESCRIPTION
Found while checking whether the package works with Homebrew and topgrade. The topgrade answer is yes; the Homebrew answer turned up a live defect.

## The Quick Start command does not work

```bash
pip install agent-security-harness

# If 'agent-security' is not found, add ~/.local/bin to your PATH:
export PATH="$HOME/.local/bin:$PATH"
```

On Homebrew Python 3.14.6:

```
error: externally-managed-environment
```

Same on Debian, Ubuntu, Fedora, and Homebrew macOS. Those interpreters ship a [PEP 668](https://peps.python.org/pep-0668/) `EXTERNALLY-MANAGED` marker.

Two things make it worse:

- **`--user` does not bypass it.** Verified. The `~/.local/bin` hint implies `--user` was the intent, but that form fails identically.
- The only override is `--break-system-packages`, which Homebrew's own error text warns "can result in a broken Homebrew installation."

So the first command a new user runs fails, on a large share of machines, with an error that reads like their fault.

## Fix

`pipx` is the correct instruction for a CLI tool with console entrypoints:

```toml
[project.scripts]
agent-security = "protocol_tests.cli:main"
ash = "protocol_tests.cli:main"
```

It builds an isolated environment, sidesteps PEP 668 entirely, and puts `agent-security` on PATH with no `~/.local/bin` workaround.

It also answers the topgrade half by construction. topgrade 17.8.0 supports `pipx`, `pip3`, and `uv` steps, so a pipx install is picked up by update-everything tooling with zero configuration.

| File | Change |
|---|---|
| `README.md` | Quick Start leads with pipx; collapsed sections for the venv path and for staying updated |
| `docs/QUICKSTART.md` | Installation rewritten; `[mcp-server]` extra and CI snippet updated |
| `SKILL.md` | pipx |
| `docs/discord-bot.md` | pipx |

The venv fallback names the `externally-managed-environment` string verbatim so anyone who already hit it finds this section by search.

**Left alone deliberately:** venv-scoped `pip install` lines (correct in context), the historical launch-post copy, and the AIUC-1 documents, where the string identifies the package on PyPI rather than instructing an install. Also stated plainly: there is no Homebrew formula.

## Verification

- `pip install` failure and `--user` non-bypass reproduced on Homebrew Python 3.14.6
- No formula or cask: `formulae.brew.sh` API 404s for both
- Isolated-environment install places **both** `agent-security` and `ash` on PATH with no PATH edit
- `tests/` + `testing/`: **484 passed, 73 subtests**
- OWASP mapping validator passes

## Unrelated, noted not fixed

`agent-security --version` returns `Error: unknown command '--version'`. Out of scope here.