### PR TITLE
feat: accept --version and -V, not just the version subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ There is no Homebrew formula for this package.
 </details>
 
 ```bash
+# Confirm which build you're on:
+agent-security --version
+
 # See it work immediately — no server needed:
 agent-security test mcp --simulate
 

--- a/protocol_tests/cli.py
+++ b/protocol_tests/cli.py
@@ -16,6 +16,7 @@ Usage:
     agent-security list l402                # List L402 test cases
 
     agent-security version                  # Show version info
+    agent-security --version                # Same, conventional flag form
 """
 
 from __future__ import annotations
@@ -366,7 +367,7 @@ def print_usage():
     print("Usage:")
     print("  agent-security test <harness> [options]    Run a test harness")
     print("  agent-security list [harness]              List available tests")
-    print("  agent-security version                     Show version")
+    print("  agent-security version | --version | -V    Show version")
     print()
     print("Harnesses:")
     for name, info in HARNESSES.items():
@@ -399,7 +400,11 @@ def main():
         print_usage()
         sys.exit(0)
 
-    if args[0] == "version":
+    # Accept the conventional flags as well as the subcommand. `--version` is
+    # the first thing anyone types to confirm which build they are on, and it
+    # previously exited with "unknown command". That matters most right after
+    # an upgrade, which is exactly when it was failing.
+    if args[0] in ("version", "--version", "-V"):
         print(f"agent-security-harness v{VERSION}")
         print(f"Tests: {_total_tests()} across {len(HARNESSES)} harness modules")
         print(f"Protocols: MCP (JSON-RPC 2.0), A2A, L402, x402")

--- a/testing/test_code_quality.py
+++ b/testing/test_code_quality.py
@@ -697,3 +697,33 @@ class TestRegAP2(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestVersionFlagForms(unittest.TestCase):
+    """`agent-security --version` used to exit with "unknown command".
+
+    It is the first thing anyone types to confirm which build they are on, and
+    it mattered most right after an upgrade, which is exactly when it failed.
+    """
+
+    def _run(self, *argv):
+        import subprocess
+        return subprocess.run(
+            [sys.executable, "-m", "protocol_tests.cli", *argv],
+            cwd=REPO_ROOT, capture_output=True, text=True,
+        )
+
+    def test_all_three_forms_report_the_same_version(self) -> None:
+        outs = []
+        for form in ("version", "--version", "-V"):
+            r = self._run(form)
+            self.assertEqual(r.returncode, 0, f"{form!r} exited {r.returncode}: {r.stderr[:200]}")
+            first = r.stdout.splitlines()[0]
+            self.assertIn("agent-security-harness v", first)
+            outs.append(first)
+        self.assertEqual(len(set(outs)), 1, f"forms disagree: {outs}")
+
+    def test_reported_version_matches_pyproject(self) -> None:
+        from protocol_tests.version import get_harness_version
+        r = self._run("--version")
+        self.assertIn(f"v{get_harness_version()}", r.stdout.splitlines()[0])


### PR DESCRIPTION
`agent-security --version` exited with:

```
Error: unknown command '--version'
```

The information was already there behind the `version` subcommand. Only the conventional flag forms were missing.

This matters more than usual this week: v4.14.0 changes behaviour, so the first thing a user does after upgrading is confirm which build they're on, and that was precisely the invocation that failed.

## Change

- `version`, `--version`, and `-V` all take the same path
- **`-v` deliberately not bound**, so it stays free for a future verbose flag
- Usage line and module docstring updated so the flag is discoverable
- README Quick Start opens with `agent-security --version`

## Guard

`TestVersionFlagForms` asserts all three forms exit 0 and print byte-identical output, and that the reported version matches `pyproject.toml` — so the flag can't drift from the package version, which is the whole reason someone types it.

```
version      -> agent-security-harness v4.14.0   exit=0
--version    -> agent-security-harness v4.14.0   exit=0
-V           -> agent-security-harness v4.14.0   exit=0
```

`tests/` + `testing/`: **486 passed, 73 subtests**.