### PR TITLE
docs: note what the comparison table does not measure

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,19 @@ Star counts verified 2026-08-02 via the GitHub API. Invariant Labs' `mcp-scan` n
 `snyk/agent-scan` and is listed once rather than as two separate projects. Competitor rows describe
 what each tool does by design; a dash means the capability is outside its stated scope, not a defect.
 
+**What the table does not measure.** Every row above is coverage: what gets tested, and how much.
+Coverage says nothing about what a result licenses you to claim. That is what the
+[E1-E5 Evidence Class Taxonomy](docs/EVIDENCE-CLASS-TAXONOMY.md) is for, and it is applied to this
+project's own output first: the AIUC-1 crosswalk is E1 material regardless of covering 19 of 20
+requirements, and this harness holds **no I2 evidence** at all, because it reads protocol responses
+the target itself emits. No claim here is deliberately made about how other projects handle this.
+
+**One external check.** The `Research backing` row says self-authored because it is. The one
+exception is [#304](https://github.com/msaleme/red-team-blue-team-agent-fabric/issues/304), where an
+outside party reimplemented the receipt-claim oracle from the published contract and replayed a
+pinned corpus. One reproduction, of one corpus, by one party, is not independent review of the
+harness as a whole, and this project still does not have that.
+
 **Use both.** Scan with [Snyk Agent Scan](https://github.com/snyk/agent-scan) or [Cisco MCP Scanner](https://github.com/cisco-ai-defense/mcp-scanner) for static analysis. Test with this framework for active exploitation. They're complementary layers.
 
 ---


### PR DESCRIPTION
The "How This Differs From Other Projects" table is entirely **coverage**: what gets tested and how much. It says nothing about what a result licenses you to claim, which is the part of this project a competitor has the least commercial reason to copy.

Two paragraphs after the table. **No new rows.**

## What was added

**What the table does not measure** — points at the evidence taxonomy and applies it to this project's own output first: the AIUC-1 crosswalk is E1 material regardless of covering 19 of 20 requirements, and this harness holds no I2 evidence at all, because it reads protocol responses the target emits.

**One external check** — cross-links #304 next to the `Research backing` row, which already honestly says *self-authored*. One outside reimplementation of one corpus is not independent review of the harness, and the paragraph says exactly that.

## Why not a table row

This was the tempting version: add **"Publishes what its evidence does not establish"** and put a dash under Snyk, Cisco, and NVIDIA.

I did not, and the reason is the table's own footer:

> Competitor rows describe what each tool does by design; a dash means the capability is outside its stated scope, not a defect.

Every existing row is a capability, and every dash is checkable. A row about evidence discipline would be an **unfalsifiable virtue claim about three named projects** — asserting an absence from a table we authored, about work we have not audited. That is the same defect pattern corrected in #341 this week, aimed outward instead of inward, and it is the row a reader would push back on hardest.

The added text says explicitly that no claim is made about how other projects handle this.

## Verification

| Claim | Source |
|---|---|
| "a mapping is E1-level material no matter how many requirements it covers" | `docs/AIUC1-CROSSWALK.md:12`, verbatim |
| "A mapping is E1-level material regardless of how many requirements it covers" | `docs/EVIDENCE-CLASS-TAXONOMY.md:41`, verbatim |
| "This harness holds no I2 evidence" | `docs/EVIDENCE-CLASS-TAXONOMY.md:116`, verbatim |
| #304 is an outside reimplementation from the published contract | issue #304, open |

Also checked the existing table against current state and it is accurate: 603 tests / 44 modules matches the regenerated catalog, the 8 human-oversight tests match the 8 `HITL-*` entries, and the AIUC-1 row carries the 2026-Q1/Q2 qualifier.

`tests/` + `testing/`: **489 passed, 73 subtests, 2 skipped**.