### PR TITLE
fix: two more modules set passed=True because the target errored

### DIFF
--- a/protocol_tests/enterprise_adapters.py
+++ b/protocol_tests/enterprise_adapters.py
@@ -41,6 +41,8 @@ from datetime import datetime, timezone
 from typing import Any
 import urllib.request
 
+from protocol_tests.http_helpers import _serviced
+
 
 # ---------------------------------------------------------------------------
 # Shared infrastructure
@@ -117,6 +119,18 @@ class EnterprisePlatformAdapter(ABC):
 
     def _record(self, result: EnterpriseTestResult):
         self.results.append(result)
+        # #350: this module computed `passed=self._check_error(resp)` at five sites and
+        # `passed=self._check_error(resp) or not self._check_leak(resp)` at six more, so a
+        # target that errored was recorded as a pass *by construction*. #348 fixed the same
+        # class in five other harnesses and did not reach here. Guarding in the base class
+        # rather than at the 12 sites, so every adapter subclass inherits it.
+        _resp = getattr(result, "response_received", None)
+        if isinstance(_resp, dict) and not _serviced(_resp):
+            result.passed = False
+            if "INCONCLUSIVE" not in (result.details or ""):
+                result.details = (
+                    "INCONCLUSIVE - target did not service the request; "
+                    f"status={_resp.get('_status', 0)}. Original finding: {result.details}")
         status = "PASS ✅" if result.passed else "FAIL ❌"
         print(f"  {status} {result.test_id}: {result.name} ({result.elapsed_s:.2f}s)")
 

--- a/protocol_tests/extended_enterprise_adapters.py
+++ b/protocol_tests/extended_enterprise_adapters.py
@@ -38,6 +38,8 @@ from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 import urllib.request
 
+from protocol_tests.http_helpers import _serviced
+
 
 # ---------------------------------------------------------------------------
 # Shared (same pattern as enterprise_adapters.py)
@@ -91,6 +93,18 @@ class ExtAdapter(ABC):
         self.results: list[ExtTestResult] = []
     def _record(self, r: ExtTestResult):
         self.results.append(r)
+        # #350: five sites here read `passed=self._err(resp) or not self._leak(resp)`, which
+        # records a pass *because* the target errored, and four more read
+        # `passed=not self._leak(resp)`, which never checks whether it answered at all.
+        # Same class as #348, which stopped at five harnesses. Guarded in the base class so
+        # every adapter subclass inherits it.
+        _resp = getattr(r, "response_received", None)
+        if isinstance(_resp, dict) and not _serviced(_resp):
+            r.passed = False
+            if "INCONCLUSIVE" not in (r.details or ""):
+                r.details = (
+                    "INCONCLUSIVE - target did not service the request; "
+                    f"status={_resp.get('_status', 0)}. Original finding: {r.details}")
         s = "PASS ✅" if r.passed else "FAIL ❌"
         print(f"  {s} {r.test_id}: {r.name} ({r.elapsed_s:.2f}s)")
     def _leak(self, resp):

--- a/testing/test_serviced_guard.py
+++ b/testing/test_serviced_guard.py
@@ -44,7 +44,7 @@ SERVICED = {
     "response": {"jsonrpc": "2.0", "id": 1, "result": {"parts": [{"text": "refused"}]}},
 }
 
-# (module, harness class, result class) for every harness guarded by #348.
+# (module, harness class, result class) for every harness carrying the guard.
 GUARDED = [
     ("protocol_tests.multi_agent_harness", "MultiAgentTests", "MultiAgentTestResult"),
     ("protocol_tests.identity_harness", "IdentitySecurityTests", "IdentityTestResult"),
@@ -52,6 +52,69 @@ GUARDED = [
     ("protocol_tests.memory_harness", "MemoryTests", "MemoryTestResult"),
     ("protocol_tests.intent_contract_harness", "IntentContractTests",
      "IntentContractTestResult"),
+    # #350: found by deriving the candidate set below rather than by reading five files.
+    ("protocol_tests.enterprise_adapters", None, "EnterpriseTestResult"),
+    ("protocol_tests.extended_enterprise_adapters", None, "ExtTestResult"),
+]
+
+# Every module that records a target response, and is therefore capable of this defect.
+# Derived, never hand-written: #348 was scoped to five harnesses by reading five files, and
+# a sixth and seventh with the same defect survived it. A hand-maintained coverage list is
+# the same failure the guard exists to prevent, one level up.
+def _candidate_modules() -> set[str]:
+    out = set()
+    for path in sorted((REPO_ROOT / "protocol_tests").glob("*.py")):
+        src = path.read_text()
+        if "def _record" in src and "response_received" in src:
+            out.add(path.stem)
+    return out
+
+
+# Modules that record a response and have NOT been checked for this defect. Listing them
+# is the honest state: #350 confirmed the defect in two of the 28 by reading them, so the
+# rest are unknown, not clean. Tracked in #351. Shrink this list by reviewing, never by
+# deleting entries.
+#
+# The point of enumerating them is the assertion below: candidates must equal
+# guarded + unreviewed exactly. A newly added harness lands in neither and fails the suite
+# until someone classifies it. That is the difference between a guard that composes and a
+# list that has to be remembered.
+UNREVIEWED = {
+    "a2a_harness",
+    "aiuc1_compliance_harness",
+    "autogen_harness",
+    "benchmark_integrity_harness",
+    "capability_profile_harness",
+    "cbrn_harness",
+    "cloud_agent_harness",
+    "crewai_cve_harness",
+    "extended_thinking_harness",
+    "framework_adapters",
+    "governance_modification_harness",
+    "gtg1002_simulation",
+    "harmful_output_harness",
+    "incident_response_harness",
+    "jailbreak_harness",
+    "kill_switch_harness",
+    "l402_harness",
+    "mcp_harness",
+    "mcp_tool_poisoning_harness",
+    "over_refusal_harness",
+    "prompt_caching_harness",
+    "provenance_harness",
+    "ptc_harness",
+    "return_channel_harness",
+    "skill_security_harness",
+    "tool_search_harness",
+    "watermark_harness",
+    "x402_harness",
+}
+
+# Concrete subclasses for the two adapter modules, whose guard lives on an ABC base rather
+# than on a single Tests class.
+ADAPTER_CASES = [
+    ("protocol_tests.enterprise_adapters", "OpenClawAdapter", "EnterpriseTestResult"),
+    ("protocol_tests.extended_enterprise_adapters", "SnowflakeAdapter", "ExtTestResult"),
 ]
 
 
@@ -112,6 +175,8 @@ class TestNoHarnessPassesAnUnservicedTarget(unittest.TestCase):
     def test_every_guarded_harness_downgrades_to_inconclusive(self) -> None:
         import importlib
         for mod_name, cls_name, res_name in GUARDED:
+            if cls_name is None:
+                continue  # adapter modules are covered by ADAPTER_CASES
             mod = importlib.import_module(mod_name)
             harness = getattr(mod, cls_name)("http://127.0.0.1:9")
             result_cls = getattr(mod, res_name)
@@ -130,6 +195,8 @@ class TestNoHarnessPassesAnUnservicedTarget(unittest.TestCase):
         """The guard must not turn real passes into failures."""
         import importlib
         for mod_name, cls_name, res_name in GUARDED:
+            if cls_name is None:
+                continue  # adapter modules are covered by ADAPTER_CASES
             mod = importlib.import_module(mod_name)
             harness = getattr(mod, cls_name)("http://127.0.0.1:9")
             r = _build(getattr(mod, res_name), passed=True, response_received=SERVICED)
@@ -138,6 +205,55 @@ class TestNoHarnessPassesAnUnservicedTarget(unittest.TestCase):
             with self.subTest(cls_name):
                 self.assertTrue(r.passed, f"{cls_name} downgraded a serviced pass")
                 self.assertNotIn("INCONCLUSIVE", r.details)
+
+    def test_adapter_base_classes_guard_every_subclass(self) -> None:
+        """#350: the guard sits on the ABC, so each adapter subclass inherits it."""
+        import importlib
+        for mod_name, cls_name, res_name in ADAPTER_CASES:
+            mod = importlib.import_module(mod_name)
+            result_cls = getattr(mod, res_name)
+            for label, resp in UNSERVICED.items():
+                with self.subTest(f"{cls_name} / {label}"):
+                    a = getattr(mod, cls_name)("http://127.0.0.1:9")
+                    a.results = []
+                    r = _build(result_cls, passed=True, response_received=resp)
+                    a._record(r)
+                    self.assertFalse(
+                        r.passed,
+                        f"{cls_name} recorded a PASS for '{label}' - this module set "
+                        "passed=True *because* the target errored")
+                    self.assertIn("INCONCLUSIVE", r.details)
+            with self.subTest(f"{cls_name} / serviced pass survives"):
+                a = getattr(mod, cls_name)("http://127.0.0.1:9")
+                a.results = []
+                r = _build(result_cls, passed=True, response_received=SERVICED)
+                a._record(r)
+                self.assertTrue(r.passed)
+
+
+class TestCoverageListIsDerived(unittest.TestCase):
+    """#350: the ratchet. A new harness cannot be silently missed a fourth time."""
+
+    def test_every_response_recording_module_is_classified(self) -> None:
+        guarded = {m.rsplit(".", 1)[1] for m, _, _ in GUARDED}
+        classified = guarded | UNREVIEWED
+        candidates = _candidate_modules()
+        unclassified = candidates - classified
+        self.assertEqual(
+            unclassified, set(),
+            "these modules record a target response but are in neither GUARDED nor "
+            f"UNREVIEWED: {sorted(unclassified)}. Check whether the verdict can be a pass "
+            "when the target never serviced the request, then add the guard or list it.")
+        stale = classified - candidates
+        self.assertEqual(
+            stale, set(), f"listed but no longer record a response: {sorted(stale)}")
+
+    def test_unreviewed_does_not_grow(self) -> None:
+        """A tripwire on the honest number, so the backlog cannot quietly expand."""
+        self.assertLessEqual(
+            len(UNREVIEWED), 28,
+            "UNREVIEWED grew. A new module recording a response should be guarded or "
+            "reviewed, not appended to the backlog.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #350. Backlog tracked in #351.

## The finding

#348's own conclusion was that the v4.13.1 repair "was scoped to the site of discovery rather than to the class." I then scoped the fix for it to five harnesses, found by reading five files. Two more modules had the same defect. **Third recurrence of one mistake.**

Both are registered in `cli.py` and counted in the 603.

```
case                        predicate   recorded passed
transport failure (down)    True        True
http 404                    True        True
http 500                    True        True
200 + nested jsonrpc error  False       True
```

`enterprise_adapters.py` has 12 sites, five of which are just `passed=self._check_error(resp)` with no other condition. `extended_enterprise_adapters.py` has 5. This is not the accidental fail-open of #348 — these set `passed=True` **because** the target errored.

## The fix that matters

Guarding on the ABC base was easy; both files already have one `_record` on a shared base, unlike the five in #348.

The real change is that **`GUARDED` is no longer hand-written.** A hand-maintained coverage list is the same failure the guard exists to prevent, one level up — and it is exactly how #348 missed these two. The test now derives every module with `_record` + `response_received` and asserts each is classified as guarded or explicitly unreviewed.

Verified by dropping in a probe module:

```
AssertionError: '_ratchet_probe' : these modules record a target response but are in
neither GUARDED nor UNREVIEWED: ['_ratchet_probe']. Check whether the verdict can be a
pass when the target never serviced the request, then add the guard or list it.
```

## Honest remaining state

35 modules record a target response. Seven are guarded. **The other 28 are unknown, not clean** — two of them were defective the moment they were read. They are listed in `UNREVIEWED` with a tripwire preventing the list from growing, and tracked in #351.

29 of the 35 never call an error predicate at all, so the shape there may differ. That has to be read, not pattern-matched.

## Verification

- `tests/` + `testing/`: **497 passed, 120 subtests, 2 skipped**
- `scripts/count_tests.py`: **603**, unchanged
- OWASP mapping validator: passes
- Both modules still import and run standalone (`python -m protocol_tests.enterprise_adapters`)