### PR TITLE
release: v4.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.15.0] - 2026-08-07
+
+### Changed — expect previously-passing results to become INCONCLUSIVE
+
+**Runs against a target that did not answer will now report fewer passes.** That is the
+point of this release, and it is the only change that affects existing users. If your
+results move, they were reporting a control holding against a request the target never
+serviced. No test was added or removed; the count is unchanged at 603.
+
+### Fixed — a verdict class that reported safety it never measured
+
+- **Seven modules recorded a PASS when the target never serviced the request** (#348,
+  #350). Every affected detector short-circuited on an error response and returned "no
+  attack indicator found," and every caller read that as "the control held." A host that
+  was not running produced a clean pass.
+
+  Verified by running the verdict expressions rather than by reading them:
+
+  | case | error predicate | recorded `passed` |
+  |---|---|---|
+  | transport failure (host down) | True | **True** |
+  | HTTP 404 | True | **True** |
+  | HTTP 500 | True | **True** |
+  | HTTP 200 carrying a JSON-RPC error envelope | False | **True** |
+
+  Affected: `multi_agent_harness` (18 tests), `identity_harness` (18),
+  `advanced_attacks` (10), `memory_harness` (10), `intent_contract_harness` (8),
+  `enterprise_adapters` (28), `extended_enterprise_adapters` (27).
+
+  In the two adapter modules the defect was explicit rather than accidental: 17 sites
+  computed `passed=self._check_error(resp)` or `passed=self._err(resp) or not _leak(resp)`,
+  setting a pass **because** the target errored.
+
+- **`_serviced()` promoted to `protocol_tests/http_helpers.py`.** v4.13.1 wrote this
+  function to fix 20 false passes in `hitl_harness.py` and left it in that file. Nothing
+  carried it to the six other modules with the same verdict pattern. It is now applied in
+  each module's recording path, so a test cannot forget a guard it never has to call.
+
+- Unserviced results are reported as `INCONCLUSIVE` with `passed=False`, preserving the
+  original finding text for audit. **A test that could not run is not a test that passed.**
+
+### Added
+
+- `testing/test_serviced_guard.py` derives the set of modules that record a target
+  response and asserts each one is classified. A newly added harness that records a
+  response fails the suite until it is guarded or explicitly reviewed. The previous
+  hand-written coverage list is exactly how #348 missed two modules.
+
+### Known gaps
+
+- 35 modules record a target response. Seven are now guarded. **The remaining 28 are
+  unknown, not clean** — two of them were found defective the moment they were read.
+  They are listed in `UNREVIEWED` with a tripwire against growth, and tracked in #351.
+
 ## [4.14.0] - 2026-08-05
 
 ### Breaking

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you cite this work in research, please use this metadata."
 title: "Agent Security Harness"
-version: "4.14.0"
+version: "4.15.0"
 abstract: "Multi-protocol agent security testing framework. 603 executable security tests across 44 modules covering MCP, A2A, L402, and x402 wire protocols. Decision-layer attack scenarios, AIUC-1 pre-certification mapping, NIST AI 800-2 aligned."
 type: software
 authors:

--- a/EVALUATION_PROTOCOL.md
+++ b/EVALUATION_PROTOCOL.md
@@ -288,4 +288,4 @@ Per NIST AI 800-2, we distinguish:
 
 _Document version: 1.0_
 _NIST AI 800-2 alignment date: March 21, 2026_
-_Framework version: 4.14.0 (603 tests)_
+_Framework version: 4.15.0 (603 tests)_

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ```
 $ agent-security test mcp --url http://localhost:8080/mcp
-Running MCP Protocol Security Tests v4.14.0...
+Running MCP Protocol Security Tests v4.15.0...
  MCP-001: Tool List Integrity Check [PASS] (0.234s)
  MCP-002: Tool Registration via Call Injection [PASS] (0.412s)
  MCP-003: Capability Escalation via Initialize [FAIL] (0.156s)

--- a/docs/OWASP-AGENTIC-T1-T15-SUBMISSION-COVERAGE.md
+++ b/docs/OWASP-AGENTIC-T1-T15-SUBMISSION-COVERAGE.md
@@ -11,7 +11,7 @@
 | Report view | Submission (T1–T15) |
 | Report version | 1.0 |
 | Project | Agent Security Harness |
-| Harness version | `4.14.0` |
+| Harness version | `4.15.0` |
 | Assessed commit | [`19dbfb871d1379a42bbfa22fa06bb2edda58a2c0`](https://github.com/msaleme/red-team-blue-team-agent-fabric/commit/19dbfb871d1379a42bbfa22fa06bb2edda58a2c0) |
 | Assessed at | 2026-08-02T18:30:00Z |
 | Repository tests | 603 (`python scripts/count_tests.py`) |
@@ -725,6 +725,7 @@ Per-test rerun commands are in the `Rerun` column of each evidence table.
 | 1.0 | v1.1 `65e3bd59f99c` | 4.13.0 | `093bdae3d97c` | 2026-08-02 | Initial T1-T17 adjudication against guide v1.1. |
 | 1.1 | v1.1 `65e3bd59f99c` | 4.13.1 | `19dbfb871d13` | 2026-08-03 | Re-pinned after the v4.13.1 HITL correctness fix. No threat, scenario or control verdict changed; the T10/T15 limitations now state the corrected guard. The adjudication itself was performed at the 1.0 commit and was not redone. |
 | 1.2 | v1.1 `65e3bd59f99c` | 4.14.0 | `19dbfb871d13` | 2026-08-05 | Re-pinned to the v4.14.0 release. No threat, scenario or control verdict changed, and no test was added or removed. v4.14.0 removes fabricated default network endpoints and corrects an attestation independence claim; the harness exercises neither. commit and assessed_at are deliberately unchanged from 1.1, because the adjudication was not redone. |
+| 1.3 | v1.1 `65e3bd59f99c` | 4.15.0 | `19dbfb871d13` | 2026-08-07 | Re-pinned to the v4.15.0 release. No threat, scenario or control verdict changed, and no test was added or removed. Unlike 1.2, this release does change runtime behaviour. Issues 348 and 350 stop seven modules recording a pass when the target never serviced the request, so those results now read INCONCLUSIVE. This mapping adjudicates coverage rather than run output, so its verdicts are unaffected and were not redone. Stated plainly for readers who rely on run output instead. Any earlier run of multi_agent_harness, identity_harness, advanced_attacks, memory_harness, intent_contract_harness, enterprise_adapters or extended_enterprise_adapters against an unresponsive target reported more passes than it measured. commit and assessed_at are deliberately unchanged from 1.1. |
 
 A status changes only through a reviewed mapping change.
 

--- a/docs/OWASP-AGENTIC-V1.1-COVERAGE.md
+++ b/docs/OWASP-AGENTIC-V1.1-COVERAGE.md
@@ -9,7 +9,7 @@
 | Report view | Complete (T1–T17) |
 | Report version | 1.0 |
 | Project | Agent Security Harness |
-| Harness version | `4.14.0` |
+| Harness version | `4.15.0` |
 | Assessed commit | [`19dbfb871d1379a42bbfa22fa06bb2edda58a2c0`](https://github.com/msaleme/red-team-blue-team-agent-fabric/commit/19dbfb871d1379a42bbfa22fa06bb2edda58a2c0) |
 | Assessed at | 2026-08-02T18:30:00Z |
 | Repository tests | 603 (`python scripts/count_tests.py`) |
@@ -974,6 +974,7 @@ Recorded for source fidelity, not as criticism of OWASP. Inconsistencies in the 
 | 1.0 | v1.1 `65e3bd59f99c` | 4.13.0 | `093bdae3d97c` | 2026-08-02 | Initial T1-T17 adjudication against guide v1.1. |
 | 1.1 | v1.1 `65e3bd59f99c` | 4.13.1 | `19dbfb871d13` | 2026-08-03 | Re-pinned after the v4.13.1 HITL correctness fix. No threat, scenario or control verdict changed; the T10/T15 limitations now state the corrected guard. The adjudication itself was performed at the 1.0 commit and was not redone. |
 | 1.2 | v1.1 `65e3bd59f99c` | 4.14.0 | `19dbfb871d13` | 2026-08-05 | Re-pinned to the v4.14.0 release. No threat, scenario or control verdict changed, and no test was added or removed. v4.14.0 removes fabricated default network endpoints and corrects an attestation independence claim; the harness exercises neither. commit and assessed_at are deliberately unchanged from 1.1, because the adjudication was not redone. |
+| 1.3 | v1.1 `65e3bd59f99c` | 4.15.0 | `19dbfb871d13` | 2026-08-07 | Re-pinned to the v4.15.0 release. No threat, scenario or control verdict changed, and no test was added or removed. Unlike 1.2, this release does change runtime behaviour. Issues 348 and 350 stop seven modules recording a pass when the target never serviced the request, so those results now read INCONCLUSIVE. This mapping adjudicates coverage rather than run output, so its verdicts are unaffected and were not redone. Stated plainly for readers who rely on run output instead. Any earlier run of multi_agent_harness, identity_harness, advanced_attacks, memory_harness, intent_contract_harness, enterprise_adapters or extended_enterprise_adapters against an unresponsive target reported more passes than it measured. commit and assessed_at are deliberately unchanged from 1.1. |
 
 A status changes only through a reviewed mapping change.
 

--- a/docs/TEST-INVENTORY.md
+++ b/docs/TEST-INVENTORY.md
@@ -7,7 +7,7 @@ See also: **[OWASP Agentic AI v1.1 Threat Coverage Report](OWASP-AGENTIC-V1.1-CO
 > **Canonical figures (verified 2026-08-02).** Main branch: 603 test IDs across
 > 44 test-bearing modules in `protocol_tests/` (files with no `test_id` — CLI,
 > helpers, telemetry, registry — are not counted as modules). `main`'s
-> `pyproject.toml` is at `agent-security-harness` v4.14.0 (603 tests); PyPI
+> `pyproject.toml` is at `agent-security-harness` v4.15.0 (603 tests); PyPI
 > itself will show this version once the release is published (see
 > `CHANGELOG.md`). Wire protocols: 4 (MCP, A2A, L402, x402). AIUC-1: 19 of
 > 20 testable requirements (95%). Research: 5 public Zenodo preprints (not

--- a/docs/coverage/owasp-agentic-v1.1.json
+++ b/docs/coverage/owasp-agentic-v1.1.json
@@ -34,7 +34,7 @@
   "assessment": {
     "project": "Agent Security Harness",
     "repository": "https://github.com/msaleme/red-team-blue-team-agent-fabric",
-    "harness_version": "4.14.0",
+    "harness_version": "4.15.0",
     "git_commit": "19dbfb871d1379a42bbfa22fa06bb2edda58a2c0",
     "assessed_at": "2026-08-02T18:30:00Z",
     "reverified_at": "2026-08-03T01:05:00Z",
@@ -59,6 +59,13 @@
         "harness": "4.14.0",
         "date": "2026-08-05",
         "change": "Re-pinned to the v4.14.0 release. No threat, scenario or control verdict changed, and no test was added or removed. v4.14.0 removes fabricated default network endpoints and corrects an attestation independence claim; the harness exercises neither. commit and assessed_at are deliberately unchanged from 1.1, because the adjudication was not redone."
+      },
+      {
+        "report": "1.3",
+        "commit": "19dbfb871d1379a42bbfa22fa06bb2edda58a2c0",
+        "harness": "4.15.0",
+        "date": "2026-08-07",
+        "change": "Re-pinned to the v4.15.0 release. No threat, scenario or control verdict changed, and no test was added or removed. Unlike 1.2, this release does change runtime behaviour. Issues 348 and 350 stop seven modules recording a pass when the target never serviced the request, so those results now read INCONCLUSIVE. This mapping adjudicates coverage rather than run output, so its verdicts are unaffected and were not redone. Stated plainly for readers who rely on run output instead. Any earlier run of multi_agent_harness, identity_harness, advanced_attacks, memory_harness, intent_contract_harness, enterprise_adapters or extended_enterprise_adapters against an unresponsive target reported more passes than it measured. commit and assessed_at are deliberately unchanged from 1.1."
       }
     ],
     "total_repository_tests": 603,

--- a/docs/coverage/owasp-agentic-v1.1.yaml
+++ b/docs/coverage/owasp-agentic-v1.1.yaml
@@ -52,7 +52,7 @@ framework:
 assessment:
   project: Agent Security Harness
   repository: https://github.com/msaleme/red-team-blue-team-agent-fabric
-  harness_version: 4.14.0
+  harness_version: 4.15.0
   git_commit: 19dbfb871d1379a42bbfa22fa06bb2edda58a2c0
   assessed_at: '2026-08-02T18:30:00Z'
   reverified_at: '2026-08-03T01:05:00Z'
@@ -79,6 +79,21 @@ assessment:
       network endpoints and corrects an attestation independence claim; the harness
       exercises neither. commit and assessed_at are deliberately unchanged from 1.1,
       because the adjudication was not redone.
+  - report: '1.3'
+    commit: 19dbfb871d1379a42bbfa22fa06bb2edda58a2c0
+    harness: 4.15.0
+    date: '2026-08-07'
+    change: Re-pinned to the v4.15.0 release. No threat, scenario or control verdict
+      changed, and no test was added or removed. Unlike 1.2, this release does change
+      runtime behaviour. Issues 348 and 350 stop seven modules recording a pass when
+      the target never serviced the request, so those results now read INCONCLUSIVE.
+      This mapping adjudicates coverage rather than run output, so its verdicts are
+      unaffected and were not redone. Stated plainly for readers who rely on run
+      output instead. Any earlier run of multi_agent_harness, identity_harness,
+      advanced_attacks, memory_harness, intent_contract_harness, enterprise_adapters
+      or extended_enterprise_adapters against an unresponsive target reported more
+      passes than it measured. commit and assessed_at are deliberately unchanged from
+      1.1.
 
   total_repository_tests: 603
   total_tests_command: python scripts/count_tests.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-security-harness"
-version = "4.14.0"
+version = "4.15.0"
 description = "603 security tests for AI agent systems - MCP, A2A, L402, x402, UCP/ACP merchant-journey, AP2 mandate + Fireblocks x402 hardening + Visa TAP / Mastercard Agentic Tokens + denial-of-settlement finality, decision governance, AIUC-1 compliance, NIST AI 800-2 aligned"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
Ships #348 and #350. Both are merged to `main` and neither is in a published release, so every `pip install agent-security-harness` still gets a build that reports a control holding against a host that is not running. Roughly 705 downloads/month.

## The user-visible change

**Runs against a target that did not answer will report fewer passes.** That is the whole release. If someone's results move, they were previously reporting a control holding against a request the target never serviced. No test added or removed; count unchanged at **603**.

## Scope

Seven modules, verified by running the verdict expressions rather than reading them:

| case | error predicate | recorded `passed` |
|---|---|---|
| transport failure (host down) | True | **True** |
| HTTP 404 | True | **True** |
| HTTP 500 | True | **True** |
| HTTP 200 carrying a JSON-RPC error envelope | False | **True** |

`multi_agent_harness` 18, `identity_harness` 18, `advanced_attacks` 10, `memory_harness` 10, `intent_contract_harness` 8, `enterprise_adapters` 28, `extended_enterprise_adapters` 27.

## On the OWASP re-pin

Re-pinned through `docs/coverage/owasp-agentic-v1.1.yaml` and regenerated. The MD and JSON views are generated output — `r18_report` caught a hand-edit and was right to.

The 1.3 note is deliberately not a copy of 1.2. v4.14.0 changed nothing the harness exercises, so "no verdict changed" was the whole story there. Here the mapping's verdicts are unaffected because it adjudicates coverage rather than run output, but that distinction only helps a reader who knows it. The note states plainly that any earlier run of the seven affected modules against an unresponsive target reported more passes than it measured.

## Known gaps, carried into the release notes

35 modules record a target response. Seven are guarded. **The other 28 are unknown, not clean** — two were found defective the moment they were read. Listed in `UNREVIEWED` with a tripwire against growth, tracked in #351.

## Verification

- `tests/` + `testing/`: **497 passed, 120 subtests, 2 skipped**
- `scripts/count_tests.py`: **603**
- `scripts/validate_owasp_agentic_mapping.py`: passes
- Version consistent across pyproject, CITATION.cff, README, EVALUATION_PROTOCOL, docs/TEST-INVENTORY, coverage YAML