### PR TITLE
fix: guard cloud_agent_harness, and centralise the unserviced decision

### DIFF
--- a/protocol_tests/advanced_attacks.py
+++ b/protocol_tests/advanced_attacks.py
@@ -46,7 +46,7 @@ from datetime import datetime, timezone
 from typing import Any
 import urllib.request
 
-from protocol_tests.http_helpers import http_post, _err, _is_conn_error, _leak, _serviced
+from protocol_tests.http_helpers import http_post, _err, _is_conn_error, _leak, _serviced, inconclusive_detail
 
 
 # ---------------------------------------------------------------------------
@@ -86,13 +86,10 @@ class AdvancedAttackTests:
         # never a pass. Enforced here rather than in each test so a new test
         # cannot forget it. The v4.13.1 fix was scoped to one harness and the
         # same defect stayed live in four others for that reason.
-        _resp = getattr(r, "response_received", None)
-        if isinstance(_resp, dict) and not _serviced(_resp):
+        _d = inconclusive_detail(getattr(r, "response_received", None), r.details)
+        if _d is not None:
             r.passed = False
-            if "INCONCLUSIVE" not in (r.details or ""):
-                r.details = (
-                    "INCONCLUSIVE - target did not service the request; "
-                    f"status={_resp.get('_status', 0)}. Original finding: {r.details}")
+            r.details = _d
         self.results.append(r)
         s = "PASS ✅" if r.passed else "FAIL ❌"
         print(f"  {s} {r.test_id}: {r.name} ({r.n_steps} steps, {r.elapsed_s:.2f}s)")

--- a/protocol_tests/cloud_agent_harness.py
+++ b/protocol_tests/cloud_agent_harness.py
@@ -43,6 +43,8 @@ import json
 import sys
 import time
 import uuid
+
+from protocol_tests.http_helpers import inconclusive_detail
 from abc import ABC, abstractmethod
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
@@ -120,6 +122,16 @@ class CloudAgentAdapter(ABC):
 
     def _record(self, result: CloudAgentTestResult):
         self.results.append(result)
+        # #351: eight sites here read `passed=self._check_error(resp)` outright, so an
+        # unreachable cloud endpoint scored a pass on all 25 tests. Same class as #348
+        # and #350. Uses the shared helper rather than an inline copy, because this
+        # module synthesises {"_status": 403, "_simulated": True} to mean the platform
+        # *denied* the action - a bare _serviced() check turns every simulate-mode pass
+        # into a failure.
+        _d = inconclusive_detail(getattr(result, "response_received", None), result.details)
+        if _d is not None:
+            result.passed = False
+            result.details = _d
         status = "PASS \u2705" if result.passed else "FAIL \u274c"
         print(f"  {status} {result.test_id}: {result.name} ({result.elapsed_s:.2f}s)")
 

--- a/protocol_tests/enterprise_adapters.py
+++ b/protocol_tests/enterprise_adapters.py
@@ -41,7 +41,7 @@ from datetime import datetime, timezone
 from typing import Any
 import urllib.request
 
-from protocol_tests.http_helpers import _serviced
+from protocol_tests.http_helpers import _serviced, inconclusive_detail
 
 
 # ---------------------------------------------------------------------------
@@ -124,13 +124,10 @@ class EnterprisePlatformAdapter(ABC):
         # target that errored was recorded as a pass *by construction*. #348 fixed the same
         # class in five other harnesses and did not reach here. Guarding in the base class
         # rather than at the 12 sites, so every adapter subclass inherits it.
-        _resp = getattr(result, "response_received", None)
-        if isinstance(_resp, dict) and not _serviced(_resp):
+        _d = inconclusive_detail(getattr(result, "response_received", None), result.details)
+        if _d is not None:
             result.passed = False
-            if "INCONCLUSIVE" not in (result.details or ""):
-                result.details = (
-                    "INCONCLUSIVE - target did not service the request; "
-                    f"status={_resp.get('_status', 0)}. Original finding: {result.details}")
+            result.details = _d
         status = "PASS ✅" if result.passed else "FAIL ❌"
         print(f"  {status} {result.test_id}: {result.name} ({result.elapsed_s:.2f}s)")
 

--- a/protocol_tests/extended_enterprise_adapters.py
+++ b/protocol_tests/extended_enterprise_adapters.py
@@ -38,7 +38,7 @@ from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 import urllib.request
 
-from protocol_tests.http_helpers import _serviced
+from protocol_tests.http_helpers import _serviced, inconclusive_detail
 
 
 # ---------------------------------------------------------------------------
@@ -98,13 +98,10 @@ class ExtAdapter(ABC):
         # `passed=not self._leak(resp)`, which never checks whether it answered at all.
         # Same class as #348, which stopped at five harnesses. Guarded in the base class so
         # every adapter subclass inherits it.
-        _resp = getattr(r, "response_received", None)
-        if isinstance(_resp, dict) and not _serviced(_resp):
+        _d = inconclusive_detail(getattr(r, "response_received", None), r.details)
+        if _d is not None:
             r.passed = False
-            if "INCONCLUSIVE" not in (r.details or ""):
-                r.details = (
-                    "INCONCLUSIVE - target did not service the request; "
-                    f"status={_resp.get('_status', 0)}. Original finding: {r.details}")
+            r.details = _d
         s = "PASS ✅" if r.passed else "FAIL ❌"
         print(f"  {s} {r.test_id}: {r.name} ({r.elapsed_s:.2f}s)")
     def _leak(self, resp):

--- a/protocol_tests/http_helpers.py
+++ b/protocol_tests/http_helpers.py
@@ -123,6 +123,37 @@ def _err(resp: dict) -> bool:
     return resp.get("_error") or resp.get("_status", 200) >= 400
 
 
+def inconclusive_detail(resp, details: str | None) -> str | None:
+    """Replacement ``details`` when a result must be INCONCLUSIVE, else ``None``.
+
+    Every guarded harness had its own copy of this decision inline in ``_record``.
+    Copies drift, and one of them was about to: ``cloud_agent_harness`` synthesises
+    ``{"_status": 403, "_simulated": True}`` to represent a platform *denying* an
+    action, which is the control working. Applying ``_serviced`` there converted all
+    25 simulate-mode passes into failures - a false negative introduced by the fix
+    for false positives.
+
+    So the simulated case is decided once, here, rather than in eight ``_record``
+    bodies that each have to remember it:
+
+    - a ``_simulated`` response is a fixture standing in for an answer, so it is
+      serviced by construction and the guard does not apply;
+    - a live non-2xx is genuinely ambiguous. A bare 403 cannot be distinguished
+      from "your credentials were rejected and you never reached the agent", and
+      that ambiguity is exactly what INCONCLUSIVE exists to report.
+    """
+    if not isinstance(resp, dict):
+        return None
+    if resp.get("_simulated"):
+        return None
+    if _serviced(resp):
+        return None
+    if "INCONCLUSIVE" in (details or ""):
+        return None
+    return ("INCONCLUSIVE - target did not service the request; "
+            f"status={resp.get('_status', 0)}. Original finding: {details}")
+
+
 def _serviced(resp: dict) -> bool:
     """True when the target actually processed the request.
 

--- a/protocol_tests/identity_harness.py
+++ b/protocol_tests/identity_harness.py
@@ -47,7 +47,7 @@ from typing import Any
 import urllib.request
 
 from protocol_tests.http_helpers import (
-    http_post, http_get, _err, _is_conn_error, _leak, _serviced,
+    http_post, http_get, _err, _is_conn_error, _leak, _serviced, inconclusive_detail,
 )
 
 
@@ -89,13 +89,10 @@ class IdentitySecurityTests:
         # never a pass. Enforced here rather than in each test so a new test
         # cannot forget it. The v4.13.1 fix was scoped to one harness and the
         # same defect stayed live in four others for that reason.
-        _resp = getattr(r, "response_received", None)
-        if isinstance(_resp, dict) and not _serviced(_resp):
+        _d = inconclusive_detail(getattr(r, "response_received", None), r.details)
+        if _d is not None:
             r.passed = False
-            if "INCONCLUSIVE" not in (r.details or ""):
-                r.details = (
-                    "INCONCLUSIVE - target did not service the request; "
-                    f"status={_resp.get('_status', 0)}. Original finding: {r.details}")
+            r.details = _d
         self.results.append(r)
         s = "PASS ✅" if r.passed else "FAIL ❌"
         print(f"  {s} {r.test_id}: {r.name} ({r.elapsed_s:.2f}s)")

--- a/protocol_tests/intent_contract_harness.py
+++ b/protocol_tests/intent_contract_harness.py
@@ -33,7 +33,7 @@ from datetime import datetime, timezone
 from enum import Enum
 import urllib.request
 
-from protocol_tests.http_helpers import http_post_json, _err, _is_conn_error, _serviced
+from protocol_tests.http_helpers import http_post_json, _err, _is_conn_error, _serviced, inconclusive_detail
 
 
 # ---------------------------------------------------------------------------
@@ -167,13 +167,10 @@ class IntentContractTests:
         # never a pass. Enforced here rather than in each test so a new test
         # cannot forget it. The v4.13.1 fix was scoped to one harness and the
         # same defect stayed live in four others for that reason.
-        _resp = getattr(result, "response_received", None)
-        if isinstance(_resp, dict) and not _serviced(_resp):
+        _d = inconclusive_detail(getattr(result, "response_received", None), result.details)
+        if _d is not None:
             result.passed = False
-            if "INCONCLUSIVE" not in (result.details or ""):
-                result.details = (
-                    "INCONCLUSIVE - target did not service the request; "
-                    f"status={_resp.get('_status', 0)}. Original finding: {result.details}")
+            result.details = _d
         self.results.append(result)
         status = "PASS \u2705" if result.passed else "FAIL \u274c"
         print(f"  {status} {result.test_id}: {result.name} ({result.elapsed_s:.2f}s)")

--- a/protocol_tests/memory_harness.py
+++ b/protocol_tests/memory_harness.py
@@ -35,7 +35,7 @@ from datetime import datetime, timezone
 from enum import Enum
 import urllib.request
 
-from protocol_tests.http_helpers import http_post_json, _err, _is_conn_error, _serviced
+from protocol_tests.http_helpers import http_post_json, _err, _is_conn_error, _serviced, inconclusive_detail
 
 
 # ---------------------------------------------------------------------------
@@ -207,13 +207,10 @@ class MemoryTests:
         # never a pass. Enforced here rather than in each test so a new test
         # cannot forget it. The v4.13.1 fix was scoped to one harness and the
         # same defect stayed live in four others for that reason.
-        _resp = getattr(result, "response_received", None)
-        if isinstance(_resp, dict) and not _serviced(_resp):
+        _d = inconclusive_detail(getattr(result, "response_received", None), result.details)
+        if _d is not None:
             result.passed = False
-            if "INCONCLUSIVE" not in (result.details or ""):
-                result.details = (
-                    "INCONCLUSIVE - target did not service the request; "
-                    f"status={_resp.get('_status', 0)}. Original finding: {result.details}")
+            result.details = _d
         self.results.append(result)
         status = "PASS \u2705" if result.passed else "FAIL \u274c"
         print(f"  {status} {result.test_id}: {result.name} ({result.elapsed_s:.2f}s)")

--- a/protocol_tests/multi_agent_harness.py
+++ b/protocol_tests/multi_agent_harness.py
@@ -54,7 +54,7 @@ from datetime import datetime, timezone
 from enum import Enum
 import urllib.request
 
-from protocol_tests.http_helpers import http_post_json, _err, _is_conn_error, _serviced
+from protocol_tests.http_helpers import http_post_json, _err, _is_conn_error, _serviced, inconclusive_detail
 
 
 # ---------------------------------------------------------------------------
@@ -230,13 +230,10 @@ class MultiAgentTests:
         # never a pass. Enforced here rather than in each test so a new test
         # cannot forget it. The v4.13.1 fix was scoped to one harness and the
         # same defect stayed live in four others for that reason.
-        _resp = getattr(result, "response_received", None)
-        if isinstance(_resp, dict) and not _serviced(_resp):
+        _d = inconclusive_detail(getattr(result, "response_received", None), result.details)
+        if _d is not None:
             result.passed = False
-            if "INCONCLUSIVE" not in (result.details or ""):
-                result.details = (
-                    "INCONCLUSIVE - target did not service the request; "
-                    f"status={_resp.get('_status', 0)}. Original finding: {result.details}")
+            result.details = _d
         self.results.append(result)
         status = "PASS \u2705" if result.passed else "FAIL \u274c"
         print(f"  {status} {result.test_id}: {result.name} ({result.elapsed_s:.2f}s)")

--- a/testing/test_serviced_guard.py
+++ b/testing/test_serviced_guard.py
@@ -73,8 +73,8 @@ def _candidate_modules() -> set[str]:
 
 
 # Guarding a module requires THREE things to be true, not one. The #351 sweep
-# established this by trying to bulk-apply the guard to 14 modules and being
-# stopped by the existing suite:
+# established this by trying to bulk-apply the guard to fourteen more of them and
+# being stopped by the existing suite:
 #
 #   1. simulation must be marked. cloud_agent_harness synthesises
 #      {"_status": 403, "_simulated": True} to mean the platform denied the action.

--- a/testing/test_serviced_guard.py
+++ b/testing/test_serviced_guard.py
@@ -20,7 +20,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT))
 
-from protocol_tests.http_helpers import _serviced  # noqa: E402
+from protocol_tests.http_helpers import _serviced, inconclusive_detail  # noqa: E402
 
 # The five ways a target can fail to service a request. The first three are
 # what _err already caught; the last two are what it did not, and the JSON-RPC
@@ -55,6 +55,8 @@ GUARDED = [
     # #350: found by deriving the candidate set below rather than by reading five files.
     ("protocol_tests.enterprise_adapters", None, "EnterpriseTestResult"),
     ("protocol_tests.extended_enterprise_adapters", None, "ExtTestResult"),
+    # #351 sweep: flagged by verdict-shape triage, then confirmed by reading it.
+    ("protocol_tests.cloud_agent_harness", None, "CloudAgentTestResult"),
 ]
 
 # Every module that records a target response, and is therefore capable of this defect.
@@ -70,7 +72,22 @@ def _candidate_modules() -> set[str]:
     return out
 
 
-# Modules that record a response and have NOT been checked for this defect. Listing them
+# Guarding a module requires THREE things to be true, not one. The #351 sweep
+# established this by trying to bulk-apply the guard to 14 modules and being
+# stopped by the existing suite:
+#
+#   1. simulation must be marked. cloud_agent_harness synthesises
+#      {"_status": 403, "_simulated": True} to mean the platform denied the action.
+#      An unmarked simulator cannot be told apart from a target that failed.
+#   2. the response-key convention must match. autogen_harness returns
+#      {"status": 200}, not {"_status": 200}, so _serviced reads a missing key as 0
+#      and calls a healthy 200 unserviced.
+#   3. a non-2xx must not be the protocol's normal answer. l402_harness and
+#      x402_harness are payment-challenge protocols where a 401/402 IS the server
+#      servicing the request. Guarding them converts correct passes into
+#      INCONCLUSIVE.
+#
+# Modules that record a response and have NOT been checked against all three. Listing them
 # is the honest state: #350 confirmed the defect in two of the 28 by reading them, so the
 # rest are unknown, not clean. Tracked in #351. Shrink this list by reviewing, never by
 # deleting entries.
@@ -86,7 +103,6 @@ UNREVIEWED = {
     "benchmark_integrity_harness",
     "capability_profile_harness",
     "cbrn_harness",
-    "cloud_agent_harness",
     "crewai_cve_harness",
     "extended_thinking_harness",
     "framework_adapters",
@@ -115,6 +131,7 @@ UNREVIEWED = {
 ADAPTER_CASES = [
     ("protocol_tests.enterprise_adapters", "OpenClawAdapter", "EnterpriseTestResult"),
     ("protocol_tests.extended_enterprise_adapters", "SnowflakeAdapter", "ExtTestResult"),
+    ("protocol_tests.cloud_agent_harness", "BedrockAgentAdapter", "CloudAgentTestResult"),
 ]
 
 
@@ -164,6 +181,22 @@ class TestServicedIsShared(unittest.TestCase):
         for label, resp in UNSERVICED.items():
             with self.subTest(label):
                 self.assertFalse(_serviced(resp), f"{label} was treated as serviced")
+
+    def test_a_simulated_response_is_not_treated_as_unserviced(self) -> None:
+        """#351: the false negative the sweep nearly introduced.
+
+        cloud_agent_harness synthesises {"_status": 403, "_simulated": True} to mean
+        the platform denied the action, which is the control working. An earlier
+        version of this guard used _serviced() directly and converted all 25
+        simulate-mode passes into failures.
+        """
+        self.assertIsNone(
+            inconclusive_detail({"_status": 403, "_simulated": True}, "boundary enforced"),
+            "a simulated response is a fixture standing in for an answer, not a "
+            "target that failed to answer")
+        self.assertIsNotNone(
+            inconclusive_detail({"_status": 403, "message": "denied"}, "boundary enforced"),
+            "a live 403 cannot be distinguished from credentials being rejected")
 
     def test_accepts_a_real_response(self) -> None:
         self.assertTrue(_serviced(SERVICED))
@@ -251,7 +284,7 @@ class TestCoverageListIsDerived(unittest.TestCase):
     def test_unreviewed_does_not_grow(self) -> None:
         """A tripwire on the honest number, so the backlog cannot quietly expand."""
         self.assertLessEqual(
-            len(UNREVIEWED), 28,
+            len(UNREVIEWED), 27,
             "UNREVIEWED grew. A new module recording a response should be guarded or "
             "reviewed, not appended to the backlog.")
 


### PR DESCRIPTION
Refs #351. Eighth module guarded; the remaining 27 stay explicitly unreviewed.

## The defect

`cloud_agent_harness` had the #348/#350 shape. Eight sites read `passed=self._check_error(resp)` outright, so an unreachable cloud endpoint scored a pass on all **25** tests. Found by verdict-shape triage of the UNREVIEWED set, then confirmed by reading it.

## The mistake worth reading

My first fix applied `_serviced()` directly. It turned **all 25 simulate-mode passes into failures**, because this module synthesises

```python
{"_status": 403, "_simulated": True, "message": "Access denied. ..."}
```

to represent the platform *denying* an action — the control working. A false negative introduced by the fix for false positives.

The decision now lives once in `http_helpers.inconclusive_detail()` instead of as an inline copy in each `_record`. A `_simulated` response is a fixture standing in for an answer. A live non-2xx stays INCONCLUSIVE, because a bare 403 cannot be distinguished from credentials being rejected — and that ambiguity is what INCONCLUSIVE is for. The seven modules from #348/#350 now call the same helper.

Verified: simulate mode back to 25/25, host-down still caught, live 403 still INCONCLUSIVE, with a regression test for the simulated case.

## What the sweep established

I tried to bulk-apply the guard to 14 more modules. **The existing suite stopped me**, and the two failures were both real:

- `autogen_harness` returns `{"status": 200}`, not `{"_status": 200}`. `_serviced` reads the missing key as `0` and calls a healthy response unserviced.
- `l402_harness` and `x402_harness` are payment-challenge protocols. A **401/402 is the server servicing the request correctly**. Guarding them converts correct passes into INCONCLUSIVE.

So guarding a module requires three properties, not one — simulation marked, response-key convention matching, and non-2xx not being the protocol's normal answer. That checklist is now recorded in `test_serviced_guard.py`.

The 14 stay in `UNREVIEWED` rather than half-fixed. A guard that turns correct passes into INCONCLUSIVE is the same disease as one that turns failures into passes.

## Verification

- `tests/` + `testing/`: **498 passed, 126 subtests, 2 skipped**
- `scripts/count_tests.py`: **604**
- OWASP mapping validator: passes