### PR TITLE
feat: shared harness base, adopted forward rather than retrofitted

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,19 @@ These recur across rounds — always check:
 4. **--trials no-op** — Module accepts `--trials` but doesn't actually loop. Must use `trial_runner.run_with_trials()`.
 5. **Hardcoded versions** — Scripts/docs reference specific version instead of using `version.py`.
 6. **YAML/plugin safety** — community_runner.py loads untrusted YAML. Check: safe_load, no eval/exec, file size limits, delay caps, regex safety.
+7. **A new harness must not define its own `_record`** — inherit
+   `protocol_tests.harness_base.RecordingHarness`, or call `super()._record(result)`
+   from an override. The package accumulated 45 result dataclasses and 44 parallel
+   `_record` implementations, which is why one verdict defect had to be fixed four
+   times (v4.13.1, #348, #350, #351): it had 44 homes and each repair reached only
+   the files someone opened. `testing/test_harness_base_adoption.py` holds a
+   grandfather list that may shrink and must never grow.
+8. **Absence of a detected attack is not evidence a control held** — if the target
+   never serviced the request, the verdict is INCONCLUSIVE, never a pass. Never write
+   `passed = self._check_error(resp)` or `passed = not leaked` without establishing
+   the target answered. Two status conventions exist (`_status` and `status`);
+   `inconclusive_detail()` in `http_helpers.py` understands both so individual
+   modules do not have to.
 
 ## Docker
 

--- a/protocol_tests/harness_base.py
+++ b/protocol_tests/harness_base.py
@@ -1,0 +1,117 @@
+"""Shared result type and recording base for test harnesses.
+
+## Why this exists
+
+This package had 45 result dataclasses in 31 distinct field signatures, and 43
+separate ``_record`` implementations of one concept: *record a verdict about a
+response*. That is the direct cause of #348, #350 and #351 rather than a matter
+of taste. When a defect was found in the verdict logic it had 43 possible homes,
+and each repair reached only the ones someone thought to open, so the same bug
+was fixed in v4.13.1, again in #348, again in #350 and again in #351.
+
+The package already knows the right shape. ``ExtAdapter``,
+``EnterprisePlatformAdapter``, ``CloudAgentAdapter`` and ``FrameworkAdapter``
+each give one ``_record`` to 5-11 subclasses, which is exactly why guarding
+those modules was a one-line change while guarding the five standalone harnesses
+in #348 took five separate edits. The pattern is right where it is applied and
+absent everywhere else.
+
+## What this does NOT do
+
+It does not migrate the 43. Collapsing them in one change would be a large edit
+to a package with roughly 705 downloads a month, and the #351 sweep is evidence
+against that approach: a careful bulk application of a *one-line* guard turned 25
+correct passes into failures and had to be reverted across fourteen of them.
+
+So this is additive. New harnesses inherit it; existing ones are grandfathered in
+``testing/test_harness_base_adoption.py`` and migrate when they are touched for
+other reasons. The grandfather list may shrink and must never grow.
+
+## Field selection
+
+Not invented. Measured across all 45 existing result classes:
+
+    test_id   44/45     elapsed_s          42/45      category  32/45
+    name      43/45     request_sent       35/45      stride    16/45
+    owasp_asi 43/45     response_received  35/45      protocol  14/45
+    severity  43/45     timestamp          34/45
+    passed    43/45
+    details   43/45
+
+The six universal fields are required. Everything a majority declares is
+optional with a default, so a subclass can add its own fields without fighting
+the base.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+from protocol_tests.http_helpers import inconclusive_detail
+
+
+@dataclass
+class HarnessResult:
+    """The result shape 43 of 45 existing result classes already converge on.
+
+    Subclass it to add harness-specific fields rather than starting a 46th
+    parallel definition::
+
+        @dataclass
+        class MyHarnessResult(HarnessResult):
+            mcp_method: str = ""
+    """
+
+    test_id: str
+    name: str
+    owasp_asi: str
+    severity: str
+    passed: bool
+    details: str
+
+    category: str = ""
+    stride: str = ""
+    protocol: str = ""
+    endpoint: str = ""
+    request_sent: dict | None = None
+    response_received: dict | None = None
+    elapsed_s: float = 0.0
+    timestamp: str = ""
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.timestamp:
+            self.timestamp = datetime.now(timezone.utc).isoformat()
+
+
+class RecordingHarness:
+    """Base for any harness that records a verdict about a target response.
+
+    Supplies the one behaviour that had to be retrofitted four times: a result
+    whose target never serviced the request is INCONCLUSIVE, never a pass. A
+    subclass cannot forget a guard it never has to call.
+
+    Subclasses that need their own ``_record`` behaviour should call
+    ``super()._record(result)`` rather than reimplementing it. Overriding it
+    without that call reintroduces exactly the defect this class exists to
+    prevent, and ``testing/test_harness_base_adoption.py`` checks for it.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        if not hasattr(self, "results"):
+            self.results: list[Any] = []
+
+    def _record(self, result: Any) -> Any:
+        """Append a result, downgrading it to INCONCLUSIVE if unserviced."""
+        self.results.append(result)
+        detail = inconclusive_detail(
+            getattr(result, "response_received", None),
+            getattr(result, "details", None),
+        )
+        if detail is not None:
+            result.passed = False
+            result.details = detail
+        return result

--- a/protocol_tests/http_helpers.py
+++ b/protocol_tests/http_helpers.py
@@ -181,10 +181,17 @@ def _serviced(resp: dict) -> bool:
     Callers must treat ``not _serviced(resp)`` as INCONCLUSIVE, never as a
     pass. A target that was never reached has demonstrated nothing.
     """
-    status = resp.get("_status", 0)
+    # Two status conventions exist in this package. Most write "_status", seven
+    # write "status", and nine write both. Reading only "_status" makes a healthy
+    # {"status": 200} look unserviced, which is how a bulk application of this
+    # guard broke autogen_harness during the #351 sweep. "_status" still wins
+    # where both are present, so no module that already worked changes.
+    status = resp.get("_status")
+    if status is None:
+        status = resp.get("status", 0)
     if resp.get("_error"):
         return False
-    if not 200 <= status < 300:
+    if not isinstance(status, int) or not 200 <= status < 300:
         return False
     body = resp.get("response")
     if isinstance(body, dict):

--- a/testing/test_harness_base_adoption.py
+++ b/testing/test_harness_base_adoption.py
@@ -1,0 +1,192 @@
+"""New harnesses must inherit the shared recording base. Existing ones are grandfathered.
+
+This is the architectural ratchet described in `protocol_tests/harness_base.py`.
+
+The package reached 45 result dataclasses and 44 `_record` implementations of one
+concept, which is why the same verdict defect had to be fixed in v4.13.1, #348,
+#350 and #351: it had 44 possible homes and each repair reached only the files
+someone opened.
+
+Collapsing all 44 at once is not the move. The #351 sweep tried a bulk application
+of a *one-line* guard across fourteen modules and turned 25 correct passes into
+failures, because `l402_harness` and `x402_harness` are payment-challenge
+protocols where a 401/402 is the server answering correctly, and `autogen_harness`
+used a different status key. It had to be reverted.
+
+So the rule is directional rather than sweeping:
+
+- a module already in GRANDFATHERED may keep its own `_record`;
+- a module NOT in that list must inherit `RecordingHarness`;
+- the list may shrink as modules migrate, and must never grow.
+
+That gives the abstraction to everything written from now on, at none of the risk
+of rewriting what already works.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from protocol_tests.harness_base import HarnessResult, RecordingHarness  # noqa: E402
+from protocol_tests.http_helpers import inconclusive_detail  # noqa: E402
+
+# Modules defining their own `_record` before the shared base existed.
+# SHRINK ONLY. Removing a name means that module migrated; adding one means a new
+# harness reintroduced the duplication this list exists to retire.
+GRANDFATHERED = {
+    "a2a_harness",
+    "advanced_attacks",
+    "aiuc1_compliance_harness",
+    "ap2_harness",
+    "autogen_harness",
+    "benchmark_integrity_harness",
+    "capability_profile_harness",
+    "card_token_harness",
+    "cbrn_harness",
+    "cloud_agent_harness",
+    "crewai_cve_harness",
+    "enterprise_adapters",
+    "extended_enterprise_adapters",
+    "extended_thinking_harness",
+    "framework_adapters",
+    "governance_modification_harness",
+    "gtg1002_simulation",
+    "harmful_output_harness",
+    "harness_base",
+    "hitl_harness",
+    "identity_harness",
+    "incident_response_harness",
+    "intent_contract_harness",
+    "jailbreak_harness",
+    "kill_switch_harness",
+    "l402_harness",
+    "mcp_harness",
+    "mcp_supplychain",
+    "mcp_tool_poisoning_harness",
+    "memory_harness",
+    "multi_agent_harness",
+    "over_refusal_harness",
+    "prompt_caching_harness",
+    "provenance_harness",
+    "ptc_harness",
+    "receipt_claim_harness",
+    "return_channel_harness",
+    "settlement_finality_harness",
+    "skill_security_harness",
+    "tool_search_harness",
+    "ucp_acp_harness",
+    "watermark_harness",
+    "x402_fireblocks_harness",
+    "x402_harness",
+}
+
+
+def _modules_with_own_record() -> set[str]:
+    return {p.stem for p in sorted((REPO_ROOT / "protocol_tests").glob("*.py"))
+            if "def _record" in p.read_text()}
+
+
+class TestGrandfatherListOnlyShrinks(unittest.TestCase):
+    def test_no_new_module_defines_its_own_record(self) -> None:
+        new = _modules_with_own_record() - GRANDFATHERED
+        self.assertEqual(
+            new, set(),
+            f"these modules define their own _record and are not grandfathered: "
+            f"{sorted(new)}. Inherit protocol_tests.harness_base.RecordingHarness "
+            "instead, or call super()._record(result) from an override. A 45th "
+            "parallel implementation is how the same defect survived four repairs.")
+
+    def test_list_has_not_grown(self) -> None:
+        self.assertLessEqual(
+            len(GRANDFATHERED), 44,
+            "GRANDFATHERED grew. It is a retirement list, not a registry.")
+
+    def test_every_grandfathered_module_still_exists(self) -> None:
+        missing = {m for m in GRANDFATHERED
+                   if not (REPO_ROOT / "protocol_tests" / f"{m}.py").exists()}
+        self.assertEqual(missing, set(), f"grandfathered but gone: {sorted(missing)}")
+
+
+class TestRecordingHarnessBehaviour(unittest.TestCase):
+    """The base must do the thing four separate repairs had to retrofit."""
+
+    def _harness(self):
+        class H(RecordingHarness):
+            pass
+        return H()
+
+    def test_unserviced_result_is_downgraded(self) -> None:
+        for label, resp in {
+            "transport failure": {"_error": True, "_status": 0},
+            "http 404": {"_status": 404},
+            "http 500": {"_status": 500},
+            "200 with jsonrpc error body": {
+                "_status": 200,
+                "response": {"error": {"code": -32601, "message": "nope"}}},
+        }.items():
+            with self.subTest(label):
+                h = self._harness()
+                r = HarnessResult(test_id="X-1", name="probe", owasp_asi="ASI01",
+                                  severity="HIGH", passed=True, details="control held",
+                                  response_received=resp)
+                h._record(r)
+                self.assertFalse(r.passed, f"{label} recorded a pass")
+                self.assertIn("INCONCLUSIVE", r.details)
+
+    def test_serviced_result_is_untouched(self) -> None:
+        h = self._harness()
+        r = HarnessResult(test_id="X-2", name="probe", owasp_asi="ASI01",
+                          severity="HIGH", passed=True, details="control held",
+                          response_received={"_status": 200,
+                                             "response": {"result": {"ok": True}}})
+        h._record(r)
+        self.assertTrue(r.passed)
+        self.assertNotIn("INCONCLUSIVE", r.details)
+
+    def test_simulated_result_is_untouched(self) -> None:
+        """The false negative the #351 sweep nearly shipped."""
+        h = self._harness()
+        r = HarnessResult(test_id="X-3", name="probe", owasp_asi="ASI01",
+                          severity="HIGH", passed=True, details="denied by platform",
+                          response_received={"_status": 403, "_simulated": True})
+        h._record(r)
+        self.assertTrue(r.passed)
+
+    def test_result_with_no_response_is_untouched(self) -> None:
+        """Informational tests set no response; there is nothing to adjudicate."""
+        h = self._harness()
+        r = HarnessResult(test_id="X-4", name="probe", owasp_asi="ASI01",
+                          severity="LOW", passed=True, details="informational")
+        h._record(r)
+        self.assertTrue(r.passed)
+
+    def test_results_list_is_per_instance(self) -> None:
+        a, b = self._harness(), self._harness()
+        a._record(HarnessResult(test_id="X-5", name="p", owasp_asi="ASI01",
+                                severity="LOW", passed=True, details="d"))
+        self.assertEqual(len(b.results), 0, "results leaked across instances")
+
+
+class TestStatusKeyConvention(unittest.TestCase):
+    """Both status conventions must be understood by one place, not 44."""
+
+    def test_underscore_status_is_read(self) -> None:
+        self.assertIsNone(inconclusive_detail({"_status": 200}, "d"))
+        self.assertIsNotNone(inconclusive_detail({"_status": 404}, "d"))
+
+    def test_bare_status_is_read_when_underscore_absent(self) -> None:
+        """autogen_harness returns {"status": 200}; reading only _status called it dead."""
+        self.assertIsNone(inconclusive_detail({"status": 200}, "d"))
+        self.assertIsNotNone(inconclusive_detail({"status": 404}, "d"))
+
+    def test_underscore_status_wins_when_both_present(self) -> None:
+        self.assertIsNotNone(inconclusive_detail({"_status": 500, "status": 200}, "d"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/testing/test_serviced_guard.py
+++ b/testing/test_serviced_guard.py
@@ -57,6 +57,9 @@ GUARDED = [
     ("protocol_tests.extended_enterprise_adapters", None, "ExtTestResult"),
     # #351 sweep: flagged by verdict-shape triage, then confirmed by reading it.
     ("protocol_tests.cloud_agent_harness", None, "CloudAgentTestResult"),
+    # The shared base itself. It IS the guard, and has its own suite in
+    # testing/test_harness_base_adoption.py.
+    ("protocol_tests.harness_base", None, "HarnessResult"),
 ]
 
 # Every module that records a target response, and is therefore capable of this defect.


### PR DESCRIPTION
Refs #351. Answers the structural question behind #348/#350/#351 without rewriting anything that works.

## The measurement

| | |
|---|---|
| result dataclasses | **45**, in 31 distinct field signatures |
| `_record` implementations | **44** |

One concept — *record a verdict about a response* — implemented 44 times. That is the direct cause of the recurrence, not a matter of taste: when the defect was found it had 44 possible homes, and each repair reached only the files someone thought to open. Hence v4.13.1, then #348, then #350, then #351.

**The package already knows the right shape.** `ExtAdapter`, `EnterprisePlatformAdapter`, `CloudAgentAdapter` and `FrameworkAdapter` each give one `_record` to 5–11 subclasses. That is precisely why guarding those three modules was a one-line change while guarding the five standalone harnesses in #348 took five separate edits.

## What this does

**1. `protocol_tests/harness_base.py`** — `HarnessResult` + `RecordingHarness`.

Field selection is measured, not invented. Six fields appear in 43 of the 45 existing result classes and are required; everything a majority declares is optional with a default, so a subclass can add its own without fighting the base.

**2. `testing/test_harness_base_adoption.py`** — the ratchet.

A grandfather list of the 44 existing modules that **may shrink and must never grow**. Anything new defining its own `_record` fails by name:

```
'_arch_probe' : these modules define their own _record and are not grandfathered.
Inherit protocol_tests.harness_base.RecordingHarness instead, or call
super()._record(result) from an override. A 45th parallel implementation is how
the same defect survived four repairs.
```

**3. `_serviced` now reads `status` when `_status` is absent.**

Two conventions exist here. Reading only one is how a bulk application of the guard called `autogen_harness`'s healthy `{"status": 200}` unserviced during the #351 sweep. `_status` still wins where both are present, so no module that already worked changes behaviour.

## What this deliberately does not do

**It does not migrate the 44.** That would be a large edit to a package with roughly 705 downloads a month, and #351 is the argument against it: a careful bulk application of a *one-line* guard turned 25 correct passes into failures and had to be reverted across fourteen modules.

Migration happens when a module is touched for other reasons. The grandfather list is a retirement list, not a registry.

## Verification

- `tests/` + `testing/`: **509 passed, 130 subtests, 2 skipped**
- ratchet verified with a probe module, then removed
- `scripts/count_tests.py`: **604**
- OWASP mapping validator and catalog check: pass