### PR TITLE
docs: drop the stale count from the UNREVIEWED comment

### DIFF
--- a/testing/test_serviced_guard.py
+++ b/testing/test_serviced_guard.py
@@ -91,9 +91,13 @@ def _candidate_modules() -> set[str]:
 #      INCONCLUSIVE.
 #
 # Modules that record a response and have NOT been checked against all three. Listing them
-# is the honest state: #350 confirmed the defect in two of the 28 by reading them, so the
+# is the honest state: #350 confirmed the defect in two of them by reading them, so the
 # rest are unknown, not clean. Tracked in #351. Shrink this list by reviewing, never by
 # deleting entries.
+#
+# Deliberately no count here. The previous wording said "two of the 28", which went stale
+# the moment #355 guarded cloud_agent_harness and left the comment contradicting the
+# tripwire twelve lines below it. len(UNREVIEWED) is the number; do not restate it in prose.
 #
 # The point of enumerating them is the assertion below: candidates must equal
 # guarded + unreviewed exactly. A newly added harness lands in neither and fails the suite


### PR DESCRIPTION
`testing/test_serviced_guard.py` line 94 read:

> `#350` confirmed the defect in two of **the 28** by reading them

That number went stale when `#355` guarded `cloud_agent_harness`. The comment then contradicted the `test_unreviewed_does_not_grow` tripwire twelve lines below it, which pins **27**.

The fix removes the restated count rather than correcting it to 27. `len(UNREVIEWED)` is already the number; restating it in prose is what created the drift in the first place. A note records why the count is deliberately absent.

Found while grounding a public reply in [discussion #177](https://github.com/msaleme/red-team-blue-team-agent-fabric/discussions/177). `#351`'s body carried the same class of drift in five places (candidates 35→36, guarded seven→nine, unreviewed 28→27, tripwire 28→27, `_err` non-callers 29→28, plus `cloud_agent_harness` still listed) and was corrected directly.

Verified: `testing/test_serviced_guard.py` passes 9 tests, 53 subtests. Comment-only change, no behaviour touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)