### PR TITLE
docs: Roadmap said Current: v4.13.1, and had no v4.15.0 row at all

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 **Even if an agent is properly authenticated and authorized, can it still be manipulated into unsafe or policy-violating behavior?**
 
-604 executable security tests across 44 modules (verified 2026-08-02 via `scripts/count_tests.py`). MCP + A2A + L402 + x402 wire-protocol testing, plus UCP/ACP merchant-journey, AP2 mandate-chain, Fireblocks x402 hardening, Visa TAP / Mastercard Agentic Token funding-instrument, and denial-of-settlement finality conformance across the full agentic-payments stack. Decision-layer attack scenarios. One `pip install` away.
+604 executable security tests across 44 modules on `main` (verified 2026-08-08 via `scripts/count_tests.py`; the v4.15.0 release carries 603). MCP + A2A + L402 + x402 wire-protocol testing, plus UCP/ACP merchant-journey, AP2 mandate-chain, Fireblocks x402 hardening, Visa TAP / Mastercard Agentic Token funding-instrument, and denial-of-settlement finality conformance across the full agentic-payments stack. Decision-layer attack scenarios. One `pip install` away.
 
 ```
 $ agent-security test mcp --url http://localhost:8080/mcp
@@ -254,12 +254,17 @@ The [constitutional-agent](https://github.com/CognitiveThoughtEngine/constitutio
 
 ## Roadmap
 
-**Current: v4.13.1** (2026-08-02). Recent shipped work — v4.5 skill supply chain and governance
+**Current: v4.15.0** (2026-08-07). Recent shipped work — v4.5 skill supply chain and governance
 modification · v4.6–v4.9 payment-stack depth (AP2 mandate chain, UCP/ACP merchant journey, card-network
 agentic tokens, settlement finality, Fireblocks x402) · v4.10 benchmark integrity · v4.11–v4.12
 decision-governance corpus currency and provenance repair · **v4.13 OWASP Agentic v1.1 T1–T17 coverage
-mapping and the human-in-the-loop harness** · **v4.13.1 a correctness fix to that harness** (see
+mapping and the human-in-the-loop harness** · v4.13.1 a correctness fix to that harness · v4.14.0
+endpoint provenance · **v4.15.0 unserviced requests are no longer recorded as passes** (see
 [CHANGELOG.md](CHANGELOG.md)).
+
+The release carries **603** tests; `main` is at **604**, which is MAG-019 landing after the tag. Both
+are correct for their own ref, and `scripts/check_public_metadata.py` compares public claims against
+the release rather than against `main` for exactly that reason.
 
 **Next — Standards & Evidence.** Reproducible settlement-time payment evidence, a methodology paper,
 and the attestation/evidence schema submitted to a standards venue. Coverage breadth and test count are

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -56,6 +56,7 @@ Dates and themes below are reconciled against `CHANGELOG.md`, which is authorita
 | **v4.13.0 — OWASP Agentic v1.1** | 2026-08-02 | T1–T17 commit-pinned coverage mapping, selector tooling, HITL harness (T10/T15) | Shipped |
 | **v4.13.1 — HITL correctness** | 2026-08-02 | All 8 HITL tests could record a verdict against a target that never serviced the request; `_serviced()` guard added | Shipped |
 | **v4.14.0 — Endpoint provenance** | 2026-08-05 | Removed fabricated default registry/telemetry endpoints pointing at domains this project never owned; both env vars now required; attestation independence claim corrected to "tested with" | Shipped |
+| **v4.15.0 — Unserviced requests are not passes** | 2026-08-07 | Seven modules recorded a `PASS` when the target never serviced the request; guard promoted to `http_helpers` and applied at each recording path. No test added or removed, count unchanged at 603 | Shipped |
 | **Next — Standards & Evidence** | — | Reproducible settlement-time payment evidence; methodology paper; schema as a standards-body informational draft | In progress |
 
 **Known gaps, stated rather than deferred.** T16-S1 (consent-flow manipulation) and T10-S1/T10-S3


### PR DESCRIPTION
Two releases had shipped since that marker was written. `ROADMAP.md`'s release history also **stopped at v4.14.0**, so the current release was missing from the table whose job is recording releases.

## Changes

- `ROADMAP.md`: adds the **v4.15.0** row, dated and described from the release notes.
- `README.md`: **Current: v4.13.1 → v4.15.0** (2026-08-07), with v4.14.0 and v4.15.0 added to the shipped-work line.

## The 603/604 split is now stated, not left to be discovered

v4.15.0 carries **603**; `main` carries **604**, the difference being MAG-019 landing after the tag. Both are correct for their own ref, and seeing either alone invites the conclusion that the other is wrong.

The README headline now says which ref it describes and names the other, and the Roadmap section explains why `check_public_metadata.py` compares public claims against the release rather than `main`.

Count-provenance date moved 2026-08-02 → 2026-08-08, since that is when it was last actually executed.

## Left alone deliberately

Historical `v4.13.1` references in ROADMAP rows, CHANGELOG, module comments and the OWASP coverage limitations. Those record **when something happened** and are not stale.

**420 passed, 130 subtests.** `check_public_metadata.py` still reports `OK` at the release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)