### PR TITLE
fix: the metadata workflow would have failed on its first run

### DIFF
--- a/.github/workflows/public-metadata.yml
+++ b/.github/workflows/public-metadata.yml
@@ -1,11 +1,14 @@
 name: Public metadata drift
 
-# The GitHub description is a claim about the latest published release, not about
-# main, so this checks out the latest release tag before comparing. Running it
-# against main would fail every time main is legitimately ahead of the release.
+# The GitHub description, the two remote READMEs and CITATION.cff are claims
+# about the latest published RELEASE, not about main, so this checks out the
+# latest release tag before comparing. Running against main would fail every
+# time main is legitimately ahead.
 #
-# Triggers: on release (the moment the claim can go stale), weekly (to catch a
-# description edited by hand afterwards), and manually.
+# The checker itself must survive that checkout. It was added AFTER v4.15.0,
+# so it does not exist at the tag, and the first version of this workflow would
+# have failed on its first scheduled run with a file-not-found. It never
+# surfaced because the workflow had not yet run. See the "Preserve" step below.
 
 on:
   release:
@@ -25,22 +28,34 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Copied out before the checkout and back in after it. The tag is
+      # immutable, so the checker can never be added to an already-cut release.
+      - name: Preserve the metadata checker
+        run: cp scripts/check_public_metadata.py "$RUNNER_TEMP/check_public_metadata.py"
+
       - name: Check out the latest release tag
         run: |
           TAG=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
           if [ -z "$TAG" ]; then
-            echo "No release tag found; nothing to compare a release-facing description against."
+            echo "No release tag found; nothing to compare a release-facing claim against."
             exit 0
           fi
           echo "Comparing against $TAG"
           echo "TAG=$TAG" >> "$GITHUB_ENV"
           git checkout -q "$TAG"
+          cp "$RUNNER_TEMP/check_public_metadata.py" scripts/check_public_metadata.py
+
+      # Fail loudly and specifically rather than with a file-not-found further down.
+      - name: Verify the checker survived the checkout
+        run: |
+          test -f scripts/check_public_metadata.py \
+            || { echo "::error::checker missing after checkout of $TAG; the Preserve step did not run"; exit 1; }
 
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 
-      - name: Compare description against the tree at ${{ env.TAG }}
+      - name: Compare public claims against the tree at ${{ env.TAG }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python3 scripts/check_public_metadata.py --repo "${{ github.repository }}"

--- a/testing/test_public_metadata_check.py
+++ b/testing/test_public_metadata_check.py
@@ -11,6 +11,7 @@ times (v4.13.1, #348, #350, #351, #355), so it is asserted here explicitly.
 from __future__ import annotations
 
 import importlib.util
+import re
 import sys
 import unittest
 import urllib.error
@@ -196,3 +197,57 @@ class TestCitationFields(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestWorkflowPreservesChecker(unittest.TestCase):
+    """The workflow checks out a release tag, and the checker is not in it.
+
+    scripts/check_public_metadata.py was added in #360, after v4.15.0 was cut.
+    A tag is immutable, so the checker can never be present in an
+    already-released tag. The first version of this workflow checked out the tag
+    and then ran the script from it, which would have failed with a
+    file-not-found on its first scheduled run. It never surfaced because the
+    workflow had not run yet, and every manual verification copied the script
+    into the worktree by hand, so none of them exercised the real path.
+    """
+
+    WORKFLOW = REPO_ROOT / ".github" / "workflows" / "public-metadata.yml"
+
+    def setUp(self) -> None:
+        self.text = self.WORKFLOW.read_text(encoding="utf-8")
+
+    def test_workflow_exists(self) -> None:
+        self.assertTrue(self.WORKFLOW.is_file())
+
+    def test_checker_is_copied_out_before_the_tag_checkout(self) -> None:
+        preserve = self.text.find("RUNNER_TEMP/check_public_metadata.py")
+        checkout = self.text.find("git checkout -q \"$TAG\"")
+        self.assertNotEqual(preserve, -1, "workflow must preserve the checker across checkout")
+        self.assertNotEqual(checkout, -1, "workflow must check out the release tag")
+        self.assertLess(preserve, checkout,
+                        "the checker must be copied out BEFORE the tag is checked out")
+
+    def test_checker_is_restored_after_the_tag_checkout(self) -> None:
+        checkout = self.text.find("git checkout -q \"$TAG\"")
+        restore = self.text.find('cp "$RUNNER_TEMP/check_public_metadata.py" scripts/')
+        self.assertNotEqual(restore, -1, "workflow must restore the checker after checkout")
+        self.assertLess(checkout, restore,
+                        "the checker must be copied back AFTER the tag is checked out")
+
+    def test_workflow_verifies_the_checker_survived(self) -> None:
+        """A missing checker must fail with a named error, not file-not-found."""
+        self.assertIn("test -f scripts/check_public_metadata.py", self.text)
+
+    def test_checker_is_absent_from_the_latest_release_tag(self) -> None:
+        """The premise. If this ever fails, the preserve dance is unnecessary."""
+        import subprocess
+        tags = subprocess.run(["git", "tag", "--sort=-v:refname"],
+                              capture_output=True, text=True, cwd=REPO_ROOT).stdout.split()
+        tag = next((t for t in tags if re.fullmatch(r"v\d+\.\d+\.\d+", t)), None)
+        if not tag:
+            self.skipTest("no release tag")
+        present = subprocess.run(
+            ["git", "cat-file", "-e", f"{tag}:scripts/check_public_metadata.py"],
+            capture_output=True, cwd=REPO_ROOT).returncode == 0
+        self.assertFalse(present,
+                         f"checker now exists at {tag}; the preserve step can be simplified")


### PR DESCRIPTION
The workflow checks out the latest release tag and then runs `scripts/check_public_metadata.py` **from it**. That script was added in #360, *after* v4.15.0 was cut, so it does not exist at the tag — and a tag is immutable, so it never can.

First scheduled run is **Monday 2026-08-10 13:17 UTC**. It would have failed with a file-not-found.

Reproduced before fixing:

```
$ git worktree add /tmp/x v4.15.0 && cd /tmp/x
$ python3 scripts/check_public_metadata.py
can't open file '/tmp/x/scripts/check_public_metadata.py'
```

GitHub reports **zero runs** for this workflow, which is why it had not surfaced operationally.

## Why my own verification missed it

Every time I checked this *"at the release tag, as the workflow runs it"*, I copied the script into the worktree first. **That is precisely what the workflow did not do.** None of those checks exercised the real path — I validated a procedure I was not running.

## Fix

Checker copied to `$RUNNER_TEMP` before the checkout and restored after, plus a verify step that fails with a named error instead of a file-not-found further down.

**Five tests guard it:** copy-out precedes checkout, restore follows it, the verify step exists, and the *premise* is pinned — if the checker ever does exist at the latest tag, the test says the preserve dance can be simplified rather than leaving it in place forever.

Simulated the exact workflow path with no manual copy:

```
OK  description, CITATION.cff and 2 remote READMEs match the tree
    (603 tests, 43 modules, v4.15.0)
```

**426 passed, 130 subtests.**

Credit to the reviewing agent for catching this before Monday.

🤖 Generated with [Claude Code](https://claude.com/claude-code)