### PR TITLE
Specify the attestation registry server contract (#333)

### DIFF
--- a/docs/ATTESTATION-REGISTRY-SERVER-CONTRACT.md
+++ b/docs/ATTESTATION-REGISTRY-SERVER-CONTRACT.md
@@ -1,0 +1,319 @@
+# Attestation Registry Server Contract
+
+Status: draft, resolves #333. Related: #114, #137, `docs/EVIDENCE-CLASS-TAXONOMY.md`,
+`docs/attestation-registry.md`, `protocol_tests/attestation_registry.py`.
+
+This document specifies the **receiving** half of the attestation registry. The client half
+already exists and ships. What did not exist, until this document, was any statement of what
+a server must do, which meant no second organization could stand one up and no third party
+could check a record without asking the operator to vouch for it.
+
+**This project operates no registry.** It specifies one. That distinction is load-bearing and
+is repeated in the design rules below.
+
+---
+
+## 1. What a submission establishes
+
+A submission establishes **I0** under `docs/EVIDENCE-CLASS-TAXONOMY.md`, and nothing more,
+**regardless of which organization submitted it**.
+
+The submitter ran a harness they obtained, against a target they control, and authored the
+oracle. Routing that result through a server does not change who produced the oracle. A
+registry that presents a submission as third-party verification manufactures independence it
+never measured, which is the exact failure the taxonomy exists to prevent.
+
+Two consequences bind the rest of this contract:
+
+- Every stored record MUST carry an explicit `evidence_class` and `independence_level`, and
+  MUST name the **system under test** the level is relative to. An I-level without a named
+  system under test is not a claim, because the axis is relative (see the taxonomy's
+  "Relative independence in practice"). A registry that stores a bare `"I0"` has stored
+  nothing checkable.
+- A server MUST NOT emit language of the form "verified", "certified", "approved", or
+  "independently confirmed" for a submitted record. The shipping client already enforces the
+  correct label on the badge it generates: `Tested with Agent Security Harness`. A server
+  MUST NOT serve a badge whose text asserts more than that.
+
+Raising a record above I0 requires a **separate** record produced by a different party from
+the specification rather than from the code (I1), or a channel the system under test does not
+author (I2). Those are different submissions with their own provenance, not a status flag an
+operator can set. See §7.
+
+## 2. Design rules
+
+**R1. No default endpoint. Ever.**
+`resolve_registry_endpoint()` requires `AGENT_SECURITY_REGISTRY_URL` and has no fallback. That
+absence is a security property, not an oversight. Until 2026-08-04 this client defaulted to a
+hostname the project did not own, and every publish with no override posted a signed
+attestation, including an optional user-supplied contact email, to a third party. A conforming
+server MUST NOT be published as a well-known host, MUST NOT be baked into a client default,
+and MUST NOT be advertised in a way that invites one. Operators configure their own.
+
+**R2. A verifier must never need to trust the operator.**
+Every guarantee in §5 is checkable from the bytes the server returns, offline, without a second
+call to that server. Where the current wire format does not permit this, §4.1 says so plainly
+rather than papering over it.
+
+**R3. Do not fork the schema.**
+`schemas/attestation-report.json` is the payload format and #137 targets it at a standards
+venue. A server MUST accept a report that validates against that schema and MUST NOT require
+registry-specific fields inside `payload.report`. Registry-specific metadata lives in the
+envelope, outside the report.
+
+**R4. Contract before UI.**
+Per `ROADMAP.md`, the evidence artifact is the product. A conforming server needs three
+endpoints. A browsable index, search, or dashboard is out of scope and MUST NOT be a
+precondition for conformance.
+
+**R5. Targets are not identifiable.**
+The client's `strip_sensitive_fields()` removes any key matching `url`, `endpoint`, `host`,
+`address`, or `path` as a substring, plus an explicit list including `request_sent`,
+`response_received`, `headers`, `auth_token`, and `api_key`. A server MUST reject a submission
+whose `payload.report` still contains such a key (§5.4). This is defense in depth: the client
+already stripped them, so their presence means the submission did not come from a conforming
+client.
+
+## 3. Endpoints
+
+A conforming server exposes exactly three. `{base}` is the value of
+`AGENT_SECURITY_REGISTRY_URL`.
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `POST` | `{base}` | Accept a submission envelope. Returns `{"id": "..."}`. |
+| `GET` | `{base}/{registry_id}` | Return the stored record. |
+| `GET` | `{base}/badge/{registry_id}` | Return a badge image. |
+
+These paths are not chosen; they are what the shipping client already calls. `publish_attestation()`
+POSTs to `{base}` itself, `verify_attestation()` GETs `{base}/{registry_id}`, and the badge URL is
+built as `{scheme}://{netloc}/badge/{registry_id}`.
+
+Note that the badge URL derives from **scheme and netloc only**, discarding any path component
+of `{base}`. A server mounted at `https://example.org/registry` will receive badge requests at
+`https://example.org/badge/{id}`. A server SHOULD mount at the origin root, or serve
+`/badge/{id}` at the origin in addition to its path prefix.
+
+`registry_id` MUST match `^[A-Za-z0-9\-]+$`. The client validates this before URL construction
+and a server MUST re-validate rather than rely on it.
+
+## 4. The submission envelope
+
+What the shipping client POSTs, verbatim:
+
+```json
+{
+  "payload": {
+    "server_name": "<string, ^[A-Za-z0-9\\-\\. ]+$, max 200>",
+    "contact": "<email or null>",
+    "report": { "...": "attestation report, sensitive fields stripped" },
+    "published_at": "<YYYY-MM-DDTHH:MM:SSZ>"
+  },
+  "signature": "<Ed25519 signature over the canonical payload bytes>",
+  "verification_hash": "<sha256 hex of the canonical payload bytes>",
+  "public_key_fingerprint": "<first 16 hex chars of sha256 of the signer's public key PEM>"
+}
+```
+
+### 4.1 Canonical payload bytes
+
+The signature and `verification_hash` are computed over:
+
+```python
+json.dumps(payload_dict, sort_keys=True).encode()
+```
+
+**Default separators.** That is `", "` and `": "`, not the compact form. This has never been
+written down anywhere, and it is the single most likely cause of an independent
+reimplementation failing to verify a signature it should accept. It is pinned here because a
+canonicalization that lives only in one implementation is not a contract.
+
+This basis sorts keys and does not define duplicate-key rejection, Unicode normalization, or
+number normalization. Do not relabel it RFC 8785 / JCS. If a future revision moves to JCS, the
+envelope MUST carry a version discriminator and both sides MUST be updated together.
+
+### 4.2 Known gap: the envelope cannot be verified as specified
+
+**The submission carries `public_key_fingerprint` but never the public key.**
+
+A fingerprint is `sha256(public_key_pem)[:16]`. From it, a verifier can confirm that a key they
+already hold is the right one. They cannot recover the key, and therefore cannot check the
+Ed25519 signature. Any third party who fetches a record from a registry today can verify the
+`verification_hash` against the payload bytes, which proves only internal consistency, and can
+verify nothing about **who** signed it.
+
+That defeats R2. An operator could store a payload they authored, compute a matching hash
+themselves, and serve a record indistinguishable from a genuine one.
+
+**Required client change.** The submission envelope gains `public_key`, carrying the signer's
+PEM-encoded Ed25519 public key, and an `envelope_version` discriminator:
+
+```json
+{
+  "envelope_version": "2",
+  "payload": { "...": "unchanged" },
+  "signature": "...",
+  "verification_hash": "...",
+  "public_key": "-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----\n",
+  "public_key_fingerprint": "..."
+}
+```
+
+`public_key_fingerprint` is retained and MUST equal `sha256(public_key)[:16]`, so a server can
+reject a mismatched pair and existing consumers of the field keep working.
+
+A server MUST accept `envelope_version: "2"`. A server MAY accept an envelope with no
+`envelope_version` and no `public_key` for compatibility with the currently shipping client,
+and if it does, it MUST mark the stored record `signature_verifiable: false`. A record that
+cannot be verified without the operator MUST say so about itself.
+
+This gap is a finding about the existing client, not a design choice. It is filed rather than
+silently fixed here because the client change belongs in its own reviewed commit.
+
+## 5. Server obligations on POST
+
+In order. Any failure is a rejection; a server MUST NOT store a partially validated record.
+
+1. **Shape.** `payload`, `signature`, `verification_hash` present. `payload.server_name` and
+   `payload.published_at` present. Reject with `400` otherwise.
+2. **Field validation.** `server_name` against `^[A-Za-z0-9\-\. ]+$`, max 200 chars. `contact`,
+   if non-null, against `^[^@\s]+@[^@\s]+\.[^@\s]+$`, max 200. These mirror the client's
+   validators; a server that trusts the client to have run them is trusting an unauthenticated
+   party.
+3. **Hash.** Recompute the canonical bytes per §4.1 and confirm `verification_hash` matches.
+   Reject with `400` on mismatch. This catches transport corruption and re-serialization
+   damage, and nothing else.
+4. **Sensitive-field scan.** Walk `payload.report` and reject with `422` if any key matches the
+   client's sensitive set. A submission that still contains a `target_url` did not come from a
+   conforming client, and storing it would publish infrastructure the submitter did not intend
+   to publish.
+5. **Schema.** Validate `payload.report` against `schemas/attestation-report.json`. Reject with
+   `422` on failure. Do not require fields the schema does not require (R3).
+6. **Signature.** If `public_key` is present, verify the Ed25519 signature over the canonical
+   bytes and reject with `400` if it fails. If absent, store `signature_verifiable: false`
+   (§4.2). A server MUST NOT report a record as signature-verified when it never checked one.
+7. **Classification.** Store `independence_level: "I0"` and the named system under test. A
+   server MUST NOT accept a submitter-supplied level above I0 (§7).
+8. **Assign an id.** Any string matching `^[A-Za-z0-9\-]+$`. Using `verification_hash[:12]` is
+   RECOMMENDED because it makes the id derivable from the record, and the client already falls
+   back to exactly that value when a response omits `id`.
+
+Response is `201` with at minimum `{"id": "<registry_id>"}`. A server MAY return the full
+stored record.
+
+**Idempotency.** Two submissions with equal `verification_hash` are the same record. A server
+SHOULD return the existing id with `200` rather than creating a duplicate.
+
+## 6. Server obligations on GET
+
+`GET {base}/{registry_id}` returns the stored record. It MUST include everything an offline
+verifier needs:
+
+```json
+{
+  "id": "...",
+  "payload": { "...": "byte-identical to what was submitted" },
+  "signature": "...",
+  "verification_hash": "...",
+  "public_key": "...",
+  "public_key_fingerprint": "...",
+  "envelope_version": "2",
+  "signature_verifiable": true,
+  "evidence_class": "E1",
+  "independence_level": "I0",
+  "system_under_test": "<name the level is relative to>",
+  "received_at": "<server timestamp, RFC 3339>",
+  "claim_label": "Tested with Agent Security Harness"
+}
+```
+
+`payload` MUST round-trip to the same canonical bytes that were signed. A server that
+normalizes, reorders, or re-encodes `payload` destroys the signature and breaks every
+downstream verification. Store the payload; do not improve it.
+
+`received_at` is the server's own observation and is **not** signed by the submitter. It is
+therefore an operator claim, and a verifier MUST treat it as such. Only `payload.published_at`
+is inside the signature.
+
+## 7. Independence is a separate record, not a flag
+
+A server MUST NOT expose an endpoint, field, or administrative action that raises a record's
+`independence_level`.
+
+An I1 claim is a distinct submission: a second party reproduced a pinned corpus using an
+implementation written from the published contract rather than from this code, and their
+result is its own record with its own signature. The relationship between the two records is
+expressed by the reproducer referencing the original's `verification_hash` inside their own
+signed payload, so the link is inside the signature rather than asserted by the operator.
+
+`#304` is the shape of a real I1 event: an outside party reproduced 11/11 RCL verdicts and
+surfaced two fixture-contract defects the author had not declared. Note what made it evidence.
+Not that it agreed, but that it **disagreed in two places**. A registry that only records
+agreement is measuring the wrong thing, so a conforming server MUST accept and serve records
+whose result is a mismatch, and MUST NOT rank, hide, or filter them relative to agreeing
+records.
+
+## 8. Operating posture
+
+Hosting a registry is an operational commitment: availability, data handling for the optional
+contact email, and a retention answer. **Self-hosted-only is a conforming answer, and is the
+default this project recommends.** An operator running one for their own organization owes
+their submitters a stated retention period and a deletion path; the contract does not require
+either of those to be public, only to exist.
+
+If an operator publishes a registry for others, they SHOULD state: retention period, deletion
+path, whether `contact` is served publicly, and their answer to §4.2 (whether unverifiable
+records are accepted). None of that is checkable by a verifier, which is the point of R2:
+nothing in §5 or §6 requires trusting the answer.
+
+## 9. Verification without trusting the operator
+
+The full offline path, given a record fetched from any registry:
+
+1. Recompute the canonical bytes from `payload` per §4.1.
+2. Confirm `sha256(bytes).hexdigest() == verification_hash`. Establishes internal consistency.
+3. Confirm `sha256(public_key)[:16] == public_key_fingerprint`. Establishes the key matches its
+   advertised fingerprint.
+4. Verify `signature` over the bytes with `public_key`. Establishes that the holder of that key
+   signed this payload.
+5. Independently establish that the key belongs to who you think it does. **The registry cannot
+   help with this and MUST NOT claim to.** Key-to-identity binding is out of scope for this
+   contract; a verifier gets it from the submitter directly, from a published fingerprint, or
+   not at all.
+6. Read `independence_level` and `system_under_test`. If the level is I0, the record is
+   self-authored evidence and steps 1 through 4 do not change that. They prove the record was
+   not altered. They prove nothing about the target.
+
+Step 6 is the one most likely to be skipped by a reader who watched the first five succeed. A
+cryptographically impeccable I0 record is still a vendor testing itself.
+
+`scripts/verify_attestation_record.py` implements steps 1 through 4 and prints step 6 as a
+statement rather than a check.
+
+## 10. Reference implementation
+
+`scripts/registry_reference_server.py`, Python standard library only, single file, in-memory
+store. It is a conformance reference, not a deployment target: no persistence, no auth, no
+TLS, no rate limiting.
+
+```bash
+python3 scripts/registry_reference_server.py --port 8787
+export AGENT_SECURITY_REGISTRY_URL="http://localhost:8787"
+```
+
+`localhost` is permitted by the client's https-or-localhost guard, so the loop is runnable
+end to end offline.
+
+## Conformance checklist
+
+- [ ] `POST {base}` performs all eight checks in §5 in order
+- [ ] Rejects a submission whose `verification_hash` does not match the canonical bytes
+- [ ] Rejects a report containing a sensitive key
+- [ ] Verifies the Ed25519 signature when `public_key` is present
+- [ ] Marks `signature_verifiable: false` when it is absent, rather than omitting the question
+- [ ] Stores `independence_level: "I0"` and a named `system_under_test`
+- [ ] Exposes no mechanism to raise `independence_level`
+- [ ] Returns `payload` byte-identically, so the signature still verifies
+- [ ] Serves `/badge/{id}` with claim text no stronger than "Tested with Agent Security Harness"
+- [ ] Accepts and serves records whose result is a mismatch, unranked
+- [ ] Is not published as a well-known host and is not a client default

--- a/docs/attestation-registry.md
+++ b/docs/attestation-registry.md
@@ -13,8 +13,8 @@
 > See `CHANGELOG.md` for the disclosure.
 >
 > **A registry you control is the only supported deployment.** See
-> [Self-Hosted Registry](#self-hosted-registry). The server contract is being
-> specified in #333.
+> [Self-Hosted Registry](#self-hosted-registry). The server contract is published in
+> [ATTESTATION-REGISTRY-SERVER-CONTRACT.md](ATTESTATION-REGISTRY-SERVER-CONTRACT.md).
 >
 > Everything below describes a client that is implemented and a server you host.
 
@@ -228,7 +228,29 @@ export AGENT_SECURITY_REGISTRY_URL=https://your-internal-registry.example.com/v1
 The client validates that the URL is `https://`, or `http://` for `localhost`,
 `127.0.0.1`, and `::1` during development.
 
-The server contract is not yet published. #333 tracks specifying it, including what
-is submitted, what a submission establishes, and how a third party verifies an entry
-without trusting the registry operator. Until that lands, a self-hosted server has to
-be written against `protocol_tests/attestation_registry.py` directly.
+The server contract is published at
+[ATTESTATION-REGISTRY-SERVER-CONTRACT.md](ATTESTATION-REGISTRY-SERVER-CONTRACT.md).
+It specifies what is submitted, what a submission establishes, and how a third party
+verifies an entry without trusting the registry operator.
+
+A runnable reference implementation ships with the harness:
+
+```bash
+python3 scripts/registry_reference_server.py --port 8787
+export AGENT_SECURITY_REGISTRY_URL="http://localhost:8787"
+```
+
+It is a conformance reference, not a deployment target: in-memory, no auth, no TLS.
+Verify any record you are given, from any registry, without contacting that registry
+again:
+
+```bash
+curl -s "$AGENT_SECURITY_REGISTRY_URL/<id>" \
+  | python3 scripts/verify_attestation_record.py -
+```
+
+**Known gap.** The submission envelope currently carries `public_key_fingerprint` but
+not the public key, so a third party cannot check the Ed25519 signature on a record
+published by today's client. Section 4.2 of the contract specifies `envelope_version`
+2, which adds `public_key`. Until the client emits it, records are stored with
+`signature_verifiable: false` and the verifier exits non-zero on them, by design.

--- a/scripts/registry_reference_server.py
+++ b/scripts/registry_reference_server.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""Reference attestation registry server (#333).
+
+Implements docs/ATTESTATION-REGISTRY-SERVER-CONTRACT.md. Python standard library
+only, except that Ed25519 verification uses `cryptography` when available -- the
+same dependency the publishing client already needs to sign.
+
+This is a CONFORMANCE REFERENCE, not a deployment target. No persistence, no
+auth, no TLS, no rate limiting, in-memory store. Run it to check a client or a
+second server implementation against the contract.
+
+    python3 scripts/registry_reference_server.py --port 8787
+    export AGENT_SECURITY_REGISTRY_URL="http://localhost:8787"
+
+This project operates no registry. See rule R1 in the contract: there is no
+well-known host and this server must not become one.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+try:  # optional: only needed to actually verify a signature
+    from cryptography.hazmat.primitives.serialization import load_pem_public_key
+    from cryptography.exceptions import InvalidSignature
+    _CRYPTO = True
+except ImportError:  # pragma: no cover - environment dependent
+    _CRYPTO = False
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = REPO_ROOT / "schemas" / "attestation-report.json"
+
+# Mirrors protocol_tests/attestation_registry.py. Duplicated deliberately: a
+# server must not import the client to decide whether the client behaved.
+SENSITIVE_FIELDS = frozenset({
+    "request_sent", "response_received", "raw_request", "raw_response",
+    "headers", "auth_token", "api_key", "target_url", "url", "endpoint",
+})
+SENSITIVE_SUBSTRINGS = ("url", "endpoint", "host", "address", "path")
+
+SERVER_NAME_RE = re.compile(r"^[A-Za-z0-9\-\. ]+$")
+EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+REGISTRY_ID_RE = re.compile(r"^[A-Za-z0-9\-]+$")
+
+CLAIM_LABEL = "Tested with Agent Security Harness"
+
+# Contract section 4.1. Default separators, NOT compact. Changing this silently
+# invalidates every signature ever produced by the shipping client.
+def canonical_bytes(payload: dict) -> bytes:
+    return json.dumps(payload, sort_keys=True).encode()
+
+
+def is_sensitive_key(key: str) -> bool:
+    if key in SENSITIVE_FIELDS:
+        return True
+    lowered = key.lower()
+    return any(s in lowered for s in SENSITIVE_SUBSTRINGS)
+
+
+def find_sensitive_keys(obj, path="report") -> list[str]:
+    found = []
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            if is_sensitive_key(key):
+                found.append(f"{path}.{key}")
+            else:
+                found.extend(find_sensitive_keys(value, f"{path}.{key}"))
+    elif isinstance(obj, list):
+        for i, item in enumerate(obj):
+            found.extend(find_sensitive_keys(item, f"{path}[{i}]"))
+    return found
+
+
+def load_schema_required() -> list[str]:
+    """Required top-level keys of the attestation report.
+
+    Deliberately a required-key check, not full JSON Schema validation: the repo
+    has no jsonschema dependency and a server that claims schema validation it
+    does not perform is the same class of defect as claiming a signature check it
+    skipped. A production server SHOULD validate fully.
+    """
+    try:
+        return json.loads(SCHEMA_PATH.read_text()).get("required", [])
+    except (OSError, json.JSONDecodeError):
+        return []
+
+
+class Store:
+    def __init__(self) -> None:
+        self._by_id: dict[str, dict] = {}
+        self._by_hash: dict[str, str] = {}
+
+    def get(self, registry_id: str) -> dict | None:
+        return self._by_id.get(registry_id)
+
+    def existing_id_for(self, verification_hash: str) -> str | None:
+        return self._by_hash.get(verification_hash)
+
+    def put(self, record: dict) -> str:
+        registry_id = record["id"]
+        self._by_id[registry_id] = record
+        self._by_hash[record["verification_hash"]] = registry_id
+        return registry_id
+
+
+class Rejected(Exception):
+    def __init__(self, status: int, reason: str) -> None:
+        super().__init__(reason)
+        self.status = status
+        self.reason = reason
+
+
+def validate_and_build(submission: dict, required_keys: list[str]) -> dict:
+    """Contract section 5. Eight checks, in order. Raises Rejected."""
+    # 1. Shape
+    if not isinstance(submission, dict):
+        raise Rejected(400, "submission must be a JSON object")
+    payload = submission.get("payload")
+    signature = submission.get("signature")
+    verification_hash = submission.get("verification_hash")
+    if not isinstance(payload, dict):
+        raise Rejected(400, "missing or non-object 'payload'")
+    if not isinstance(signature, str) or not signature:
+        raise Rejected(400, "missing 'signature'")
+    if not isinstance(verification_hash, str) or not verification_hash:
+        raise Rejected(400, "missing 'verification_hash'")
+    server_name = payload.get("server_name")
+    if not isinstance(server_name, str) or not server_name:
+        raise Rejected(400, "missing 'payload.server_name'")
+    if not isinstance(payload.get("published_at"), str):
+        raise Rejected(400, "missing 'payload.published_at'")
+    report = payload.get("report")
+    if not isinstance(report, dict):
+        raise Rejected(400, "missing or non-object 'payload.report'")
+
+    # 2. Field validation (re-run, never trusted from an unauthenticated party)
+    if len(server_name) > 200 or not SERVER_NAME_RE.match(server_name):
+        raise Rejected(400, "'server_name' fails the contract pattern or length limit")
+    contact = payload.get("contact")
+    if contact is not None:
+        if not isinstance(contact, str) or len(contact) > 200 or not EMAIL_RE.match(contact):
+            raise Rejected(400, "'contact' fails the contract pattern or length limit")
+
+    # 3. Hash over the canonical bytes
+    recomputed = hashlib.sha256(canonical_bytes(payload)).hexdigest()
+    if recomputed != verification_hash:
+        raise Rejected(
+            400,
+            "'verification_hash' does not match the canonical payload bytes "
+            "(contract 4.1: json.dumps(payload, sort_keys=True), default separators)",
+        )
+
+    # 4. Sensitive-field scan
+    leaked = find_sensitive_keys(report)
+    if leaked:
+        raise Rejected(422, f"report contains sensitive keys: {', '.join(sorted(leaked)[:8])}")
+
+    # 5. Schema required keys
+    missing = [k for k in required_keys if k not in report]
+    if missing:
+        raise Rejected(422, f"report missing schema-required keys: {', '.join(missing)}")
+
+    # 6. Signature
+    public_key = submission.get("public_key")
+    fingerprint = submission.get("public_key_fingerprint")
+    signature_verifiable = False
+    if public_key:
+        if not isinstance(public_key, str):
+            raise Rejected(400, "'public_key' must be a PEM string")
+        pem = public_key.encode()
+        if fingerprint and hashlib.sha256(pem).hexdigest()[:16] != fingerprint:
+            raise Rejected(400, "'public_key_fingerprint' does not match 'public_key'")
+        if not _CRYPTO:
+            raise Rejected(
+                501,
+                "signature verification unavailable: install 'cryptography'. Accepting a "
+                "signed envelope without checking it would report a verification that "
+                "never happened (contract 5.6)",
+            )
+        try:
+            key = load_pem_public_key(pem)
+            key.verify(bytes.fromhex(signature), canonical_bytes(payload))
+        except (InvalidSignature, ValueError) as exc:
+            raise Rejected(400, f"Ed25519 signature verification failed: {exc}") from exc
+        signature_verifiable = True
+
+    # 7. Classification. I0 always; never submitter-supplied.
+    if submission.get("independence_level") not in (None, "I0"):
+        raise Rejected(
+            422,
+            "a submitted record is I0 by construction; the registry does not accept a "
+            "submitter-asserted independence level (contract 1 and 7)",
+        )
+
+    # 8. Id
+    registry_id = verification_hash[:12]
+
+    return {
+        "id": registry_id,
+        "payload": payload,  # stored verbatim: normalizing it destroys the signature
+        "signature": signature,
+        "verification_hash": verification_hash,
+        "public_key": public_key,
+        "public_key_fingerprint": fingerprint,
+        "envelope_version": submission.get("envelope_version", "1"),
+        "signature_verifiable": signature_verifiable,
+        "evidence_class": report.get("evidence_class", "E1"),
+        "independence_level": "I0",
+        "system_under_test": server_name,
+        "received_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "claim_label": CLAIM_LABEL,
+    }
+
+
+BADGE_SVG = (
+    '<svg xmlns="http://www.w3.org/2000/svg" width="260" height="20" role="img" '
+    'aria-label="{label}">'
+    '<rect width="260" height="20" fill="#555"/>'
+    '<text x="8" y="14" fill="#fff" font-family="Verdana,sans-serif" font-size="11">'
+    "{label}</text></svg>"
+)
+
+
+class Handler(BaseHTTPRequestHandler):
+    store: Store
+    required_keys: list[str]
+    server_version = "agent-security-registry-reference/1.0"
+
+    def log_message(self, fmt, *args):  # quieter default logging
+        sys.stderr.write("%s - %s\n" % (self.address_string(), fmt % args))
+
+    def _json(self, status: int, body: dict) -> None:
+        data = json.dumps(body, indent=2).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def do_POST(self) -> None:  # noqa: N802
+        length = int(self.headers.get("Content-Length") or 0)
+        if length <= 0 or length > 5_000_000:
+            self._json(400, {"error": "missing or oversized body"})
+            return
+        try:
+            submission = json.loads(self.rfile.read(length))
+        except json.JSONDecodeError as exc:
+            self._json(400, {"error": f"invalid JSON: {exc}"})
+            return
+
+        try:
+            record = validate_and_build(submission, self.required_keys)
+        except Rejected as rej:
+            self._json(rej.status, {"error": rej.reason})
+            return
+
+        existing = self.store.existing_id_for(record["verification_hash"])
+        if existing:
+            self._json(200, {"id": existing, "idempotent": True})
+            return
+
+        self._json(201, {"id": self.store.put(record)})
+
+    def do_GET(self) -> None:  # noqa: N802
+        path = self.path.split("?", 1)[0].rstrip("/")
+        segments = [s for s in path.split("/") if s]
+
+        if len(segments) == 2 and segments[-2] == "badge":
+            registry_id = segments[-1]
+            if not REGISTRY_ID_RE.match(registry_id) or not self.store.get(registry_id):
+                self._json(404, {"error": "unknown registry_id"})
+                return
+            svg = BADGE_SVG.format(label=CLAIM_LABEL).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "image/svg+xml")
+            self.send_header("Content-Length", str(len(svg)))
+            self.end_headers()
+            self.wfile.write(svg)
+            return
+
+        if len(segments) >= 1:
+            registry_id = segments[-1]
+            if not REGISTRY_ID_RE.match(registry_id):
+                self._json(400, {"error": "registry_id fails ^[A-Za-z0-9\\-]+$"})
+                return
+            record = self.store.get(registry_id)
+            if not record:
+                self._json(404, {"error": "unknown registry_id"})
+                return
+            self._json(200, record)
+            return
+
+        self._json(404, {"error": "not found"})
+
+
+def build_server(port: int) -> ThreadingHTTPServer:
+    Handler.store = Store()
+    Handler.required_keys = load_schema_required()
+    return ThreadingHTTPServer(("127.0.0.1", port), Handler)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--port", type=int, default=8787)
+    args = ap.parse_args()
+
+    httpd = build_server(args.port)
+    base = f"http://127.0.0.1:{args.port}"
+    print(f"reference registry on {base}")
+    print(f"  export AGENT_SECURITY_REGISTRY_URL=\"{base}\"")
+    if not _CRYPTO:
+        print("  WARNING: 'cryptography' not importable; signed envelopes will be "
+              "rejected with 501 rather than silently unverified")
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        print("\nstopped")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_attestation_record.py
+++ b/scripts/verify_attestation_record.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Verify an attestation registry record without trusting the registry (#333).
+
+Implements section 9 of docs/ATTESTATION-REGISTRY-SERVER-CONTRACT.md. Steps 1-4
+are checks. Steps 5 and 6 are printed as statements, because neither is something
+this script -- or any registry -- can decide for you.
+
+    # from a file
+    python3 scripts/verify_attestation_record.py record.json
+
+    # from a registry you were given a link to
+    curl -s "$AGENT_SECURITY_REGISTRY_URL/<id>" | python3 scripts/verify_attestation_record.py -
+
+Exit status is 0 only when every applicable check passes. A record with no
+public_key cannot be verified at all and exits non-zero: see contract 4.2.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+
+try:
+    from cryptography.hazmat.primitives.serialization import load_pem_public_key
+    from cryptography.exceptions import InvalidSignature
+    _CRYPTO = True
+except ImportError:  # pragma: no cover - environment dependent
+    _CRYPTO = False
+
+OK, BAD, NOTE = "PASS", "FAIL", "NOTE"
+
+
+def canonical_bytes(payload: dict) -> bytes:
+    """Contract 4.1: sort_keys, DEFAULT separators. Not compact. Not JCS."""
+    return json.dumps(payload, sort_keys=True).encode()
+
+
+def line(status: str, text: str) -> None:
+    print(f"  [{status}] {text}")
+
+
+def verify(record: dict) -> bool:
+    failures = 0
+    payload = record.get("payload")
+    if not isinstance(payload, dict):
+        line(BAD, "record has no 'payload' object; nothing to verify")
+        return False
+
+    raw = canonical_bytes(payload)
+
+    # Step 1-2: internal consistency
+    digest = hashlib.sha256(raw).hexdigest()
+    claimed = record.get("verification_hash")
+    if digest == claimed:
+        line(OK, f"verification_hash matches the canonical payload bytes ({digest[:16]}...)")
+    else:
+        line(BAD, f"verification_hash mismatch: computed {digest[:16]}..., record claims "
+                  f"{str(claimed)[:16]}...")
+        failures += 1
+
+    # Step 3: key matches its advertised fingerprint
+    public_key = record.get("public_key")
+    fingerprint = record.get("public_key_fingerprint")
+    if public_key and fingerprint:
+        actual = hashlib.sha256(public_key.encode()).hexdigest()[:16]
+        if actual == fingerprint:
+            line(OK, f"public_key matches public_key_fingerprint ({fingerprint})")
+        else:
+            line(BAD, f"public_key_fingerprint mismatch: computed {actual}, record claims "
+                      f"{fingerprint}")
+            failures += 1
+
+    # Step 4: the signature itself
+    signature = record.get("signature")
+    if not public_key:
+        line(BAD, "record carries no 'public_key', so the signature CANNOT be checked. "
+                  "Only the registry operator's word supports this record. See contract 4.2.")
+        failures += 1
+    elif not signature:
+        line(BAD, "record carries no 'signature'")
+        failures += 1
+    elif not _CRYPTO:
+        line(BAD, "'cryptography' is not installed, so the signature was not checked. "
+                  "Install it rather than treating an unchecked signature as valid.")
+        failures += 1
+    else:
+        try:
+            load_pem_public_key(public_key.encode()).verify(bytes.fromhex(signature), raw)
+            line(OK, "Ed25519 signature verifies over the canonical payload bytes")
+        except (InvalidSignature, ValueError) as exc:
+            line(BAD, f"Ed25519 signature verification failed: {exc}")
+            failures += 1
+
+    # Step 5: key-to-identity binding, which no registry can supply
+    line(NOTE, "key-to-identity binding is OUT OF SCOPE. The checks above prove a holder of "
+               "this key signed this payload. They do not prove whose key it is.")
+
+    # Step 6: what the record actually establishes
+    level = record.get("independence_level", "unstated")
+    sut = record.get("system_under_test", "unstated")
+    if level == "I0":
+        line(NOTE, f"independence_level I0, system under test '{sut}'. The submitter authored "
+                   f"the oracle. A passing signature proves the record was not altered. It "
+                   f"proves NOTHING about the target.")
+    else:
+        line(NOTE, f"independence_level '{level}' relative to system under test '{sut}'. An "
+                   f"I-level with no named system under test is not a claim.")
+
+    if record.get("signature_verifiable") is False:
+        line(NOTE, "the registry itself reports signature_verifiable: false")
+    received = record.get("received_at")
+    if received:
+        line(NOTE, f"received_at {received} is the OPERATOR's claim and is outside the "
+                   f"signature; only payload.published_at is signed")
+
+    return failures == 0
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(__doc__)
+        return 2
+    source = sys.argv[1]
+    try:
+        text = sys.stdin.read() if source == "-" else open(source, encoding="utf-8").read()
+        record = json.loads(text)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"could not read a JSON record from {source!r}: {exc}", file=sys.stderr)
+        return 2
+
+    print(f"Verifying record {record.get('id', '<no id>')}")
+    ok = verify(record)
+    print("\nRESULT:", "all applicable checks passed" if ok else "VERIFICATION FAILED")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_registry_server_contract.py
+++ b/tests/test_registry_server_contract.py
@@ -1,0 +1,392 @@
+"""Conformance tests for the attestation registry server contract.
+
+Tracks GitHub issue #333. Asserts docs/ATTESTATION-REGISTRY-SERVER-CONTRACT.md
+against scripts/registry_reference_server.py and
+scripts/verify_attestation_record.py.
+
+The reference server is the executable form of the contract, so an untested
+reference is a contract nothing checks. Each test names the contract section it
+pins.
+"""
+
+import copy
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import threading
+import urllib.error
+import urllib.request
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from scripts.registry_reference_server import (  # noqa: E402
+    CLAIM_LABEL,
+    Rejected,
+    Store,
+    build_server,
+    canonical_bytes,
+    find_sensitive_keys,
+    load_schema_required,
+    validate_and_build,
+)
+
+cryptography = pytest.importorskip("cryptography")
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (  # noqa: E402
+    Ed25519PrivateKey,
+)
+from cryptography.hazmat.primitives.serialization import (  # noqa: E402
+    Encoding,
+    PublicFormat,
+)
+
+REQUIRED = load_schema_required()
+
+
+def _report():
+    return {
+        "schema_version": "1.0",
+        "harness_version": "4.15.0",
+        "suite": "mcp",
+        "timestamp": "2026-08-14T12:00:00Z",
+        "summary": {"total": 1, "passed": 1, "failed": 0},
+        "entries": [{"id": "MCP-001", "result": "pass"}],
+    }
+
+
+def _keypair():
+    key = Ed25519PrivateKey.generate()
+    pub = key.public_key().public_bytes(
+        Encoding.PEM, PublicFormat.SubjectPublicKeyInfo
+    ).decode()
+    return key, pub
+
+
+def _envelope(payload_overrides=None, signed=True, key=None, pub=None):
+    payload = {
+        "server_name": "demo-server",
+        "contact": None,
+        "report": _report(),
+        "published_at": "2026-08-14T12:00:00Z",
+    }
+    payload.update(payload_overrides or {})
+    raw = canonical_bytes(payload)
+    envelope = {
+        "payload": payload,
+        "signature": "00" * 64,
+        "verification_hash": hashlib.sha256(raw).hexdigest(),
+    }
+    if signed:
+        if key is None:
+            key, pub = _keypair()
+        envelope["envelope_version"] = "2"
+        envelope["signature"] = key.sign(raw).hex()
+        envelope["public_key"] = pub
+        envelope["public_key_fingerprint"] = hashlib.sha256(pub.encode()).hexdigest()[:16]
+    return envelope
+
+
+def _resign(envelope, key):
+    raw = canonical_bytes(envelope["payload"])
+    envelope["verification_hash"] = hashlib.sha256(raw).hexdigest()
+    envelope["signature"] = key.sign(raw).hex()
+    return envelope
+
+
+# --- Contract 4.1: canonicalization -----------------------------------------
+
+def test_canonical_bytes_use_default_separators_not_compact():
+    """4.1. The pinned basis is the ONLY reason an independent reimplementation
+    can verify a signature. Compact separators produce different bytes."""
+    payload = {"b": 1, "a": 2}
+    assert canonical_bytes(payload) == b'{"a": 2, "b": 1}'
+    assert canonical_bytes(payload) != json.dumps(
+        payload, sort_keys=True, separators=(",", ":")
+    ).encode()
+
+
+def test_canonical_bytes_sort_keys():
+    assert canonical_bytes({"z": 1, "a": 2}) == canonical_bytes({"a": 2, "z": 1})
+
+
+# --- Contract 5: the eight POST obligations, in order ------------------------
+
+def test_missing_payload_is_rejected():
+    """5.1 shape."""
+    with pytest.raises(Rejected) as exc:
+        validate_and_build({"signature": "x", "verification_hash": "y"}, REQUIRED)
+    assert exc.value.status == 400
+
+
+@pytest.mark.parametrize("name", ["has/slash", "semi;colon", "", "a" * 201])
+def test_server_name_pattern_is_reenforced_server_side(name):
+    """5.2. A server that trusts the client's validator trusts an
+    unauthenticated party."""
+    key, pub = _keypair()
+    env = _resign(_envelope(signed=True, key=key, pub=pub) | {}, key)
+    env["payload"]["server_name"] = name
+    _resign(env, key)
+    with pytest.raises(Rejected) as exc:
+        validate_and_build(env, REQUIRED)
+    assert exc.value.status == 400
+
+
+def test_invalid_contact_is_rejected():
+    """5.2."""
+    key, pub = _keypair()
+    env = _envelope({"contact": "not-an-email"}, key=key, pub=pub)
+    _resign(env, key)
+    with pytest.raises(Rejected) as exc:
+        validate_and_build(env, REQUIRED)
+    assert exc.value.status == 400
+
+
+def test_tampered_payload_fails_the_hash_check():
+    """5.3. Mutating the payload after signing must not survive."""
+    env = _envelope()
+    env["payload"]["server_name"] = "tampered-after-signing"
+    with pytest.raises(Rejected) as exc:
+        validate_and_build(env, REQUIRED)
+    assert exc.value.status == 400
+    assert "canonical payload bytes" in exc.value.reason
+
+
+def test_sensitive_key_in_report_is_rejected_with_its_path():
+    """5.4. Defense in depth: its presence means a non-conforming client."""
+    key, pub = _keypair()
+    env = _envelope(key=key, pub=pub)
+    env["payload"]["report"]["entries"][0]["target_url"] = "https://internal.example"
+    _resign(env, key)
+    with pytest.raises(Rejected) as exc:
+        validate_and_build(env, REQUIRED)
+    assert exc.value.status == 422
+    assert "target_url" in exc.value.reason
+
+
+@pytest.mark.parametrize("key_name", ["target_url", "auth_token", "raw_response", "hostname"])
+def test_sensitive_scan_covers_exact_and_substring_matches(key_name):
+    """5.4. Mirrors the client's _is_sensitive_key, including substrings."""
+    assert find_sensitive_keys({key_name: "x"}) == [f"report.{key_name}"]
+
+
+def test_schema_required_key_missing_is_rejected():
+    """5.5. Uses schemas/attestation-report.json rather than a local copy (R3)."""
+    key, pub = _keypair()
+    env = _envelope(key=key, pub=pub)
+    del env["payload"]["report"]["entries"]
+    _resign(env, key)
+    with pytest.raises(Rejected) as exc:
+        validate_and_build(env, REQUIRED)
+    assert exc.value.status == 422
+    assert "entries" in exc.value.reason
+
+
+def test_required_keys_are_read_from_the_shipped_schema():
+    """R3. The server must not fork the schema."""
+    assert "entries" in REQUIRED and "summary" in REQUIRED
+
+
+def test_valid_signature_marks_the_record_verifiable():
+    """5.6."""
+    record = validate_and_build(_envelope(), REQUIRED)
+    assert record["signature_verifiable"] is True
+
+
+def test_signature_over_different_bytes_is_rejected():
+    """5.6. A signature valid for some other payload must not pass."""
+    key, pub = _keypair()
+    env = _envelope(key=key, pub=pub)
+    env["signature"] = key.sign(b"a different message").hex()
+    with pytest.raises(Rejected) as exc:
+        validate_and_build(env, REQUIRED)
+    assert exc.value.status == 400
+
+
+def test_public_key_not_matching_its_fingerprint_is_rejected():
+    """5.6."""
+    _, other_pub = _keypair()
+    env = _envelope()
+    env["public_key"] = other_pub
+    with pytest.raises(Rejected) as exc:
+        validate_and_build(env, REQUIRED)
+    assert exc.value.status == 400
+    assert "fingerprint" in exc.value.reason
+
+
+def test_unsigned_envelope_is_stored_as_not_verifiable():
+    """4.2. The currently shipping client sends no public key. The record must
+    say so about itself rather than omitting the question."""
+    record = validate_and_build(_envelope(signed=False), REQUIRED)
+    assert record["signature_verifiable"] is False
+    assert record["envelope_version"] == "1"
+
+
+def test_submitter_cannot_assert_an_independence_level():
+    """1 and 7. Independence is not a flag an operator or submitter can set."""
+    env = _envelope()
+    env["independence_level"] = "I2"
+    with pytest.raises(Rejected) as exc:
+        validate_and_build(env, REQUIRED)
+    assert exc.value.status == 422
+
+
+def test_record_is_always_i0_with_a_named_system_under_test():
+    """1. An I-level with no named system under test is not a claim."""
+    record = validate_and_build(_envelope(), REQUIRED)
+    assert record["independence_level"] == "I0"
+    assert record["system_under_test"] == "demo-server"
+
+
+def test_claim_label_is_not_stronger_than_tested_with():
+    """1. 'Verified'/'certified' would present self-authored evidence as review."""
+    record = validate_and_build(_envelope(), REQUIRED)
+    assert record["claim_label"] == CLAIM_LABEL
+    assert "Tested with" in CLAIM_LABEL
+    for forbidden in ("verified", "certified", "approved", "confirmed"):
+        assert forbidden not in CLAIM_LABEL.lower()
+
+
+def test_id_is_derivable_from_the_record():
+    """5.8. Matches the client's fallback when a response omits 'id'."""
+    env = _envelope()
+    record = validate_and_build(env, REQUIRED)
+    assert record["id"] == env["verification_hash"][:12]
+
+
+# --- Contract 6: GET obligations --------------------------------------------
+
+def test_payload_is_stored_verbatim_so_the_signature_still_verifies():
+    """6. A server that normalizes the payload destroys every downstream check."""
+    env = _envelope()
+    record = validate_and_build(env, REQUIRED)
+    assert canonical_bytes(record["payload"]) == canonical_bytes(env["payload"])
+    assert hashlib.sha256(canonical_bytes(record["payload"])).hexdigest() == (
+        record["verification_hash"]
+    )
+
+
+def test_received_at_is_present_and_distinct_from_the_signed_timestamp():
+    """6. received_at is an operator claim outside the signature."""
+    record = validate_and_build(_envelope(), REQUIRED)
+    assert record["received_at"]
+    assert "received_at" not in record["payload"]
+
+
+def test_store_is_idempotent_on_verification_hash():
+    """5. Two identical submissions are one record."""
+    store = Store()
+    record = validate_and_build(_envelope(), REQUIRED)
+    store.put(record)
+    assert store.existing_id_for(record["verification_hash"]) == record["id"]
+
+
+# --- Contract 9: verification without trusting the operator ------------------
+
+def _verify(record):
+    script = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        "scripts", "verify_attestation_record.py",
+    )
+    return subprocess.run(
+        [sys.executable, script, "-"], input=json.dumps(record),
+        capture_output=True, text=True,
+    )
+
+
+def test_signed_record_verifies_offline():
+    """9. Steps 1-4 pass with no call back to the registry."""
+    result = _verify(validate_and_build(_envelope(), REQUIRED))
+    assert result.returncode == 0, result.stdout
+    assert "Ed25519 signature verifies" in result.stdout
+
+
+def test_unsigned_record_cannot_be_verified_and_says_why():
+    """4.2. The gap in the shipping client, asserted rather than described."""
+    result = _verify(validate_and_build(_envelope(signed=False), REQUIRED))
+    assert result.returncode == 1
+    assert "CANNOT be checked" in result.stdout
+
+
+def test_verifier_states_that_i0_proves_nothing_about_the_target():
+    """9 step 6. The step most likely skipped after four passing checks."""
+    result = _verify(validate_and_build(_envelope(), REQUIRED))
+    assert "NOTHING about the target" in result.stdout
+
+
+def test_verifier_rejects_a_record_whose_payload_was_swapped():
+    """9. The operator-tampering case R2 exists to defeat."""
+    record = validate_and_build(_envelope(), REQUIRED)
+    record["payload"]["server_name"] = "operator-substituted"
+    result = _verify(record)
+    assert result.returncode == 1
+
+
+# --- Contract 3: the wire, end to end ----------------------------------------
+
+@pytest.fixture
+def live_server():
+    httpd = build_server(0)
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    yield f"http://127.0.0.1:{httpd.server_address[1]}"
+    httpd.shutdown()
+    httpd.server_close()
+
+
+def _post(base, envelope):
+    req = urllib.request.Request(
+        base, data=json.dumps(envelope).encode(),
+        headers={"Content-Type": "application/json"}, method="POST",
+    )
+    try:
+        resp = urllib.request.urlopen(req, timeout=10)
+        return resp.status, json.loads(resp.read())
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read())
+
+
+def test_post_then_get_round_trip(live_server):
+    """3. The three endpoints the shipping client already calls."""
+    status, body = _post(live_server, _envelope())
+    assert status == 201
+    record = json.loads(urllib.request.urlopen(f"{live_server}/{body['id']}").read())
+    assert record["id"] == body["id"]
+    assert record["independence_level"] == "I0"
+    assert _verify(record).returncode == 0
+
+
+def test_repost_returns_the_same_id(live_server):
+    envelope = _envelope()
+    first = _post(live_server, envelope)
+    second = _post(live_server, envelope)
+    assert first[1]["id"] == second[1]["id"]
+    assert second[0] == 200
+
+
+def test_badge_is_served_and_carries_the_bounded_claim(live_server):
+    _, body = _post(live_server, _envelope())
+    with urllib.request.urlopen(f"{live_server}/badge/{body['id']}") as resp:
+        svg = resp.read().decode()
+    assert CLAIM_LABEL in svg
+    assert "Verified by" not in svg
+
+
+def test_registry_id_pattern_is_enforced_on_get(live_server):
+    """3. Path-traversal shaped ids are rejected before lookup."""
+    req = urllib.request.Request(f"{live_server}/..%2Fetc", method="GET")
+    try:
+        status = urllib.request.urlopen(req, timeout=10).status
+    except urllib.error.HTTPError as exc:
+        status = exc.code
+    assert status in (400, 404)
+
+
+def test_unknown_id_is_404(live_server):
+    try:
+        status = urllib.request.urlopen(f"{live_server}/deadbeef1234", timeout=10).status
+    except urllib.error.HTTPError as exc:
+        status = exc.code
+    assert status == 404


### PR DESCRIPTION
Closes #333.

Specifies the receiving half of the attestation registry, with a runnable reference implementation and an offline verification path. Meets the issue's definition of done: a published contract, a locally runnable reference, and a verification path that does not require trusting the registry operator. **No hosted service, no dashboard.**

## The four open questions, settled

**What a submission establishes: I0, regardless of submitter.** Routing a self-authored oracle through a server does not change who authored it. Every record must carry `evidence_class`, `independence_level`, **and the named system under test** — per the `#346` resolution the axis is relative, so a bare `"I0"` is not a checkable claim.

**What is submitted:** the full stripped report, unchanged. The registry must not fork `schemas/attestation-report.json` (`#137`); registry metadata lives in the envelope, outside `payload.report`.

**Hosting:** self-hosted-only is conforming and recommended. Rule R1 forbids a well-known host or a client default. The absence of a default is the property that would have prevented the 2026-03-28 fabricated-endpoint exfiltration path, so it is written in as a requirement rather than left as an omission.

**Independence cannot be granted by an operator.** An I1 claim is a *separate signed record* referencing the original's `verification_hash` from inside its own signature. And per `#304`, a conforming server must accept and serve **disagreeing** records unranked — that reproduction was evidence precisely because it disagreed in two places.

## Two findings about the shipping client, demonstrated rather than asserted

**1. The envelope cannot be independently verified.** It carries `public_key_fingerprint` but never the public key, so no third party can check the Ed25519 signature. A record fetched today is supported only by the operator's word, which defeats the whole point. Publishing through the real client and then verifying gives:

```
[PASS] verification_hash matches the canonical payload bytes
[FAIL] record carries no 'public_key', so the signature CANNOT be checked.
RESULT: VERIFICATION FAILED
```

Contract §4.2 specifies `envelope_version: "2"` adding `public_key`. **The client is not changed here** — that belongs in its own reviewed commit, filed separately.

**2. The canonical signing bytes were written down nowhere.** They are `json.dumps(payload, sort_keys=True)` with **default** separators, not compact and not JCS. That is the most likely reason an independent reimplementation would fail to verify a signature it should accept, and §4.1 pins it.

## What ships

| File | Purpose |
|---|---|
| `docs/ATTESTATION-REGISTRY-SERVER-CONTRACT.md` | The contract: 3 endpoints, 8 ordered POST obligations, GET record shape, conformance checklist |
| `scripts/registry_reference_server.py` | Stdlib reference server, in-memory, runnable against localhost |
| `scripts/verify_attestation_record.py` | Offline verification needing no second call to the registry |
| `tests/test_registry_server_contract.py` | 36 conformance tests, each naming the section it pins |

`docs/attestation-registry.md` said the contract was "not yet published" and that self-hosting "has to be written against `protocol_tests/attestation_registry.py` directly". Both were true and are now false; replaced with the contract link, the reference invocation, the verification one-liner, and the §4.2 gap stated plainly.

## Testing

- `tests/test_registry_server_contract.py` — 36 passed
- `tests/` — 147 passed, 2 skipped (excluding `test_mcp_server_runtime.py`, which fails collection on `main` too for a missing optional `mcp` dependency in this environment)
- `testing/` — 435 passed, 136 subtests passed

Rejection paths each asserted with their specified status: tampered payload `400`, leaked sensitive key `422` with its JSON path, submitter-asserted `I2` `422`, missing schema-required key `422`, wrong `verification_hash` `400`, idempotent re-submit `200` with the original id.

Three tests exist to stop the contract drifting into flattery: an unsigned envelope must store `signature_verifiable: false`, the verifier must exit non-zero on it, and the verifier must still print that an I0 record proves nothing about the target *after* four checks pass. That last one is the step a reader skips.