### PR TITLE
docs: index the attestation registry docs (#333)

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,8 @@ The [constitutional-agent](https://github.com/CognitiveThoughtEngine/constitutio
 | Canonical coverage mapping (source of truth) | [docs/coverage/owasp-agentic-v1.1.yaml](docs/coverage/owasp-agentic-v1.1.yaml) |
 | Release history & known gaps | [ROADMAP.md](ROADMAP.md) · [CHANGELOG.md](CHANGELOG.md) |
 | E1-E5 Evidence Class Taxonomy (canonical) | [docs/EVIDENCE-CLASS-TAXONOMY.md](docs/EVIDENCE-CLASS-TAXONOMY.md) |
+| Attestation registry (client, opt-in publishing) | [docs/attestation-registry.md](docs/attestation-registry.md) |
+| Attestation registry server contract (self-hosted; no registry is operated by this project) | [docs/ATTESTATION-REGISTRY-SERVER-CONTRACT.md](docs/ATTESTATION-REGISTRY-SERVER-CONTRACT.md) |
 | AIUC-1 Evidence Field Guide (external, not version-pinned) | [msaleme.github.io/aiuc1-readiness](https://msaleme.github.io/aiuc1-readiness/) |
 | AIUC-1 Crosswalk | [docs/AIUC1-CROSSWALK.md](docs/AIUC1-CROSSWALK.md) |
 | Advanced Capabilities | [docs/ADVANCED.md](docs/ADVANCED.md) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,9 @@ This directory contains detailed documentation for the Agent Security Harness fr
 |---|---|
 | [../agent-fabric-red-blue-team-spec.md](../agent-fabric-red-blue-team-spec.md) | **Original specification** - 20 STRIDE scenarios, architecture overview, threat model |
 | [CASE_STUDY_FALSE_PASS.md](CASE_STUDY_FALSE_PASS.md) | **False pass case study** - Analysis of security testing failure modes |
+| [EVIDENCE-CLASS-TAXONOMY.md](EVIDENCE-CLASS-TAXONOMY.md) | **E1-E5 evidence classes and the I0-I2 independence axis** - what a result establishes, and about which system under test |
+| [attestation-registry.md](attestation-registry.md) | **Attestation registry client** - opt-in publishing, sensitive-field stripping, no default endpoint |
+| [ATTESTATION-REGISTRY-SERVER-CONTRACT.md](ATTESTATION-REGISTRY-SERVER-CONTRACT.md) | **Registry server contract** - what a submission establishes (I0), the eight receive obligations, and offline verification that does not require trusting the operator |
 
 ## Executive Materials  
 


### PR DESCRIPTION
Follow-up to #370. The server contract landed and neither documentation index referenced it — nor did either reference `docs/attestation-registry.md`, which has shipped for some time. The client half was documented and unreachable from any index.

- **README docs table**: both attestation rows, placed next to the evidence taxonomy, since what a submission establishes is an evidence-class question before it is a transport one. The server-contract row states in its link text that this project operates no registry, because the first thing a reader assumes about a registry is that someone is hosting it.
- **docs/README.md**: the same two, plus `EVIDENCE-CLASS-TAXONOMY.md` — also unindexed despite being named canonical in the main README.

All local markdown links in both indexes verified to resolve.

**Repository description updated separately** (not in this diff): it led with `603 executable tests` while `main` carries 606 — the same release-versus-main ambiguity the README already resolves explicitly and that the AIUC-1 page still carries. Now reads `606 executable tests on main, 603 in the v4.15.0 release`. I dropped `0 not evidenced` from the OWASP clause to fit the 350-character limit; 13 direct + 4 partial still accounts for all of T1–T17.

Note for coordination: `tasks.md` records a hold on modifying the repository description and public claims copy from this lane pending ownership reconciliation. This change was made under explicit direction; flagging it so the other lane is not surprised.