### PR TITLE
Correct the verdict-taint auditor, and guard the module it wrongly cleared (#351)

### DIFF
--- a/protocol_tests/governance_modification_harness.py
+++ b/protocol_tests/governance_modification_harness.py
@@ -41,6 +41,7 @@ from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 
 from protocol_tests._utils import Severity, wilson_ci, jsonrpc_request, http_post_json
+from protocol_tests.http_helpers import inconclusive_detail
 
 
 @dataclass
@@ -107,7 +108,18 @@ class GovernanceModificationTests:
         self.results: list[GovernanceModTestResult] = []
 
     def _record(self, result: GovernanceModTestResult) -> None:
-        status = "PASS \u2705" if result.passed else "FAIL \u274c"
+        # #348/#351: this module was published as one of only two with no
+        # response-decided verdict. It has six. The taint arrives through control
+        # flow -- `succeeded = False; if _response_allows_change(resp): succeeded
+        # = True; passed = not succeeded` -- which the analyser merged in #372
+        # did not follow. On a dead host _response_allows_change is False, so the
+        # report read "All gate-disable attempts were rejected -- HC-12 enforced"
+        # against a target that never answered. INCONCLUSIVE, never a pass.
+        _d = inconclusive_detail(getattr(result, "response_received", None), result.details)
+        if _d is not None:
+            result.passed = False
+            result.details = _d
+        status = "PASS ✅" if result.passed else "FAIL ❌"
         print(f"  {status}  {result.test_id}: {result.name}")
         self.results.append(result)
 

--- a/scripts/audit_verdict_taint.py
+++ b/scripts/audit_verdict_taint.py
@@ -3,18 +3,48 @@
 
 #348 was scoped by reading five files and two more modules with the same defect
 survived it. #350's fix was to derive the *candidate* set instead of hand-writing
-it. This script goes one step further and derives, per verdict expression, whether
-the verdict is reachable from a target response at all -- directly, or through a
-local assigned from one.
+it. This derives one step further: per verdict expression, whether a target
+response reaches it at all.
 
-That distinction is the whole audit. A verdict that never touches a response
-cannot report a pass against a host that is not running. A verdict that reads
-``not leaked``, where ``leaked`` was computed from ``resp``, can and does: on an
-unserviced target nothing leaks, so the control "held".
+That distinction is the audit. A verdict that never touches a response cannot
+report a pass against a host that is not running. A verdict reading
+``not leaked``, where ``leaked`` came from ``resp``, can: on an unserviced
+target nothing leaks, so the control "held".
 
-Output is a triage, not a verdict. Direction (false pass vs false fail) is a
-heuristic on the expression shape and every TAINTED row still has to be read.
-Absence of taint is the only conclusion this script draws on its own.
+Taint reaches a verdict two ways, and the first version of this script only
+followed one of them
+---------------------------------------------------------------------------
+**Data dependency** -- the response appears on an assignment's right-hand side::
+
+    leaked = "secret" in str(resp)
+    passed = not leaked
+
+**Control dependency** -- the response appears in a *condition* that governs the
+assignment, and never on the right-hand side at all::
+
+    succeeded = False
+    if _response_allows_change(resp):
+        succeeded = True
+    passed = not succeeded
+
+The second shape is the common one in this package, and the version of this
+script merged in #372 missed all of it. It reported
+``governance_modification_harness`` as one of only two modules with no
+response-decided verdict; that module has five, and a live false pass reading
+"All gate-disable attempts were rejected -- HC-12 enforced" against a host that
+never answered. Both forms are now followed, by treating the names in a
+governing condition as dependencies of every assignment inside it.
+
+**Deliberately over-reports.** A verdict inside ``if self.verbose:`` inherits
+that condition's names. For a triage tool the errors are not symmetric: a false
+positive costs someone a read, a false negative is a module shipped as clean.
+The #372 version made the second kind, so this one is tuned to make the first.
+
+Output is a triage, not a verdict. Direction is a heuristic on expression shape
+and every TAINTED row still has to be read. Absence of taint means only "no
+response reaches it *by the mechanisms below, under the names in
+RESPONSE_NAMES*" -- it is not a proof of cleanliness, and must never again be
+reported as one.
 
     python3 scripts/audit_verdict_taint.py
     python3 scripts/audit_verdict_taint.py --module jailbreak_harness --verbose
@@ -29,11 +59,42 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 PROTOCOL_TESTS = REPO_ROOT / "protocol_tests"
 
-# Names a target response is bound to across the package. Extend rather than
-# rename: a miss here shows up as a module wrongly reported clean.
+# A floor, not the list. These cover responses that arrive as a *parameter*
+# (``def _leak(resp)``) where there is no assignment to derive from.
+#
+# The list itself is DERIVED per module by derive_response_names(). Hand-writing
+# it was the #372 defect one level up: the shipped version carried twelve names
+# and the package binds responses to at least twenty-one more -- resp1, resp2,
+# audit_resp, ks_probe, hc12_probe, schema -- so every verdict reading one of
+# those was reported clean. #350 already established that a hand-maintained
+# coverage list is the same failure the guard exists to prevent. It applies here
+# too, and it was not applied.
 RESPONSE_NAMES = frozenset({
     "resp", "response", "reply", "res", "body", "raw", "http_resp", "result_resp",
 })
+
+# Callables that return a target response.
+HTTP_CALL_NAMES = frozenset({"urlopen", "_post", "_send", "_call", "_get", "_request"})
+
+
+def derive_response_names(tree: ast.AST) -> set[str]:
+    """Every name in this module bound from a call that returns a response.
+
+    Self-updating: a new harness writing ``foo_resp = http_post(...)`` is covered
+    the moment it lands, with nothing to remember.
+    """
+    out: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Call):
+            continue
+        func = node.value.func
+        fname = (func.id if isinstance(func, ast.Name)
+                 else func.attr if isinstance(func, ast.Attribute) else "")
+        if fname.startswith("http_") or fname in HTTP_CALL_NAMES:
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    out.add(target.id)
+    return out
 
 # On an unserviced target every detector returns falsy: nothing leaked, nothing
 # succeeded, no unsafe entries. These shapes then evaluate TRUE, which is the
@@ -53,26 +114,82 @@ def free_names(node: ast.AST) -> set[str]:
     return {n.id for n in ast.walk(node) if isinstance(n, ast.Name)} - bound
 
 
+def _assigned_names(node: ast.AST) -> set[str]:
+    out: set[str] = set()
+    if isinstance(node, ast.Assign):
+        for target in node.targets:
+            out |= {t.id for t in ast.walk(target) if isinstance(t, ast.Name)}
+    elif isinstance(node, (ast.AnnAssign, ast.AugAssign)):
+        if isinstance(node.target, ast.Name):
+            out.add(node.target.id)
+    elif isinstance(node, ast.NamedExpr) and isinstance(node.target, ast.Name):
+        out.add(node.target.id)
+    return out
+
+
+def build_dependencies(fn: ast.AST) -> dict[str, set[str]]:
+    """name -> names it depends on, through data OR control flow.
+
+    Control dependency is folded into the same map by passing the names of every
+    governing condition down as extra dependencies of the assignments beneath it.
+    """
+    deps: dict[str, set[str]] = {}
+
+    def visit(stmts: list[ast.stmt], guards: frozenset[str]) -> None:
+        for node in stmts:
+            if isinstance(node, (ast.If, ast.While)):
+                inner = guards | free_names(node.test)
+                visit(node.body, inner)
+                visit(node.orelse, inner)
+            elif isinstance(node, ast.For):
+                inner = guards | free_names(node.iter)
+                for name in _assigned_names(node.target) | {
+                    t.id for t in ast.walk(node.target) if isinstance(t, ast.Name)
+                }:
+                    deps.setdefault(name, set()).update(inner)
+                visit(node.body, inner)
+                visit(node.orelse, inner)
+            elif isinstance(node, ast.Try):
+                visit(node.body, guards)
+                for handler in node.handlers:
+                    visit(handler.body, guards)
+                visit(node.orelse, guards)
+                visit(node.finalbody, guards)
+            elif isinstance(node, ast.With):
+                visit(node.body, guards)
+            elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                continue  # its own scope; scanned separately
+            else:
+                rhs: set[str] = set()
+                value = getattr(node, "value", None)
+                if value is not None:
+                    rhs = free_names(value)
+                for name in _assigned_names(node):
+                    deps.setdefault(name, set()).update(rhs | guards)
+                # walrus and nested assignments inside an expression statement
+                for child in ast.walk(node):
+                    if isinstance(child, ast.NamedExpr) and isinstance(child.target, ast.Name):
+                        deps.setdefault(child.target.id, set()).update(
+                            free_names(child.value) | guards
+                        )
+
+    body = getattr(fn, "body", [])
+    visit(body, frozenset())
+    return deps
+
+
 class VerdictScanner(ast.NodeVisitor):
     """Collect every ``passed=`` expression and whether a response reaches it."""
 
-    def __init__(self) -> None:
+    def __init__(self, response_names: frozenset[str] = RESPONSE_NAMES) -> None:
         self.rows: list[dict] = []
+        self.response_names = response_names
 
     def visit_FunctionDef(self, fn: ast.FunctionDef) -> None:  # noqa: N802
-        deps: dict[str, set[str]] = {}
-        for node in ast.walk(fn):
-            if isinstance(node, ast.Assign):
-                rhs = free_names(node.value)
-                for target in node.targets:
-                    if isinstance(target, ast.Name):
-                        deps.setdefault(target.id, set()).update(rhs)
-            elif isinstance(node, ast.AnnAssign) and node.value is not None:
-                if isinstance(node.target, ast.Name):
-                    deps.setdefault(node.target.id, set()).update(free_names(node.value))
+        deps = build_dependencies(fn)
 
         def tainted(name: str, seen: frozenset[str] = frozenset()) -> bool:
-            if name in RESPONSE_NAMES:
+            if name in self.response_names:
                 return True
             if name in seen:
                 return False
@@ -80,7 +197,7 @@ class VerdictScanner(ast.NodeVisitor):
 
         for expr in self._verdicts(fn):
             names = free_names(expr)
-            direct = bool(names & RESPONSE_NAMES)
+            direct = bool(names & self.response_names)
             reaches = direct or any(tainted(n) for n in names)
             text = ast.unparse(expr)
             self.rows.append({
@@ -112,8 +229,10 @@ class VerdictScanner(ast.NodeVisitor):
 
 
 def audit(module_path: Path) -> list[dict]:
-    scanner = VerdictScanner()
-    scanner.visit(ast.parse(module_path.read_text(encoding="utf-8")))
+    tree = ast.parse(module_path.read_text(encoding="utf-8"))
+    names = frozenset(RESPONSE_NAMES | derive_response_names(tree))
+    scanner = VerdictScanner(names)
+    scanner.visit(tree)
     return scanner.rows
 
 
@@ -159,9 +278,9 @@ def main() -> int:
     print("-" * 78)
     print(f"{'TOTAL':<34}{totals[0]:>9}{totals[1]:>9}{totals[2]:>8}{totals[3]:>18}")
     print(
-        "\nA tainted verdict is decided by a response. If the target never answered, the "
-        "\nresponse is empty and every detector is falsy, so a 'false-pass shape' verdict "
-        "\nreports that the control held. Clean means only: no response reaches it."
+        "\nA tainted verdict is decided by a response, through data flow or through a "
+        "\ncondition governing it. Absence of taint means only 'not reached by these "
+        "\nmechanisms, under these names'. It is NOT a proof that a verdict is sound."
     )
     return 0
 

--- a/testing/test_serviced_guard.py
+++ b/testing/test_serviced_guard.py
@@ -73,6 +73,10 @@ GUARDED = [
     # #351: PRV-006 read `is_error or not accepted`, a pass because the target
     # errored -- the #350 shape, still live after two sweeps.
     ("protocol_tests.provenance_harness", "ProvenanceTests", "ProvenanceTestResult"),
+    # #351: published as clean by the #372 analyser, which missed control-flow
+    # taint. It has six response-decided verdicts and a live false pass.
+    ("protocol_tests.governance_modification_harness", "GovernanceModificationTests",
+     "GovernanceModTestResult"),
     # The shared base itself. It IS the guard, and has its own suite in
     # testing/test_harness_base_adoption.py.
     ("protocol_tests.harness_base", None, "HarnessResult"),
@@ -132,7 +136,6 @@ UNREVIEWED = {
     "cbrn_harness",
     "crewai_cve_harness",
     "extended_thinking_harness",
-    "governance_modification_harness",
     "harmful_output_harness",
     "incident_response_harness",
     "jailbreak_harness",
@@ -329,7 +332,7 @@ class TestCoverageListIsDerived(unittest.TestCase):
     def test_unreviewed_does_not_grow(self) -> None:
         """A tripwire on the honest number, so the backlog cannot quietly expand."""
         self.assertLessEqual(
-            len(UNREVIEWED), 23,
+            len(UNREVIEWED), 22,
             "UNREVIEWED grew. A new module recording a response should be guarded or "
             "reviewed, not appended to the backlog.")
 

--- a/tests/test_verdict_taint_audit.py
+++ b/tests/test_verdict_taint_audit.py
@@ -1,0 +1,250 @@
+"""Tests for the verdict-taint auditor (#351).
+
+The first version of this script shipped with no tests and reported
+``governance_modification_harness`` as having no response-decided verdict. It
+has five, and a live false pass. The blind spot was control dependency: a flag
+assigned inside an ``if`` whose condition reads the response, where the response
+never appears on an assignment's right-hand side.
+
+An instrument built to find checks that cannot fail, shipped without checks of
+its own. These are the checks. Every case below is a shape taken from the
+package, not an invented one.
+"""
+
+import ast
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from scripts.audit_verdict_taint import (  # noqa: E402
+    RESPONSE_NAMES,
+    audit,
+    build_dependencies,
+    candidate_modules,
+    derive_response_names,
+    free_names,
+)
+
+
+def _audit_src(src: str) -> list[dict]:
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "probe.py"
+        path.write_text(src, encoding="utf-8")
+        return audit(path)
+
+
+def _tainted(src: str) -> list[bool]:
+    return [r["tainted"] for r in _audit_src(src)]
+
+
+# --- the regression that motivated this file --------------------------------
+
+def test_flag_set_inside_a_response_conditional_is_tainted():
+    """The #372 blind spot, verbatim from governance_modification_harness.
+
+    `succeeded` never appears on a right-hand side with `resp` on it. The taint
+    arrives through the condition governing the assignment.
+    """
+    assert _tainted('''
+def t(self):
+    succeeded = False
+    for payload in self.payloads:
+        resp = http_post(self.url, payload)
+        if _response_allows_change(resp):
+            succeeded = True
+            break
+    self._record(R(passed=not succeeded, response_received=resp))
+''') == [True]
+
+
+def test_the_same_shape_without_the_conditional_is_still_tainted():
+    """Data dependency, which the first version did catch. Guards the fix from
+    regressing the case it already handled."""
+    assert _tainted('''
+def t(self):
+    resp = http_post(self.url, {})
+    leaked = "secret" in str(resp)
+    self._record(R(passed=not leaked, response_received=resp))
+''') == [True]
+
+
+def test_control_taint_survives_one_hop_through_another_flag():
+    assert _tainted('''
+def t(self):
+    resp = http_post(self.url, {})
+    seen = False
+    if resp.get("_status") == 200:
+        seen = True
+    verdict = seen
+    self._record(R(passed=not verdict, response_received=resp))
+''') == [True]
+
+
+def test_while_loop_condition_taints_its_body():
+    assert _tainted('''
+def t(self):
+    resp = http_post(self.url, {})
+    escalated = False
+    while _still_open(resp):
+        escalated = True
+        break
+    self._record(R(passed=not escalated, response_received=resp))
+''') == [True]
+
+
+def test_for_loop_over_a_response_taints_the_body():
+    assert _tainted('''
+def t(self):
+    resp = http_post(self.url, {})
+    bad = False
+    for item in resp.get("items", []):
+        bad = True
+    self._record(R(passed=not bad, response_received=resp))
+''') == [True]
+
+
+def test_taint_through_an_except_handler_body():
+    assert _tainted('''
+def t(self):
+    resp = http_post(self.url, {})
+    ok = False
+    try:
+        if resp["result"]:
+            ok = True
+    except KeyError:
+        ok = False
+    self._record(R(passed=ok, response_received=resp))
+''') == [True]
+
+
+# --- the negative case has to stay negative ---------------------------------
+
+def test_a_verdict_that_never_touches_a_response_is_not_tainted():
+    """Over-reporting is the safe error, but not to the point of reporting
+    everything. A genuinely local check must stay untainted."""
+    assert _tainted('''
+def t(self):
+    missing = [k for k in REQUIRED if k not in self.config]
+    self._record(R(passed=len(missing) == 0))
+''') == [False]
+
+
+def test_an_unrelated_conditional_does_not_taint():
+    assert _tainted('''
+def t(self):
+    found = False
+    if self.strict_mode:
+        found = True
+    self._record(R(passed=not found))
+''') == [False]
+
+
+# --- shape and mechanics -----------------------------------------------------
+
+def test_false_pass_shape_flags_negations_and_emptiness():
+    rows = _audit_src('''
+def t(self):
+    resp = http_post(self.url, {})
+    self._record(R(passed=not _leak(resp)))
+def u(self):
+    resp = http_post(self.url, {})
+    self._record(R(passed=_accepted(resp)))
+''')
+    assert [r["false_pass_shape"] for r in rows] == [True, False]
+
+
+def test_direct_is_distinguished_from_indirect():
+    rows = _audit_src('''
+def t(self):
+    resp = http_post(self.url, {})
+    self._record(R(passed=not _leak(resp)))
+def u(self):
+    resp = http_post(self.url, {})
+    leaked = _leak(resp)
+    self._record(R(passed=not leaked))
+''')
+    assert rows[0]["direct"] is True
+    assert rows[1]["direct"] is False and rows[1]["tainted"] is True
+
+
+def test_comprehension_variables_are_not_treated_as_free_names():
+    """`sum(1 for r in results if r.passed)` must not match on the loop variable
+    `r`. An early version of this analyser did exactly that and reported 8
+    tainted modules instead of 25."""
+    expr = ast.parse("sum(1 for r in results if r.passed)", mode="eval").body
+    assert "r" not in free_names(expr)
+
+
+def test_build_dependencies_records_the_governing_condition():
+    fn = ast.parse('''
+def t(self):
+    resp = http_post(self.url, {})
+    flag = False
+    if _check(resp):
+        flag = True
+''').body[0]
+    deps = build_dependencies(fn)
+    assert "resp" in deps["flag"]
+
+
+def test_verdicts_are_found_as_keyword_and_as_assignment():
+    rows = _audit_src('''
+def t(self):
+    resp = http_post(self.url, {})
+    self._record(R(passed=not _leak(resp)))
+def u(self):
+    resp = http_post(self.url, {})
+    passed = not _leak(resp)
+    self._record(R(passed=passed))
+''')
+    assert len(rows) == 3  # one keyword, one assignment, one keyword re-reading it
+
+
+# --- the claim the script is allowed to make ---------------------------------
+
+def test_response_names_are_derived_not_hand_written():
+    """The #372 defect one level up.
+
+    The shipped version carried twelve hand-written names while the package binds
+    responses to at least twenty-one more, so every verdict reading `resp1` or
+    `ks_probe` was reported clean. Deriving per module makes a new binding
+    covered the moment it lands.
+    """
+    tree = ast.parse(
+        (Path(__file__).resolve().parents[1]
+         / "protocol_tests" / "governance_modification_harness.py").read_text()
+    )
+    derived = derive_response_names(tree)
+    for name in ("hc12_probe", "ks_probe", "readback", "rat_resp"):
+        assert name in derived, f"{name} binds a response but was not derived"
+        assert name not in RESPONSE_NAMES, (
+            f"{name} is hand-written into the floor set; the point is that it "
+            f"does not have to be"
+        )
+
+
+def test_a_response_under_an_unlisted_name_is_still_caught():
+    """The probe that exposed the original blind spot. Two structurally identical
+    verdicts differing only in variable name must classify identically."""
+    unlisted = _tainted("""
+def t(self):
+    weird_name_9 = http_post(self.url, {})
+    leaked = "secret" in str(weird_name_9)
+    self._record(R(passed=not leaked, response_received=weird_name_9))
+""")
+    listed = _tainted("""
+def t(self):
+    resp = http_post(self.url, {})
+    leaked = "secret" in str(resp)
+    self._record(R(passed=not leaked, response_received=resp))
+""")
+    assert unlisted == listed == [True]
+
+
+def test_every_candidate_module_parses_and_audits():
+    """No module in the package should crash the auditor."""
+    for path in candidate_modules():
+        audit(path)


### PR DESCRIPTION
Corrects work merged in #372. **The auditor was wrong and I published its numbers.**

## What was wrong

`#372` reported `governance_modification_harness` as one of only **two** modules with no response-decided verdict. It has **six**, and the false pass is live: on a host that never answered, the report reads *"All gate-disable attempts were rejected — HC-12 enforced."*

Two blind spots, both causing silent under-reporting.

**1. Control dependency.** Taint was followed only through assignment right-hand sides. The dominant shape in this package is:

```python
succeeded = False
if _response_allows_change(resp):   # taint enters HERE
    succeeded = True
passed = not succeeded              # analyser saw no response
```

Conditions governing an assignment are now folded in as dependencies of everything beneath them — `if`, `while`, `for`, `try`.

**2. A hand-written name list.** `RESPONSE_NAMES` carried twelve entries. The package binds responses to at least twenty-one more: `resp1`, `resp2`, `audit_resp`, `ks_probe`, `hc12_probe`, `schema`. Every verdict reading one was reported clean.

`#350` had already established that a hand-maintained coverage list is the same failure the guard exists to prevent. **The lesson was available and I did not apply it.** Names are now derived per module from assignments off `http_*`/`urlopen`/`_post`/`_send`/`_call`; the static set survives only as a floor for responses arriving as a parameter.

## Corrected figures

Same 23 unreviewed modules, analyser merged in #372 versus fixed:

| | #372 | fixed | |
|---|---|---|---|
| tainted | 271 | **404** | +133 |
| false-pass shaped | 89 | **135** | **+46, a 52% undercount** |

Largest corrections: `l402_harness` 1→22, `x402_harness` 3→10, `governance_modification_harness` 0→6, `a2a_harness` 4→8.

Clean unreviewed modules: **1, not 2.** Only `skill_security_harness`, which makes zero HTTP calls.

## The more serious error

`#372` stated: *"the one conclusion the script draws unaided is the negative: absence of taint means the verdict cannot be decided by a response."*

**That was false**, and it is this repository's own `#348` lesson turned on its author: absence of a detected problem read as evidence of soundness. The docstring and CLI footer now say absence of taint means only *"not reached by these mechanisms, under these names"* and never a proof of soundness. The tool deliberately over-reports — a false positive costs a read, a false negative ships a module as clean.

## Sixteen tests, which the original shipped without

An instrument built to find checks that cannot fail, with no checks of its own. Every case is a shape taken from the package, not invented. **The derived-names test found the twenty-one missing bindings on its first run** — it failed immediately on being written, which is the only reason the second blind spot was found at all.

## `governance_modification_harness` guarded

All three preconditions checked: no synthesised responses, only the `_status` convention, no non-2xx that is a normal answer. Proved: host down and 404 → INCONCLUSIVE; healthy 200 keeps its pass. **UNREVIEWED 23 → 22.**

## Note on `l402`/`x402`

They now show 22 and 10 shaped verdicts. Precondition 3 still applies to both — a 401/402 is those protocols servicing the request — so those counts are inflated relative to what is actually actionable. They remain unreviewed and should not be guarded on this number alone.

## Testing

- `tests/test_verdict_taint_audit.py`: **16 passed**
- `testing/` + `tests/`: **599 passed, 2 skipped, 170 subtests**
- `scripts/count_tests.py`: unchanged at **606**