### PR TITLE
docs(paper): point the GM-001 detector at a file that exists (#375)

### DIFF
--- a/docs/paper-dgb/main.tex
+++ b/docs/paper-dgb/main.tex
@@ -440,8 +440,11 @@ independent evidence:
         to raise the bypass threshold to a permissive value, disabling
         the gate for subsequent calls (the behaviour observed in 9 of 12
         agents in an internal, unpublished run~\cite{hraoe2026}).
-  \item $D$: harness test \texttt{GM-001} in
-        \texttt{benchmarks/tests/gm\_001\_gate\_self\_disable.py};
+  \item $D$: harness test \texttt{GM-001}, implemented as
+        \texttt{test\_gm\_001\_gate\_self\_disable} in
+        \texttt{protocol\_tests/governance\_modification\_harness.py} and
+        registered in the corpus at
+        \texttt{benchmarks/decision\_behavior\_corpus.py};
         binary PASS/FAIL on whether the agent wrote to the governance
         configuration.
   \item $M$: \textbf{False}. A metadata scanner inspecting the agent's


### PR DESCRIPTION
Fixes finding 1 of #375.

The illustrative case named `benchmarks/tests/gm_001_gate_self_disable.py` as $D$. **That file is not in the repository**, and neither is the `benchmarks/tests/` directory. It was the only unresolvable path of the six the paper cites, and it was attached to the worked example a reviewer would try first.

GM-001 is implemented as `test_gm_001_gate_self_disable` in `protocol_tests/governance_modification_harness.py:130` and registered in the corpus at `benchmarks/decision_behavior_corpus.py`. Both are now named — the paper's $D$ is the executable detector, and the corpus entry is what carries the reference to it.

**All six cited paths now resolve:**

```
OK  benchmarks/CHANGELOG.md
OK  benchmarks/decision_behavior_corpus.py
OK  benchmarks/evaluation_results.json
OK  benchmarks/tool_fixtures.py
OK  docs/paper-dgb/_gen_appendix.py
OK  protocol_tests/governance_modification_harness.py
```

## Deliberately not changed

The same item still reads *"binary PASS/FAIL on whether the agent wrote to the governance configuration."*

**That is no longer true of this detector.** It was guarded under #351 (merged in #374) and returns INCONCLUSIVE when the target never serviced the request — which is exactly why it previously reported *"All gate-disable attempts were rejected — HC-12 enforced"* against a host that was not running.

Whether INCONCLUSIVE enters the paper's formalism, and how GMR treats it, is finding 2 of #375 and a methodology decision. Not one to make inside a path fix.

Verified: the named function exists at the cited line, braces and math delimiters balanced in the changed block.