### PR TITLE
Attestation envelope v2: carry the key, not just its fingerprint (#371)

### DIFF
--- a/docs/ATTESTATION-REGISTRY-SERVER-CONTRACT.md
+++ b/docs/ATTESTATION-REGISTRY-SERVER-CONTRACT.md
@@ -132,7 +132,7 @@ This basis sorts keys and does not define duplicate-key rejection, Unicode norma
 number normalization. Do not relabel it RFC 8785 / JCS. If a future revision moves to JCS, the
 envelope MUST carry a version discriminator and both sides MUST be updated together.
 
-### 4.2 Known gap: the envelope cannot be verified as specified
+### 4.2 Envelope v2: carrying the public key (closed 2026-08-15, #371)
 
 **The submission carries `public_key_fingerprint` but never the public key.**
 

--- a/docs/attestation-registry.md
+++ b/docs/attestation-registry.md
@@ -249,8 +249,12 @@ curl -s "$AGENT_SECURITY_REGISTRY_URL/<id>" \
   | python3 scripts/verify_attestation_record.py -
 ```
 
-**Known gap.** The submission envelope currently carries `public_key_fingerprint` but
-not the public key, so a third party cannot check the Ed25519 signature on a record
-published by today's client. Section 4.2 of the contract specifies `envelope_version`
-2, which adds `public_key`. Until the client emits it, records are stored with
-`signature_verifiable: false` and the verifier exits non-zero on them, by design.
+**Closed 2026-08-15 (#371).** The client emits `envelope_version: "2"`, carrying the
+signer's PEM public key alongside its fingerprint, so a record published today verifies
+offline against any registry. Before this, the envelope carried only
+`sha256(public_key)[:16]`: enough to confirm a key you already held, not enough to
+recover one, so the verification property described above was unreachable by anyone.
+
+A conforming server still accepts a v1 envelope and marks those records
+`signature_verifiable: false`; the verifier exits non-zero on them, by design. A record
+that cannot be checked without the operator says so about itself.

--- a/protocol_tests/attestation_registry.py
+++ b/protocol_tests/attestation_registry.py
@@ -268,19 +268,37 @@ def publish_attestation(
         "published_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
     }
 
+    # Canonical bytes: sort_keys with DEFAULT separators, not compact and not
+    # JCS. Pinned in docs/ATTESTATION-REGISTRY-SERVER-CONTRACT.md section 4.1,
+    # because a canonicalisation that lives in one implementation is not a
+    # contract and an independent verifier reproducing it wrongly gets a valid
+    # signature that will not verify.
     payload_bytes = json.dumps(payload_dict, sort_keys=True).encode()
 
     # Sign so the registry can verify authenticity
     signature = _sign_payload(payload_bytes)
     verification_hash = hashlib.sha256(payload_bytes).hexdigest()
 
+    # Envelope v2 (#371): carry the public KEY, not only its fingerprint.
+    #
+    # v1 sent sha256(public_key_pem)[:16] and nothing else. A fingerprint lets
+    # someone confirm a key they already hold; it does not let them recover one.
+    # So a third party fetching a record could check that verification_hash
+    # matched the payload -- internal consistency, and nothing more -- and could
+    # verify NOTHING about who signed it. docs/attestation-registry.md states
+    # that a third party can check an entry without trusting the operator. As
+    # shipped, nobody could. An operator could author a payload, compute a
+    # matching hash, and serve a record indistinguishable from a genuine one.
+    pub_pem = (_KEY_DIR / "signing_key_pub.pem").read_bytes()
     submission = {
+        "envelope_version": "2",
         "payload": payload_dict,
         "signature": signature,
         "verification_hash": verification_hash,
-        "public_key_fingerprint": hashlib.sha256(
-            (_KEY_DIR / "signing_key_pub.pem").read_bytes()
-        ).hexdigest()[:16],
+        # Retained so a server can reject a public_key that does not match it,
+        # and so existing consumers of the field keep working.
+        "public_key_fingerprint": hashlib.sha256(pub_pem).hexdigest()[:16],
+        "public_key": pub_pem.decode("utf-8"),
     }
 
     endpoint = resolve_registry_endpoint()

--- a/tests/test_registry_server_contract.py
+++ b/tests/test_registry_server_contract.py
@@ -390,3 +390,57 @@ def test_unknown_id_is_404(live_server):
     except urllib.error.HTTPError as exc:
         status = exc.code
     assert status == 404
+
+# --- Contract 4.2: the client half ------------------------------------------
+
+def test_client_emits_envelope_v2_carrying_the_public_key(monkeypatch, tmp_path):
+    """#371. v1 sent only sha256(pub)[:16], so no third party could check the
+    signature and the verification property the docs promise was unreachable."""
+    import protocol_tests.attestation_registry as reg
+
+    captured = {}
+
+    class _Resp:
+        @staticmethod
+        def read():
+            return json.dumps({"id": "abc123"}).encode()
+
+    def _fake_urlopen(req, timeout=15):
+        captured["body"] = json.loads(req.data.decode())
+        return _Resp()
+
+    monkeypatch.setenv("AGENT_SECURITY_REGISTRY_URL", "https://registry.invalid")
+    monkeypatch.setattr(reg, "urlopen", _fake_urlopen)
+    reg.publish_attestation(_report(), server_name="probe")
+
+    body = captured["body"]
+    assert body["envelope_version"] == "2"
+    assert body["public_key"].startswith("-----BEGIN PUBLIC KEY-----")
+    assert hashlib.sha256(body["public_key"].encode()).hexdigest()[:16] == (
+        body["public_key_fingerprint"]
+    ), "fingerprint must match the key it now travels with"
+
+
+def test_a_record_from_the_real_client_verifies_offline(monkeypatch):
+    """The whole point of #371: the round trip a third party actually performs."""
+    import protocol_tests.attestation_registry as reg
+
+    captured = {}
+
+    class _Resp:
+        @staticmethod
+        def read():
+            return json.dumps({"id": "abc123"}).encode()
+
+    def _fake_urlopen(req, timeout=15):
+        captured["body"] = json.loads(req.data.decode())
+        return _Resp()
+
+    monkeypatch.setenv("AGENT_SECURITY_REGISTRY_URL", "https://registry.invalid")
+    monkeypatch.setattr(reg, "urlopen", _fake_urlopen)
+    reg.publish_attestation(_report(), server_name="probe")
+
+    record = validate_and_build(captured["body"], REQUIRED)
+    assert record["signature_verifiable"] is True
+    assert record["envelope_version"] == "2"
+    assert _verify(record).returncode == 0


### PR DESCRIPTION
Closes #371.

`docs/attestation-registry.md` states that a third party can check a published entry without trusting the registry operator. **As shipped, nobody could.**

The submission carried `public_key_fingerprint` — `sha256(public_key_pem)[:16]` — and never the key. A fingerprint confirms a key you already hold; it does not let you recover one. So a third party fetching a record could verify `verification_hash` against the payload bytes (internal consistency, nothing more) and could establish **nothing about who signed it**. An operator could author a payload, compute a matching hash, and serve a record indistinguishable from a genuine one.

## The fix

`publish_attestation` now emits `envelope_version: "2"` with the signer's PEM public key alongside the fingerprint. The fingerprint is retained so a server can reject a mismatched pair and existing consumers keep working. Shape and rationale were specified in §4.2 of the server contract (#333 / #370) and filed as #371 rather than folded into the contract that found it.

## Before and after, same round trip

```
v1:  [PASS] verification_hash matches the canonical payload bytes
     [FAIL] record carries no 'public_key', so the signature CANNOT be checked
     RESULT: VERIFICATION FAILED

v2:  [PASS] verification_hash matches the canonical payload bytes
     [PASS] public_key matches public_key_fingerprint
     [PASS] Ed25519 signature verifies over the canonical payload bytes
     RESULT: all applicable checks passed
```

Run against the reference server with the real client, not a mock.

## Backward compatibility unchanged

A v1 envelope is still accepted and stored `signature_verifiable: false`; the verifier still exits non-zero on it. A record that cannot be checked without the operator says so about itself.

## Tests

Two regressions pin it: the client must emit v2 with a key whose `sha256` prefix equals the advertised fingerprint, and a record built from the real client's own submission must verify offline. `tests/test_registry_server_contract.py` now at **38 passed**.

## Docs

The "Known gap" block in `attestation-registry.md` and the "cannot be verified as specified" heading in the contract both described a live defect that no longer exists. **A stale gap notice is its own kind of wrong claim**, so both are corrected rather than left to age.

Suites: **601 passed, 2 skipped, 170 subtests**. `count_tests.py` unchanged at **606**.