### PR TITLE
Make reproduction cheap, and commit to publishing disagreement

### DIFF
--- a/.github/ISSUE_TEMPLATE/reproduction-report.yml
+++ b/.github/ISSUE_TEMPLATE/reproduction-report.yml
@@ -1,0 +1,114 @@
+name: Reproduction Report
+description: Report the result of independently reproducing a pinned corpus — including a result that disagrees with ours
+title: "[Reproduction] "
+labels: ["reproduction", "evidence"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Disagreement is the useful outcome.** A reproduction that matches is weak evidence:
+        both implementations may share the same wrong assumption. A reproduction that
+        *diverges* has found something, and we will publish it either way.
+
+        This is not a contribution. Nothing you post here is submitted for inclusion in the
+        repository, and you keep your own artifacts in your own repository.
+
+        Under [docs/EVIDENCE-CLASS-TAXONOMY.md](../../docs/EVIDENCE-CLASS-TAXONOMY.md), a
+        report from a **second implementation written from the published contract rather
+        than from our code** is **I1** for this harness. A run of *our* code against *your*
+        target is not — that is I0 for you, and we cannot cite it as independent.
+
+  - type: input
+    id: pinned-commit
+    attributes:
+      label: Pinned commit
+      description: The exact revision you ran against. A branch name is not a pin.
+      placeholder: "5e25bc6465ccced079ca6a6b8f54e065a1677a69"
+    validations:
+      required: true
+
+  - type: input
+    id: artifact-digest
+    attributes:
+      label: Artifact and its SHA-256
+      description: The corpus or fixture file you consumed, with its digest as you computed it.
+      placeholder: "fixtures/rcl/rcl-oracle-fixtures.v1.json — 4164151383605d9d68230d81cc9ae1dd31eb5cfb3fb1348289abf71ee64773ea"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: independence
+    attributes:
+      label: How was your implementation produced?
+      description: This determines the I-level, and it is the question that decides whether the report is citable as independent.
+      options:
+        - Written from the published contract, without reading our implementation (I1)
+        - Written after reading our implementation (I0 — still useful, say so)
+        - Ran our code against my own target (I0 for me — not independent evidence for this harness)
+        - An out-of-band sensor our code does not author (I2 — describe it below)
+    validations:
+      required: true
+
+  - type: textarea
+    id: method
+    attributes:
+      label: What your implementation actually checks
+      description: Enough that someone could tell whether a match is meaningful or coincidental.
+      placeholder: |
+        Verifies envelope and authority signatures from the exported public keys only;
+        recomputes action and parameter digests; checks authorization and occurrence
+        linkage to the exact action; preserves the acceptance controls rather than
+        passing by rejecting everything.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected
+      placeholder: "All 11 recorded verdicts match, and both acceptance controls are retained."
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual — including every divergence
+      description: |
+        List disagreements explicitly. Do not round them off. #304 is the model: it matched
+        11/11 and *also* surfaced two undeclared fixture-contract defects, and those two are
+        the reason it counted as evidence rather than as agreement.
+      placeholder: |
+        Matched 11/11 verdicts, claim families, and reason strings.
+        Diverged on: <case> — we computed X, the recorded verdict is Y, because ...
+    validations:
+      required: true
+
+  - type: input
+    id: artifacts
+    attributes:
+      label: Your artifacts
+      description: A link to your runner and report, in your repository. We will not vendor them.
+      placeholder: "https://github.com/you/your-lab/blob/main/evidence/CROSS_EVALUATION.md"
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      placeholder: "Runtime and version, OS, and the exact command you ran."
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: boundaries
+    attributes:
+      label: Boundaries
+      options:
+        - label: This is a reproducibility report, not a contribution, and I am not submitting code or text for inclusion.
+          required: true
+        - label: My artifacts live in my own repository and I am not asking for them to be vendored here.
+          required: true
+        - label: I understand a matching result will be recorded as agreement, not as validation, and that a diverging result is more useful.
+          required: true

--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ The [constitutional-agent](https://github.com/CognitiveThoughtEngine/constitutio
 | Canonical coverage mapping (source of truth) | [docs/coverage/owasp-agentic-v1.1.yaml](docs/coverage/owasp-agentic-v1.1.yaml) |
 | Release history & known gaps | [ROADMAP.md](ROADMAP.md) · [CHANGELOG.md](CHANGELOG.md) |
 | E1-E5 Evidence Class Taxonomy (canonical) | [docs/EVIDENCE-CLASS-TAXONOMY.md](docs/EVIDENCE-CLASS-TAXONOMY.md) |
+| Reproducing this harness (and disagreeing with it) | [docs/REPRODUCING.md](docs/REPRODUCING.md) |
 | Attestation registry (client, opt-in publishing) | [docs/attestation-registry.md](docs/attestation-registry.md) |
 | Attestation registry server contract (self-hosted; no registry is operated by this project) | [docs/ATTESTATION-REGISTRY-SERVER-CONTRACT.md](docs/ATTESTATION-REGISTRY-SERVER-CONTRACT.md) |
 | AIUC-1 Evidence Field Guide (external, not version-pinned) | [msaleme.github.io/aiuc1-readiness](https://msaleme.github.io/aiuc1-readiness/) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ This directory contains detailed documentation for the Agent Security Harness fr
 |---|---|
 | [../agent-fabric-red-blue-team-spec.md](../agent-fabric-red-blue-team-spec.md) | **Original specification** - 20 STRIDE scenarios, architecture overview, threat model |
 | [CASE_STUDY_FALSE_PASS.md](CASE_STUDY_FALSE_PASS.md) | **False pass case study** - Analysis of security testing failure modes |
+| [REPRODUCING.md](REPRODUCING.md) | **Independent reproduction** - what counts as I1, the pinned RCL corpus, and the commitment to publish contradicting results |
 | [EVIDENCE-CLASS-TAXONOMY.md](EVIDENCE-CLASS-TAXONOMY.md) | **E1-E5 evidence classes and the I0-I2 independence axis** - what a result establishes, and about which system under test |
 | [attestation-registry.md](attestation-registry.md) | **Attestation registry client** - opt-in publishing, sensitive-field stripping, no default endpoint |
 | [ATTESTATION-REGISTRY-SERVER-CONTRACT.md](ATTESTATION-REGISTRY-SERVER-CONTRACT.md) | **Registry server contract** - what a submission establishes (I0), the eight receive obligations, and offline verification that does not require trusting the operator |

--- a/docs/REPRODUCING.md
+++ b/docs/REPRODUCING.md
@@ -1,0 +1,101 @@
+# Reproducing this harness, and disagreeing with it
+
+This document exists because the harness has been reproduced independently **once**, in
+[#304](https://github.com/msaleme/red-team-blue-team-agent-fabric/issues/304), and once is
+not a track record. Everything below is written to make the second time cheaper than the
+first.
+
+## The commitment
+
+**We will publish a reproduction that contradicts ours, in full, without negotiating it
+down first.** If your implementation disagrees with a recorded verdict, that result gets
+its own issue, stays open until it is resolved on the merits, and is linked from the
+corpus it disputes. If we are wrong, the corpus changes.
+
+This is not generosity. Under
+[`docs/EVIDENCE-CLASS-TAXONOMY.md`](EVIDENCE-CLASS-TAXONOMY.md), agreement between two
+implementations is **weak** evidence — both may share the same wrong assumption, which is
+the I1 row's stated blind spot. **Divergence is the signal.** A project that only
+publishes confirmations is measuring whether people agree with it, not whether it is
+right.
+
+## What counts as independent, and what does not
+
+| You did | I-level for this harness | Citable as independent |
+| --- | --- | --- |
+| Wrote a second implementation from the published contract, without reading ours | **I1** | Yes |
+| Wrote one after reading our implementation | I0 | No — shared assumptions survive |
+| Ran *our* code against *your* target | I0 for you | No |
+| Observed via a channel our code does not author | **I2** | Yes, and rarer |
+
+The I-level is **relative to a named system under test**. A result that is I2 for you may
+be I0 for us. State the system you are making the claim about, or the level means nothing.
+
+## The reproducible surface
+
+The receipt-claim (RCL) oracle corpus is the piece designed for outside reproduction: it is
+a single pinned file, it needs no network target, and it carries acceptance controls so an
+implementation cannot pass by rejecting everything.
+
+```bash
+git clone https://github.com/msaleme/red-team-blue-team-agent-fabric
+cd red-team-blue-team-agent-fabric
+
+# Pin what you consumed, and record the digest you computed yourself.
+git rev-parse HEAD
+sha256sum fixtures/rcl/rcl-oracle-fixtures.v1.json
+```
+
+At the time of writing that file is
+`4164151383605d9d68230d81cc9ae1dd31eb5cfb3fb1348289abf71ee64773ea`. **Compute it yourself
+rather than quoting this line** — a digest you did not calculate is a claim you are
+repeating, not evidence you hold.
+
+The corpus contains nine validly signed receipts a conforming verifier must **reject**, and
+two acceptance controls it must **accept**. The controls are the point: a verifier that
+rejects everything scores nine out of nine on the reject cases and is worthless.
+
+Contract for what the fields mean:
+[`docs/ATTESTATION-REGISTRY-SERVER-CONTRACT.md`](ATTESTATION-REGISTRY-SERVER-CONTRACT.md)
+§4.1 pins the canonical byte basis, which is the single most common reason an independent
+implementation computes a different digest for material it read correctly.
+
+## What a good report looks like
+
+[#304](https://github.com/msaleme/red-team-blue-team-agent-fabric/issues/304) is the model,
+and it is worth being precise about *why*. It matched 11/11 recorded verdicts — and it also
+surfaced **two undeclared fixture-contract defects**. Those two are the reason it counted as
+evidence. Had it only agreed, it would have established that two implementations shared a
+reading.
+
+Use the [Reproduction Report](../../issues/new?template=reproduction-report.yml) template.
+It asks for the pinned commit, the digest you computed, how your implementation was
+produced, what it actually checks, expected versus actual **including every divergence**,
+and a link to artifacts **in your own repository**. We will not vendor your code, and your
+report is not a contribution.
+
+## What we will not do
+
+- **Claim your result as validation of the harness.** A reproduction establishes that a
+  second implementation read the same corpus the same way. It does not establish that the
+  corpus is correct, that any product is secure, or that anything is certified.
+- **Quietly fix a divergence and close your issue.** If your finding changes the corpus,
+  the change references your report.
+- **Ask you to soften a finding.** If the disagreement is real, it is published as you
+  wrote it.
+
+## Verifying an attestation you were handed
+
+If someone gives you a published attestation record rather than a corpus, you can check it
+offline without trusting whoever served it:
+
+```bash
+curl -s "$AGENT_SECURITY_REGISTRY_URL/<id>" \
+  | python3 scripts/verify_attestation_record.py -
+```
+
+That checks the canonical bytes, the key against its advertised fingerprint, and the
+Ed25519 signature. It deliberately does **not** tell you whose key it is — key-to-identity
+binding is out of scope, and no registry can supply it. It also prints, after every check
+passes, that an I0 record still proves nothing about the target. That last line is the one
+readers skip.


### PR DESCRIPTION
The harness has been independently reproduced **once** — #304 — and once is not a track record. External validation is the stated bottleneck, and nothing in the repository made the second attempt cheaper than the first.

Adds `docs/REPRODUCING.md` and a **Reproduction Report** issue template, both modelled on #304 because it is the only working example.

## Built to elicit disagreement, not confirmation

Under `docs/EVIDENCE-CLASS-TAXONOMY.md`, agreement between two implementations is **weak** evidence — both may share the same wrong assumption, which is the I1 row's own stated blind spot.

**#304 counted as evidence because it matched 11/11 *and* surfaced two undeclared fixture-contract defects.** Had it only agreed, it would have established that two implementations shared a reading.

So the template:
- requires expected-versus-actual **"including every divergence"**, with #304 named as the model
- asks **how the implementation was produced** — the question that decides I1 versus I0, and the one a reporter will otherwise skip
- makes the reporter acknowledge that a match is recorded as *agreement*, not validation

And the doc states what will **not** be done: no claiming a result as validation, no quietly fixing a divergence and closing the issue, no asking anyone to soften a finding.

## One detail worth keeping

It tells the reader to compute the fixture digest themselves rather than quote the one in the doc — *a digest you did not calculate is a claim you are repeating, not evidence you hold.* Same reasoning as naming release-versus-main on the test count.

## Verified

Template YAML parses (10 fields, 8 required), every doc link resolves, and the quoted digest was checked against the actual file. Indexed in both README and `docs/README.md`.

Suites: **599 passed, 2 skipped, 170 subtests** on this branch. (601 belongs to PR #377, which adds the #371 envelope-v2 tests and is not in this branch.)