### PR TITLE
docs: tighten seven precision claims in the defect-class note

### DIFF
--- a/conformance/external/veritas-omega/REPORT.md
+++ b/conformance/external/veritas-omega/REPORT.md
@@ -42,7 +42,7 @@ SHA-256 digests compared  : 14   matched: 14
 total divergences         : 0
 ```
 
-## Finding: the track's pass condition cannot detect a canonicalisation divergence
+## Finding: matching decisions do not establish correct canonicalisation
 
 Canonicalisation affects the track's 14 packet digests. Where a decision compares digests,
 both operands come from the same canonicaliser, so a consistently wrong implementation
@@ -63,18 +63,22 @@ decision-field divergences from the correct run : 0    <- all 12 cases still dec
 digest divergences                              : 14   <- every digest is wrong
 ```
 
-The `packet` digests are the only outputs that catch it. `required_result_fields` includes
-`packet`, but the protocol does not state that the digest values inside it must be compared,
-so a submission could satisfy the stated criteria while having reproduced none of the
-serialisation contract.
+**The challenge's prose rule already catches this.** Track 1 says *"At minimum, compare"* and
+its fourth bullet is *"case-specific packet digests and counts"*. A submission that compares
+those digests detects a wrong canonicaliser. This section is therefore not a defect report
+against the acceptance rule, and an earlier version of it overstated exactly that.
 
-This is the same shape as the challenge's own rule 5 — a verifier that rejects everything has
-not reproduced the contract — applied one level up: a verifier that decides everything
-correctly has not necessarily reproduced the contract either.
+The residual observation is a specification divergence: the machine-readable protocol lists
+`packet` among `required_result_fields`, while the prose requires comparing the digest
+*values* inside it. An evaluator built from the JSON alone would not require what the prose
+does.
 
-**Suggested fix:** require the `packet` digest values in the submitted artifact and compare
-them, or add one case whose decision depends on a digest *equality* against a fixed expected
-value rather than on an inequality between two computed ones.
+It is adjacent to the challenge's own rule 5 — a verifier that rejects everything has not
+reproduced the contract — one level up: a verifier that decides everything correctly has not
+necessarily reproduced it either. Your prose rule already accounts for this; the JSON does not.
+
+**Suggested fix:** bring the machine-readable protocol into line with the prose, by naming the
+digest values rather than only the `packet` field.
 
 ## Untested boundaries
 

--- a/conformance/external/veritas-omega/REPORT.md
+++ b/conformance/external/veritas-omega/REPORT.md
@@ -44,10 +44,15 @@ total divergences         : 0
 
 ## Finding: the track's pass condition cannot detect a canonicalisation divergence
 
-Every decision in track 1 is derived from a digest **inequality** — `mismatch = a !== b` —
-so it is true whenever the inputs differ, independent of how they were serialised. An
-implementation that gets `canonicalize` wrong therefore still produces all twelve correct
-decisions.
+Canonicalisation affects the track's 14 packet digests. Where a decision compares digests,
+both operands come from the same canonicaliser, so a consistently wrong implementation
+preserves their equality or inequality. In the other case families the decision does not
+depend on canonicalisation at all: `forged-verdict` compares claimed and recomputed states,
+`nonce-replay` checks prior consumption, `correlated-quorum` counts independent groups, and
+`silent-monitor` compares heartbeat age against a TTL.
+
+Either way, an implementation that gets `canonicalize` wrong still produces all twelve
+correct decisions.
 
 Demonstrated by re-running the implementation with a deliberately wrong canonicalisation
 (pretty-printed rather than `JSON.stringify`'s compact separators, the single most likely

--- a/docs/VERIFICATION-DESIGN-DEFECT.md
+++ b/docs/VERIFICATION-DESIGN-DEFECT.md
@@ -1,6 +1,6 @@
 # The acceptance criterion that does not require the mechanism
 
-Status: draft. Five recorded instances, four systems, three authors.
+Status: draft. Five reproducible instances across multiple verification designs.
 
 ---
 
@@ -9,7 +9,11 @@ Status: draft. Five recorded instances, four systems, three authors.
 A verification system has a mechanism `M` that is supposed to do the work, and an acceptance
 criterion `A` that is supposed to establish `M` worked.
 
-**The defect is any `A` that can be satisfied while `M` is absent, broken, or never ran.**
+**A verification design is defective when its acceptance rule can report success even
+though a required mechanism is absent, broken, or never executed.**
+
+One criterion may be only part of a larger acceptance rule; the defect is a property of the
+rule as a whole, not of any single check within it.
 
 This is not a bug class in the ordinary sense. Each instance below was written by someone
 competent, reviewed, and shipped. In four of the five the author's stated purpose was
@@ -20,7 +24,8 @@ The diagnostic that catches all five is a single question:
 
 > **What is the cheapest way to satisfy this criterion without doing the work?**
 
-If the answer is "do nothing", the criterion measures nothing.
+If the cheapest way to pass is "do nothing", the criterion provides no evidence that the
+required mechanism ran. It may still measure an absence; it does not establish an operation.
 
 ---
 
@@ -32,7 +37,7 @@ If the answer is "do nothing", the criterion measures nothing.
 | 2 | Verdict-taint auditor | taint analysis | no taint found | the analysis is incomplete |
 | 3 | Decision Governance Benchmark | governance maintained | binary PASS | the case never executed |
 | 4 | Token-Bleed Benchmark | retrieval from a catalog | correct columns returned | the answer key was handed over |
-| 5 | VERITAS Omega Trust Lab | canonical serialisation | decisions reproduce | any serialisation is used |
+| 5 | VERITAS Omega Trust Lab | canonical serialisation | decisions reproduce | the demonstrated compact-versus-pretty serialisation error is used |
 
 ### 1. Absence of a detected attack, read as a control holding
 
@@ -40,13 +45,16 @@ Harness issues [#348], [#350], [#351]. Verdicts of the form `passed = not leaked
 `passed = not succeeded`. On a host that is not running, nothing leaks and nothing succeeds,
 so the control "held".
 
-Worth recording precisely: **this was repaired four times.** v4.13.1 fixed it in one harness
+Worth recording precisely: **the same defect has been addressed in four rounds so far, and
+the work is not finished.** v4.13.1 fixed it in one harness
 and defined the guard locally. #348 carried it to five more, found by reading five files. #350
 found two further modules the reading had missed. #351 derived the candidate set instead of
 reading, and remains open with 22 of the package's test-bearing harnesses still
 unreviewed for it.
 
-Each repair was correct. Each was scoped to where the author had looked.
+Each local repair was correct, and each successive round found additional unexamined sites.
+As of [#374], 22 candidate modules remained unreviewed. (The body of [#351] still states 27,
+which predates that PR.)
 
 ### 2. Absence of detected taint, read as proof of cleanliness
 
@@ -81,7 +89,7 @@ than about the model.
 
 ### 4. A benchmark that could only confirm
 
-`token-bleed-benchmark`, first commit: `route_governed` passed exactly the columns where
+`token-bleed-benchmark`, [first commit][tb-initial]: `route_governed` passed exactly the columns where
 `is_gov_id` was true — the answer key. A perfect-echo reply scored F1 1.000 at every tier. The
 governed route could not lose on precision because nothing in its input was wrong.
 
@@ -92,7 +100,7 @@ disconfirming result.
 Repaired by giving the classifier false positives the model must discriminate, then a
 false-negative rate, then a cheap lexical baseline whose README states that if the regex
 captures most of the advantage, *the honest result is about filtering labels, not governed
-metadata*.
+metadata*. The correction is [`27d20b8`][tb-fix].
 
 ### 5. A pass condition that does not require the contract
 
@@ -103,8 +111,9 @@ Every decision in the track derives from a digest **inequality** — `mismatch =
 which holds whenever the inputs differ, regardless of how they were serialised. An
 implementation that gets `canonicalize` wrong still produces all twelve correct decisions.
 
-Demonstrated rather than argued. Re-running a verified-correct independent implementation
-with a deliberately wrong canonicalisation, pretty-printed instead of compact:
+**A deliberately wrong pretty-printed serialiser changed all 14 digests while leaving all 12
+decisions unchanged.** Demonstrated rather than argued, by re-running a verified-correct
+independent implementation with that one substitution:
 
 ```
 decision-field divergences from the correct run : 0    all 12 cases still decide identically
@@ -133,8 +142,8 @@ usually a different subsystem.
 incomplete analysis produces a short findings list. Both are indistinguishable, at a glance,
 from the healthy case — and better-looking than it.
 
-**The fix generalises worse than the defect.** Instance 1 was repaired four times because
-each repair was scoped to the sites the author had read. The defect propagates by
+**The fix generalises worse than the defect.** Instance 1 has taken four rounds because each
+round was scoped to the sites its author had read. The defect propagates by
 copy-and-adapt; the repair propagates by someone remembering.
 
 ---
@@ -155,9 +164,11 @@ mechanism being present**, and every instance above lacked one at the level wher
 - instance 4 had no route that could beat the favoured one
 - instance 5 has no case whose decision depends on a digest *equality*
 
-**A third state.** Two states force every unknown into one of them, and it is always the
-favourable one. `INCONCLUSIVE` is not a nicety; it is the only way a system can report that
-it learned nothing.
+**A third state.** A binary model must either collapse unknown into PASS or FAIL, or
+represent validity somewhere outside the verdict. A binary system *can* fail closed; in the
+instances above, unknown was repeatedly absorbed into the favourable state instead.
+`INCONCLUSIVE` is the clearest way to report that the system learned nothing. An equivalent
+separate validity or execution-status field serves the same purpose.
 
 **Derive the coverage set; never hand-write it.** Instance 1 recurred because the coverage
 list was what someone had read. Instance 2 recurred because the name list was what someone
@@ -186,3 +197,5 @@ public commits and issues, which is the property this document is offering.
 [#374]: https://github.com/msaleme/red-team-blue-team-agent-fabric/pull/374
 [#375]: https://github.com/msaleme/red-team-blue-team-agent-fabric/issues/375
 [VrtxOmega/veritas-agent-trust-lab]: https://github.com/VrtxOmega/veritas-agent-trust-lab
+[tb-initial]: https://github.com/msaleme/token-bleed-benchmark/commit/dd6e2c465ac428e231b48848cae3682e3bcc02ad
+[tb-fix]: https://github.com/msaleme/token-bleed-benchmark/commit/27d20b8d533fcab06af4da2863cb7acde32b5dad

--- a/docs/VERIFICATION-DESIGN-DEFECT.md
+++ b/docs/VERIFICATION-DESIGN-DEFECT.md
@@ -107,9 +107,16 @@ metadata*. The correction is [`27d20b8`][tb-fix].
 [VrtxOmega/veritas-agent-trust-lab], *Break VERITAS: External Verification Challenge v1*,
 track `independent-result-recomputation`.
 
-Every decision in the track derives from a digest **inequality** — `mismatch = a !== b` —
-which holds whenever the inputs differ, regardless of how they were serialised. An
-implementation that gets `canonicalize` wrong still produces all twelve correct decisions.
+Canonicalisation affects the track's 14 packet digests. Where a decision compares digests,
+both operands are produced by the same canonicaliser, so a consistently wrong implementation
+preserves their equality or inequality. In the other case families the decision does not
+depend on canonicalisation at all: `forged-verdict` compares claimed and recomputed states,
+`nonce-replay` checks prior consumption, `correlated-quorum` counts independent groups, and
+`silent-monitor` compares heartbeat age against a TTL.
+
+The protocol requires the `packet` field but does not explicitly require the digest values
+inside it to match the reference outputs. A submission can therefore satisfy the stated
+decision criteria without reproducing the canonicalisation contract.
 
 **A deliberately wrong pretty-printed serialiser changed all 14 digests while leaving all 12
 decisions unchanged.** Demonstrated rather than argued, by re-running a verified-correct
@@ -122,7 +129,8 @@ digest divergences                              : 14   every digest is wrong
 
 Evidence and implementation: [`conformance/external/veritas-omega/`](../conformance/external/veritas-omega/).
 
-**This instance is the one that makes the other four a class rather than a postmortem.** It
+**This external instance supports treating the pattern as a reusable defect class rather than
+only one project's postmortem.** It
 is a different author, a different language, a different problem domain, and a project whose
 own published rules already state the closely related principle — *a verifier that rejects
 everything has not reproduced the contract*. They wrote the acceptance-control rule and the
@@ -148,7 +156,10 @@ copy-and-adapt; the repair propagates by someone remembering.
 
 ---
 
-## What actually works
+## What the evidence supports
+
+These appear to be necessary design requirements. The five instances do not establish that
+they are sufficient.
 
 **Acceptance controls.** A case that *must* pass, so an implementation cannot score by
 rejecting everything. RCL-008 and RCL-009 in this repository; rule 5 of the VERITAS
@@ -161,7 +172,7 @@ mechanism being present**, and every instance above lacked one at the level wher
 - instance 1 had no case requiring that the target answered
 - instance 2 had no case requiring that the analysis was complete
 - instance 3 had no outcome distinguishing "maintained" from "never tested"
-- instance 4 had no route that could beat the favoured one
+- instance 4 had no candidate set on which the favoured route could lose precision
 - instance 5 has no case whose decision depends on a digest *equality*
 
 **A third state.** A binary model must either collapse unknown into PASS or FAIL, or

--- a/docs/VERIFICATION-DESIGN-DEFECT.md
+++ b/docs/VERIFICATION-DESIGN-DEFECT.md
@@ -1,6 +1,7 @@
 # The acceptance criterion that does not require the mechanism
 
-Status: draft. Five reproducible instances across multiple verification designs.
+Status: draft. Four reproduced instances across multiple verification designs, and one
+related external boundary case.
 
 ---
 
@@ -16,11 +17,11 @@ One criterion may be only part of a larger acceptance rule; the defect is a prop
 rule as a whole, not of any single check within it.
 
 This is not a bug class in the ordinary sense. Each instance below was written by someone
-competent, reviewed, and shipped. In four of the five the author's stated purpose was
+competent, reviewed, and shipped. In every case the author's stated purpose was
 precisely to prevent this kind of error, and in one the author was auditing for this exact
 defect at the time they introduced it.
 
-The diagnostic that catches all five is a single question:
+The diagnostic that catches the four defects is a single question:
 
 > **What is the cheapest way to satisfy this criterion without doing the work?**
 
@@ -29,7 +30,7 @@ required mechanism ran. It may still measure an absence; it does not establish a
 
 ---
 
-## Five instances
+## Four instances
 
 | # | System | Mechanism `M` | Criterion `A` | `A` holds when |
 |---|---|---|---|---|
@@ -37,7 +38,6 @@ required mechanism ran. It may still measure an absence; it does not establish a
 | 2 | Verdict-taint auditor | taint analysis | no taint found | the analysis is incomplete |
 | 3 | Decision Governance Benchmark | governance maintained | binary PASS | the case never executed |
 | 4 | Token-Bleed Benchmark | retrieval from a catalog | correct columns returned | the answer key was handed over |
-| 5 | VERITAS Omega Trust Lab | canonical serialisation | decisions reproduce | the demonstrated compact-versus-pretty serialisation error is used |
 
 ### 1. Absence of a detected attack, read as a control holding
 
@@ -102,41 +102,45 @@ false-negative rate, then a cheap lexical baseline whose README states that if t
 captures most of the advantage, *the honest result is about filtering labels, not governed
 metadata*. The correction is [`27d20b8`][tb-fix].
 
-### 5. A pass condition that does not require the contract
+## Related case: decision equivalence does not establish contract equivalence
 
 [VrtxOmega/veritas-agent-trust-lab], *Break VERITAS: External Verification Challenge v1*,
 track `independent-result-recomputation`.
 
-Canonicalisation affects the track's 14 packet digests. Where a decision compares digests,
-both operands are produced by the same canonicaliser, so a consistently wrong implementation
-preserves their equality or inequality. In the other case families the decision does not
-depend on canonicalisation at all: `forged-verdict` compares claimed and recomputed states,
-`nonce-replay` checks prior consumption, `correlated-quorum` counts independent groups, and
-`silent-monitor` compares heartbeat age against a TTL.
+**This is not a fifth instance, and the distinction is exactly what the narrowed definition
+above is for.** The challenge's prose acceptance rule is correct. It says *"At minimum,
+compare"*, and its fourth bullet is *"case-specific packet digests and counts"*. A wrong
+canonicaliser is caught by the complete human-readable rule.
 
-The protocol requires the `packet` field but does not explicitly require the digest values
-inside it to match the reference outputs. A submission can therefore satisfy the stated
-decision criteria without reproducing the canonicalisation contract.
+What the experiment establishes is narrower, and still worth stating:
 
-**A deliberately wrong pretty-printed serialiser changed all 14 digests while leaving all 12
-decisions unchanged.** Demonstrated rather than argued, by re-running a verified-correct
-independent implementation with that one substitution:
+> **Matching decisions does not establish correct canonicalisation.**
+
+A deliberately wrong pretty-printed serialiser changed all 14 digests while leaving all 12
+decisions unchanged:
 
 ```
 decision-field divergences from the correct run : 0    all 12 cases still decide identically
 digest divergences                              : 14   every digest is wrong
 ```
 
-Evidence and implementation: [`conformance/external/veritas-omega/`](../conformance/external/veritas-omega/).
+Canonicalisation affects the 14 packet digests. Where a decision compares digests, both
+operands come from the same canonicaliser, so a consistently wrong implementation *can*
+preserve their equality or inequality, as the demonstrated mutation did. In the other four
+families the decision does not depend on canonicalisation at all: `forged-verdict` compares
+claimed and recomputed states, `nonce-replay` checks prior consumption, `correlated-quorum`
+counts independent groups, and `silent-monitor` compares heartbeat age against a TTL.
 
-**This external instance supports treating the pattern as a reusable defect class rather than
-only one project's postmortem.** It
-is a different author, a different language, a different problem domain, and a project whose
-own published rules already state the closely related principle — *a verifier that rejects
-everything has not reproduced the contract*. They wrote the acceptance-control rule and the
-defect still appeared one level up, in the criterion that decides whether a submission passes.
+The residual observation is a **specification divergence, not a defective acceptance rule**.
+The machine-readable protocol lists `packet` among `required_result_fields`; the prose
+requires comparing the digest *values* inside it. An evaluator built from the JSON alone
+would not require what the prose does. That is worth fixing and it is not the same thing as
+a rule that reports success without the mechanism.
 
----
+Full agreement was established first — 12 cases, 48 decision fields, 14 SHA-256 digests, zero
+divergences — which is what makes the mutation result interpretable rather than an excuse for
+a mismatch. Evidence and implementation:
+[`conformance/external/veritas-omega/`](../conformance/external/veritas-omega/).
 
 ## Why competence does not prevent it
 
@@ -150,16 +154,17 @@ usually a different subsystem.
 incomplete analysis produces a short findings list. Both are indistinguishable, at a glance,
 from the healthy case — and better-looking than it.
 
-**The fix generalises worse than the defect.** Instance 1 has taken four rounds because each
-round was scoped to the sites its author had read. The defect propagates by
+**The fix generalises worse than the defect.** Instance 1 has taken four rounds because the early
+repairs were scoped to manually identified sites; only the later work derived the candidate
+set. The defect propagates by
 copy-and-adapt; the repair propagates by someone remembering.
 
 ---
 
 ## What the evidence supports
 
-These appear to be necessary design requirements. The five instances do not establish that
-they are sufficient.
+These appear to be necessary design requirements. Four instances do not establish that they
+are sufficient.
 
 **Acceptance controls.** A case that *must* pass, so an implementation cannot score by
 rejecting everything. RCL-008 and RCL-009 in this repository; rule 5 of the VERITAS
@@ -173,7 +178,6 @@ mechanism being present**, and every instance above lacked one at the level wher
 - instance 2 had no case requiring that the analysis was complete
 - instance 3 had no outcome distinguishing "maintained" from "never tested"
 - instance 4 had no candidate set on which the favoured route could lose precision
-- instance 5 has no case whose decision depends on a digest *equality*
 
 **A third state.** A binary model must either collapse unknown into PASS or FAIL, or
 represent validity somewhere outside the verdict. A binary system *can* fail closed; in the
@@ -192,10 +196,11 @@ claims. Instance 2 exists because one was written as the other.
 
 ## Limits of this document
 
-Five instances is not a survey. Four are from one author's systems, which is a strong
+Four instances is not a survey, and all four are from one author's systems. That is a strong
 selection effect: they were found because that author was looking, and the count says as much
-about the looking as about the population. Instance 5 is the only external one, and it was
-found while reciprocating a favour rather than by sampling.
+about the looking as about the population. The one external case examined did **not** turn out
+to be an instance — its acceptance rule was adequate — which is a data point against the
+pattern being universal, and is reported here for that reason.
 
 No claim is made about prevalence, about other verification systems, or about whether the
 remedies are sufficient rather than merely necessary. Every instance is reproducible from


### PR DESCRIPTION
Review corrections to `docs/VERIFICATION-DESIGN-DEFECT.md`. All seven applied.

| # | Was | Now |
|---|---|---|
| 1 | "any `A` that can be satisfied" | scoped to the **acceptance rule as a whole**; one criterion may be only part of it |
| 2 | "the criterion measures nothing" | "provides no evidence the mechanism ran" — it may still measure an absence |
| 3 | "five instances, four systems, three authors" | count removed; it contradicted both the table and the limits section |
| 4 | "repaired four times" | "addressed in four rounds so far, and the work is not finished" |
| 5 | instance 4 uncited | both token-bleed commits linked |
| 6 | "any serialisation is used" | narrowed to the compact-versus-pretty error actually tested |
| 7 | "the only way" / "always the favourable one" | both softened |

## The two that mattered most

**#3 was a real internal contradiction.** The status line said four systems; the table names five; the limits section says four of five come from one author. Neither "system" nor "author" was defined tightly enough to defend a count, so the count is gone rather than patched.

**#6 was an overclaim of exactly the kind the document is about.** I demonstrated *one* deliberately wrong serialiser, not every possible implementation. The section now leads with the measured result instead of the generalisation:

> A deliberately wrong pretty-printed serialiser changed all 14 digests while leaving all 12 decisions unchanged.

## #4 also surfaced a stale artifact

"Repaired four times" read as resolved while #351 is open. The corrected text carries the current figure — **22 candidate modules unreviewed as of #374** — and notes that **#351's own body still says 27**, because it predates that PR. That staleness is real and outside this diff.

## On #5

The review supplied two commit SHAs. I resolved both locally against the repository before pasting them rather than copying them on trust — pasting a hash I hadn't verified is the specific failure I made earlier today in an external report.

## Verified

All eight reference links return **200**, including the two new commits. Suites: **601 passed, 2 skipped, 170 subtests**.

Positioning left alone deliberately: this stays a technical research note, with no HRAO-E, TAM, or commercial framing.