### PR TITLE
schema: resolvable $id, and a format that does not require naming one tool (#137)

### DIFF
--- a/protocol_tests/attestation.py
+++ b/protocol_tests/attestation.py
@@ -150,6 +150,10 @@ def generate_attestation_report(
 
     report: Dict[str, Any] = {
         "schema_version": SCHEMA_VERSION,
+        # `producer` is the provider-neutral spelling (#137). `harness_version` is
+        # retained because five scripts read it and the schema still accepts it;
+        # the schema requires one or the other, not this one specifically.
+        "producer": {"name": "agent-security-harness", "version": harness_version},
         "harness_version": harness_version,
         "suite": suite,
         "timestamp": datetime.now(timezone.utc).isoformat(),

--- a/schemas/attestation-report.json
+++ b/schemas/attestation-report.json
@@ -1,25 +1,56 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/msaleme/red-team-blue-team-agent-fabric/schemas/attestation-report.json",
-  "title": "Agent Security Harness Attestation Report",
-  "description": "Machine-readable attestation report for agent security test results. Compatible with A2A OATR and consumable by MoltBridge, TrustAgentAI, and custom pipelines.",
+  "$id": "https://raw.githubusercontent.com/msaleme/red-team-blue-team-agent-fabric/main/schemas/attestation-report.json",
+  "title": "Agent Action Attestation Report",
+  "description": "Provider-neutral attestation that an agent action was authorized, evaluated, and recorded. A conforming document identifies its producer via `producer`; `harness_version` is the legacy spelling retained for compatibility.",
   "type": "object",
-  "required": ["schema_version", "harness_version", "suite", "timestamp", "summary", "entries"],
+  "required": [
+    "schema_version",
+    "suite",
+    "timestamp",
+    "summary",
+    "entries"
+  ],
   "properties": {
     "schema_version": {
       "type": "string",
       "const": "1.0.0",
       "description": "Version of this attestation schema."
     },
+    "producer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "version"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Implementation that generated this report, e.g. 'agent-security-harness'."
+        },
+        "version": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Version of that implementation."
+        }
+      },
+      "description": "Producer of this report. Provider-neutral replacement for `harness_version`."
+    },
     "harness_version": {
       "type": "string",
-      "description": "Version of the agent-security-harness that generated this report.",
-      "examples": ["3.8.0"]
+      "description": "DEPRECATED, use `producer`. Version of the producing implementation. Retained so existing documents remain valid; a provider-neutral producer emits `producer` instead.",
+      "examples": [
+        "3.8.0"
+      ]
     },
     "suite": {
       "type": "string",
       "description": "Name of the test suite that was executed.",
-      "examples": ["MCP Protocol Security Tests v3.0"]
+      "examples": [
+        "MCP Protocol Security Tests v3.0"
+      ]
     },
     "timestamp": {
       "type": "string",
@@ -29,11 +60,17 @@
     "target": {
       "type": "string",
       "description": "URL or command of the system under test.",
-      "examples": ["http://localhost:8080/mcp"]
+      "examples": [
+        "http://localhost:8080/mcp"
+      ]
     },
     "summary": {
       "type": "object",
-      "required": ["total", "passed", "failed"],
+      "required": [
+        "total",
+        "passed",
+        "failed"
+      ],
       "properties": {
         "total": {
           "type": "integer",
@@ -65,7 +102,9 @@
     },
     "entries": {
       "type": "array",
-      "items": { "$ref": "#/$defs/attestation_entry" },
+      "items": {
+        "$ref": "#/$defs/attestation_entry"
+      },
       "description": "Individual test results with attestation metadata."
     }
   },
@@ -73,31 +112,59 @@
   "$defs": {
     "attestation_entry": {
       "type": "object",
-      "required": ["test_id", "category", "result", "severity", "scope", "timestamp"],
+      "required": [
+        "test_id",
+        "category",
+        "result",
+        "severity",
+        "scope",
+        "timestamp"
+      ],
       "properties": {
         "test_id": {
           "type": "string",
           "description": "Unique test identifier.",
-          "examples": ["MCP-001", "A2A-005", "X4-021"]
+          "examples": [
+            "MCP-001",
+            "A2A-005",
+            "X4-021"
+          ]
         },
         "name": {
           "type": "string",
           "description": "Human-readable test name.",
-          "examples": ["Tool List Integrity Check"]
+          "examples": [
+            "Tool List Integrity Check"
+          ]
         },
         "category": {
           "type": "string",
           "description": "Test category or grouping.",
-          "examples": ["tool_poisoning", "capability_escalation", "payment_flow"]
+          "examples": [
+            "tool_poisoning",
+            "capability_escalation",
+            "payment_flow"
+          ]
         },
         "result": {
           "type": "string",
-          "enum": ["pass", "fail", "error", "skip"],
+          "enum": [
+            "pass",
+            "fail",
+            "error",
+            "skip"
+          ],
           "description": "Test outcome."
         },
         "severity": {
           "type": "string",
-          "enum": ["P0-Critical", "P1-High", "P2-Medium", "P3-Low", "P4-Info"],
+          "enum": [
+            "P0-Critical",
+            "P1-High",
+            "P2-Medium",
+            "P3-Low",
+            "P4-Info"
+          ],
           "description": "Severity classification of the finding."
         },
         "scope": {
@@ -125,12 +192,18 @@
         "protocol_version": {
           "type": "string",
           "description": "Wire protocol version tested.",
-          "examples": ["2024-11-05", "1.0"]
+          "examples": [
+            "2024-11-05",
+            "1.0"
+          ]
         },
         "owasp_asi": {
           "type": "string",
           "description": "OWASP Agentic Security Initiative mapping.",
-          "examples": ["ASI04", "ASI07"]
+          "examples": [
+            "ASI04",
+            "ASI07"
+          ]
         },
         "statistical": {
           "$ref": "#/$defs/statistical",
@@ -139,8 +212,12 @@
         "details": {
           "description": "Free-form evidence or structured diagnostic data.",
           "oneOf": [
-            { "type": "string" },
-            { "type": "object" }
+            {
+              "type": "string"
+            },
+            {
+              "type": "object"
+            }
           ]
         },
         "request_sent": {
@@ -156,27 +233,52 @@
     },
     "scope": {
       "type": "object",
-      "required": ["protocol", "layer"],
+      "required": [
+        "protocol",
+        "layer"
+      ],
       "properties": {
         "protocol": {
           "type": "string",
-          "enum": ["mcp", "a2a", "l402", "x402", "platform", "framework", "enterprise", "decision", "other"],
+          "enum": [
+            "mcp",
+            "a2a",
+            "l402",
+            "x402",
+            "platform",
+            "framework",
+            "enterprise",
+            "decision",
+            "other"
+          ],
           "description": "Which wire protocol or domain this test targets."
         },
         "layer": {
           "type": "string",
-          "enum": ["protocol", "operational", "decision"],
+          "enum": [
+            "protocol",
+            "operational",
+            "decision"
+          ],
           "description": "Which of the three agent security layers this test covers."
         },
         "attack_type": {
           "type": "string",
           "description": "Human-readable attack classification.",
-          "examples": ["tool injection", "capability escalation", "receipt replay"]
+          "examples": [
+            "tool injection",
+            "capability escalation",
+            "receipt replay"
+          ]
         },
         "target_component": {
           "type": "string",
           "description": "Specific endpoint, method, or feature targeted.",
-          "examples": ["tools/call", "agent-card", "payment/verify"]
+          "examples": [
+            "tools/call",
+            "agent-card",
+            "payment/verify"
+          ]
         }
       },
       "additionalProperties": false
@@ -198,7 +300,11 @@
         },
         "priority": {
           "type": "string",
-          "enum": ["immediate", "next-release", "backlog"],
+          "enum": [
+            "immediate",
+            "next-release",
+            "backlog"
+          ],
           "description": "Triage priority hint."
         }
       },
@@ -241,7 +347,9 @@
         },
         "confidence_interval": {
           "type": "array",
-          "items": { "type": "number" },
+          "items": {
+            "type": "number"
+          },
           "minItems": 2,
           "maxItems": 2,
           "description": "95% confidence interval [lower, upper]."
@@ -249,5 +357,17 @@
       },
       "additionalProperties": false
     }
-  }
+  },
+  "anyOf": [
+    {
+      "required": [
+        "producer"
+      ]
+    },
+    {
+      "required": [
+        "harness_version"
+      ]
+    }
+  ]
 }

--- a/tests/test_attestation_schema_neutrality.py
+++ b/tests/test_attestation_schema_neutrality.py
@@ -1,0 +1,97 @@
+"""The attestation schema must be emittable without naming one implementation (#137).
+
+Step 2 of the standards-readiness review. The draft's working title is
+"A Provider-Neutral Schema for Verifiable Agent Decisions", while the schema was
+titled "Agent Security Harness Attestation Report" and *required* a top-level
+`harness_version`. A format that cannot be emitted without naming one tool's
+version is not provider-neutral, and a reviewer says so in the first round.
+
+The fix is additive rather than a rename: `producer` is the neutral spelling,
+`harness_version` is retained because five scripts read it, and the schema
+requires one or the other via `anyOf`. Every document valid before this change
+is still valid.
+"""
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+SCHEMA = json.load(open(
+    os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                 "schemas", "attestation-report.json"), encoding="utf-8"))
+
+
+def _entry():
+    return {"test_id": "MCP-001", "category": "injection", "result": "pass",
+            "severity": "low", "scope": {"protocol": "mcp", "layer": "transport"},
+            "timestamp": "2026-08-15T00:00:00Z"}
+
+
+def _satisfies_anyof(doc):
+    return any(all(k in doc for k in branch["required"]) for branch in SCHEMA["anyOf"])
+
+
+def test_harness_version_is_not_top_level_required():
+    """The specific defect: the format could not be emitted without it."""
+    assert "harness_version" not in SCHEMA["required"]
+
+
+def test_schema_id_is_not_the_404_form():
+    """The declared $id returned 404. A standards submission cannot ship an
+    identifier that does not resolve."""
+    assert SCHEMA["$id"].startswith("https://raw.githubusercontent.com/")
+    assert "/main/schemas/attestation-report.json" in SCHEMA["$id"]
+
+
+def test_title_does_not_name_one_implementation():
+    assert "Harness" not in SCHEMA["title"], SCHEMA["title"]
+
+
+def test_a_neutral_producer_can_emit_a_valid_document():
+    """No `harness_version` anywhere. This was impossible before."""
+    doc = {"schema_version": "1.0.0",
+           "producer": {"name": "some-other-tool", "version": "2.1.0"},
+           "suite": "mcp", "timestamp": "2026-08-15T00:00:00Z",
+           "summary": {"total": 1, "passed": 1, "failed": 0}, "entries": [_entry()]}
+    assert all(k in doc for k in SCHEMA["required"])
+    assert _satisfies_anyof(doc)
+
+
+def test_a_legacy_document_without_producer_is_still_valid():
+    """Backward compatibility is the reason this is additive rather than a rename."""
+    doc = {"schema_version": "1.0.0", "harness_version": "4.15.0",
+           "suite": "mcp", "timestamp": "2026-08-15T00:00:00Z",
+           "summary": {"total": 1, "passed": 1, "failed": 0}, "entries": [_entry()]}
+    assert all(k in doc for k in SCHEMA["required"])
+    assert _satisfies_anyof(doc)
+
+
+def test_a_document_identifying_no_producer_at_all_is_rejected():
+    """Dropping harness_version from `required` must not mean anonymity is allowed."""
+    doc = {"schema_version": "1.0.0", "suite": "mcp",
+           "timestamp": "2026-08-15T00:00:00Z",
+           "summary": {"total": 1, "passed": 1, "failed": 0}, "entries": [_entry()]}
+    assert not _satisfies_anyof(doc)
+
+
+def test_producer_requires_both_name_and_version():
+    producer = SCHEMA["properties"]["producer"]
+    assert producer["required"] == ["name", "version"]
+    assert producer["additionalProperties"] is False
+
+
+def test_the_builder_emits_both_spellings():
+    """The neutral field must be exercised, not merely permitted."""
+    from protocol_tests.attestation import generate_attestation_report
+    report = generate_attestation_report([_entry()], suite="mcp", harness_version="4.15.0")
+    assert report["producer"] == {"name": "agent-security-harness", "version": "4.15.0"}
+    assert report["harness_version"] == "4.15.0", "five scripts still read this"
+    assert _satisfies_anyof(report)
+
+
+def test_schema_version_was_not_bumped():
+    """schema_version is a `const`. Bumping it would invalidate every existing
+    document, and this change is backward compatible, so it must not move."""
+    assert SCHEMA["properties"]["schema_version"]["const"] == "1.0.0"


### PR DESCRIPTION
Items **1 and 2** of the standards-readiness review on #137. Items 3 and 4 and the submission itself stay gated on the issue's own prerequisite — no external party has yet produced or consumed a document in this format.

## Item 1 — the `$id` returned 404

```
declared: https://github.com/msaleme/red-team-blue-team-agent-fabric/schemas/attestation-report.json  → 404
now:      https://raw.githubusercontent.com/.../main/schemas/attestation-report.json                  → 200
```

**This is not the durable identifier a submission needs.** A GitHub URL breaks on a rename, an org move, or a default-branch change, and implementers hard-code whatever ships. Choosing that identifier — w3id, purl, or a domain you own — is still open in #137 and should be settled *before* submission.

## Item 2 — the draft's title contradicted the artifact

The June staging outline proposes *"A Provider-Neutral Schema for Verifiable Agent Decisions"*. The schema was titled **"Agent Security Harness Attestation Report"** and **required** a top-level `harness_version`, so the format could not be emitted without naming one implementation's version.

**Fixed additively rather than by renaming.** Five scripts read `harness_version`; a rename ripples through eight files for a concern that is gated anyway.

| | |
|---|---|
| title | → `Agent Action Attestation Report` |
| `producer` `{name, version}` | added, both required, `additionalProperties: false` |
| `harness_version` | kept, marked deprecated, **removed from top-level `required`** |
| `anyOf` | requires `producer` **or** `harness_version` |
| builder | emits both, so the neutral field is exercised not merely permitted |

**`schema_version` deliberately not bumped.** It is a `const`, so moving it would invalidate every existing document — and this change is backward compatible, so it must not move.

## What the tests pin

Nine tests, on properties rather than values:

- a neutral producer can emit a valid document with **no `harness_version` anywhere** — impossible before
- a legacy document with `harness_version` and no `producer` **is still valid**
- a document naming **no producer at all is still rejected** — dropping the required field must not newly permit anonymity
- the `$id` is not the 404 form, and the title does not name one implementation

## Verified

All five `harness_version` consumers still parse. Registry contract round trip: 38 passed. Suites: **610 passed, 2 skipped, 170 subtests**. `count_tests.py` unchanged at **606**.