### PR TITLE
evidence: the first attestation record, and the six defects producing it exposed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ november-meeting-extracted.txt
 *.fdb_latexmk
 *.synctex.gz
 *.pdf
+
+# Attestation records are deliverables, not run output. #384
+!attestations/**/*.json

--- a/attestations/self/2026-08-17-receipt-claim-record.json
+++ b/attestations/self/2026-08-17-receipt-claim-record.json
@@ -1,0 +1,250 @@
+{
+  "envelope_version": "2",
+  "payload": {
+    "server_name": "agent-security-harness self-test (receipt-claim, offline corpus)",
+    "contact": null,
+    "report": {
+      "schema_version": "1.0.0",
+      "producer": {
+        "name": "agent-security-harness",
+        "version": "4.15.0"
+      },
+      "harness_version": "4.15.0",
+      "suite": "receipt-claim",
+      "timestamp": "2026-08-18T02:10:20.787628+00:00",
+      "summary": {
+        "total": 11,
+        "passed": 11,
+        "failed": 0
+      },
+      "entries": [
+        {
+          "test_id": "RCL-001",
+          "category": "receipt_claim",
+          "result": "pass",
+          "severity": "P1-High",
+          "scope": {
+            "protocol": "other",
+            "layer": "operational",
+            "attack_type": "receipt claim"
+          },
+          "timestamp": "2026-08-18T02:10:20.787490+00:00",
+          "name": "Omitted mandatory evidence",
+          "owasp_asi": "ASI09",
+          "details": "envelope_valid=True; claim verdict=reject (occurrence: missing evidence)",
+          "remediation": {
+            "description": "Review test details and apply protocol-specific hardening.",
+            "references": [],
+            "priority": "next-release"
+          }
+        },
+        {
+          "test_id": "RCL-002",
+          "category": "receipt_claim",
+          "result": "pass",
+          "severity": "P1-High",
+          "scope": {
+            "protocol": "other",
+            "layer": "operational",
+            "attack_type": "receipt claim"
+          },
+          "timestamp": "2026-08-18T02:10:20.787507+00:00",
+          "name": "Substituted evidence, re-signed envelope",
+          "owasp_asi": "ASI09",
+          "details": "envelope_valid=True; claim verdict=reject (check: checker attestation does not verify (substituted or forged))",
+          "remediation": {
+            "description": "Review test details and apply protocol-specific hardening.",
+            "references": [],
+            "priority": "next-release"
+          }
+        },
+        {
+          "test_id": "RCL-003",
+          "category": "receipt_claim",
+          "result": "pass",
+          "severity": "P1-High",
+          "scope": {
+            "protocol": "other",
+            "layer": "operational",
+            "attack_type": "receipt claim"
+          },
+          "timestamp": "2026-08-18T02:10:20.787513+00:00",
+          "name": "Stale checker transcript",
+          "owasp_asi": "ASI09",
+          "details": "envelope_valid=True; claim verdict=reject (check: stale transcript (outside freshness window))",
+          "remediation": {
+            "description": "Review test details and apply protocol-specific hardening.",
+            "references": [],
+            "priority": "next-release"
+          }
+        },
+        {
+          "test_id": "RCL-004",
+          "category": "receipt_claim",
+          "result": "pass",
+          "severity": "P1-High",
+          "scope": {
+            "protocol": "other",
+            "layer": "operational",
+            "attack_type": "receipt claim"
+          },
+          "timestamp": "2026-08-18T02:10:20.787520+00:00",
+          "name": "Check bound to the wrong tool-set digest",
+          "owasp_asi": "ASI09",
+          "details": "envelope_valid=True; claim verdict=reject (check: result bound to the wrong tool-set digest)",
+          "remediation": {
+            "description": "Review test details and apply protocol-specific hardening.",
+            "references": [],
+            "priority": "next-release"
+          }
+        },
+        {
+          "test_id": "RCL-005",
+          "category": "receipt_claim",
+          "result": "pass",
+          "severity": "P1-High",
+          "scope": {
+            "protocol": "other",
+            "layer": "operational",
+            "attack_type": "receipt claim"
+          },
+          "timestamp": "2026-08-18T02:10:20.787523+00:00",
+          "name": "Authorization bound to different parameters",
+          "owasp_asi": "ASI09",
+          "details": "envelope_valid=True; claim verdict=reject (authorization: params do not match the action)",
+          "remediation": {
+            "description": "Review test details and apply protocol-specific hardening.",
+            "references": [],
+            "priority": "next-release"
+          }
+        },
+        {
+          "test_id": "RCL-006",
+          "category": "receipt_claim",
+          "result": "pass",
+          "severity": "P1-High",
+          "scope": {
+            "protocol": "other",
+            "layer": "operational",
+            "attack_type": "receipt claim"
+          },
+          "timestamp": "2026-08-18T02:10:20.787526+00:00",
+          "name": "Execution ack bound to another action",
+          "owasp_asi": "ASI09",
+          "details": "envelope_valid=True; claim verdict=reject (occurrence: acknowledgment bound to another action)",
+          "remediation": {
+            "description": "Review test details and apply protocol-specific hardening.",
+            "references": [],
+            "priority": "next-release"
+          }
+        },
+        {
+          "test_id": "RCL-007",
+          "category": "receipt_claim",
+          "result": "pass",
+          "severity": "P1-High",
+          "scope": {
+            "protocol": "other",
+            "layer": "operational",
+            "attack_type": "receipt claim"
+          },
+          "timestamp": "2026-08-18T02:10:20.787529+00:00",
+          "name": "Emitter self-assertion, no independent attestation",
+          "owasp_asi": "ASI09",
+          "details": "envelope_valid=True; claim verdict=reject (check: attested by the emitter, not the checker authority)",
+          "remediation": {
+            "description": "Review test details and apply protocol-specific hardening.",
+            "references": [],
+            "priority": "next-release"
+          }
+        },
+        {
+          "test_id": "RCL-008",
+          "category": "receipt_claim",
+          "result": "pass",
+          "severity": "P1-High",
+          "scope": {
+            "protocol": "other",
+            "layer": "operational",
+            "attack_type": "receipt claim"
+          },
+          "timestamp": "2026-08-18T02:10:20.787532+00:00",
+          "name": "Fully-supported receipt accepted (control)",
+          "owasp_asi": "ASI09",
+          "details": "envelope_valid=True; claim verdict=accept",
+          "remediation": {
+            "description": "Review test details and apply protocol-specific hardening.",
+            "references": [],
+            "priority": "next-release"
+          }
+        },
+        {
+          "test_id": "RCL-009",
+          "category": "receipt_claim",
+          "result": "pass",
+          "severity": "P1-High",
+          "scope": {
+            "protocol": "other",
+            "layer": "operational",
+            "attack_type": "receipt claim"
+          },
+          "timestamp": "2026-08-18T02:10:20.787534+00:00",
+          "name": "Wired MCP-019 check (clean) accepted",
+          "owasp_asi": "ASI09",
+          "details": "envelope_valid=True; claim verdict=accept (all four properties independently supported); expected accept",
+          "remediation": {
+            "description": "Review test details and apply protocol-specific hardening.",
+            "references": [],
+            "priority": "next-release"
+          }
+        },
+        {
+          "test_id": "RCL-010",
+          "category": "receipt_claim",
+          "result": "pass",
+          "severity": "P1-High",
+          "scope": {
+            "protocol": "other",
+            "layer": "operational",
+            "attack_type": "receipt claim"
+          },
+          "timestamp": "2026-08-18T02:10:20.787537+00:00",
+          "name": "Wired MCP-019 check (composite found) rejected",
+          "owasp_asi": "ASI09",
+          "details": "envelope_valid=True; claim verdict=reject (check: recorded output is not a pass); expected reject",
+          "remediation": {
+            "description": "Review test details and apply protocol-specific hardening.",
+            "references": [],
+            "priority": "next-release"
+          }
+        },
+        {
+          "test_id": "RCL-011",
+          "category": "receipt_claim",
+          "result": "pass",
+          "severity": "P1-High",
+          "scope": {
+            "protocol": "other",
+            "layer": "operational",
+            "attack_type": "receipt claim"
+          },
+          "timestamp": "2026-08-18T02:10:20.787539+00:00",
+          "name": "Wired MCP-019 check bound to wrong tool set rejected",
+          "owasp_asi": "ASI09",
+          "details": "envelope_valid=True; claim verdict=reject (check: result bound to the wrong tool-set digest); expected reject",
+          "remediation": {
+            "description": "Review test details and apply protocol-specific hardening.",
+            "references": [],
+            "priority": "next-release"
+          }
+        }
+      ],
+      "target": "offline fixture corpus (no network target)"
+    },
+    "published_at": "2026-08-18T02:11:12Z"
+  },
+  "signature": "36dff6e8f2b4d8b77fd2e8b732dc91cbccf19654dc32da40daa633ce15a532c5135413edd34c399aea5c0bd00f7f5d6797ef0c4846b55ea859e8a179c2ab4301",
+  "verification_hash": "e69e70f89fe32c48f5db83a49ecf43ea802a3b79f8d10d4a002bf78689f10674",
+  "public_key_fingerprint": "205ee7a00ca4d29e",
+  "public_key": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAHTF118NnBOVzidkFPC4UpfmC8SBmKUpJfTmed8zytP4=\n-----END PUBLIC KEY-----\n"
+}

--- a/attestations/self/2026-08-17-receipt-claim-report.json
+++ b/attestations/self/2026-08-17-receipt-claim-report.json
@@ -1,0 +1,238 @@
+{
+  "schema_version": "1.0.0",
+  "producer": {
+    "name": "agent-security-harness",
+    "version": "4.15.0"
+  },
+  "harness_version": "4.15.0",
+  "suite": "receipt-claim",
+  "timestamp": "2026-08-18T02:10:20.787628+00:00",
+  "summary": {
+    "total": 11,
+    "passed": 11,
+    "failed": 0
+  },
+  "entries": [
+    {
+      "test_id": "RCL-001",
+      "category": "receipt_claim",
+      "result": "pass",
+      "severity": "P1-High",
+      "scope": {
+        "protocol": "other",
+        "layer": "operational",
+        "attack_type": "receipt claim"
+      },
+      "timestamp": "2026-08-18T02:10:20.787490+00:00",
+      "name": "Omitted mandatory evidence",
+      "owasp_asi": "ASI09",
+      "details": "envelope_valid=True; claim verdict=reject (occurrence: missing evidence)",
+      "remediation": {
+        "description": "Review test details and apply protocol-specific hardening.",
+        "references": [],
+        "priority": "next-release"
+      }
+    },
+    {
+      "test_id": "RCL-002",
+      "category": "receipt_claim",
+      "result": "pass",
+      "severity": "P1-High",
+      "scope": {
+        "protocol": "other",
+        "layer": "operational",
+        "attack_type": "receipt claim"
+      },
+      "timestamp": "2026-08-18T02:10:20.787507+00:00",
+      "name": "Substituted evidence, re-signed envelope",
+      "owasp_asi": "ASI09",
+      "details": "envelope_valid=True; claim verdict=reject (check: checker attestation does not verify (substituted or forged))",
+      "remediation": {
+        "description": "Review test details and apply protocol-specific hardening.",
+        "references": [],
+        "priority": "next-release"
+      }
+    },
+    {
+      "test_id": "RCL-003",
+      "category": "receipt_claim",
+      "result": "pass",
+      "severity": "P1-High",
+      "scope": {
+        "protocol": "other",
+        "layer": "operational",
+        "attack_type": "receipt claim"
+      },
+      "timestamp": "2026-08-18T02:10:20.787513+00:00",
+      "name": "Stale checker transcript",
+      "owasp_asi": "ASI09",
+      "details": "envelope_valid=True; claim verdict=reject (check: stale transcript (outside freshness window))",
+      "remediation": {
+        "description": "Review test details and apply protocol-specific hardening.",
+        "references": [],
+        "priority": "next-release"
+      }
+    },
+    {
+      "test_id": "RCL-004",
+      "category": "receipt_claim",
+      "result": "pass",
+      "severity": "P1-High",
+      "scope": {
+        "protocol": "other",
+        "layer": "operational",
+        "attack_type": "receipt claim"
+      },
+      "timestamp": "2026-08-18T02:10:20.787520+00:00",
+      "name": "Check bound to the wrong tool-set digest",
+      "owasp_asi": "ASI09",
+      "details": "envelope_valid=True; claim verdict=reject (check: result bound to the wrong tool-set digest)",
+      "remediation": {
+        "description": "Review test details and apply protocol-specific hardening.",
+        "references": [],
+        "priority": "next-release"
+      }
+    },
+    {
+      "test_id": "RCL-005",
+      "category": "receipt_claim",
+      "result": "pass",
+      "severity": "P1-High",
+      "scope": {
+        "protocol": "other",
+        "layer": "operational",
+        "attack_type": "receipt claim"
+      },
+      "timestamp": "2026-08-18T02:10:20.787523+00:00",
+      "name": "Authorization bound to different parameters",
+      "owasp_asi": "ASI09",
+      "details": "envelope_valid=True; claim verdict=reject (authorization: params do not match the action)",
+      "remediation": {
+        "description": "Review test details and apply protocol-specific hardening.",
+        "references": [],
+        "priority": "next-release"
+      }
+    },
+    {
+      "test_id": "RCL-006",
+      "category": "receipt_claim",
+      "result": "pass",
+      "severity": "P1-High",
+      "scope": {
+        "protocol": "other",
+        "layer": "operational",
+        "attack_type": "receipt claim"
+      },
+      "timestamp": "2026-08-18T02:10:20.787526+00:00",
+      "name": "Execution ack bound to another action",
+      "owasp_asi": "ASI09",
+      "details": "envelope_valid=True; claim verdict=reject (occurrence: acknowledgment bound to another action)",
+      "remediation": {
+        "description": "Review test details and apply protocol-specific hardening.",
+        "references": [],
+        "priority": "next-release"
+      }
+    },
+    {
+      "test_id": "RCL-007",
+      "category": "receipt_claim",
+      "result": "pass",
+      "severity": "P1-High",
+      "scope": {
+        "protocol": "other",
+        "layer": "operational",
+        "attack_type": "receipt claim"
+      },
+      "timestamp": "2026-08-18T02:10:20.787529+00:00",
+      "name": "Emitter self-assertion, no independent attestation",
+      "owasp_asi": "ASI09",
+      "details": "envelope_valid=True; claim verdict=reject (check: attested by the emitter, not the checker authority)",
+      "remediation": {
+        "description": "Review test details and apply protocol-specific hardening.",
+        "references": [],
+        "priority": "next-release"
+      }
+    },
+    {
+      "test_id": "RCL-008",
+      "category": "receipt_claim",
+      "result": "pass",
+      "severity": "P1-High",
+      "scope": {
+        "protocol": "other",
+        "layer": "operational",
+        "attack_type": "receipt claim"
+      },
+      "timestamp": "2026-08-18T02:10:20.787532+00:00",
+      "name": "Fully-supported receipt accepted (control)",
+      "owasp_asi": "ASI09",
+      "details": "envelope_valid=True; claim verdict=accept",
+      "remediation": {
+        "description": "Review test details and apply protocol-specific hardening.",
+        "references": [],
+        "priority": "next-release"
+      }
+    },
+    {
+      "test_id": "RCL-009",
+      "category": "receipt_claim",
+      "result": "pass",
+      "severity": "P1-High",
+      "scope": {
+        "protocol": "other",
+        "layer": "operational",
+        "attack_type": "receipt claim"
+      },
+      "timestamp": "2026-08-18T02:10:20.787534+00:00",
+      "name": "Wired MCP-019 check (clean) accepted",
+      "owasp_asi": "ASI09",
+      "details": "envelope_valid=True; claim verdict=accept (all four properties independently supported); expected accept",
+      "remediation": {
+        "description": "Review test details and apply protocol-specific hardening.",
+        "references": [],
+        "priority": "next-release"
+      }
+    },
+    {
+      "test_id": "RCL-010",
+      "category": "receipt_claim",
+      "result": "pass",
+      "severity": "P1-High",
+      "scope": {
+        "protocol": "other",
+        "layer": "operational",
+        "attack_type": "receipt claim"
+      },
+      "timestamp": "2026-08-18T02:10:20.787537+00:00",
+      "name": "Wired MCP-019 check (composite found) rejected",
+      "owasp_asi": "ASI09",
+      "details": "envelope_valid=True; claim verdict=reject (check: recorded output is not a pass); expected reject",
+      "remediation": {
+        "description": "Review test details and apply protocol-specific hardening.",
+        "references": [],
+        "priority": "next-release"
+      }
+    },
+    {
+      "test_id": "RCL-011",
+      "category": "receipt_claim",
+      "result": "pass",
+      "severity": "P1-High",
+      "scope": {
+        "protocol": "other",
+        "layer": "operational",
+        "attack_type": "receipt claim"
+      },
+      "timestamp": "2026-08-18T02:10:20.787539+00:00",
+      "name": "Wired MCP-019 check bound to wrong tool set rejected",
+      "owasp_asi": "ASI09",
+      "details": "envelope_valid=True; claim verdict=reject (check: result bound to the wrong tool-set digest); expected reject",
+      "remediation": {
+        "description": "Review test details and apply protocol-specific hardening.",
+        "references": [],
+        "priority": "next-release"
+      }
+    }
+  ],
+  "target": "offline fixture corpus (no network target)"
+}

--- a/attestations/self/README.md
+++ b/attestations/self/README.md
@@ -1,0 +1,40 @@
+# First attestation record
+
+The first attestation record this project has ever produced. Its purpose is to test whether
+the format survives contact with its own first use, per #384.
+
+## What is here
+
+| File | What it is |
+|---|---|
+| `2026-08-17-receipt-claim-report.json` | The attestation report: 11 `receipt-claim` results from a real run |
+| `2026-08-17-receipt-claim-record.json` | The signed envelope v2 record built from that report |
+
+- Suite: `receipt-claim`, 11/11 passed, including both positive controls (RCL-008, RCL-009).
+- Target: offline fixture corpus. No network target, so no verdict here rests on an unserviced host.
+- Harness version 4.15.0, repository commit `6a0277df768ae308dd1b0597ee83df1a50384866`.
+- `verification_hash`: `e69e70f89fe32c48f5db83a49ecf43ea802a3b79f8d10d4a002bf78689f10674`
+
+## What it establishes
+
+**I0 and nothing more.** We ran our own harness against our own corpus and authored the oracle.
+Per §1 of `docs/ATTESTATION-REGISTRY-SERVER-CONTRACT.md`, that is true regardless of how the
+record is distributed. The signature proves the record was not altered. It proves nothing about
+the target.
+
+## Reproduce the verification
+
+```bash
+python3 scripts/verify_attestation_record.py attestations/self/2026-08-17-receipt-claim-record.json
+```
+
+Steps 1 to 4 of §9 pass: the hash matches the canonical payload bytes, the public key matches its
+fingerprint, and the Ed25519 signature verifies. Step 5, key-to-identity binding, is out of scope
+and the verifier says so. Step 6 prints the independence caveat.
+
+## Known gaps this record exposes
+
+Recorded in #384. In short: the record reports `independence_level 'unstated'` and
+`system_under_test 'unstated'`, because the generator emits neither and the schema does not
+carry them, while §1 of the contract requires every stored record to have both. It was also
+produced without the shipped publish API, which cannot emit a record without a registry.


### PR DESCRIPTION
Closes the experiment proposed in #384: produce one record, verify it offline, and find out whether the format survives its own first use.

It does. `scripts/verify_attestation_record.py` passes steps 1 through 4 of the contract's §9 against the committed record. Six defects surfaced along the way.

## The record

`attestations/self/` — `receipt-claim`, 11/11 including both positive controls (RCL-008, RCL-009), against the offline fixture corpus so no verdict rests on an unserviced host. Establishes **I0 and nothing more**.

```
[PASS] verification_hash matches the canonical payload bytes (e69e70f89fe32c48...)
[PASS] public_key matches public_key_fingerprint (205ee7a00ca4d29e)
[PASS] Ed25519 signature verifies over the canonical payload bytes
```

## Defects found by doing it

1. **`--json > file` does not produce JSON.** 714 bytes of human-readable results go to stdout before the array, so the documented flag redirected to a file yields an unparseable file.
2. **No adapter between a run and a report.** Harness entries carry `passed: bool`; attestation entries need `result: "pass"|"fail"`. Nothing bridges them.
3. **The published schema is never validated against.** `tests/test_attestation_schema_neutrality.py` hand-checks, `jsonschema` is not a declared dependency, and no test feeds a generated report through the schema file. The report does validate cleanly once `jsonschema` is installed.
4. **A signed record cannot be produced without a registry.** `publish_attestation()` builds the envelope and POSTs it in the same function. This record was assembled from §4.1 directly. That matters because §7's peer-to-peer linking by `verification_hash` is the contract's answer to distribution, and the API cannot produce the artifact it depends on.
5. **The record cannot state its own independence.** It reports `independence_level 'unstated'`, `system_under_test 'unstated'`. The generator emits neither field, the schema does not define them, and only the reference server supplies them — server-side, outside the signature. §1 requires every stored record to carry both, so as shipped the producer cannot make a conforming record and the claim exists only as unsigned operator metadata.
6. **`.gitignore:42 '*.json'` silently dropped both artifacts** — the same class that hit `conformance/external/veritas-omega`. Fixed here with a negation rule rather than `git add -f`, so the next record is not dropped either.

Defect 5 is the one worth acting on. Refs #384, #333.