### PR TITLE
fix(#384): a record states its own independence, inside the signature

### DIFF
--- a/attestations/self/2026-08-17-receipt-claim-record.json
+++ b/attestations/self/2026-08-17-receipt-claim-record.json
@@ -11,7 +11,7 @@
       },
       "harness_version": "4.15.0",
       "suite": "receipt-claim",
-      "timestamp": "2026-08-18T02:23:58.449387+00:00",
+      "timestamp": "2026-08-18T02:26:40.602977+00:00",
       "summary": {
         "total": 11,
         "passed": 11,
@@ -28,7 +28,7 @@
             "layer": "operational",
             "attack_type": "receipt claim"
           },
-          "timestamp": "2026-08-18T02:23:58.449204+00:00",
+          "timestamp": "2026-08-18T02:26:40.602847+00:00",
           "name": "Omitted mandatory evidence",
           "owasp_asi": "ASI09",
           "details": "envelope_valid=True; claim verdict=reject (occurrence: missing evidence)",
@@ -48,7 +48,7 @@
             "layer": "operational",
             "attack_type": "receipt claim"
           },
-          "timestamp": "2026-08-18T02:23:58.449226+00:00",
+          "timestamp": "2026-08-18T02:26:40.602864+00:00",
           "name": "Substituted evidence, re-signed envelope",
           "owasp_asi": "ASI09",
           "details": "envelope_valid=True; claim verdict=reject (check: checker attestation does not verify (substituted or forged))",
@@ -68,7 +68,7 @@
             "layer": "operational",
             "attack_type": "receipt claim"
           },
-          "timestamp": "2026-08-18T02:23:58.449234+00:00",
+          "timestamp": "2026-08-18T02:26:40.602870+00:00",
           "name": "Stale checker transcript",
           "owasp_asi": "ASI09",
           "details": "envelope_valid=True; claim verdict=reject (check: stale transcript (outside freshness window))",
@@ -88,7 +88,7 @@
             "layer": "operational",
             "attack_type": "receipt claim"
           },
-          "timestamp": "2026-08-18T02:23:58.449239+00:00",
+          "timestamp": "2026-08-18T02:26:40.602874+00:00",
           "name": "Check bound to the wrong tool-set digest",
           "owasp_asi": "ASI09",
           "details": "envelope_valid=True; claim verdict=reject (check: result bound to the wrong tool-set digest)",
@@ -108,7 +108,7 @@
             "layer": "operational",
             "attack_type": "receipt claim"
           },
-          "timestamp": "2026-08-18T02:23:58.449243+00:00",
+          "timestamp": "2026-08-18T02:26:40.602877+00:00",
           "name": "Authorization bound to different parameters",
           "owasp_asi": "ASI09",
           "details": "envelope_valid=True; claim verdict=reject (authorization: params do not match the action)",
@@ -128,7 +128,7 @@
             "layer": "operational",
             "attack_type": "receipt claim"
           },
-          "timestamp": "2026-08-18T02:23:58.449247+00:00",
+          "timestamp": "2026-08-18T02:26:40.602879+00:00",
           "name": "Execution ack bound to another action",
           "owasp_asi": "ASI09",
           "details": "envelope_valid=True; claim verdict=reject (occurrence: acknowledgment bound to another action)",
@@ -148,7 +148,7 @@
             "layer": "operational",
             "attack_type": "receipt claim"
           },
-          "timestamp": "2026-08-18T02:23:58.449251+00:00",
+          "timestamp": "2026-08-18T02:26:40.602882+00:00",
           "name": "Emitter self-assertion, no independent attestation",
           "owasp_asi": "ASI09",
           "details": "envelope_valid=True; claim verdict=reject (check: attested by the emitter, not the checker authority)",
@@ -168,7 +168,7 @@
             "layer": "operational",
             "attack_type": "receipt claim"
           },
-          "timestamp": "2026-08-18T02:23:58.449258+00:00",
+          "timestamp": "2026-08-18T02:26:40.602884+00:00",
           "name": "Fully-supported receipt accepted (control)",
           "owasp_asi": "ASI09",
           "details": "envelope_valid=True; claim verdict=accept",
@@ -188,7 +188,7 @@
             "layer": "operational",
             "attack_type": "receipt claim"
           },
-          "timestamp": "2026-08-18T02:23:58.449265+00:00",
+          "timestamp": "2026-08-18T02:26:40.602887+00:00",
           "name": "Wired MCP-019 check (clean) accepted",
           "owasp_asi": "ASI09",
           "details": "envelope_valid=True; claim verdict=accept (all four properties independently supported); expected accept",
@@ -208,7 +208,7 @@
             "layer": "operational",
             "attack_type": "receipt claim"
           },
-          "timestamp": "2026-08-18T02:23:58.449269+00:00",
+          "timestamp": "2026-08-18T02:26:40.602891+00:00",
           "name": "Wired MCP-019 check (composite found) rejected",
           "owasp_asi": "ASI09",
           "details": "envelope_valid=True; claim verdict=reject (check: recorded output is not a pass); expected reject",
@@ -228,7 +228,7 @@
             "layer": "operational",
             "attack_type": "receipt claim"
           },
-          "timestamp": "2026-08-18T02:23:58.449273+00:00",
+          "timestamp": "2026-08-18T02:26:40.602894+00:00",
           "name": "Wired MCP-019 check bound to wrong tool set rejected",
           "owasp_asi": "ASI09",
           "details": "envelope_valid=True; claim verdict=reject (check: result bound to the wrong tool-set digest); expected reject",
@@ -244,10 +244,10 @@
       "system_under_test": "agent-security-harness receipt-claim suite",
       "evidence_class": "E2"
     },
-    "published_at": "2026-08-18T02:24:09Z"
+    "published_at": "2026-08-18T02:26:40Z"
   },
-  "signature": "a8e38e9895137f34b3005759ad36a452ef8fdf4f41c6e2e4964299bdf8bacdfd2de1f7b9bd8b958b1a4ea428427c1461ac495c4ba24bb8f68183ae75c886c20e",
-  "verification_hash": "8b7bea79421da5f2bb578b9bb5844367d1cd3551a00ee5f6e50dc919caaaf6de",
+  "signature": "1ddae064a5a046c3a668cf51d71cebd669702c2eab480215c75713c80785be765dd793c3b1342c8e1e438165cf6fbec7f5ad62f70be79fde810f3b43c1417f00",
+  "verification_hash": "48235d1b77d097f37dd88cd5716e0bcf9a6829cf7acb113404cbbfd51bb9a5ff",
   "public_key_fingerprint": "205ee7a00ca4d29e",
   "public_key": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAHTF118NnBOVzidkFPC4UpfmC8SBmKUpJfTmed8zytP4=\n-----END PUBLIC KEY-----\n"
 }

--- a/attestations/self/2026-08-17-receipt-claim-record.json
+++ b/attestations/self/2026-08-17-receipt-claim-record.json
@@ -1,7 +1,7 @@
 {
   "envelope_version": "2",
   "payload": {
-    "server_name": "agent-security-harness self-test (receipt-claim, offline corpus)",
+    "server_name": "agent-security-harness self-test receipt-claim offline corpus",
     "contact": null,
     "report": {
       "schema_version": "1.0.0",
@@ -11,7 +11,7 @@
       },
       "harness_version": "4.15.0",
       "suite": "receipt-claim",
-      "timestamp": "2026-08-18T02:10:20.787628+00:00",
+      "timestamp": "2026-08-18T02:23:58.449387+00:00",
       "summary": {
         "total": 11,
         "passed": 11,
@@ -28,7 +28,7 @@
             "layer": "operational",
             "attack_type": "receipt claim"
           },
-          "timestamp": "2026-08-18T02:10:20.787490+00:00",
+          "timestamp": "2026-08-18T02:23:58.449204+00:00",
           "name": "Omitted mandatory evidence",
           "owasp_asi": "ASI09",
           "details": "envelope_valid=True; claim verdict=reject (occurrence: missing evidence)",
@@ -48,7 +48,7 @@
             "layer": "operational",
             "attack_type": "receipt claim"
           },
-          "timestamp": "2026-08-18T02:10:20.787507+00:00",
+          "timestamp": "2026-08-18T02:23:58.449226+00:00",
           "name": "Substituted evidence, re-signed envelope",
           "owasp_asi": "ASI09",
           "details": "envelope_valid=True; claim verdict=reject (check: checker attestation does not verify (substituted or forged))",
@@ -68,7 +68,7 @@
             "layer": "operational",
             "attack_type": "receipt claim"
           },
-          "timestamp": "2026-08-18T02:10:20.787513+00:00",
+          "timestamp": "2026-08-18T02:23:58.449234+00:00",
           "name": "Stale checker transcript",
           "owasp_asi": "ASI09",
           "details": "envelope_valid=True; claim verdict=reject (check: stale transcript (outside freshness window))",
@@ -88,7 +88,7 @@
             "layer": "operational",
             "attack_type": "receipt claim"
           },
-          "timestamp": "2026-08-18T02:10:20.787520+00:00",
+          "timestamp": "2026-08-18T02:23:58.449239+00:00",
           "name": "Check bound to the wrong tool-set digest",
           "owasp_asi": "ASI09",
           "details": "envelope_valid=True; claim verdict=reject (check: result bound to the wrong tool-set digest)",
@@ -108,7 +108,7 @@
             "layer": "operational",
             "attack_type": "receipt claim"
           },
-          "timestamp": "2026-08-18T02:10:20.787523+00:00",
+          "timestamp": "2026-08-18T02:23:58.449243+00:00",
           "name": "Authorization bound to different parameters",
           "owasp_asi": "ASI09",
           "details": "envelope_valid=True; claim verdict=reject (authorization: params do not match the action)",
@@ -128,7 +128,7 @@
             "layer": "operational",
             "attack_type": "receipt claim"
           },
-          "timestamp": "2026-08-18T02:10:20.787526+00:00",
+          "timestamp": "2026-08-18T02:23:58.449247+00:00",
           "name": "Execution ack bound to another action",
           "owasp_asi": "ASI09",
           "details": "envelope_valid=True; claim verdict=reject (occurrence: acknowledgment bound to another action)",
@@ -148,7 +148,7 @@
             "layer": "operational",
             "attack_type": "receipt claim"
           },
-          "timestamp": "2026-08-18T02:10:20.787529+00:00",
+          "timestamp": "2026-08-18T02:23:58.449251+00:00",
           "name": "Emitter self-assertion, no independent attestation",
           "owasp_asi": "ASI09",
           "details": "envelope_valid=True; claim verdict=reject (check: attested by the emitter, not the checker authority)",
@@ -168,7 +168,7 @@
             "layer": "operational",
             "attack_type": "receipt claim"
           },
-          "timestamp": "2026-08-18T02:10:20.787532+00:00",
+          "timestamp": "2026-08-18T02:23:58.449258+00:00",
           "name": "Fully-supported receipt accepted (control)",
           "owasp_asi": "ASI09",
           "details": "envelope_valid=True; claim verdict=accept",
@@ -188,7 +188,7 @@
             "layer": "operational",
             "attack_type": "receipt claim"
           },
-          "timestamp": "2026-08-18T02:10:20.787534+00:00",
+          "timestamp": "2026-08-18T02:23:58.449265+00:00",
           "name": "Wired MCP-019 check (clean) accepted",
           "owasp_asi": "ASI09",
           "details": "envelope_valid=True; claim verdict=accept (all four properties independently supported); expected accept",
@@ -208,7 +208,7 @@
             "layer": "operational",
             "attack_type": "receipt claim"
           },
-          "timestamp": "2026-08-18T02:10:20.787537+00:00",
+          "timestamp": "2026-08-18T02:23:58.449269+00:00",
           "name": "Wired MCP-019 check (composite found) rejected",
           "owasp_asi": "ASI09",
           "details": "envelope_valid=True; claim verdict=reject (check: recorded output is not a pass); expected reject",
@@ -228,7 +228,7 @@
             "layer": "operational",
             "attack_type": "receipt claim"
           },
-          "timestamp": "2026-08-18T02:10:20.787539+00:00",
+          "timestamp": "2026-08-18T02:23:58.449273+00:00",
           "name": "Wired MCP-019 check bound to wrong tool set rejected",
           "owasp_asi": "ASI09",
           "details": "envelope_valid=True; claim verdict=reject (check: result bound to the wrong tool-set digest); expected reject",
@@ -239,12 +239,15 @@
           }
         }
       ],
-      "target": "offline fixture corpus (no network target)"
+      "target": "offline fixture corpus (no network target)",
+      "independence_level": "I0",
+      "system_under_test": "agent-security-harness receipt-claim suite",
+      "evidence_class": "E2"
     },
-    "published_at": "2026-08-18T02:11:12Z"
+    "published_at": "2026-08-18T02:24:09Z"
   },
-  "signature": "36dff6e8f2b4d8b77fd2e8b732dc91cbccf19654dc32da40daa633ce15a532c5135413edd34c399aea5c0bd00f7f5d6797ef0c4846b55ea859e8a179c2ab4301",
-  "verification_hash": "e69e70f89fe32c48f5db83a49ecf43ea802a3b79f8d10d4a002bf78689f10674",
+  "signature": "a8e38e9895137f34b3005759ad36a452ef8fdf4f41c6e2e4964299bdf8bacdfd2de1f7b9bd8b958b1a4ea428427c1461ac495c4ba24bb8f68183ae75c886c20e",
+  "verification_hash": "8b7bea79421da5f2bb578b9bb5844367d1cd3551a00ee5f6e50dc919caaaf6de",
   "public_key_fingerprint": "205ee7a00ca4d29e",
   "public_key": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAHTF118NnBOVzidkFPC4UpfmC8SBmKUpJfTmed8zytP4=\n-----END PUBLIC KEY-----\n"
 }

--- a/attestations/self/2026-08-17-receipt-claim-report.json
+++ b/attestations/self/2026-08-17-receipt-claim-report.json
@@ -6,7 +6,7 @@
   },
   "harness_version": "4.15.0",
   "suite": "receipt-claim",
-  "timestamp": "2026-08-18T02:10:20.787628+00:00",
+  "timestamp": "2026-08-18T02:23:58.449387+00:00",
   "summary": {
     "total": 11,
     "passed": 11,
@@ -23,7 +23,7 @@
         "layer": "operational",
         "attack_type": "receipt claim"
       },
-      "timestamp": "2026-08-18T02:10:20.787490+00:00",
+      "timestamp": "2026-08-18T02:23:58.449204+00:00",
       "name": "Omitted mandatory evidence",
       "owasp_asi": "ASI09",
       "details": "envelope_valid=True; claim verdict=reject (occurrence: missing evidence)",
@@ -43,7 +43,7 @@
         "layer": "operational",
         "attack_type": "receipt claim"
       },
-      "timestamp": "2026-08-18T02:10:20.787507+00:00",
+      "timestamp": "2026-08-18T02:23:58.449226+00:00",
       "name": "Substituted evidence, re-signed envelope",
       "owasp_asi": "ASI09",
       "details": "envelope_valid=True; claim verdict=reject (check: checker attestation does not verify (substituted or forged))",
@@ -63,7 +63,7 @@
         "layer": "operational",
         "attack_type": "receipt claim"
       },
-      "timestamp": "2026-08-18T02:10:20.787513+00:00",
+      "timestamp": "2026-08-18T02:23:58.449234+00:00",
       "name": "Stale checker transcript",
       "owasp_asi": "ASI09",
       "details": "envelope_valid=True; claim verdict=reject (check: stale transcript (outside freshness window))",
@@ -83,7 +83,7 @@
         "layer": "operational",
         "attack_type": "receipt claim"
       },
-      "timestamp": "2026-08-18T02:10:20.787520+00:00",
+      "timestamp": "2026-08-18T02:23:58.449239+00:00",
       "name": "Check bound to the wrong tool-set digest",
       "owasp_asi": "ASI09",
       "details": "envelope_valid=True; claim verdict=reject (check: result bound to the wrong tool-set digest)",
@@ -103,7 +103,7 @@
         "layer": "operational",
         "attack_type": "receipt claim"
       },
-      "timestamp": "2026-08-18T02:10:20.787523+00:00",
+      "timestamp": "2026-08-18T02:23:58.449243+00:00",
       "name": "Authorization bound to different parameters",
       "owasp_asi": "ASI09",
       "details": "envelope_valid=True; claim verdict=reject (authorization: params do not match the action)",
@@ -123,7 +123,7 @@
         "layer": "operational",
         "attack_type": "receipt claim"
       },
-      "timestamp": "2026-08-18T02:10:20.787526+00:00",
+      "timestamp": "2026-08-18T02:23:58.449247+00:00",
       "name": "Execution ack bound to another action",
       "owasp_asi": "ASI09",
       "details": "envelope_valid=True; claim verdict=reject (occurrence: acknowledgment bound to another action)",
@@ -143,7 +143,7 @@
         "layer": "operational",
         "attack_type": "receipt claim"
       },
-      "timestamp": "2026-08-18T02:10:20.787529+00:00",
+      "timestamp": "2026-08-18T02:23:58.449251+00:00",
       "name": "Emitter self-assertion, no independent attestation",
       "owasp_asi": "ASI09",
       "details": "envelope_valid=True; claim verdict=reject (check: attested by the emitter, not the checker authority)",
@@ -163,7 +163,7 @@
         "layer": "operational",
         "attack_type": "receipt claim"
       },
-      "timestamp": "2026-08-18T02:10:20.787532+00:00",
+      "timestamp": "2026-08-18T02:23:58.449258+00:00",
       "name": "Fully-supported receipt accepted (control)",
       "owasp_asi": "ASI09",
       "details": "envelope_valid=True; claim verdict=accept",
@@ -183,7 +183,7 @@
         "layer": "operational",
         "attack_type": "receipt claim"
       },
-      "timestamp": "2026-08-18T02:10:20.787534+00:00",
+      "timestamp": "2026-08-18T02:23:58.449265+00:00",
       "name": "Wired MCP-019 check (clean) accepted",
       "owasp_asi": "ASI09",
       "details": "envelope_valid=True; claim verdict=accept (all four properties independently supported); expected accept",
@@ -203,7 +203,7 @@
         "layer": "operational",
         "attack_type": "receipt claim"
       },
-      "timestamp": "2026-08-18T02:10:20.787537+00:00",
+      "timestamp": "2026-08-18T02:23:58.449269+00:00",
       "name": "Wired MCP-019 check (composite found) rejected",
       "owasp_asi": "ASI09",
       "details": "envelope_valid=True; claim verdict=reject (check: recorded output is not a pass); expected reject",
@@ -223,7 +223,7 @@
         "layer": "operational",
         "attack_type": "receipt claim"
       },
-      "timestamp": "2026-08-18T02:10:20.787539+00:00",
+      "timestamp": "2026-08-18T02:23:58.449273+00:00",
       "name": "Wired MCP-019 check bound to wrong tool set rejected",
       "owasp_asi": "ASI09",
       "details": "envelope_valid=True; claim verdict=reject (check: result bound to the wrong tool-set digest); expected reject",
@@ -234,5 +234,8 @@
       }
     }
   ],
-  "target": "offline fixture corpus (no network target)"
+  "target": "offline fixture corpus (no network target)",
+  "independence_level": "I0",
+  "system_under_test": "agent-security-harness receipt-claim suite",
+  "evidence_class": "E2"
 }

--- a/attestations/self/2026-08-17-receipt-claim-report.json
+++ b/attestations/self/2026-08-17-receipt-claim-report.json
@@ -6,7 +6,7 @@
   },
   "harness_version": "4.15.0",
   "suite": "receipt-claim",
-  "timestamp": "2026-08-18T02:23:58.449387+00:00",
+  "timestamp": "2026-08-18T02:26:40.602977+00:00",
   "summary": {
     "total": 11,
     "passed": 11,
@@ -23,7 +23,7 @@
         "layer": "operational",
         "attack_type": "receipt claim"
       },
-      "timestamp": "2026-08-18T02:23:58.449204+00:00",
+      "timestamp": "2026-08-18T02:26:40.602847+00:00",
       "name": "Omitted mandatory evidence",
       "owasp_asi": "ASI09",
       "details": "envelope_valid=True; claim verdict=reject (occurrence: missing evidence)",
@@ -43,7 +43,7 @@
         "layer": "operational",
         "attack_type": "receipt claim"
       },
-      "timestamp": "2026-08-18T02:23:58.449226+00:00",
+      "timestamp": "2026-08-18T02:26:40.602864+00:00",
       "name": "Substituted evidence, re-signed envelope",
       "owasp_asi": "ASI09",
       "details": "envelope_valid=True; claim verdict=reject (check: checker attestation does not verify (substituted or forged))",
@@ -63,7 +63,7 @@
         "layer": "operational",
         "attack_type": "receipt claim"
       },
-      "timestamp": "2026-08-18T02:23:58.449234+00:00",
+      "timestamp": "2026-08-18T02:26:40.602870+00:00",
       "name": "Stale checker transcript",
       "owasp_asi": "ASI09",
       "details": "envelope_valid=True; claim verdict=reject (check: stale transcript (outside freshness window))",
@@ -83,7 +83,7 @@
         "layer": "operational",
         "attack_type": "receipt claim"
       },
-      "timestamp": "2026-08-18T02:23:58.449239+00:00",
+      "timestamp": "2026-08-18T02:26:40.602874+00:00",
       "name": "Check bound to the wrong tool-set digest",
       "owasp_asi": "ASI09",
       "details": "envelope_valid=True; claim verdict=reject (check: result bound to the wrong tool-set digest)",
@@ -103,7 +103,7 @@
         "layer": "operational",
         "attack_type": "receipt claim"
       },
-      "timestamp": "2026-08-18T02:23:58.449243+00:00",
+      "timestamp": "2026-08-18T02:26:40.602877+00:00",
       "name": "Authorization bound to different parameters",
       "owasp_asi": "ASI09",
       "details": "envelope_valid=True; claim verdict=reject (authorization: params do not match the action)",
@@ -123,7 +123,7 @@
         "layer": "operational",
         "attack_type": "receipt claim"
       },
-      "timestamp": "2026-08-18T02:23:58.449247+00:00",
+      "timestamp": "2026-08-18T02:26:40.602879+00:00",
       "name": "Execution ack bound to another action",
       "owasp_asi": "ASI09",
       "details": "envelope_valid=True; claim verdict=reject (occurrence: acknowledgment bound to another action)",
@@ -143,7 +143,7 @@
         "layer": "operational",
         "attack_type": "receipt claim"
       },
-      "timestamp": "2026-08-18T02:23:58.449251+00:00",
+      "timestamp": "2026-08-18T02:26:40.602882+00:00",
       "name": "Emitter self-assertion, no independent attestation",
       "owasp_asi": "ASI09",
       "details": "envelope_valid=True; claim verdict=reject (check: attested by the emitter, not the checker authority)",
@@ -163,7 +163,7 @@
         "layer": "operational",
         "attack_type": "receipt claim"
       },
-      "timestamp": "2026-08-18T02:23:58.449258+00:00",
+      "timestamp": "2026-08-18T02:26:40.602884+00:00",
       "name": "Fully-supported receipt accepted (control)",
       "owasp_asi": "ASI09",
       "details": "envelope_valid=True; claim verdict=accept",
@@ -183,7 +183,7 @@
         "layer": "operational",
         "attack_type": "receipt claim"
       },
-      "timestamp": "2026-08-18T02:23:58.449265+00:00",
+      "timestamp": "2026-08-18T02:26:40.602887+00:00",
       "name": "Wired MCP-019 check (clean) accepted",
       "owasp_asi": "ASI09",
       "details": "envelope_valid=True; claim verdict=accept (all four properties independently supported); expected accept",
@@ -203,7 +203,7 @@
         "layer": "operational",
         "attack_type": "receipt claim"
       },
-      "timestamp": "2026-08-18T02:23:58.449269+00:00",
+      "timestamp": "2026-08-18T02:26:40.602891+00:00",
       "name": "Wired MCP-019 check (composite found) rejected",
       "owasp_asi": "ASI09",
       "details": "envelope_valid=True; claim verdict=reject (check: recorded output is not a pass); expected reject",
@@ -223,7 +223,7 @@
         "layer": "operational",
         "attack_type": "receipt claim"
       },
-      "timestamp": "2026-08-18T02:23:58.449273+00:00",
+      "timestamp": "2026-08-18T02:26:40.602894+00:00",
       "name": "Wired MCP-019 check bound to wrong tool set rejected",
       "owasp_asi": "ASI09",
       "details": "envelope_valid=True; claim verdict=reject (check: result bound to the wrong tool-set digest); expected reject",

--- a/protocol_tests/attestation.py
+++ b/protocol_tests/attestation.py
@@ -19,10 +19,17 @@ __all__ = [
     "generate_attestation_report",
     "AttestationEntry",
     "SCHEMA_VERSION",
+    "EVIDENCE_CLASSES",
+    "INDEPENDENCE_LEVELS",
 ]
 
 SCHEMA_VERSION = "1.0.0"
 SCHEMA_PATH = Path(__file__).parent.parent / "schemas" / "attestation-report.json"
+
+# docs/EVIDENCE-CLASS-TAXONOMY.md. Kept here so a report can state its own class
+# rather than having a server assign one outside the signature (#384).
+EVIDENCE_CLASSES = ("E1", "E2", "E3", "E4", "E5")
+INDEPENDENCE_LEVELS = ("I0", "I1", "I2")
 
 # ---------------------------------------------------------------------------
 # Scope/remediation lookup for known test IDs
@@ -141,8 +148,35 @@ def generate_attestation_report(
     suite: str,
     harness_version: str,
     target: Optional[str] = None,
+    evidence_class: Optional[str] = None,
+    independence_level: str = "I0",
+    system_under_test: Optional[str] = None,
 ) -> Dict[str, Any]:
-    """Build a complete attestation report dict."""
+    """Build a complete attestation report dict.
+
+    `independence_level` and `system_under_test` land INSIDE the report, which is
+    the signed payload. Before #384 neither field existed here, so the only source
+    of them was the receiving server -- assigned server-side, outside the
+    signature, which is the operator assertion section 7 of the registry contract
+    exists to avoid.
+
+    An I-level is relative to a named system under test, so passing one without
+    the other is rejected rather than silently recorded.
+    """
+    if independence_level is not None and independence_level not in INDEPENDENCE_LEVELS:
+        raise ValueError(
+            f"independence_level must be one of {INDEPENDENCE_LEVELS}, got {independence_level!r}"
+        )
+    if evidence_class is not None and evidence_class not in EVIDENCE_CLASSES:
+        raise ValueError(
+            f"evidence_class must be one of {EVIDENCE_CLASSES}, got {evidence_class!r}"
+        )
+    if independence_level is not None and not system_under_test:
+        raise ValueError(
+            "system_under_test is required whenever independence_level is set. "
+            "An I-level with no named system under test is not a claim "
+            "(docs/EVIDENCE-CLASS-TAXONOMY.md)."
+        )
     passed = sum(1 for e in entries if e.get("result") == "pass")
     failed = sum(1 for e in entries if e.get("result") == "fail")
     errored = sum(1 for e in entries if e.get("result") == "error")
@@ -171,6 +205,11 @@ def generate_attestation_report(
         report["summary"]["skipped"] = skipped
     if target:
         report["target"] = target
+    if independence_level is not None:
+        report["independence_level"] = independence_level
+        report["system_under_test"] = system_under_test
+    if evidence_class is not None:
+        report["evidence_class"] = evidence_class
 
     return report
 
@@ -237,6 +276,15 @@ def validate_attestation_report(report: Dict[str, Any]) -> List[str]:
             errors.append(f"{path}: {error.message}")
 
     except ImportError:
+        # #384: this fallback is weaker than the schema, and before this change it
+        # returned the same empty list, so "no errors" meant either "validated" or
+        # "the validator was not installed". A criterion that reports success
+        # without the mechanism having run is the defect class this repo tracks,
+        # so the degradation is now stated rather than silent.
+        errors.append(
+            "NOT SCHEMA-VALIDATED: jsonschema is not installed, so only basic "
+            "structural checks ran. Install jsonschema for real validation."
+        )
         # Fallback: basic structural validation
         for field in ("schema_version", "harness_version", "suite", "timestamp", "summary", "entries"):
             if field not in report:
@@ -257,6 +305,22 @@ def validate_attestation_report(report: Dict[str, Any]) -> List[str]:
                         errors.append(f"entries[{i}].scope: missing 'protocol'")
                     if "layer" not in scope:
                         errors.append(f"entries[{i}].scope: missing 'layer'")
+
+    # Taxonomy rule, enforced regardless of which path above ran: an I-level is a
+    # property of the relationship between a record and a NAMED system under test,
+    # so a bare level is not a claim (docs/EVIDENCE-CLASS-TAXONOMY.md).
+    lvl = report.get("independence_level")
+    if lvl is not None:
+        if lvl not in INDEPENDENCE_LEVELS:
+            errors.append(f"independence_level: invalid value {lvl!r}")
+        if not report.get("system_under_test"):
+            errors.append(
+                "independence_level is set but system_under_test is missing. "
+                "An I-level with no named system under test is not a claim."
+            )
+    ec = report.get("evidence_class")
+    if ec is not None and ec not in EVIDENCE_CLASSES:
+        errors.append(f"evidence_class: invalid value {ec!r}")
 
     return errors
 

--- a/protocol_tests/attestation.py
+++ b/protocol_tests/attestation.py
@@ -149,7 +149,7 @@ def generate_attestation_report(
     harness_version: str,
     target: Optional[str] = None,
     evidence_class: Optional[str] = None,
-    independence_level: str = "I0",
+    independence_level: Optional[str] = None,
     system_under_test: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Build a complete attestation report dict.
@@ -162,6 +162,12 @@ def generate_attestation_report(
 
     An I-level is relative to a named system under test, so passing one without
     the other is rejected rather than silently recorded.
+
+    The default is to state NO independence claim rather than to default to I0.
+    Defaulting to I0 would require inventing a system under test to attach it to,
+    and an operator-invented system under test is the same manufactured claim this
+    change removes from the server. A record that makes no claim should be visibly
+    silent; verify_attestation_record.py reports the absence explicitly.
     """
     if independence_level is not None and independence_level not in INDEPENDENCE_LEVELS:
         raise ValueError(

--- a/protocol_tests/attestation_registry.py
+++ b/protocol_tests/attestation_registry.py
@@ -229,6 +229,55 @@ def _validate_registry_id(registry_id: str) -> None:
         )
 
 
+def build_record(
+    report: dict,
+    server_name: str,
+    contact: str | None = None,
+) -> dict:
+    """Build a signed envelope v2 record. Performs NO network I/O.
+
+    Split out of publish_attestation() for #384. Before this, the only code that
+    produced a signed record also POSTed it, so a record could not exist without a
+    registry -- while section 7 of the server contract says the link between two
+    records lives in the signature, not in an operator's assertion. The file-based
+    exchange the contract relies on was unreachable through the shipped API.
+
+    Returns the submission dict. Write it to a file, commit it, hand it to someone:
+    it verifies offline with scripts/verify_attestation_record.py either way.
+    """
+    _validate_server_name(server_name)
+    if contact:
+        _validate_contact(contact)
+
+    cleaned = strip_sensitive_fields(report)
+
+    payload_dict = {
+        "server_name": server_name,
+        "contact": contact,
+        "report": cleaned,
+        "published_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+
+    # Canonical bytes: sort_keys with DEFAULT separators, not compact and not
+    # JCS. Pinned in docs/ATTESTATION-REGISTRY-SERVER-CONTRACT.md section 4.1,
+    # because a canonicalisation that lives in one implementation is not a
+    # contract and an independent verifier reproducing it wrongly gets a valid
+    # signature that will not verify.
+    payload_bytes = json.dumps(payload_dict, sort_keys=True).encode()
+    signature = _sign_payload(payload_bytes)
+    verification_hash = hashlib.sha256(payload_bytes).hexdigest()
+
+    pub_pem = (_KEY_DIR / "signing_key_pub.pem").read_bytes()
+    return {
+        "envelope_version": "2",
+        "payload": payload_dict,
+        "signature": signature,
+        "verification_hash": verification_hash,
+        "public_key_fingerprint": hashlib.sha256(pub_pem).hexdigest()[:16],
+        "public_key": pub_pem.decode("utf-8"),
+    }
+
+
 def publish_attestation(
     report: dict,
     server_name: str,
@@ -253,53 +302,8 @@ def publish_attestation(
     Raises:
         ValueError: If server_name or contact fail validation.
     """
-    # Validate inputs (#113)
-    _validate_server_name(server_name)
-    if contact:
-        _validate_contact(contact)
-
-    # Strip ALL sensitive fields before the data leaves this machine
-    cleaned = strip_sensitive_fields(report)
-
-    payload_dict = {
-        "server_name": server_name,
-        "contact": contact,
-        "report": cleaned,
-        "published_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-    }
-
-    # Canonical bytes: sort_keys with DEFAULT separators, not compact and not
-    # JCS. Pinned in docs/ATTESTATION-REGISTRY-SERVER-CONTRACT.md section 4.1,
-    # because a canonicalisation that lives in one implementation is not a
-    # contract and an independent verifier reproducing it wrongly gets a valid
-    # signature that will not verify.
-    payload_bytes = json.dumps(payload_dict, sort_keys=True).encode()
-
-    # Sign so the registry can verify authenticity
-    signature = _sign_payload(payload_bytes)
-    verification_hash = hashlib.sha256(payload_bytes).hexdigest()
-
-    # Envelope v2 (#371): carry the public KEY, not only its fingerprint.
-    #
-    # v1 sent sha256(public_key_pem)[:16] and nothing else. A fingerprint lets
-    # someone confirm a key they already hold; it does not let them recover one.
-    # So a third party fetching a record could check that verification_hash
-    # matched the payload -- internal consistency, and nothing more -- and could
-    # verify NOTHING about who signed it. docs/attestation-registry.md states
-    # that a third party can check an entry without trusting the operator. As
-    # shipped, nobody could. An operator could author a payload, compute a
-    # matching hash, and serve a record indistinguishable from a genuine one.
-    pub_pem = (_KEY_DIR / "signing_key_pub.pem").read_bytes()
-    submission = {
-        "envelope_version": "2",
-        "payload": payload_dict,
-        "signature": signature,
-        "verification_hash": verification_hash,
-        # Retained so a server can reject a public_key that does not match it,
-        # and so existing consumers of the field keep working.
-        "public_key_fingerprint": hashlib.sha256(pub_pem).hexdigest()[:16],
-        "public_key": pub_pem.decode("utf-8"),
-    }
+    submission = build_record(report, server_name, contact)
+    verification_hash = submission["verification_hash"]
 
     endpoint = resolve_registry_endpoint()
 

--- a/schemas/attestation-report.json
+++ b/schemas/attestation-report.json
@@ -106,6 +106,31 @@
         "$ref": "#/$defs/attestation_entry"
       },
       "description": "Individual test results with attestation metadata."
+    },
+    "evidence_class": {
+      "type": "string",
+      "enum": [
+        "E1",
+        "E2",
+        "E3",
+        "E4",
+        "E5"
+      ],
+      "description": "Evidence strength per docs/EVIDENCE-CLASS-TAXONOMY.md."
+    },
+    "independence_level": {
+      "type": "string",
+      "enum": [
+        "I0",
+        "I1",
+        "I2"
+      ],
+      "description": "Who produced the oracle, relative to system_under_test. Not a property of the record alone."
+    },
+    "system_under_test": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The system the independence_level is relative to. Required whenever independence_level is present."
     }
   },
   "additionalProperties": false,
@@ -369,5 +394,10 @@
         "harness_version"
       ]
     }
-  ]
+  ],
+  "dependentRequired": {
+    "independence_level": [
+      "system_under_test"
+    ]
+  }
 }

--- a/scripts/registry_reference_server.py
+++ b/scripts/registry_reference_server.py
@@ -210,9 +210,26 @@ def validate_and_build(submission: dict, required_keys: list[str]) -> dict:
         "public_key_fingerprint": fingerprint,
         "envelope_version": submission.get("envelope_version", "1"),
         "signature_verifiable": signature_verifiable,
+        # #384: prefer what the submitter SIGNED. Before this, both of these were
+        # assigned here, outside the signature -- so the independence claim existed
+        # only as operator metadata a verifier could not check, which is the
+        # assertion contract section 7 exists to avoid. The registry classification
+        # stays I0 per section 1 (a submission establishes I0 regardless of who
+        # sent it), but the system under test now comes from inside the signature
+        # when the report states it, and the record says which.
         "evidence_class": report.get("evidence_class", "E1"),
+        "evidence_class_source": (
+            "signed_payload" if report.get("evidence_class") else "server_default"
+        ),
         "independence_level": "I0",
-        "system_under_test": server_name,
+        "independence_level_basis": (
+            "contract section 1: a submission establishes I0 regardless of submitter"
+        ),
+        "signed_independence_level": report.get("independence_level"),
+        "system_under_test": report.get("system_under_test") or server_name,
+        "system_under_test_source": (
+            "signed_payload" if report.get("system_under_test") else "server_assigned"
+        ),
         "received_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "claim_label": CLAIM_LABEL,
     }

--- a/scripts/verify_attestation_record.py
+++ b/scripts/verify_attestation_record.py
@@ -95,9 +95,26 @@ def verify(record: dict) -> bool:
     line(NOTE, "key-to-identity binding is OUT OF SCOPE. The checks above prove a holder of "
                "this key signed this payload. They do not prove whose key it is.")
 
-    # Step 6: what the record actually establishes
-    level = record.get("independence_level", "unstated")
-    sut = record.get("system_under_test", "unstated")
+    # Step 6: what the record actually establishes.
+    #
+    # #384: read the SIGNED location first. These fields live inside
+    # payload.report, which is covered by the signature; a server also echoes them
+    # at the envelope top level, where they are operator metadata a verifier cannot
+    # check. Preferring the top level meant a file-based record -- the whole point
+    # of contract section 7 -- reported its independence as 'unstated'.
+    signed_report = (record.get("payload") or {}).get("report") or {}
+    level = signed_report.get("independence_level")
+    sut = signed_report.get("system_under_test")
+    source = "signed payload"
+    if level is None:
+        level = record.get("independence_level")
+        sut = record.get("system_under_test")
+        source = "envelope top level, NOT covered by the signature"
+    if level is None:
+        level, sut, source = "unstated", "unstated", "absent"
+    else:
+        line(NOTE, f"independence fields read from: {source}")
+    sut = sut or "unstated"
     if level == "I0":
         line(NOTE, f"independence_level I0, system under test '{sut}'. The submitter authored "
                    f"the oracle. A passing signature proves the record was not altered. It "

--- a/scripts/verify_attestation_record.py
+++ b/scripts/verify_attestation_record.py
@@ -111,10 +111,13 @@ def verify(record: dict) -> bool:
         sut = record.get("system_under_test")
         source = "envelope top level, NOT covered by the signature"
     if level is None:
-        level, sut, source = "unstated", "unstated", "absent"
+        line(NOTE, "this record makes NO independence claim: neither "
+                   "independence_level nor system_under_test is present. That is "
+                   "an absence, not an I0 result.")
+        level, sut = None, "unstated"
     else:
         line(NOTE, f"independence fields read from: {source}")
-    sut = sut or "unstated"
+        sut = sut or "unstated"
     if level == "I0":
         line(NOTE, f"independence_level I0, system under test '{sut}'. The submitter authored "
                    f"the oracle. A passing signature proves the record was not altered. It "

--- a/tests/test_record_states_its_own_independence.py
+++ b/tests/test_record_states_its_own_independence.py
@@ -47,10 +47,13 @@ def test_report_states_independence_and_system_under_test():
     assert r["system_under_test"] == "agent-security-harness"
 
 
-def test_independence_defaults_to_i0_but_still_needs_a_named_system():
-    """The default is I0, not 'absent'. A bare level is still rejected."""
-    with pytest.raises(ValueError, match="system_under_test is required"):
-        _report(system_under_test=None)
+def test_default_states_no_claim_rather_than_defaulting_to_i0():
+    """Defaulting to I0 would require inventing a system under test to attach it
+    to, which is the manufactured claim this change removes from the server. An
+    absence must stay an absence."""
+    r = _report()
+    assert "independence_level" not in r
+    assert "system_under_test" not in r
 
 
 def test_i_level_without_system_under_test_is_rejected():
@@ -76,14 +79,14 @@ def test_every_taxonomy_value_is_accepted():
 # --- the validator enforces the taxonomy rule -----------------------------
 
 def test_validator_flags_a_bare_independence_level():
-    r = _report(system_under_test="x")
+    r = _report(independence_level="I0", system_under_test="x")
     r.pop("system_under_test")
     errs = validate_attestation_report(r)
     assert any("system_under_test is missing" in e for e in errs), errs
 
 
 def test_validator_flags_an_invalid_level_that_bypassed_the_generator():
-    r = _report(system_under_test="x")
+    r = _report(independence_level="I0", system_under_test="x")
     r["independence_level"] = "I7"
     assert any("invalid value" in e for e in errs) if (errs := validate_attestation_report(r)) else False
 
@@ -147,7 +150,8 @@ def test_verifier_rejects_a_tampered_record(tmp_path):
     """Negative control. A verifier that only ever passes proves nothing."""
     from protocol_tests.attestation_registry import build_record
 
-    rec = build_record(_report(system_under_test="x"), server_name="unit test target")
+    rec = build_record(_report(independence_level="I0", system_under_test="x"),
+                       server_name="unit test target")
     rec["payload"]["report"]["summary"]["passed"] = 999
     path = tmp_path / "tampered.json"
     path.write_text(json.dumps(rec))

--- a/tests/test_record_states_its_own_independence.py
+++ b/tests/test_record_states_its_own_independence.py
@@ -1,0 +1,160 @@
+"""#384: a record must be able to state its own independence, inside the signature.
+
+Before this, `generate_attestation_report()` emitted neither `independence_level`
+nor `system_under_test`, the schema did not define them, and only the reference
+server supplied them -- server-side, outside the signature. So a file-based record,
+which is the exchange mechanism section 7 of the registry contract depends on,
+reported its own independence as 'unstated'.
+"""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+
+from protocol_tests.attestation import (  # noqa: E402
+    EVIDENCE_CLASSES,
+    INDEPENDENCE_LEVELS,
+    generate_attestation_report,
+    validate_attestation_report,
+)
+
+# Use the shipped inference rather than a hand-written scope: a hand-written one
+# drifted from the schema enums the first time this test was run.
+from protocol_tests.attestation import _infer_scope  # noqa: E402
+
+ENTRY = {
+    "test_id": "RCL-001", "category": "receipt_claim", "result": "pass",
+    "severity": "P1-High", "scope": _infer_scope("RCL-001", "receipt_claim"),
+    "timestamp": "2026-08-17T00:00:00+00:00",
+}
+
+
+def _report(**kw):
+    return generate_attestation_report([ENTRY], suite="receipt-claim",
+                                       harness_version="4.15.0", **kw)
+
+
+# --- the generator states the fields --------------------------------------
+
+def test_report_states_independence_and_system_under_test():
+    r = _report(independence_level="I0", system_under_test="agent-security-harness")
+    assert r["independence_level"] == "I0"
+    assert r["system_under_test"] == "agent-security-harness"
+
+
+def test_independence_defaults_to_i0_but_still_needs_a_named_system():
+    """The default is I0, not 'absent'. A bare level is still rejected."""
+    with pytest.raises(ValueError, match="system_under_test is required"):
+        _report(system_under_test=None)
+
+
+def test_i_level_without_system_under_test_is_rejected():
+    for lvl in INDEPENDENCE_LEVELS:
+        with pytest.raises(ValueError, match="system_under_test is required"):
+            _report(independence_level=lvl, system_under_test="")
+
+
+def test_invalid_levels_and_classes_are_rejected():
+    with pytest.raises(ValueError, match="independence_level must be one of"):
+        _report(independence_level="I3", system_under_test="x")
+    with pytest.raises(ValueError, match="evidence_class must be one of"):
+        _report(evidence_class="E9", system_under_test="x")
+
+
+def test_every_taxonomy_value_is_accepted():
+    for lvl in INDEPENDENCE_LEVELS:
+        assert _report(independence_level=lvl, system_under_test="x")["independence_level"] == lvl
+    for ec in EVIDENCE_CLASSES:
+        assert _report(evidence_class=ec, system_under_test="x")["evidence_class"] == ec
+
+
+# --- the validator enforces the taxonomy rule -----------------------------
+
+def test_validator_flags_a_bare_independence_level():
+    r = _report(system_under_test="x")
+    r.pop("system_under_test")
+    errs = validate_attestation_report(r)
+    assert any("system_under_test is missing" in e for e in errs), errs
+
+
+def test_validator_flags_an_invalid_level_that_bypassed_the_generator():
+    r = _report(system_under_test="x")
+    r["independence_level"] = "I7"
+    assert any("invalid value" in e for e in errs) if (errs := validate_attestation_report(r)) else False
+
+
+def test_a_well_formed_report_validates_clean():
+    r = _report(evidence_class="E2", independence_level="I0", system_under_test="x")
+    errs = [e for e in validate_attestation_report(r) if "NOT SCHEMA-VALIDATED" not in e]
+    assert errs == [], errs
+
+
+# --- the schema carries them ----------------------------------------------
+
+def test_schema_defines_the_fields_and_the_dependency():
+    schema = json.loads((REPO / "schemas" / "attestation-report.json").read_text())
+    props = schema["properties"]
+    assert props["independence_level"]["enum"] == list(INDEPENDENCE_LEVELS)
+    assert props["evidence_class"]["enum"] == list(EVIDENCE_CLASSES)
+    assert schema["dependentRequired"]["independence_level"] == ["system_under_test"]
+
+
+def test_schema_version_still_not_bumped_and_required_unchanged():
+    """New fields are optional + dependentRequired, so records predating #384 stay
+    valid. Adding them to `required` would need a schema_version bump."""
+    schema = json.loads((REPO / "schemas" / "attestation-report.json").read_text())
+    assert schema["properties"]["schema_version"]["const"] == "1.0.0"
+    assert "independence_level" not in schema["required"]
+
+
+# --- a record can be built with no registry -------------------------------
+
+def test_build_record_performs_no_network_io():
+    import inspect
+
+    from protocol_tests import attestation_registry as ar
+    src = inspect.getsource(ar.build_record)
+    for banned in ("urlopen", "Request(", "resolve_registry_endpoint"):
+        assert banned not in src, f"build_record must not do network I/O: found {banned}"
+
+
+def test_build_record_round_trips_through_the_offline_verifier(tmp_path):
+    from protocol_tests.attestation_registry import build_record
+
+    report = _report(evidence_class="E2", independence_level="I0",
+                     system_under_test="agent-security-harness")
+    rec = build_record(report, server_name="unit test target")
+    path = tmp_path / "record.json"
+    path.write_text(json.dumps(rec))
+
+    out = subprocess.run(
+        [sys.executable, str(REPO / "scripts" / "verify_attestation_record.py"), str(path)],
+        capture_output=True, text=True,
+    )
+    assert out.returncode == 0, out.stdout + out.stderr
+    # the point of #384: read from the SIGNED location, not 'unstated'
+    assert "unstated" not in out.stdout, out.stdout
+    assert "signed payload" in out.stdout, out.stdout
+    assert "agent-security-harness" in out.stdout, out.stdout
+
+
+def test_verifier_rejects_a_tampered_record(tmp_path):
+    """Negative control. A verifier that only ever passes proves nothing."""
+    from protocol_tests.attestation_registry import build_record
+
+    rec = build_record(_report(system_under_test="x"), server_name="unit test target")
+    rec["payload"]["report"]["summary"]["passed"] = 999
+    path = tmp_path / "tampered.json"
+    path.write_text(json.dumps(rec))
+
+    out = subprocess.run(
+        [sys.executable, str(REPO / "scripts" / "verify_attestation_record.py"), str(path)],
+        capture_output=True, text=True,
+    )
+    assert out.returncode == 1, out.stdout
+    assert "VERIFICATION FAILED" in out.stdout


### PR DESCRIPTION
Fixes defect 5 from #385, the only one of the six that changes what the artifact can claim.

## The defect

`generate_attestation_report()` emitted neither `independence_level` nor `system_under_test`, the schema did not define them, and only the reference server supplied them — **server-side, outside the signature**. So the first record this project produced reported its own independence as `unstated`, and the claim existed only as unsigned operator metadata a verifier could not check. That is the assertion §7 of the registry contract exists to avoid.

## The fix

- **Generator** takes `evidence_class`, `independence_level`, `system_under_test` and emits them into the report, which is the signed payload. An I-level without a named system under test raises: the axis is relative, so a bare level is not a claim.
- **Default is no claim, not I0.** Defaulting to I0 would require inventing a system under test to attach it to, which is the same manufactured claim being removed from the server. An absence stays an absence, and the verifier now says so explicitly instead of printing `'unstated' relative to 'unstated'`.
- **`build_record()`** returns a signed envelope with no network I/O; `publish_attestation()` calls it. Previously the only code producing a signed record also POSTed it, so the artifact §7 depends on was unreachable through the API.
- **Reference server** reads `system_under_test` and `evidence_class` from the signed payload when present and records which source it used. Registry classification stays I0 per §1.
- **Verifier** reads the signed location first. It only checked the envelope top level, where a *server* puts these, which is why a file record said `unstated`.
- **Schema** gains the three fields with taxonomy enums plus `dependentRequired: independence_level → system_under_test`. Deliberately **not** added to `required` and `schema_version` **not** bumped, so records predating this stay valid.
- **Validator** no longer returns an empty error list when `jsonschema` is absent. It said "no errors" for both *validated* and *the validator was not installed* — the report-success-without-the-mechanism class this repo tracks, inside the validator itself.

## Verification

Clean disposable clone, fresh venv, `.[mcp-server]` installed as CI does:

| Suite | Result |
|---|---|
| `tests/` | **194 passed** |
| `testing/` | **436 passed + 170 subtests** |

`tests/test_record_states_its_own_independence.py` adds 13 tests, including a negative control that a tampered record exits 1, and an assertion that `build_record` contains no network I/O.

Live round-trip against the reference server now stores `system_under_test: 'agent-security-harness receipt-claim suite'` with `system_under_test_source: 'signed_payload'` — from inside the signature, not from the operator-supplied `server_name`.

Two notes on method. The first round-trip attempt hit a **stale server left running on a busy port**, so it reported the old behaviour and was not evidence; it was redone on a fresh instance. And the regenerated record exposed that the previously committed one carried a `server_name` `_validate_server_name()` would have **rejected** — hand-assembly skipped a check the API enforces, which is itself an argument for `build_record()`.

Refs #384, #385.