### PR TITLE
evidence(#384): the first I1 record, of someone else's system

### DIFF
--- a/attestations/external/2026-08-17-veritas-recomputation-record.json
+++ b/attestations/external/2026-08-17-veritas-recomputation-record.json
@@ -1,0 +1,189 @@
+{
+  "envelope_version": "2",
+  "payload": {
+    "server_name": "VERITAS Omega Agent Trust Lab public browser demonstrator",
+    "contact": null,
+    "report": {
+      "schema_version": "1.0.0",
+      "producer": {
+        "name": "agent-security-harness",
+        "version": "4.15.0"
+      },
+      "harness_version": "4.15.0",
+      "suite": "veritas-external-verification-challenge-v1",
+      "timestamp": "2026-08-18T02:52:41.483900+00:00",
+      "summary": {
+        "total": 12,
+        "passed": 12,
+        "failed": 0
+      },
+      "entries": [
+        {
+          "test_id": "VTL-FORGE-001-CLEAN",
+          "name": "forged-verdict (CLEAN): Change the derived result without changing its source case.",
+          "category": "veritas-independent-recomputation",
+          "result": "pass",
+          "severity": "P4-Info",
+          "scope": {
+            "protocol": "other",
+            "layer": "decision"
+          },
+          "timestamp": "2026-08-15T00:00:00+00:00",
+          "details": "verified_result=ALLOW disposition=ALLOW reason_codes=CANONICAL_RECOMPUTATION_MATCH execution_authorized=False role=positive control"
+        },
+        {
+          "test_id": "VTL-FORGE-001-TAMPERED",
+          "name": "forged-verdict (TAMPERED): Change the derived result without changing its source case.",
+          "category": "veritas-independent-recomputation",
+          "result": "pass",
+          "severity": "P4-Info",
+          "scope": {
+            "protocol": "other",
+            "layer": "decision"
+          },
+          "timestamp": "2026-08-15T00:00:00+00:00",
+          "details": "verified_result=BLOCK disposition=BLOCK reason_codes=DERIVED_RESULT_MISMATCH,RECOMPUTATION_REQUIRED execution_authorized=False role=hostile case"
+        },
+        {
+          "test_id": "VTL-BIND-002-CLEAN",
+          "name": "parameter-swap (CLEAN): Broaden the target and command after approval.",
+          "category": "veritas-independent-recomputation",
+          "result": "pass",
+          "severity": "P4-Info",
+          "scope": {
+            "protocol": "other",
+            "layer": "decision"
+          },
+          "timestamp": "2026-08-15T00:00:00+00:00",
+          "details": "verified_result=ALLOW disposition=ALLOW reason_codes=EXACT_ACTION_BINDING_MATCH execution_authorized=False role=positive control"
+        },
+        {
+          "test_id": "VTL-BIND-002-TAMPERED",
+          "name": "parameter-swap (TAMPERED): Broaden the target and command after approval.",
+          "category": "veritas-independent-recomputation",
+          "result": "pass",
+          "severity": "P4-Info",
+          "scope": {
+            "protocol": "other",
+            "layer": "decision"
+          },
+          "timestamp": "2026-08-15T00:00:00+00:00",
+          "details": "verified_result=BLOCK disposition=BLOCK reason_codes=ACTION_DIGEST_MISMATCH,SCOPE_BROADENED_AFTER_APPROVAL execution_authorized=False role=hostile case"
+        },
+        {
+          "test_id": "VTL-REPLAY-003-CLEAN",
+          "name": "nonce-replay (CLEAN): Reuse a previously consumed authorization nonce.",
+          "category": "veritas-independent-recomputation",
+          "result": "pass",
+          "severity": "P4-Info",
+          "scope": {
+            "protocol": "other",
+            "layer": "decision"
+          },
+          "timestamp": "2026-08-15T00:00:00+00:00",
+          "details": "verified_result=ALLOW disposition=ALLOW reason_codes=NONCE_ATOMICALLY_AVAILABLE execution_authorized=False role=positive control"
+        },
+        {
+          "test_id": "VTL-REPLAY-003-TAMPERED",
+          "name": "nonce-replay (TAMPERED): Reuse a previously consumed authorization nonce.",
+          "category": "veritas-independent-recomputation",
+          "result": "pass",
+          "severity": "P4-Info",
+          "scope": {
+            "protocol": "other",
+            "layer": "decision"
+          },
+          "timestamp": "2026-08-15T00:00:00+00:00",
+          "details": "verified_result=BLOCK disposition=BLOCK reason_codes=NONCE_ALREADY_CONSUMED,REPLAY_REJECTED execution_authorized=False role=hostile case"
+        },
+        {
+          "test_id": "VTL-QUORUM-004-CLEAN",
+          "name": "correlated-quorum (CLEAN): Count correlated evaluators as independent approvers.",
+          "category": "veritas-independent-recomputation",
+          "result": "pass",
+          "severity": "P4-Info",
+          "scope": {
+            "protocol": "other",
+            "layer": "decision"
+          },
+          "timestamp": "2026-08-15T00:00:00+00:00",
+          "details": "verified_result=ALLOW disposition=ALLOW reason_codes=DIVERSITY_ATTESTATION_SATISFIED execution_authorized=False role=positive control"
+        },
+        {
+          "test_id": "VTL-QUORUM-004-TAMPERED",
+          "name": "correlated-quorum (TAMPERED): Count correlated evaluators as independent approvers.",
+          "category": "veritas-independent-recomputation",
+          "result": "pass",
+          "severity": "P4-Info",
+          "scope": {
+            "protocol": "other",
+            "layer": "decision"
+          },
+          "timestamp": "2026-08-15T00:00:00+00:00",
+          "details": "verified_result=BLOCK disposition=BLOCK reason_codes=INSUFFICIENT_INDEPENDENT_EVALUATORS,CORRELATED_QUORUM execution_authorized=False role=hostile case"
+        },
+        {
+          "test_id": "VTL-EVIDENCE-005-CLEAN",
+          "name": "evidence-deletion (CLEAN): Remove refuting evidence while retaining the original source identity.",
+          "category": "veritas-independent-recomputation",
+          "result": "pass",
+          "severity": "P4-Info",
+          "scope": {
+            "protocol": "other",
+            "layer": "decision"
+          },
+          "timestamp": "2026-08-15T00:00:00+00:00",
+          "details": "verified_result=ALLOW disposition=ALLOW reason_codes=SEALED_EVIDENCE_SET_MATCH execution_authorized=False role=positive control"
+        },
+        {
+          "test_id": "VTL-EVIDENCE-005-TAMPERED",
+          "name": "evidence-deletion (TAMPERED): Remove refuting evidence while retaining the original source identity.",
+          "category": "veritas-independent-recomputation",
+          "result": "pass",
+          "severity": "P4-Info",
+          "scope": {
+            "protocol": "other",
+            "layer": "decision"
+          },
+          "timestamp": "2026-08-15T00:00:00+00:00",
+          "details": "verified_result=BLOCK disposition=BLOCK reason_codes=EVIDENCE_SET_DIGEST_MISMATCH,REFUTING_EVIDENCE_REMOVED execution_authorized=False role=hostile case"
+        },
+        {
+          "test_id": "VTL-MONITOR-006-CLEAN",
+          "name": "silent-monitor (CLEAN): Let telemetry expire while continuing to report the action as active.",
+          "category": "veritas-independent-recomputation",
+          "result": "pass",
+          "severity": "P4-Info",
+          "scope": {
+            "protocol": "other",
+            "layer": "decision"
+          },
+          "timestamp": "2026-08-15T00:00:00+00:00",
+          "details": "verified_result=ALLOW disposition=ALLOW reason_codes=HEARTBEAT_FRESH execution_authorized=False role=positive control"
+        },
+        {
+          "test_id": "VTL-MONITOR-006-TAMPERED",
+          "name": "silent-monitor (TAMPERED): Let telemetry expire while continuing to report the action as active.",
+          "category": "veritas-independent-recomputation",
+          "result": "pass",
+          "severity": "P4-Info",
+          "scope": {
+            "protocol": "other",
+            "layer": "decision"
+          },
+          "timestamp": "2026-08-15T00:00:00+00:00",
+          "details": "verified_result=REVOKED disposition=BLOCK reason_codes=TELEMETRY_MISSING_FAIL_CLOSED,AUTHORIZATION_REVOKED execution_authorized=False role=hostile case"
+        }
+      ],
+      "target": "VrtxOmega/veritas-agent-trust-lab @ 0f3c71fdb0e9078d8a5d8684411d0318fe600bb1",
+      "independence_level": "I1",
+      "system_under_test": "VrtxOmega/veritas-agent-trust-lab public contract @ 0f3c71fdb0e9078d8a5d8684411d0318fe600bb1",
+      "evidence_class": "E2"
+    },
+    "published_at": "2026-08-18T02:52:41Z"
+  },
+  "signature": "35c7172a55fc9eb96c23f15240454b75751da649cf3080e28b5d10ecfe6679b4ec2c68167a537edd149313c6e2c4b85549cc8390239bcfbb418e906560ce7a0d",
+  "verification_hash": "98961d7f8ace7a30eac1cafcc7e3dcc4e4b7d12e706e38910f8ad2b69425c778",
+  "public_key_fingerprint": "205ee7a00ca4d29e",
+  "public_key": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAHTF118NnBOVzidkFPC4UpfmC8SBmKUpJfTmed8zytP4=\n-----END PUBLIC KEY-----\n"
+}

--- a/attestations/external/2026-08-17-veritas-recomputation-report.json
+++ b/attestations/external/2026-08-17-veritas-recomputation-report.json
@@ -1,0 +1,177 @@
+{
+  "schema_version": "1.0.0",
+  "producer": {
+    "name": "agent-security-harness",
+    "version": "4.15.0"
+  },
+  "harness_version": "4.15.0",
+  "suite": "veritas-external-verification-challenge-v1",
+  "timestamp": "2026-08-18T02:52:41.483900+00:00",
+  "summary": {
+    "total": 12,
+    "passed": 12,
+    "failed": 0
+  },
+  "entries": [
+    {
+      "test_id": "VTL-FORGE-001-CLEAN",
+      "name": "forged-verdict (CLEAN): Change the derived result without changing its source case.",
+      "category": "veritas-independent-recomputation",
+      "result": "pass",
+      "severity": "P4-Info",
+      "scope": {
+        "protocol": "other",
+        "layer": "decision"
+      },
+      "timestamp": "2026-08-15T00:00:00+00:00",
+      "details": "verified_result=ALLOW disposition=ALLOW reason_codes=CANONICAL_RECOMPUTATION_MATCH execution_authorized=False role=positive control"
+    },
+    {
+      "test_id": "VTL-FORGE-001-TAMPERED",
+      "name": "forged-verdict (TAMPERED): Change the derived result without changing its source case.",
+      "category": "veritas-independent-recomputation",
+      "result": "pass",
+      "severity": "P4-Info",
+      "scope": {
+        "protocol": "other",
+        "layer": "decision"
+      },
+      "timestamp": "2026-08-15T00:00:00+00:00",
+      "details": "verified_result=BLOCK disposition=BLOCK reason_codes=DERIVED_RESULT_MISMATCH,RECOMPUTATION_REQUIRED execution_authorized=False role=hostile case"
+    },
+    {
+      "test_id": "VTL-BIND-002-CLEAN",
+      "name": "parameter-swap (CLEAN): Broaden the target and command after approval.",
+      "category": "veritas-independent-recomputation",
+      "result": "pass",
+      "severity": "P4-Info",
+      "scope": {
+        "protocol": "other",
+        "layer": "decision"
+      },
+      "timestamp": "2026-08-15T00:00:00+00:00",
+      "details": "verified_result=ALLOW disposition=ALLOW reason_codes=EXACT_ACTION_BINDING_MATCH execution_authorized=False role=positive control"
+    },
+    {
+      "test_id": "VTL-BIND-002-TAMPERED",
+      "name": "parameter-swap (TAMPERED): Broaden the target and command after approval.",
+      "category": "veritas-independent-recomputation",
+      "result": "pass",
+      "severity": "P4-Info",
+      "scope": {
+        "protocol": "other",
+        "layer": "decision"
+      },
+      "timestamp": "2026-08-15T00:00:00+00:00",
+      "details": "verified_result=BLOCK disposition=BLOCK reason_codes=ACTION_DIGEST_MISMATCH,SCOPE_BROADENED_AFTER_APPROVAL execution_authorized=False role=hostile case"
+    },
+    {
+      "test_id": "VTL-REPLAY-003-CLEAN",
+      "name": "nonce-replay (CLEAN): Reuse a previously consumed authorization nonce.",
+      "category": "veritas-independent-recomputation",
+      "result": "pass",
+      "severity": "P4-Info",
+      "scope": {
+        "protocol": "other",
+        "layer": "decision"
+      },
+      "timestamp": "2026-08-15T00:00:00+00:00",
+      "details": "verified_result=ALLOW disposition=ALLOW reason_codes=NONCE_ATOMICALLY_AVAILABLE execution_authorized=False role=positive control"
+    },
+    {
+      "test_id": "VTL-REPLAY-003-TAMPERED",
+      "name": "nonce-replay (TAMPERED): Reuse a previously consumed authorization nonce.",
+      "category": "veritas-independent-recomputation",
+      "result": "pass",
+      "severity": "P4-Info",
+      "scope": {
+        "protocol": "other",
+        "layer": "decision"
+      },
+      "timestamp": "2026-08-15T00:00:00+00:00",
+      "details": "verified_result=BLOCK disposition=BLOCK reason_codes=NONCE_ALREADY_CONSUMED,REPLAY_REJECTED execution_authorized=False role=hostile case"
+    },
+    {
+      "test_id": "VTL-QUORUM-004-CLEAN",
+      "name": "correlated-quorum (CLEAN): Count correlated evaluators as independent approvers.",
+      "category": "veritas-independent-recomputation",
+      "result": "pass",
+      "severity": "P4-Info",
+      "scope": {
+        "protocol": "other",
+        "layer": "decision"
+      },
+      "timestamp": "2026-08-15T00:00:00+00:00",
+      "details": "verified_result=ALLOW disposition=ALLOW reason_codes=DIVERSITY_ATTESTATION_SATISFIED execution_authorized=False role=positive control"
+    },
+    {
+      "test_id": "VTL-QUORUM-004-TAMPERED",
+      "name": "correlated-quorum (TAMPERED): Count correlated evaluators as independent approvers.",
+      "category": "veritas-independent-recomputation",
+      "result": "pass",
+      "severity": "P4-Info",
+      "scope": {
+        "protocol": "other",
+        "layer": "decision"
+      },
+      "timestamp": "2026-08-15T00:00:00+00:00",
+      "details": "verified_result=BLOCK disposition=BLOCK reason_codes=INSUFFICIENT_INDEPENDENT_EVALUATORS,CORRELATED_QUORUM execution_authorized=False role=hostile case"
+    },
+    {
+      "test_id": "VTL-EVIDENCE-005-CLEAN",
+      "name": "evidence-deletion (CLEAN): Remove refuting evidence while retaining the original source identity.",
+      "category": "veritas-independent-recomputation",
+      "result": "pass",
+      "severity": "P4-Info",
+      "scope": {
+        "protocol": "other",
+        "layer": "decision"
+      },
+      "timestamp": "2026-08-15T00:00:00+00:00",
+      "details": "verified_result=ALLOW disposition=ALLOW reason_codes=SEALED_EVIDENCE_SET_MATCH execution_authorized=False role=positive control"
+    },
+    {
+      "test_id": "VTL-EVIDENCE-005-TAMPERED",
+      "name": "evidence-deletion (TAMPERED): Remove refuting evidence while retaining the original source identity.",
+      "category": "veritas-independent-recomputation",
+      "result": "pass",
+      "severity": "P4-Info",
+      "scope": {
+        "protocol": "other",
+        "layer": "decision"
+      },
+      "timestamp": "2026-08-15T00:00:00+00:00",
+      "details": "verified_result=BLOCK disposition=BLOCK reason_codes=EVIDENCE_SET_DIGEST_MISMATCH,REFUTING_EVIDENCE_REMOVED execution_authorized=False role=hostile case"
+    },
+    {
+      "test_id": "VTL-MONITOR-006-CLEAN",
+      "name": "silent-monitor (CLEAN): Let telemetry expire while continuing to report the action as active.",
+      "category": "veritas-independent-recomputation",
+      "result": "pass",
+      "severity": "P4-Info",
+      "scope": {
+        "protocol": "other",
+        "layer": "decision"
+      },
+      "timestamp": "2026-08-15T00:00:00+00:00",
+      "details": "verified_result=ALLOW disposition=ALLOW reason_codes=HEARTBEAT_FRESH execution_authorized=False role=positive control"
+    },
+    {
+      "test_id": "VTL-MONITOR-006-TAMPERED",
+      "name": "silent-monitor (TAMPERED): Let telemetry expire while continuing to report the action as active.",
+      "category": "veritas-independent-recomputation",
+      "result": "pass",
+      "severity": "P4-Info",
+      "scope": {
+        "protocol": "other",
+        "layer": "decision"
+      },
+      "timestamp": "2026-08-15T00:00:00+00:00",
+      "details": "verified_result=REVOKED disposition=BLOCK reason_codes=TELEMETRY_MISSING_FAIL_CLOSED,AUTHORIZATION_REVOKED execution_authorized=False role=hostile case"
+    }
+  ],
+  "target": "VrtxOmega/veritas-agent-trust-lab @ 0f3c71fdb0e9078d8a5d8684411d0318fe600bb1",
+  "independence_level": "I1",
+  "system_under_test": "VrtxOmega/veritas-agent-trust-lab public contract @ 0f3c71fdb0e9078d8a5d8684411d0318fe600bb1",
+  "evidence_class": "E2"
+}

--- a/attestations/external/README.md
+++ b/attestations/external/README.md
@@ -1,0 +1,40 @@
+# External attestation records
+
+Records whose **system under test is someone else's system**, so the independence level is
+stated relative to them rather than to this project.
+
+## 2026-08-17 — VERITAS Omega, independent result recomputation
+
+The first **I1** record this project has produced.
+
+| | |
+|---|---|
+| System under test | `VrtxOmega/veritas-agent-trust-lab` public contract @ `0f3c71fd` |
+| Track | `independent-result-recomputation` (Break VERITAS External Verification Challenge v1) |
+| Evidence class | E2 |
+| Independence level | **I1**, relative to VERITAS |
+| Cases | 12 (6 CLEAN positive controls, 6 TAMPERED hostile) |
+| `verification_hash` | `98961d7f8ace7a30eac1cafcc7e3dcc4e4b7d12e706e38910f8ad2b69425c778` |
+
+I1 because the implementation was written from their **published contract**, not from their
+code, per rule 2 of their challenge: `lib/trust-engine.js` was not imported, called, wrapped,
+transpiled, or vendored. The reference engine was used only as a comparison oracle.
+
+Source evidence and the implementation: [`conformance/external/veritas-omega/`](../../conformance/external/veritas-omega/).
+
+## What it does not establish
+
+**I1 is a claim this record states, not one it proves.** A reader must still confirm the
+implementation separation independently; a signature cannot demonstrate that two implementations
+were written apart. The verifier says so.
+
+It also establishes nothing about the Agent Security Harness. The system under test here is
+VERITAS. Citing this record as validation of our own work would invert the axis, which is the
+error `docs/EVIDENCE-CLASS-TAXONOMY.md` exists to prevent.
+
+## Verify
+
+```bash
+python3 scripts/verify_attestation_record.py \
+  attestations/external/2026-08-17-veritas-recomputation-record.json
+```

--- a/scripts/verify_attestation_record.py
+++ b/scripts/verify_attestation_record.py
@@ -114,17 +114,23 @@ def verify(record: dict) -> bool:
         line(NOTE, "this record makes NO independence claim: neither "
                    "independence_level nor system_under_test is present. That is "
                    "an absence, not an I0 result.")
-        level, sut = None, "unstated"
     else:
         line(NOTE, f"independence fields read from: {source}")
         sut = sut or "unstated"
-    if level == "I0":
+    if level is None:
+        pass  # already reported above; do not also describe a level that is absent
+    elif level == "I0":
         line(NOTE, f"independence_level I0, system under test '{sut}'. The submitter authored "
                    f"the oracle. A passing signature proves the record was not altered. It "
                    f"proves NOTHING about the target.")
+    elif sut == "unstated":
+        line(NOTE, f"independence_level '{level}' with NO named system under test. The axis is "
+                   f"relative, so this is not a claim.")
     else:
-        line(NOTE, f"independence_level '{level}' relative to system under test '{sut}'. An "
-                   f"I-level with no named system under test is not a claim.")
+        line(NOTE, f"independence_level {level} relative to system under test '{sut}'. The oracle "
+                   f"was NOT produced by the author of that system. A reader must still confirm "
+                   f"the implementation separation the level asserts; this record states it, it "
+                   f"does not prove it.")
 
     if record.get("signature_verifiable") is False:
         line(NOTE, "the registry itself reports signature_verifiable: false")

--- a/tests/test_record_states_its_own_independence.py
+++ b/tests/test_record_states_its_own_independence.py
@@ -162,3 +162,54 @@ def test_verifier_rejects_a_tampered_record(tmp_path):
     )
     assert out.returncode == 1, out.stdout
     assert "VERIFICATION FAILED" in out.stdout
+
+
+# --- the I1 case: a record about someone ELSE's system ---------------------
+
+def _run_verifier(path):
+    return subprocess.run(
+        [sys.executable, str(REPO / "scripts" / "verify_attestation_record.py"), str(path)],
+        capture_output=True, text=True,
+    )
+
+
+def test_committed_i1_record_verifies_and_names_the_other_partys_system():
+    """The first I1 record: our independent recomputation of the VERITAS public
+    contract. I1 is relative to THEIR system, not ours."""
+    rec = REPO / "attestations" / "external" / "2026-08-17-veritas-recomputation-record.json"
+    assert rec.exists(), "the I1 record must stay committed"
+    report = json.loads(rec.read_text())["payload"]["report"]
+    assert report["independence_level"] == "I1"
+    assert "veritas-agent-trust-lab" in report["system_under_test"]
+    # pinned, so the claim is checkable against a specific baseline
+    assert "0f3c71fd" in report["system_under_test"]
+
+    out = _run_verifier(rec)
+    assert out.returncode == 0, out.stdout + out.stderr
+    assert "independence_level I1" in out.stdout
+    assert "NOT produced by the author of that system" in out.stdout
+
+
+def test_the_three_independence_states_are_distinguishable(tmp_path):
+    """I0, I1 and 'no claim' must each print something different. An absence that
+    reads like an I0 result is the defect this whole change removes."""
+    from protocol_tests.attestation_registry import build_record
+
+    cases = {}
+    for label, kw in (
+        ("none", {}),
+        ("i0", {"independence_level": "I0", "system_under_test": "our own suite"}),
+        ("i1", {"independence_level": "I1", "system_under_test": "someone else's system"}),
+    ):
+        p = tmp_path / f"{label}.json"
+        p.write_text(json.dumps(build_record(_report(**kw), server_name="state test")))
+        out = _run_verifier(p)
+        assert out.returncode == 0, out.stdout
+        cases[label] = out.stdout
+
+    assert "makes NO independence claim" in cases["none"]
+    assert "independence_level I0" in cases["i0"]
+    assert "independence_level I1" in cases["i1"]
+    # and the absent case must never be described as a level
+    assert "independence_level 'None'" not in cases["none"]
+    assert len({cases["none"], cases["i0"], cases["i1"]}) == 3


### PR DESCRIPTION
Recommendation 1 was *ask VrtxOmega for the second record*. The interlocutor registry says the opposite is the move for this party:

> Reciprocity is the move: they asked to be broken, we have the instrument, and giving evidence rather than asking for it is how the Poke-nushi dependency happened.

So this gives first.

## What it is

We already reproduced their public contract independently, back in August: 12 cases, 6 CLEAN positive controls and 6 TAMPERED hostile, an implementation written from their **published contract** rather than their code per rule 2 of their challenge, reference engine used only as a comparison oracle. Zero divergences across 48 decision fields and 14 SHA-256 digests.

That work was sitting in `conformance/external/veritas-omega/` in an ad-hoc shape. It is exactly the fact recorded in #384: *the one time there was something real to record, the attestation format went unused.*

It is now a signed record stating:

| | |
|---|---|
| `evidence_class` | E2 |
| `independence_level` | **I1** |
| `system_under_test` | `VrtxOmega/veritas-agent-trust-lab public contract @ 0f3c71fd` |
| `verification_hash` | `98961d7f8ace7a30…` |

**I1 is relative to their system, not ours.** This record establishes nothing about the Agent Security Harness, and `attestations/external/README.md` says so explicitly — citing it as validation of our own work would invert the axis the taxonomy exists to protect.

It also states rather than proves the independence: a signature cannot demonstrate that two implementations were written apart. The verifier now says that too.

## Fix the I1 case exposed

The non-I0 branch printed *"An I-level with no named system under test is not a claim"* even when one **was** named. It now distinguishes three states, and a test asserts all three print differently — an absence that reads like an I0 result is the whole defect this line of work removes.

## Verification

Clean disposable clone, fresh venv, `.[mcp-server]` as CI installs it:

| Suite | Result |
|---|---|
| `tests/` | **196 passed** |
| `testing/` | **436 passed + 170 subtests** |

Refs #384, #386.