### PR TITLE
docs: add diagnostic-agent authority evaluation design

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ This directory contains detailed documentation for the Agent Security Harness fr
 | [../agent-fabric-red-blue-team-spec.md](../agent-fabric-red-blue-team-spec.md) | **Original specification** - 20 STRIDE scenarios, architecture overview, threat model |
 | [CASE_STUDY_FALSE_PASS.md](CASE_STUDY_FALSE_PASS.md) | **False pass case study** - Analysis of security testing failure modes |
 | [VERIFICATION-DESIGN-DEFECT.md](VERIFICATION-DESIGN-DEFECT.md) | **Acceptance criteria satisfiable without the mechanism** - five recorded instances across four systems and three authors, with the diagnostic question and the remedies that held |
+| [research/DIAGNOSTIC-AGENT-CONTROLS-2026-08.md](research/DIAGNOSTIC-AGENT-CONTROLS-2026-08.md) | Private research note: vendor-neutral evaluation design for production diagnostic-agent authority and receipts |
 | [REPRODUCING.md](REPRODUCING.md) | **Independent reproduction** - what counts as I1, the pinned RCL corpus, and the commitment to publish contradicting results |
 | [EVIDENCE-CLASS-TAXONOMY.md](EVIDENCE-CLASS-TAXONOMY.md) | **E1-E5 evidence classes and the I0-I2 independence axis** - what a result establishes, and about which system under test |
 | [attestation-registry.md](attestation-registry.md) | **Attestation registry client** - opt-in publishing, sensitive-field stripping, no default endpoint |

--- a/docs/research/DIAGNOSTIC-AGENT-CONTROLS-2026-08.md
+++ b/docs/research/DIAGNOSTIC-AGENT-CONTROLS-2026-08.md
@@ -2,8 +2,8 @@
 
 **Status:** private research note and test-design input. Not a security assessment of any named product.
 
-**Collected:** 2026-08-23  
-**Author:** Michael K. Saleme  
+**Collected:** 2026-08-23
+**Author:** Michael K. Saleme
 **Scope:** public vendor and author statements plus Hacker News discussion. No target was tested, no
 vendor claim was independently reproduced, and this note makes no claim that a named system is
 secure or insecure.

--- a/docs/research/DIAGNOSTIC-AGENT-CONTROLS-2026-08.md
+++ b/docs/research/DIAGNOSTIC-AGENT-CONTROLS-2026-08.md
@@ -1,0 +1,150 @@
+# Diagnostic agents: narrow authority needs inspectable evidence
+
+**Status:** private research note and test-design input. Not a security assessment of any named product.
+
+**Collected:** 2026-08-23  
+**Author:** Michael K. Saleme  
+**Scope:** public vendor and author statements plus Hacker News discussion. No target was tested, no
+vendor claim was independently reproduced, and this note makes no claim that a named system is
+secure or insecure.
+
+## Why this matters
+
+Agent platforms are becoming durable systems: they retain memory, run on schedules, connect to
+services, and can act in production-adjacent environments. The immediate controls now visible in
+public designs are useful: sandboxing, credential mediation, request policy, approval gates,
+read-only probes, capture limits, and redaction.
+
+The unresolved control question is narrower:
+
+> Can an independent reviewer determine that one executed diagnostic action remained within its
+> declared authority, scope, data policy, and expiry, and can they detect harmful composition across
+> individually permitted observations?
+
+This question complements isolation and access control. It does not replace them.
+
+## Public signals, with claim boundaries
+
+### OneCLI: durable team agents with a mediated egress path
+
+OneCLI's public README describes a platform that gives each employee an agent sandbox, routes
+outbound requests through a gateway, injects credentials at request time, and supports approval
+flows for selected high-impact actions. It also describes durable memory and scheduling. These are
+the project's stated properties, not independently evaluated properties.[^onecli]
+
+For evaluation, the important boundary is approval binding. A reviewable authorization should be
+able to connect the approved intent to the final gateway request, including its canonical parameters
+or a digest of them, relevant policy and tool-contract versions, expiry, and the execution outcome.
+An approval screen alone does not establish that binding.
+
+### HyperProbe: production diagnostic authority is also data authority
+
+HyperProbe's HN launch description says that an SDK can place read-only probes in a running service,
+capture bounded variable state when real traffic reaches a point, sanitize data in-process, and send
+the result to an agent. The founders also describe hit, memory, payload, and timing guardrails in
+the thread. These are vendor statements, including the stated performance ranges.[^hyperprobe-hn]
+
+The useful engineering distinction is that *read-only* is not synonymous with *low impact*. A
+capture can reveal credentials, regulated data, business-sensitive state, or system topology. The
+unit of authority should therefore bind at least: incident or purpose, target service and location,
+field/data-class policy, capture limits, retention, approved viewer, and expiry.
+
+### Agentic engineering: reliability patterns need a runtime-control counterpart
+
+Simon Willison's framing treats agentic engineering as professional engineers working with agents
+that can generate and execute code, test it, and iterate. The associated pattern work emphasizes
+repeatable engineering practice rather than hands-off automation.[^willison]
+
+Testing and review improve reliability. They do not, by themselves, prove that a connected agent had
+authority for one runtime action or preserve evidence of what actually happened. A compatible
+pattern is **action-bound authority receipts**: make the approval, execution, and evidence chain
+explicit and machine-checkable.
+
+### Single-packet authorization: a useful access analogy, not a governance solution
+
+The cited SPA design makes a privileged network interface non-default reachable, then grants a
+cryptographically authenticated, source-specific, time-limited path. It is a helpful analogy for
+activating a capability narrowly instead of assigning a standing entitlement.[^spa]
+
+The analogy stops at reachability. SPA does not determine whether an SSH action is appropriate, nor
+does it account for aggregate risk across repeated grants.
+
+## Evaluation matrix
+
+| Control question | Evidence an evaluator needs | What is not established by a vendor statement alone |
+| --- | --- | --- |
+| Who acts? | Agent identity, delegating principal, credential selection facts | That the identity was the intended actor at execution |
+| What can it reach? | Capability profile, sandbox/gateway policy, tool-contract version | That every actual request stayed inside the declared boundary |
+| What authorizes one action? | Purpose/incident binding, canonical payload or digest, policy hash, approver, expiry | That an approval for one request covered a changed request |
+| What data may be observed? | Target location, field-classification and redaction policy, capture and retention limits | That "read-only" prevented sensitive disclosure |
+| What happened? | Signed decision receipt, execution acknowledgment, output/change digest, time record | That a log line or signature proves authorization or outcome |
+| What compounds? | Budget/reservation state and cross-session linkage | That individually allowed actions remain acceptable in aggregate |
+
+## Proposed engineering pattern: action-bound authority receipt
+
+**Intent.** Permit one described diagnostic operation under delegated authority while preserving
+enough evidence for later verification.
+
+**Minimum decision inputs.**
+
+- actor and delegating principal;
+- purpose or incident identifier;
+- service, source location, and approved observation expression or canonical digest;
+- data-classification/redaction policy and retention policy versions;
+- tool-contract and runtime-policy versions;
+- hit, duration, payload, and budget limits;
+- expiry and revocation state;
+- a reservation or ledger reference when cumulative observation risk matters.
+
+**Decision.** Permit, deny, or escalate. A permit must bind to the exact approved input set, or to a
+canonical serialization/digest whose construction is specified.
+
+**Evidence.** Persist the decision receipt, execution acknowledgment, result or capture digest,
+observed policy versions, and the expiry/revocation outcome. A receipt should distinguish assertions
+from independently verifiable facts.
+
+**Failure modes.** Broad capability approval; a mutable payload after approval; stale policy or
+tool-contract binding; capture after expiry; an audit artifact that omits target, data class, or
+retention; and multiple individually bounded captures that jointly disclose sensitive state.
+
+## Candidate evaluation scenarios
+
+These are proposed scenarios, not claims of existing Harness coverage and not tests of OneCLI,
+HyperProbe, or any other third-party system.
+
+1. **Purpose-scope mismatch:** an incident tied to service A is used to request a capture from
+   service B or an unrelated source location. Expected result: deny or escalate with an explicit
+   reason.
+2. **Post-approval mutation:** the final observation expression, target, or capture limit differs
+   from the approved canonical input. Expected result: the gateway rejects the request.
+3. **Expiry and revocation race:** a capture executes after approval expiry or revocation. Expected
+   result: no capture is produced and the evidence records the expired/revoked decision.
+4. **Redaction-policy drift:** a redaction or data-classification policy changes between approval
+   and execution. Expected result: fail closed or require fresh approval, with both policy versions
+   retained.
+5. **Incomplete receipt:** a result receipt omits the target, field classification, retention rule,
+   or execution binding. Expected result: a verifier rejects the receipt for the stronger claim.
+6. **Cross-session composition:** several low-volume captures collectively exceed an approved
+   data-exposure budget. Expected result: the system detects the aggregation, denies or escalates,
+   and preserves the ledger state used for the decision.
+
+The current Harness already has relevant, narrower test areas: receipt verification for omitted
+evidence and parameter/execution mismatches, approval-context checks, incident-log completeness,
+and cross-context leakage. Any new module should reuse only those pieces that can be exercised
+against an authorized, adapter-specific target; the scenarios above require a clear diagnostic-agent
+protocol or fixture contract before implementation.[^catalog]
+
+## Recommended next step
+
+Do not comment on the HN threads or contact the vendors. First define a vendor-neutral diagnostic
+probe fixture and receipt schema, then implement only the scenarios that can be asserted without
+guessing at a target's internals. A self-hosted reference fixture would create stronger evidence than
+a paper comparison alone.
+
+## Sources
+
+[^onecli]: OneCLI README, [OneCLI repository](https://github.com/onecli/onecli), accessed 2026-08-23.
+[^hyperprobe-hn]: HyperProbe founders, [Launch HN: Agents that do read-only debugging in prod](https://news.ycombinator.com/item?id=49185389), accessed 2026-08-23.
+[^willison]: Simon Willison, [Writing about Agentic Engineering Patterns](https://simonwillison.net/2026/Feb/23/agentic-engineering-patterns/), accessed 2026-08-23.
+[^spa]: Michele Bologna, [Why I close SSH port 22 entirely (and what I use instead)](https://www.michelebologna.net/2026/ssh-port-22-fwknop-single-packet-authorization/), accessed 2026-08-23.
+[^catalog]: [Agent Security Harness canonical test catalog](../../HARNESS_TEST_CATALOG.md), generated at commit `75e941d`, inspected 2026-08-23.


### PR DESCRIPTION
## Summary
- add a private, vendor-neutral research note grounded in public sources
- distinguish vendor statements from independently verified properties
- propose a fixture-level authority-receipt evaluation contract and six scenarios

## Boundaries
No third-party system was tested, no outreach was made, and this PR makes no security claim about a named product.

## Verification
- `git diff --check`