### PR TITLE
fix(ci): read the release-scoped test count from the description

### DIFF
--- a/scripts/check_public_metadata.py
+++ b/scripts/check_public_metadata.py
@@ -239,14 +239,49 @@ def check_surface(label: str, text: str, want: dict[str, str]) -> list[str]:
     return problems
 
 
+# A description may state one test count or two. When it states two, the
+# release figure is the one this check is about: the workflow compares against
+# the tree at the latest release tag, so the main-branch figure is a claim about
+# something else entirely. The description grew to this shape:
+#
+#     "<main count> executable tests on main, <release count> in the vX.Y.Z release"
+#
+# re.search returns the FIRST match, so a bare "<N> executable tests" pattern
+# read the MAIN count and compared it against the release tree, which of course
+# holds the release count. The description was correct and the check was wrong,
+# and it failed that way on two consecutive scheduled runs (2026-08-17 and
+# 2026-08-24) before anyone looked at it.
+#
+# (Figures are described rather than quoted here, for the same reason the module
+# docstring gives: a literal count in a live file is what
+# test_no_stale_test_count_anywhere exists to catch, and quoting the main count
+# in a comment would go stale the next time main's count moves.)
+#
+# A check that fails on a true statement gets muted. That is the same reasoning
+# that made the version check presence-scoped rather than exclusive above, and
+# the fix is the same shape: narrow what the check reads instead of asking the
+# honest text to get worse. Naming both counts is more informative than naming
+# one, so the parser learns the phrasing rather than the description losing it.
+RELEASE_COUNT_RE = re.compile(
+    r"(\d{3,4})\s+(?:executable\s+tests\s+)?in the v\d+\.\d+\.\d+ release")
+
+# Fallback for a description that names a single count, which is the shape this
+# check was written against and still the shape of the two remote READMEs.
+BARE_COUNT_RE = re.compile(r"(\d{3,4})\s+executable tests")
+
+
 def extract(description: str) -> tuple[str | None, str | None]:
-    """Pull the test count and version out of the description.
+    """Pull the release-facing test count and version out of the description.
 
     Returns (count, version), either of which may be None when the description
     does not state it. A missing field is a failure, not a pass: the description
     is expected to carry both.
+
+    When the description names both a main-branch and a release count, this
+    returns the RELEASE one, because the release tree is what it is compared
+    against. See RELEASE_COUNT_RE above.
     """
-    c = re.search(r"(\d{3,4})\s+executable tests", description)
+    c = RELEASE_COUNT_RE.search(description) or BARE_COUNT_RE.search(description)
     v = re.search(r"\bv(\d+\.\d+\.\d+)\b", description)
     return (c.group(1) if c else None, v.group(1) if v else None)
 

--- a/testing/test_public_metadata_check.py
+++ b/testing/test_public_metadata_check.py
@@ -62,6 +62,30 @@ class TestExtract(unittest.TestCase):
         """'603' alone is not a count claim; the unit has to be present."""
         self.assertIsNone(cpm.extract("603 things happened here")[0])
 
+    def test_prefers_the_release_count_over_the_main_count(self) -> None:
+        """A description naming both counts yields the release one.
+
+        This is the 2026-08-17 and 2026-08-24 failure. The description had
+        grown to name main and the release separately, re.search took the
+        FIRST match - main's - and the check compared it against the tree at
+        the release tag. The description was true and the check said DRIFT.
+        """
+        dual = (f"AI agent security harness: {FRESH_COUNT} {_TESTS} on main, "
+                f"{STALE_COUNT} in the v4.15.0 release, across MCP. v4.15.0")
+        self.assertEqual(cpm.extract(dual), (STALE_COUNT, "4.15.0"))
+
+    def test_release_count_selected_by_scope_not_by_position(self) -> None:
+        """Order must not decide it, or this is the same bug facing the door."""
+        dual = (f"{STALE_COUNT} in the v4.15.0 release, {FRESH_COUNT} "
+                f"{_TESTS} on main. v4.15.0")
+        self.assertEqual(cpm.extract(dual)[0], STALE_COUNT)
+
+    def test_release_count_with_the_unit_spelled_out(self) -> None:
+        """Both phrasings of the release figure read the same."""
+        dual = (f"{FRESH_COUNT} {_TESTS} on main, {STALE_COUNT} {_TESTS} "
+                f"in the v4.15.0 release. v4.15.0")
+        self.assertEqual(cpm.extract(dual)[0], STALE_COUNT)
+
 
 class TestExitCodes(unittest.TestCase):
     def _run(self, description=None, exc=None, count=None, version="4.15.0"):
@@ -97,6 +121,25 @@ class TestExitCodes(unittest.TestCase):
     def test_todays_real_drift_would_have_been_caught(self) -> None:
         """The exact 2026-08-08 state: 603/v4.13.1 against a 603/v4.15.0 tree."""
         self.assertEqual(self._run(REAL, count=STALE_COUNT, version="4.15.0"), 1)
+
+    def test_dual_count_description_agrees_with_the_release_tree(self) -> None:
+        """The live description shape against the release tree: exit 0.
+
+        This returned 1 on the 2026-08-17 and 2026-08-24 scheduled runs.
+        """
+        dual = (f"{FRESH_COUNT} {_TESTS} on main, {STALE_COUNT} in the "
+                f"v4.15.0 release. v4.15.0")
+        self.assertEqual(self._run(dual, count=STALE_COUNT), 0)
+
+    def test_a_wrong_release_count_still_exits_one(self) -> None:
+        """Scoping the read must not produce a check that cannot fail.
+
+        Here the release figure is genuinely wrong - it repeats main's count -
+        and that is real drift on the claim a visitor installs against.
+        """
+        dual = (f"{FRESH_COUNT} {_TESTS} on main, {FRESH_COUNT} in the "
+                f"v4.15.0 release. v4.15.0")
+        self.assertEqual(self._run(dual, count=STALE_COUNT), 1)
 
     def test_missing_fields_exit_one(self) -> None:
         self.assertEqual(self._run("A security harness."), 1)


### PR DESCRIPTION
## What

`Public metadata drift` has been red on `main` for **two consecutive scheduled runs** — [2026-08-17](https://github.com/msaleme/red-team-blue-team-agent-fabric/actions/runs/32035368903) and [2026-08-24](https://github.com/msaleme/red-team-blue-team-agent-fabric/actions/runs/32733557315) — both with the identical message:

```
- test count: description says 606, tree says 603
```

That reads as stale metadata. **It is not.** The description is correct on both figures; the check is wrong.

## Why it fails

The description states two counts — one for `main`, one for the published release:

> ... `<main count>` executable tests on main, `<release count>` in the vX.Y.Z release ...

`extract()` matched a bare `"<N> executable tests"` using `re.search`, which returns the **first** match — the main-branch figure. `main()` then compares that against the tree at the latest release tag, which by the workflow's own design holds the *release* figure:

> The description is a claim about a published release, not about `main`, because that is what a visitor installs. So the workflow checks out the latest release tag and runs this against that tree.
> — `scripts/check_public_metadata.py` module docstring

So the check compared a main-branch claim to a release tree. **It could not pass while the description named both counts, however accurate it was.**

## The fix

A check that fails on a true statement gets muted, and this one was two runs into exactly that. The repair follows the shape already used for the version check in this same file — narrow what the check *reads* rather than asking the honest text to get worse:

- `extract()` now prefers a **release-scoped** count (`"<N> in the vX.Y.Z release"`, with or without the unit spelled out).
- It falls back to the bare single-count form, which is still the shape of both remote READMEs (`msaleme/msaleme` states no count; `msaleme/start-here` states the release count only — both verified, both currently passing).

Naming both counts is more informative than naming one, so the parser learns the phrasing rather than the description losing it.

## Verification

Ran the checker exactly as the workflow does — v4.15.0 checked out, checker copied in, real live description over the API:

| Checker | Result |
|---|---|
| `origin/main` (current) | `DRIFT ... description says 606, tree says 603` → exit **1** |
| this branch | `OK ... description, CITATION.cff and 2 remote READMEs match the tree (603 tests, 43 modules, v4.15.0)` → exit **0** |

Same tree, same live description. The only variable is this change.

`testing/` suite: **441 passed, 170 subtests passed**, including the full `test_code_quality.py` guard set.

## Tests

Five added, using the existing split-literal idiom so no live file carries a non-canonical count:

- release figure wins over the main figure
- selection is **by scope, not by position** (reversed order still picks the release figure)
- both phrasings of the release figure read alike
- the live dual-count description exits 0
- **a genuinely wrong release count still exits 1** — the scoping must not produce a check that is unable to fail

That last one is deliberate: `test_the_count_guard_can_actually_fail` exists in this repo because a guard sat green for months with an unreachable assertion. This change should not add a second one.

## Note

Figures are described rather than quoted in the new comment, per the convention the module docstring already states — a literal count in a live file is what `test_no_stale_test_count_anywhere` exists to catch, and quoting `main`'s count would go stale the next time it moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)