### PR TITLE
fix(identity): remove the dead --simulate flag

### DIFF
--- a/protocol_tests/identity_harness.py
+++ b/protocol_tests/identity_harness.py
@@ -91,10 +91,9 @@ class IdentityTestResult:
 class IdentitySecurityTests:
     """Agent Identity & Authorization tests per NIST NCCoE concept paper."""
 
-    def __init__(self, base_url: str, headers: dict | None = None, simulate: bool = False):
+    def __init__(self, base_url: str, headers: dict | None = None):
         self.base_url = base_url.rstrip("/")
         self.headers = headers or {}
-        self.simulate = simulate
         self.results: list[IdentityTestResult] = []
 
     def _record(self, r: IdentityTestResult):
@@ -905,7 +904,6 @@ def main():
     ap.add_argument("--header", action="append", default=[])
     ap.add_argument("--trials", type=int, default=1,
                     help="Run each test N times for statistical analysis (NIST AI 800-2)")
-    ap.add_argument("--simulate", action="store_true", help="Run in simulate mode")
     args = ap.parse_args()
 
     headers = {}
@@ -920,7 +918,7 @@ def main():
             from protocol_tests.trial_runner import run_with_trials as _run_trials
 
             def _single_run():
-                suite = IdentitySecurityTests(args.url, headers=headers, simulate=getattr(args, "simulate", False))
+                suite = IdentitySecurityTests(args.url, headers=headers)
                 return {"results": suite.run_all(categories=categories)}
 
             merged = _run_trials(_single_run, trials=args.trials,
@@ -931,7 +929,7 @@ def main():
                 print(f"Report written to {args.report}")
             results = merged.get("results", [])
         else:
-            suite = IdentitySecurityTests(args.url, headers=headers, simulate=getattr(args, "simulate", False))
+            suite = IdentitySecurityTests(args.url, headers=headers)
             results = suite.run_all(categories=categories)
             if args.report:
                 generate_report(results, args.report)

--- a/protocol_tests/receipt_claim_harness.py
+++ b/protocol_tests/receipt_claim_harness.py
@@ -367,6 +367,18 @@ class ReceiptClaimTests:
     (RCL-008)."""
 
     def __init__(self, simulate: bool = False):
+        # `simulate` is accepted but not read, and that is deliberate. This module
+        # performs no network I/O: it builds receipts locally and runs them through
+        # ClaimLevelVerifier against a frozen clock, so every run is already an
+        # offline reference run and the flag has nothing to switch. Unlike #356's
+        # identity_harness case, the help text here is accurate rather than false.
+        #
+        # Do not remove the parameter or the --simulate flag. Both are load-bearing
+        # as a published interface: testing/test_receipt_claim.py constructs
+        # ReceiptClaimTests(simulate=True), and the retained evidence report
+        # reports/round_26/VS-R04-receipt-claim-evidence.md publishes
+        # `python3 -m protocol_tests.receipt_claim_harness --simulate` as its
+        # reproduction command. A retained report's repro command must keep working.
         self.simulate = simulate
         self.results: list[RCLResult] = []
         self.now = 1_750_000_000


### PR DESCRIPTION
Closes #356.

## The defect

`identity_harness` accepted `--simulate`, assigned it to `self.simulate`, and never read it again. The module makes live HTTP calls, so the flag told the operator it was simulating while sending real traffic at whatever `--url` pointed at.

Removed the flag, the constructor parameter, and both call sites. Option 1 from the issue. The direct module now fails loudly with `unrecognized arguments: --simulate` instead of silently going live.

## Blast radius, checked before removing

- Nothing outside the module constructs `IdentitySecurityTests`. `testing/test_serviced_guard.py` instantiates it via `getattr` with a single positional `base_url`.
- No document or retained report publishes `identity_harness --simulate` as a reproduction command.
- **The CLI path is unaffected.** `cli.py:560` intercepts `--simulate`, calls `_simulate_harness()`, and `sys.exit(0)`s before the module runs, forwarding the flag only for `aiuc1`. `cli test identity --simulate --json` still returns `"mode": "simulation"`, `"simulated": true`.

## Why receipt_claim_harness is annotated, not fixed

Derived the candidate set rather than fixing only where the defect was noticed. Of the **23 modules that accept `--simulate`, 21 read it; two do not.** The second is `receipt_claim_harness` — and the sweep is also the reason it is not being changed:

| | network I/O | help text | verdict |
|---|---|---|---|
| `identity_harness` | live HTTP | "Run in simulate mode" | **false claim — removed** |
| `receipt_claim_harness` | **none** | "offline reference run" | **accurate — kept** |

`receipt_claim_harness` has no `requests`, no `urllib`, no `http_helpers`, and no `base_url`. It builds receipts locally and verifies them against a frozen clock, so every run is already an offline reference run and the flag has nothing to switch. Same code smell, different defect class: this is **not** a #348/#350/#351 surface that reports an activity it never performed.

It is also a published interface:

- `testing/test_receipt_claim.py:50` constructs `ReceiptClaimTests(simulate=True)`
- `reports/round_26/VS-R04-receipt-claim-evidence.md:41` publishes `python3 -m protocol_tests.receipt_claim_harness --simulate` as its reproduction command

A retained report's reproduction command has to keep working. Deleting the flag to make a grep look tidy would have broken a test and invalidated a retained evidence artifact. So it gets a comment recording why the no-op is deliberate — that record is the durable output of the sweep.

## Verification

```
testing/: 441 passed, 170 subtests passed in 7.89s
```

`testing/` green is not CI green; hosted checks are the gate.