### PR TITLE
fix(#369): attestation README stated a verification_hash no artifact carries

### DIFF
--- a/attestations/self/README.md
+++ b/attestations/self/README.md
@@ -13,7 +13,7 @@ the format survives contact with its own first use, per #384.
 - Suite: `receipt-claim`, 11/11 passed, including both positive controls (RCL-008, RCL-009).
 - Target: offline fixture corpus. No network target, so no verdict here rests on an unserviced host.
 - Harness version 4.15.0, repository commit `6a0277df768ae308dd1b0597ee83df1a50384866`.
-- `verification_hash`: `e69e70f89fe32c48f5db83a49ecf43ea802a3b79f8d10d4a002bf78689f10674`
+- `verification_hash`: `48235d1b77d097f37dd88cd5716e0bcf9a6829cf7acb113404cbbfd51bb9a5ff`
 
 ## What it establishes
 
@@ -34,7 +34,19 @@ and the verifier says so. Step 6 prints the independence caveat.
 
 ## Known gaps this record exposes
 
-Recorded in #384. In short: the record reports `independence_level 'unstated'` and
-`system_under_test 'unstated'`, because the generator emits neither and the schema does not
-carry them, while §1 of the contract requires every stored record to have both. It was also
-produced without the shipped publish API, which cannot emit a record without a registry.
+Recorded in #384. **The independence gap recorded here originally is now closed** by #386
+(`2c7a9ec`, "a record states its own independence, inside the signature"). The signed payload
+now carries `independence_level: I0` and
+`system_under_test: agent-security-harness receipt-claim suite`, and
+`protocol_tests/attestation.py` rejects an `independence_level` set without a
+`system_under_test`, so the schema now requires the pair rather than omitting it. Running the
+verifier prints both, read `from: signed payload`.
+
+What remains open:
+
+- **Key-to-identity binding.** The verifier says so itself: the checks prove *a holder of this
+  key* signed this payload, not *whose* key it is. This is the blocker #384 names, and no
+  amount of hosting closes it.
+- **The publish path.** This record was produced without the shipped publish API
+  (`protocol_tests/attestation_registry.py:publish_attestation`), which submits to a registry
+  and returns a `registry_id`/`registry_url`. It still cannot emit a record without one.

--- a/testing/test_attestation_readme_consistency.py
+++ b/testing/test_attestation_readme_consistency.py
@@ -1,0 +1,90 @@
+"""Every attestation README must state the verification_hash its record carries.
+
+Why this exists (#369, found while auditing #384's material):
+
+`attestations/self/README.md` published `verification_hash: e69e70f8...` for a record
+whose canonical hash is `48235d1b...`. The stated value matched no artifact in the
+repository -- not a file digest, not either record, not either report. It was a
+64-hex identifier with no referent, sitting in the one directory whose entire purpose
+is evidentiary integrity.
+
+The cause was not carelessness about a number. #386 (`2c7a9ec`) regenerated the record
+so it states its own independence inside the signature. That changed the signed payload,
+which changed the canonical hash by construction. The record moved and its README did
+not, so the README kept describing the pre-fix record -- both the old hash and a "known
+gap" that the same commit had closed.
+
+That is the #369 drift class: a fact restated in prose next to the artifact that owns
+it, with nothing asserting the two agree. The durable fix for a restated value is to
+delete it or to automate the comparison. These records are published evidence, so the
+hash has to stay legible in the README -- which leaves automating the comparison.
+
+Scope: this checks one fact, that README prose agrees with the record it documents. It
+is not the #369 release-claims manifest and does not check test counts, release tags, or
+coverage revisions. It says nothing about whether a record's contents are true; a
+matching hash proves the README and the record agree, not that either is correct.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ATTESTATIONS = REPO_ROOT / "attestations"
+
+# Both README styles carry the value on one line with its label:
+#   - `verification_hash`: `<64 hex>`
+#   | `verification_hash` | `<64 hex>` |
+HASH_ON_LABELLED_LINE = re.compile(r"verification_hash.*?([0-9a-f]{64})")
+
+
+def _record_files() -> list[Path]:
+    if not ATTESTATIONS.is_dir():
+        return []
+    return sorted(ATTESTATIONS.glob("*/*-record.json"))
+
+
+def test_attestation_records_are_present():
+    """Assert a positive expected set, so an empty glob cannot read as success.
+
+    Without this, deleting the attestations directory would make every parametrised
+    case below vanish and the suite would still report green.
+    """
+    records = _record_files()
+    assert records, (
+        "no attestation records found under attestations/*/*-record.json. "
+        "If records were intentionally removed, remove this test in the same commit."
+    )
+    dirs = {p.parent.name for p in records}
+    assert {"self", "external"} <= dirs, (
+        f"expected both self/ and external/ attestation records, found dirs: {sorted(dirs)}"
+    )
+
+
+@pytest.mark.parametrize("record_path", _record_files(), ids=lambda p: f"{p.parent.name}/{p.name}")
+def test_readme_states_the_hash_its_record_carries(record_path: Path):
+    record = json.loads(record_path.read_text(encoding="utf-8"))
+    actual = record.get("verification_hash")
+    assert actual, f"{record_path.relative_to(REPO_ROOT)} carries no verification_hash"
+
+    readme = record_path.parent / "README.md"
+    assert readme.is_file(), (
+        f"{record_path.relative_to(REPO_ROOT)} has no sibling README.md. A published "
+        f"record without a README is unreviewable by a reader who is not us."
+    )
+
+    stated = HASH_ON_LABELLED_LINE.findall(readme.read_text(encoding="utf-8"))
+    assert stated, (
+        f"{readme.relative_to(REPO_ROOT)} states no verification_hash. The record at "
+        f"{record_path.name} carries {actual}, and a reader has no way to check they agree."
+    )
+    assert actual in stated, (
+        f"{readme.relative_to(REPO_ROOT)} states verification_hash {stated!r}, but "
+        f"{record_path.name} carries {actual!r}. The README is describing a different "
+        f"record than the one committed beside it -- most likely the record was "
+        f"regenerated and the prose was not updated (see #386)."
+    )


### PR DESCRIPTION
Found while auditing #384's material. Refs #369, #384.

## The defect

`attestations/self/README.md` published:

```
verification_hash: e69e70f89fe32c48f5db83a49ecf43ea802a3b79f8d10d4a002bf78689f10674
```

The record it documents carries:

```
verification_hash: 48235d1b77d097f37dd88cd5716e0bcf9a6829cf7acb113404cbbfd51bb9a5ff
```

The stated value matched **nothing in the repository** — not a file digest of either record or either report, not a value inside any record, not any other file. A 64-hex identifier with no referent, in the one directory whose entire purpose is evidentiary integrity. `scripts/verify_attestation_record.py` prints the real hash on its first `[PASS]` line, so the two disagreed in the open.

## Root cause: one event, two symptoms

#386 (`2c7a9ec`, *"a record states its own independence, inside the signature"*) regenerated the record so `independence_level` and `system_under_test` live **inside the signed payload**. Changing the payload changes the canonical hash by construction. The record moved; its README did not. So the README kept describing the pre-fix record — the old hash, **and** a "known gap" that the same commit had closed.

## What changed

**1. The hash now matches the record.**

**2. The known-gaps section no longer reports the independence gap as open.** The signed payload carries `independence_level: I0` and `system_under_test: agent-security-harness receipt-claim suite`, and `protocol_tests/attestation.py` rejects an `independence_level` set without a `system_under_test` — so the schema now *requires* the pair rather than omitting it.

What remains open is stated instead, and neither part is new:

- **Key-to-identity binding** — the verifier declares it out of scope itself: the checks prove *a holder of this key* signed the payload, not *whose* key it is. This is the blocker #384 names, and no amount of hosting closes it.
- **The publish path** — `attestation_registry.publish_attestation` still submits to a registry and returns a `registry_id`/`registry_url`, so it still cannot emit a record without one. **This claim was rechecked and kept because it is still true.**

## Everything else in the file was verified, not assumed

Correcting one line and leaving its neighbour wrong is the exact failure mode this README already demonstrated:

| Claim | Verified |
|---|---|
| 11/11 passed, incl. RCL-008 and RCL-009 | ✓ both present; entries record `result: 'pass'` |
| Harness version 4.15.0 | ✓ `harness_version: 4.15.0` |
| Commit `6a0277df…` | ✓ real commit, 2026-08-15 |
| Target "offline fixture corpus, no network target" | ✓ matches the record |
| `attestations/external/README.md` | ✓ already matched; unchanged |

## The guard

`testing/test_attestation_readme_consistency.py`. A restated value is held either by deleting it or by automating the comparison — and these are published evidence, so the hash must stay legible in the prose. That leaves automating it.

- Derives its cases from the records on disk, not a hand-written list.
- **Asserts a positive expected set first**, so an empty `attestations/` fails loudly instead of collecting zero cases and reporting green.
- **Proven in both directions**, because a checker that cannot fail is not a checker: passes on this tree (3 passed), and reverting only the README makes it fail on the real defect with both hashes named.

## Verification

```
testing/                                   444 passed, 170 subtests
ruff check testing/test_attestation_...    All checks passed
ruff check --select F821 (the CI gate)     All checks passed
verify_attestation_record.py               all applicable checks passed
```

No signed bytes were touched.

## Scope

One fact: that README prose agrees with the record beside it. **This is not the #369 release-claims manifest** and checks no test count, release tag, or coverage revision. A matching hash proves the README and the record agree — not that either is correct.