### PR TITLE
feat(#369): bind release-facing facts to the revision that produced them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,12 @@ november-meeting-extracted.txt
 # Published fixture sets are deliverables, not run artifacts: they are versioned,
 # byte-stable, and meant to be consumed by external evaluation harnesses.
 !reports/round_26/rcl-oracle-fixtures-*.json
+# Same reason, fourth time (see PR #299, #316): the release-claims manifest is the
+# artifact scripts/verify_release_claims.py and testing/test_release_claims.py both
+# read. `git add -A` reported success and committed the validator and its test while
+# silently dropping the file they validate; CI failed on FileNotFoundError. The
+# manifest's own "must be present and non-empty" assertion is what caught it.
+!docs/release-claims.json
 
 # LaTeX build artifacts (docs/paper-dgb/ -- source of truth is main.tex +
 # references.bib; compiled output is regenerated locally per its README)

--- a/docs/release-claims.json
+++ b/docs/release-claims.json
@@ -1,0 +1,51 @@
+{
+  "manifest_version": "1.0.0",
+  "purpose": "Bind each release-facing fact to the revision, command, and value that produced it, so a reader can reproduce or reject it without relying on narrative text. See scripts/verify_release_claims.py and GitHub issue #369.",
+  "not_established": "This manifest records provenance. It does not create independent evidence, change the E-class or I-level of any result, or support a claim that the harness improves the security of any target. A test count is an inventory fact, not a security-efficacy claim.",
+  "claims": [
+    {
+      "id": "release-test-count",
+      "fact": "The v4.15.0 release carries 603 unique test IDs.",
+      "value": "603",
+      "release_tag": "v4.15.0",
+      "commit": "90f552baae65e33f83201e4a95e2c4d3ed249c6e",
+      "command": "python3 scripts/count_tests.py",
+      "value_extraction": "Definitive count:\\s*(\\d+)",
+      "generated_on": "2026-08-29",
+      "coverage_report_revision": null,
+      "evidence_class": "E1",
+      "independence_level": "I0",
+      "limitation": "An inventory of test identifiers present at that revision. It says nothing about whether any test executed, whether a target passed, or whether the identifiers are well chosen.",
+      "surfaces": [
+        {
+          "path": "README.md",
+          "pattern": "the v4\\.15\\.0 release carries (\\d+)"
+        },
+        {
+          "path": "README.md",
+          "pattern": "The release carries \\*\\*(\\d+)\\*\\* tests"
+        }
+      ]
+    },
+    {
+      "id": "main-test-count",
+      "fact": "main carries 606 unique test IDs.",
+      "value": "606",
+      "release_tag": null,
+      "commit": "HEAD",
+      "command": "python3 scripts/count_tests.py",
+      "value_extraction": "Definitive count:\\s*(\\d+)",
+      "generated_on": "2026-08-29",
+      "coverage_report_revision": null,
+      "evidence_class": "E1",
+      "independence_level": "I0",
+      "limitation": "Same inventory limitation as release-test-count. This value moves with main by design; testing/test_code_quality.py::TestRegTestCount already pins it into pyproject.toml, README, SKILL.md and cli.py, so it is listed here for completeness rather than because it was unguarded.",
+      "surfaces": [
+        {
+          "path": "README.md",
+          "pattern": "`main` is at \\*\\*(\\d+)\\*\\*"
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/verify_release_claims.py
+++ b/scripts/verify_release_claims.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Fail when a release-facing fact disagrees with the manifest that owns it (#369).
+
+## Why this exists
+
+`testing/test_code_quality.py::TestRegTestCount` pins the **main-branch** count into
+`pyproject.toml`, `README.md`, `SKILL.md` and `cli.py`. `scripts/check_public_metadata.py`
+pins the GitHub description. Between them, main's count is well guarded.
+
+The **release** count is not. `main` is at 606 and v4.15.0 carries 603, and README states
+the 603 twice in prose that no suite reads. The failure mode is not hypothetical and it is
+not a typo: when the next release ships, `count_tests.py` moves and every main-count surface
+updates with it automatically, while 603 stays exactly where it is and silently becomes a
+false claim about a release. A number that only a human remembers to update is a number that
+drifts, and this repository has the history to prove it (see the header of
+`check_public_metadata.py` for two more instances of the same class).
+
+So this checks the fact that had no owner, and gives the ones that do a single place to
+declare their provenance.
+
+## Two modes, and the difference is reported, never hidden
+
+    SURFACE     Does every declared surface state the manifest's value?
+                Pure text. Runs anywhere, including a shallow CI clone.
+
+    REGENERATE  Does re-running the declared command at the declared revision still
+                produce that value? Requires the tag object, so it needs a full clone.
+
+`actions/checkout@v4` defaults to depth 1 and the test jobs in `ci.yml` do not override it,
+so REGENERATE cannot run there. It would have been easy to skip it silently and let the run
+go green. That is the "no failures is not the same as passing" trap: a green result would
+then mean "the text agrees with itself", while reading as "the number was reproduced".
+
+This prints which modes actually ran, and `--require-regenerate` turns an unavailable
+revision into a failure for callers that can guarantee a full clone.
+
+## Usage
+
+    python3 scripts/verify_release_claims.py                      # surface + regenerate if possible
+    python3 scripts/verify_release_claims.py --require-regenerate  # fail if a revision is unreachable
+    python3 scripts/verify_release_claims.py --json                # machine-readable result
+
+## What this does not establish
+
+Provenance, not truth. A reproduced count proves the command yields that value at that
+revision. It does not make the fact meaningful, and a test count is an inventory fact rather
+than a security-efficacy claim. Reproducing a claim says nothing about the E-class or
+I-level of any result the harness produces.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = REPO_ROOT / "docs" / "release-claims.json"
+
+OK, BAD, SKIP = "PASS", "FAIL", "SKIP"
+
+
+def _load() -> dict:
+    with MANIFEST.open(encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _revision_available(rev: str) -> bool:
+    if rev in ("HEAD", None):
+        return True
+    return subprocess.run(
+        ["git", "rev-parse", "--verify", "--quiet", f"{rev}^{{commit}}"],
+        cwd=REPO_ROOT, capture_output=True, check=False,
+    ).returncode == 0
+
+
+def check_surfaces(claim: dict) -> list[tuple[str, str, str]]:
+    """Every declared surface must state the manifest's value."""
+    out = []
+    for surface in claim.get("surfaces", []):
+        path = REPO_ROOT / surface["path"]
+        label = f"{claim['id']} surface {surface['path']}"
+        if not path.is_file():
+            out.append((BAD, label, f"declared surface does not exist: {surface['path']}"))
+            continue
+        found = re.findall(surface["pattern"], path.read_text(encoding="utf-8"))
+        if not found:
+            out.append((BAD, label, (
+                f"pattern {surface['pattern']!r} matched nothing. Either the surface was "
+                f"reworded and the manifest was not updated, or the claim was removed from "
+                f"the document without being removed here.")))
+        elif any(str(f) != str(claim["value"]) for f in found):
+            out.append((BAD, label, (
+                f"states {found!r}, manifest says {claim['value']!r}")))
+        else:
+            out.append((OK, label, f"states {claim['value']}"))
+    return out
+
+
+def regenerate(claim: dict) -> tuple[str, str, str]:
+    """Re-run the declared command at the declared revision and compare."""
+    rev = claim.get("commit") or "HEAD"
+    label = f"{claim['id']} regenerate @ {claim.get('release_tag') or rev[:12]}"
+
+    if not _revision_available(rev):
+        return (SKIP, label, (
+            f"revision {rev[:12]} is not present in this clone (shallow checkout?). "
+            f"The value was NOT reproduced. Run in a full clone, or pass "
+            f"--require-regenerate to make this a failure."))
+
+    cmd = claim["command"].split()
+    try:
+        if rev == "HEAD":
+            proc = subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True,
+                                  text=True, timeout=300, check=False)
+        else:
+            # A worktree so the checked-out tree is never disturbed. Running the
+            # command against a temporary checkout is the point: reading the value
+            # out of the current tree would reproduce nothing.
+            with tempfile.TemporaryDirectory() as td:
+                wt = Path(td) / "rev"
+                add = subprocess.run(
+                    ["git", "worktree", "add", "--detach", str(wt), rev],
+                    cwd=REPO_ROOT, capture_output=True, text=True, check=False)
+                if add.returncode != 0:
+                    return (SKIP, label, f"could not create worktree: {add.stderr.strip()[:160]}")
+                try:
+                    proc = subprocess.run(cmd, cwd=wt, capture_output=True, text=True,
+                                          timeout=300, check=False)
+                finally:
+                    subprocess.run(["git", "worktree", "remove", "--force", str(wt)],
+                                   cwd=REPO_ROOT, capture_output=True, check=False)
+    except subprocess.TimeoutExpired:
+        return (BAD, label, f"command timed out: {claim['command']}")
+
+    if proc.returncode != 0:
+        return (BAD, label, f"command failed rc={proc.returncode}: {proc.stderr.strip()[:160]}")
+
+    m = re.search(claim["value_extraction"], proc.stdout)
+    if not m:
+        return (BAD, label, (
+            f"value_extraction {claim['value_extraction']!r} matched nothing in the output of "
+            f"{claim['command']!r}. The command may have changed its output format."))
+    got = m.group(1)
+    if got != str(claim["value"]):
+        return (BAD, label, (
+            f"reproduced {got!r}, manifest says {claim['value']!r}. Either the manifest is "
+            f"stale or the revision does not carry the value claimed for it."))
+    return (OK, label, f"reproduced {got}")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--require-regenerate", action="store_true",
+                    help="treat an unreachable revision as a failure (full clones only)")
+    ap.add_argument("--json", action="store_true", help="emit machine-readable results")
+    args = ap.parse_args()
+
+    manifest = _load()
+    rows: list[tuple[str, str, str]] = []
+    for claim in manifest["claims"]:
+        rows.extend(check_surfaces(claim))
+        rows.append(regenerate(claim))
+
+    failed = [r for r in rows if r[0] == BAD]
+    skipped = [r for r in rows if r[0] == SKIP]
+
+    if args.json:
+        print(json.dumps({
+            "manifest_version": manifest["manifest_version"],
+            "results": [{"status": s, "check": c, "detail": d} for s, c, d in rows],
+            "failed": len(failed), "skipped": len(skipped),
+        }, indent=2))
+    else:
+        for status, check, detail in rows:
+            print(f"  [{status}] {check}: {detail}")
+        print()
+        print(f"{len(rows) - len(failed) - len(skipped)} passed, "
+              f"{len(failed)} failed, {len(skipped)} not reproduced")
+        if skipped and not args.require_regenerate:
+            print("NOTE: a SKIP means the value was not reproduced, only that its surfaces "
+                  "agree with the manifest. Do not read this run as having verified it.")
+
+    if failed:
+        return 1
+    if skipped and args.require_regenerate:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/testing/test_release_claims.py
+++ b/testing/test_release_claims.py
@@ -1,0 +1,102 @@
+"""The release-claims manifest must stay true to the documents it describes (#369).
+
+`TestRegTestCount` pins main's count into the in-tree surfaces, and
+`check_public_metadata.py` pins the GitHub description. The *release* count had no
+owner: main is at 606, v4.15.0 carries 603, and README states the 603 twice in prose
+that nothing read. When the next release ships, `count_tests.py` moves and every
+main-count surface follows it automatically, while 603 stays put and quietly becomes
+a false claim about a release.
+
+## What this test does and does not cover
+
+It runs the manifest's **surface** checks: does every document still state the value
+the manifest claims for it. That is the half that works in CI.
+
+It deliberately does **not** run regeneration. Re-deriving 603 means checking out
+`v4.15.0` and running `count_tests.py` there, and `actions/checkout@v4` defaults to
+depth 1 -- the test jobs in `ci.yml` do not override it, so the tag object is not in
+the clone. A test that tried would either fail on every CI run or, worse, be written
+to skip quietly and turn a green suite into a claim it had not checked.
+
+Regeneration lives in `scripts/verify_release_claims.py`, which reports whether it
+actually ran and offers `--require-regenerate` for callers with a full clone. Run it
+before publishing anything that quotes a release-facing number.
+
+So: this test asserts the documents and the manifest agree. It does not assert the
+manifest is *correct* -- that is what regeneration is for, and a green run here must
+not be read as having reproduced any value.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+MANIFEST_PATH = REPO_ROOT / "docs" / "release-claims.json"
+
+REQUIRED_FIELDS = {
+    "id", "fact", "value", "release_tag", "commit", "command", "value_extraction",
+    "generated_on", "evidence_class", "independence_level", "limitation", "surfaces",
+}
+
+
+class TestReleaseClaimsManifest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+    def test_manifest_is_present_and_non_empty(self):
+        """Assert a positive expected set: an empty manifest must not read as success."""
+        self.assertTrue(MANIFEST_PATH.is_file(), f"{MANIFEST_PATH} is missing")
+        self.assertTrue(
+            self.manifest.get("claims"),
+            "the manifest declares no claims. An empty manifest passes every check below "
+            "while guarding nothing, which is the exact shape of a false green.")
+
+    def test_every_claim_declares_its_provenance(self):
+        for claim in self.manifest["claims"]:
+            with self.subTest(claim=claim.get("id", "<no id>")):
+                missing = REQUIRED_FIELDS - set(claim)
+                self.assertEqual(
+                    missing, set(),
+                    f"claim {claim.get('id')!r} omits {sorted(missing)}. A claim without a "
+                    f"command and a revision cannot be reproduced, which is the whole point.")
+                self.assertTrue(
+                    claim["surfaces"],
+                    f"claim {claim['id']!r} declares no surface. A claim stated in no document "
+                    f"is not a release-facing fact; remove it or name where it appears.")
+
+    def test_a_release_claim_pins_a_tag_and_a_commit(self):
+        """A release-facing fact bound to a moving ref is not bound to anything."""
+        release_claims = [c for c in self.manifest["claims"] if c.get("release_tag")]
+        self.assertTrue(
+            release_claims,
+            "no claim carries a release_tag. #369 exists because release-facing facts were "
+            "stated against unqualified main; at least one claim must pin a tag.")
+        for claim in release_claims:
+            with self.subTest(claim=claim["id"]):
+                self.assertNotIn(
+                    claim["commit"], ("HEAD", "main", "", None),
+                    f"claim {claim['id']!r} names tag {claim['release_tag']!r} but commit "
+                    f"{claim['commit']!r}. A tagged claim needs the SHA the tag resolved to.")
+                self.assertRegex(
+                    claim["commit"], r"^[0-9a-f]{40}$",
+                    f"claim {claim['id']!r} must pin a full 40-character SHA.")
+
+    def test_every_surface_states_the_manifest_value(self):
+        """The check that would have caught 603 going stale."""
+        from verify_release_claims import check_surfaces
+
+        for claim in self.manifest["claims"]:
+            for status, label, detail in check_surfaces(claim):
+                with self.subTest(check=label):
+                    self.assertEqual(status, "PASS", f"{label}: {detail}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs #369, #351, #356.

## The gap was one number with no owner

`TestRegTestCount` pins the **main** count into `pyproject.toml`, `README.md`, `SKILL.md` and `cli.py`. `check_public_metadata.py` pins the GitHub description. Between them main's count is well guarded.

**The release count is not.** `main` is at 606, v4.15.0 carries 603, and README states the 603 twice in prose no suite reads:

```
README.md:14   the v4.15.0 release carries 603
README.md:269  The release carries **603** tests
```

That is not a typo waiting to happen, it is a countdown. When the next release ships, `count_tests.py` moves and every main-count surface follows it automatically — while **603 stays exactly where it is and silently becomes a false claim about a release**. A number only a human remembers to update is a number that drifts, and the header of `check_public_metadata.py` already records two other instances of this class on other surfaces.

## Three pieces, deliberately small

**`docs/release-claims.json`** — binds each fact to tag, full commit SHA, command, extraction pattern, value, generation date, evidence class, independence level, limitation, and the documents that state it.

**`scripts/verify_release_claims.py`** — two modes, and it reports which one actually ran:

| Mode | Question | Needs |
|---|---|---|
| `SURFACE` | Does every declared document still state the manifest's value? | nothing — pure text |
| `REGENERATE` | Does re-running the declared command at the declared revision still produce that value? | the tag object |

`REGENERATE` is **real reproduction, not a text comparison** — it adds a detached worktree at the pinned revision, runs the command there, and removes it, so the checked-out tree is never disturbed. Reading the value out of the current tree would reproduce nothing.

The modes are separate because `actions/checkout@v4` defaults to depth 1 and the `ci.yml` test jobs do not override it, so the tag is not in the CI clone. The easy version skips regeneration quietly and lets the run go green — turning *"the text agrees with itself"* into something that reads as *"the number was reproduced."* A `SKIP` is printed as **NOT reproduced**, and `--require-regenerate` makes an unreachable revision a failure for callers with a full clone.

**`testing/test_release_claims.py`** — runs the surface half in CI, plus manifest well-formedness: every claim carries a command and a revision, every claim names at least one document, and any claim with a `release_tag` pins a full 40-character SHA rather than `HEAD` or `main`. It asserts a **non-empty manifest first**, so an empty one cannot pass every check while guarding nothing. Its docstring states plainly that it does not run regeneration and must not be read as having reproduced a value.

## Verified in both directions

A checker that cannot fail is not a checker.

| Scenario | Result |
|---|---|
| clean | `5 passed, 0 failed, 0 not reproduced` (exit 0), incl. **`regenerate @ v4.15.0: reproduced 603`** |
| README drift — rewrote 603 → 604 | surface check **FAILED** |
| manifest drift — set value 999 | surface **and** regenerate both **FAILED** |
| `--require-regenerate` on a full clone | exit 0 |

```
testing/                     448 passed, 182 subtests   (was 444/176)
ruff (both new files)        All checks passed
ruff --select F821           All checks passed
```

## Acceptance criteria from the issue

> *A reviewer can select any public release-facing fact, identify its exact source revision and generation command, and reproduce or reject it without relying on narrative text alone.*

```bash
python3 scripts/verify_release_claims.py            # reproduce
python3 scripts/verify_release_claims.py --json     # machine-readable
```

## Scope and non-claims

Two claims, to establish the format on the fact that needed it and the one that did not. **This is not a content-management system** and does not touch release bodies or external pages.

**Provenance is not truth.** A reproduced count proves the command yields that value at that revision. A test count is an inventory fact, not a security-efficacy claim. Nothing here creates independent evidence or changes the E-class or I-level of any result.