### PR TITLE
fix(mcp): an unreachable target is INCONCLUSIVE, not a green run

### DIFF
--- a/protocol_tests/mcp_harness.py
+++ b/protocol_tests/mcp_harness.py
@@ -3097,10 +3097,18 @@ def build_report(
     error: str | None = None,
     protocol_version: str | None = None,
 ) -> dict:
-    """Build report dict from results."""
+    """Build report dict from results.
+
+    ``status`` exists so a report cannot be read as a completed evaluation when
+    nothing ran. An unreachable target produced ``{"total": 0, "passed": 0,
+    "failed": 0}`` with no other signal in the file, which is indistinguishable
+    from a clean run of zero tests. It is INCONCLUSIVE, not success.
+    """
+    inconclusive = bool(error) or not results
     report = {
         "suite": "MCP Protocol Security Tests v3.0",
         "timestamp": datetime.now(timezone.utc).isoformat(),
+        "status": "inconclusive" if inconclusive else "completed",
         "summary": {
             "total": len(results),
             "passed": sum(1 for r in results if r.passed),
@@ -3167,9 +3175,15 @@ def generate_report(
     results: list[MCPTestResult],
     output_path: str,
     protocol_version: str | None = None,
+    error: str | None = None,
 ):
-    """Write JSON report."""
-    report = build_report(results, protocol_version=protocol_version)
+    """Write JSON report.
+
+    ``error`` is not optional in practice. It was omitted here while the --json
+    stdout path passed it, so the written file -- the surface a CI job actually
+    reads -- silently dropped the connection failure.
+    """
+    report = build_report(results, error=error, protocol_version=protocol_version)
     with open(output_path, "w") as f:
         json.dump(report, f, indent=2, default=str)
     print(f"Report written to {output_path}")
@@ -3513,6 +3527,10 @@ def main():
         ))
         sys.exit(1 if failed else 0)
 
+    # Hoisted: the exit logic below runs after both branches, and conn_error was
+    # only ever assigned inside the single-run one.
+    conn_error = None
+
     if args.trials > 1:
         # Multi-trial statistical mode via shared trial runner
         # NOTE: no initial transport is created here (#78) - each trial
@@ -3562,7 +3580,6 @@ def main():
                                  task_read=task_read, task_attacker_headers=task_attacker_headers,
                                  trace_probe=trace_probe, trace_attacker_headers=trace_attacker_headers,
                                  issuer_probe=issuer_probe, issuer_attacker_headers=issuer_attacker_headers)
-        conn_error = None
         try:
             results = suite.run_all(categories=categories)
             conn_error = getattr(suite, "_connection_error", None)
@@ -3571,15 +3588,24 @@ def main():
                 transport.close()
 
         if args.report:
-            generate_report(results, args.report, protocol_version=suite.selected_protocol_version)
+            generate_report(results, args.report,
+                            protocol_version=suite.selected_protocol_version,
+                            error=conn_error)
 
         if json_output:
             report = build_report(results, error=conn_error, protocol_version=suite.selected_protocol_version)
             print(json.dumps(report, indent=2, default=str))
 
-    # Exit code
+    # Exit code. An empty result set is INCONCLUSIVE, never success. If the target
+    # was unreachable then `failed` is 0, and `1 if failed > 0` returned 0, so a CI
+    # job reading only the exit status treated "no test ever ran" as a pass. Zero
+    # failures out of zero tests is not a green run.
+    #
+    # Deliberately NOT synthesising a failed result per test: the accurate statement
+    # is "not executed", not "32 tests failed".
     failed = sum(1 for r in results if not r.passed)
-    sys.exit(1 if failed > 0 else 0)
+    inconclusive = bool(conn_error) or not results
+    sys.exit(1 if (failed > 0 or inconclusive) else 0)
 
 
 if __name__ == "__main__":

--- a/testing/test_mcp_result_integrity.py
+++ b/testing/test_mcp_result_integrity.py
@@ -1,0 +1,137 @@
+"""An unreachable MCP target must not exit 0 with an empty, error-free report.
+
+Found by an external clean-room execution review, 2026-08-28, against v4.15.0,
+the published PyPI wheel, and main. All three behaved the same way:
+
+    agent-security test mcp --transport http --url <closed port> --json --report r.json
+    -> exit 0
+    -> {"summary": {"total": 0, "passed": 0, "failed": 0}, "results": []}
+    -> the --report FILE dropped the connection error that stdout carried
+
+Three separate things had to line up for that to be reachable, which is why it
+survived: `build_report` had no field distinguishing "ran nothing" from "ran
+cleanly"; `generate_report` did not take the `error` argument its stdout
+counterpart was already being passed; and the exit code read
+`1 if failed > 0 else 0`, where an empty result list makes `failed` zero.
+
+A CI job reading the exit status, or reading only the generated report, would
+treat "no test ever ran" as a pass. That is the harness's own documented rule
+turned on itself: absence of a detected failure is not evidence a control held.
+
+Note what the fix does NOT do. It does not synthesise one failed result per test
+that would have run. "32 tests failed" is a different and false statement; the
+accurate one is "not executed", carried as an explicit status with a nonzero exit
+for automation.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from protocol_tests.mcp_harness import (
+    MCPTestResult,
+    build_report,
+    generate_report,
+)
+
+# Nothing listens on port 9 (discard). Same target the serviced-guard suite uses.
+CLOSED_PORT_URL = "http://127.0.0.1:9"
+
+
+def _passing_result() -> MCPTestResult:
+    """Built from the dataclass rather than a hand-written field list.
+
+    The first version of this helper guessed `attack_category` and broke on a
+    field named `category`. Introspecting is the same fix `_build` in
+    test_serviced_guard.py already carries, for the same reason.
+    """
+    from dataclasses import MISSING, fields
+
+    kw = {"passed": True}
+    for f in fields(MCPTestResult):
+        if f.name in kw or f.default is not MISSING or f.default_factory is not MISSING:
+            continue
+        kw[f.name] = True if f.type in ("bool", bool) else "fixture"
+    return MCPTestResult(**kw)
+
+
+class TestBuildReportStatus(unittest.TestCase):
+    """The unit half: a report has to say which of the two things happened."""
+
+    def test_empty_with_error_is_inconclusive_and_keeps_the_error(self):
+        report = build_report([], error="Initialize failed: Connection refused")
+        self.assertEqual(report["status"], "inconclusive")
+        self.assertIn("error", report)
+        self.assertIn("Connection refused", report["error"])
+
+    def test_empty_without_error_is_still_inconclusive(self):
+        """Zero tests is never a completed evaluation, however it came about.
+
+        The defect needed only an empty result list; the error was a second,
+        separate signal that the file happened to be dropping. Keying the status
+        on the error alone would leave every other zero-test path reading as a
+        clean run.
+        """
+        self.assertEqual(build_report([])["status"], "inconclusive")
+
+    def test_a_real_result_set_is_completed(self):
+        """The guard must be able to pass, or it is not a guard."""
+        report = build_report([_passing_result()])
+        self.assertEqual(report["status"], "completed")
+        self.assertEqual(report["summary"], {"total": 1, "passed": 1, "failed": 0})
+        self.assertNotIn("error", report)
+
+    def test_generate_report_writes_the_error_to_the_file(self):
+        """The written file is the surface CI reads, and it was the one dropping it."""
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "report.json"
+            generate_report([], str(path), error="Initialize failed: Connection refused")
+            written = json.loads(path.read_text(encoding="utf-8"))
+        self.assertEqual(written["status"], "inconclusive")
+        self.assertIn("Connection refused", written.get("error", ""))
+
+
+class TestUnreachableTargetExitStatus(unittest.TestCase):
+    """The subprocess half: the exit code is what automation actually branches on."""
+
+    def test_closed_port_exits_nonzero_with_an_inconclusive_report(self):
+        with tempfile.TemporaryDirectory() as td:
+            report_path = Path(td) / "report.json"
+            proc = subprocess.run(
+                [sys.executable, "-m", "protocol_tests.mcp_harness",
+                 "--transport", "http", "--url", CLOSED_PORT_URL,
+                 "--json", "--report", str(report_path)],
+                cwd=REPO_ROOT, capture_output=True, text=True, timeout=120, check=False,
+            )
+
+            self.assertNotEqual(
+                proc.returncode, 0,
+                "an unreachable target exited 0. A CI job branching on the exit status "
+                "would read 'no test ever ran' as a pass.")
+
+            self.assertTrue(report_path.is_file(), "--report wrote no file")
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(
+            report.get("status"), "inconclusive",
+            f"report file must carry an explicit inconclusive status, got "
+            f"{report.get('status')!r} with summary {report.get('summary')!r}")
+        self.assertTrue(
+            report.get("error"),
+            "the report file dropped the connection error that stdout carried")
+        self.assertEqual(
+            report.get("results"), [],
+            "no results should be synthesised; 'not executed' is the accurate "
+            "statement, not 'every test failed'")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Found by a clean-room execution review, 2026-08-28. Reproduced on `main` before changing anything. Refs #351, #369.

**On independence:** that review classifies itself **I0 for this repository** — clean checkouts and an independently downloaded wheel, but run by Mike's own agent against Mike's own implementation. It is not independent validation and this PR does not treat it as any.

## The defect

Identical on `v4.15.0`, the published PyPI wheel, and `main`:

```
agent-security test mcp --transport http --url <closed port> --json --report r.json
  exit 0
  {"summary": {"total": 0, "passed": 0, "failed": 0}, "results": []}
  and the --report FILE dropped the connection error that stdout carried
```

A CI job branching on the exit status, or reading only the generated report, would treat **"no test ever ran" as a pass**. That is this project's own rule turned on itself: absence of a detected failure is not evidence a control held.

## Three things had to line up

Which is why it survived a released version. Each is individually reasonable.

| Component | Problem |
|---|---|
| `build_report` | no field distinguishing "ran nothing" from "ran cleanly" |
| `generate_report` | did not take the `error` argument the stdout path was already being passed — so only the **file** lost it |
| exit code | `1 if failed > 0 else 0`, and an empty list makes `failed` zero |

Together they make an unreachable target indistinguishable from a clean run of zero tests.

## The fix

- **`build_report`** gains `status: "completed" | "inconclusive"`. Empty results are inconclusive *whether or not* an error was captured — keying on the error alone would leave every other zero-test path reading as a clean run.
- **`generate_report`** accepts and writes `error`, so the file and stdout agree.
- **`conn_error`** hoisted above the trials/single-run branch, since the exit logic runs after both and it was only assigned inside one. Exit is nonzero when a real test failed **or** the run was inconclusive.

**Deliberately not synthesising** one failed result per test that would have run. *"32 tests failed"* is a different and false statement; *"not executed"* is the accurate one.

## Acceptance condition from the review

```
Given: --url http://127.0.0.1:9 --json --report report.json
```

| Condition | Result |
|---|---|
| process exit code != 0 | **1** ✓ |
| stdout JSON has explicit error or inconclusive status | `status: "inconclusive"`, error present ✓ |
| report.json has the same status | `status: "inconclusive"`, error present ✓ |
| summary cannot be read as successful 0-test evaluation | `status` sits beside the 0/0/0 summary ✓ |
| no synthesised failures | `results: []` ✓ |

## Regression coverage

Both levels the review asked for, **proven in both directions**: 5 tests pass here, and all 5 fail with only `mcp_harness.py` reverted.

- unit — `build_report` status semantics, `generate_report` writing the error to the file
- subprocess — CLI exit status and the written report against a closed port

The result fixture **derives its fields from the dataclass** rather than naming them. The first version guessed `attack_category` against a field called `category` — the same failure `_build` in `test_serviced_guard.py` already documents.

## Unchanged behaviour

`testing/test_integration.py` against the vulnerable mock target: **4 passed, 6 subtests**, MCP-001 failing and MCP-002..007 passing.

```
testing/          453 passed, 182 subtests   (was 448)
ruff (new file)   All checks passed
ruff --select F821  All checks passed
```

`mcp_harness.py` reports 11 ruff findings — identical in count and kind to `main` before this change. None introduced, none in scope.

## Known limit, not addressed here

The `--trials > 1` path writes its merged report directly rather than through `build_report`, so it carries no `status` field. The exit-code fix **does** cover it, since an empty merged result set is inconclusive.