### PR TITLE
build: pin the release build environment off known-vulnerable setuptools, and record it

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -20,8 +20,50 @@ jobs:
         with:
           python-version: "3.12"
 
+      # A clean-room execution review (2026-08-28) reported two advisories against
+      # the setuptools present in a build environment, and noted that a release
+      # pipeline should use a patched build environment and record it. `pip install
+      # build` resolved whatever was current, and nothing recorded what that was.
+      #
+      # setuptools is this package's build backend (see pyproject.toml
+      # build-system), so its version governs the artifact that ships. 79.0.1
+      # carries GHSA-h35f-9h28-mq5c and PYSEC-2026-3447, both fixed in 83.0.0,
+      # confirmed against OSV rather than taken from the report.
+      #
+      # Scope, honestly: GHSA-h35f-9h28-mq5c is a MANIFEST.in exclusion bypass in
+      # sdist. This repository has no MANIFEST.in, so that mechanism had nothing to
+      # bypass here. This is build hygiene and provenance, not the closing of a live
+      # exploit path, and should not be described as one.
       - name: Install build tools
-        run: pip install build
+        run: pip install "build>=1.3.0" "setuptools>=83.0.0" "wheel>=0.45.0"
+
+      - name: Record the build environment
+        run: |
+          {
+            echo "# Build environment for $GITHUB_REF_NAME"
+            echo "commit:   $GITHUB_SHA"
+            echo "ref:      $GITHUB_REF_NAME"
+            echo "runner:   $RUNNER_OS $(uname -m)"
+            echo "built_at: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            echo "python:   $(python -VV | tr '\n' ' ')"
+            echo "---"
+            pip freeze
+          } > build-environment.txt
+          cat build-environment.txt
+
+      - name: Fail if the build backend is a version with known advisories
+        run: |
+          # A recorded environment that nobody checks is a log, not a control.
+          python - <<'EOF'
+          import sys
+          from importlib.metadata import version
+          v = version("setuptools")
+          parts = [int(p) for p in v.split(".")[:1] if p.isdigit()]
+          if not parts or parts[0] < 83:
+              sys.exit(f"setuptools {v} is below the 83.0.0 floor "
+                       f"(GHSA-h35f-9h28-mq5c, PYSEC-2026-3447)")
+          print(f"setuptools {v} meets the floor")
+          EOF
 
       - name: Build package
         run: python -m build
@@ -30,7 +72,9 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: dist
-          path: dist/
+          path: |
+            dist/
+            build-environment.txt
 
   publish:
     name: Publish to PyPI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,8 @@
 [build-system]
-requires = ["setuptools>=68.0", "wheel"]
+# setuptools>=83.0.0: 68.0 permitted 79.0.1, which carries GHSA-h35f-9h28-mq5c
+# and PYSEC-2026-3447 (both fixed in 83.0.0). setuptools is this package's build
+# backend, so the floor governs what builds the released artifact.
+requires = ["setuptools>=83.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
Acting on the clean-room review's second recommendation (2026-08-28): *"a release pipeline should nevertheless use a patched build environment and record it."* `pip install build` resolved whatever was current, and nothing recorded what that turned out to be. Refs #369.

## Verified against OSV, not taken from the report

| setuptools | advisories |
|---|---|
| **79.0.1** | GHSA-h35f-9h28-mq5c, PYSEC-2026-3447 — both fixed in 83.0.0 |
| 83.0.0 | 0 |
| 84.0.0 | 0 |

This matters here specifically because **setuptools is this package's build backend** and pyproject's floor was `setuptools>=68.0` — which permits 79.0.1. The floor governs what builds the released artifact.

## Scope, stated honestly and not upgraded

GHSA-h35f-9h28-mq5c is a **MANIFEST.in exclusion bypass in sdist**. This repository has **no MANIFEST.in**, so that mechanism had nothing to bypass. This is build hygiene and provenance, **not** the closing of a live exploit path. The workflow comment says so in the same words, so a later reader doesn't inflate it.

The review was right to attribute the finding away from the runtime dependency set — the declared runtime dependency is `PyYAML>=6.0`. What it under-read is that build tooling for a package whose *backend* is setuptools is not incidental.

## Three changes

1. **`pyproject.toml`** — `build-system.requires` raised to `setuptools>=83.0.0`.
2. **`publish-pypi.yml`** — pinned floors for `build`, `setuptools`, `wheel` instead of bare `pip install build`; writes `build-environment.txt` with commit, ref, runner, timestamp, full Python version and `pip freeze`, uploaded alongside `dist/`.
3. **A guard step** — because a recorded environment nobody checks is a log, not a control. The build fails if resolved setuptools is below the floor.

Point 2 is the same provenance argument as #369, one layer down: a release fact nobody can tie to the thing that generated it is a narrative fact.

## Verified in clean venvs

| Check | Result |
|---|---|
| resolved tooling | build 1.6.0, setuptools 84.0.0, wheel 0.48.0 |
| guard on 84.0.0 | `setuptools 84.0.0 meets the floor`, exit 0 |
| guard on 79.0.1 | **exit 1**, naming both advisory IDs |
| `python -m build` | sdist + wheel build successfully under the new floor |

## What actually ships

Checked, since the advisory concerns sdist contents:

- wheel carries only `mcp_server`, `protocol_tests`, `scripts`, dist-info
- sdist carries **no** `testing/` files
- wheel has 91 entries vs the 85 the review observed at v4.15.0 — that is files added to `scripts/` and `protocol_tests/` since the tag, not a packaging change

No defect there.

```
testing/            453 passed, 182 subtests
ruff --select F821  All checks passed
workflow YAML       parses
```

## Not established

This does not make any released artifact independently verified, and no wheel already on PyPI is rebuilt or changed by it.