### PR TITLE
fix(cli): --version banner stated the registered count, not the test-bearing one

### DIFF
--- a/protocol_tests/cli.py
+++ b/protocol_tests/cli.py
@@ -360,6 +360,25 @@ def _total_tests() -> int:
     return total
 
 
+def _test_bearing_modules() -> int:
+    """Registered harnesses that actually contribute tests. NOT len(HARNESSES).
+
+    `community` hosts community-contributed YAML patterns and ships none of its
+    own, so 44 commands are registered and 43 bear tests. Derived from the same
+    descriptions `_total_tests` sums, so the numerator and denominator of the
+    banner cannot drift apart.
+
+    testing/test_code_quality.py::_harness_count fixed exactly this conflation
+    for README and TEST-INVENTORY on 2026-08-09, computing the figure from
+    scripts/count_tests.py instead of len(HARNESSES). The `--version` banner was
+    not reached by that repair and kept printing the registered count against the
+    test total, so `agent-security --version` said "606 across 44 harness
+    modules" while the README it shipped beside said 43. Flagged 2026-08-29.
+    """
+    return sum(1 for info in HARNESSES.values()
+               if re.search(r'\((\d+)\s+tests', info["description"]))
+
+
 def print_usage():
     print(f"Agent Security Harness v{VERSION}")
     print(f"{_total_tests()} security tests for AI agent systems")
@@ -406,7 +425,8 @@ def main():
     # an upgrade, which is exactly when it was failing.
     if args[0] in ("version", "--version", "-V"):
         print(f"agent-security-harness v{VERSION}")
-        print(f"Tests: {_total_tests()} across {len(HARNESSES)} harness modules")
+        print(f"Tests: {_total_tests()} across {_test_bearing_modules()} test-bearing "
+              f"modules ({len(HARNESSES)} registered harnesses)")
         print(f"Protocols: MCP (JSON-RPC 2.0), A2A, L402, x402")
         print(f"Platforms: 25 cloud + 20 enterprise adapters")
         print(f"Standards: OWASP Agentic Top 10, NIST AI 800-2, NIST AI RMF, AIUC-1")

--- a/testing/test_code_quality.py
+++ b/testing/test_code_quality.py
@@ -159,6 +159,40 @@ class TestRegTestCount(unittest.TestCase):
         """
         from protocol_tests.cli import HARNESSES
         self.assertEqual(int(self._harness_count()), len(HARNESSES) - 1)
+
+    def test_cli_version_banner_states_the_test_bearing_count(self):
+        """The --version banner was the third surface with this conflation.
+
+        _harness_count above fixed README and TEST-INVENTORY on 2026-08-09 by
+        computing the figure instead of using len(HARNESSES). The banner was not
+        reached by that repair, so a user who installed the wheel read
+
+            Tests: 606 across 44 harness modules
+
+        and the README shipped beside it said 43 test-bearing modules. Both
+        numbers were defensible in isolation and irreconcilable side by side,
+        with the test total attached to the denominator that includes a module
+        contributing none of it.
+
+        Asserted against the real subprocess output, not the helper, because the
+        format string is the surface. Checking _test_bearing_modules() alone
+        would pass while the banner still printed len(HARNESSES).
+        """
+        import subprocess
+        out = subprocess.check_output(
+            [sys.executable, "-m", "protocol_tests.cli", "--version"],
+            text=True, cwd=REPO_ROOT)
+        m = re.search(r"Tests: (\d+) across (\d+) test-bearing modules \((\d+) registered", out)
+        self.assertIsNotNone(
+            m, f"--version banner no longer states both counts in the expected shape:\n{out}")
+        total, bearing, registered = m.groups()
+        from protocol_tests.cli import HARNESSES
+        self.assertEqual(total, self._canonical_count(),
+                         "banner test total disagrees with count_tests.py")
+        self.assertEqual(bearing, self._harness_count(),
+                         "banner module count is not the test-bearing count")
+        self.assertEqual(int(registered), len(HARNESSES),
+                         "banner registered count is not len(HARNESSES)")
     def test_readme_module_count(self):
         count = self._harness_count()
         with open(os.path.join(REPO_ROOT, "README.md")) as f: readme = f.read()


### PR DESCRIPTION
Refs #369. Found by the current-state quality review, 2026-08-29.

## The defect

`agent-security --version` printed:

```
Tests: 606 across 44 harness modules
```

while the README shipped beside it says **"606 executable security tests across 43 test-bearing modules."**

Both numbers are defensible in isolation and irreconcilable side by side — and the banner attached the **test total** to the denominator that includes a module contributing none of it. `cli.py` registers 44 commands; `community` hosts community-contributed YAML patterns and ships none of its own.

## This is the third surface, and the first two were already fixed

`testing/test_code_quality.py::_harness_count` records it in its own docstring:

> *This method returned `len(HARNESSES)` until 2026-08-09, so README and TEST-INVENTORY were required to state 44 test-bearing modules when the declared source of truth said 43.*

That repair computed the figure from `scripts/count_tests.py` instead of `len(HARNESSES)` — and fixed the two surfaces someone was looking at. The `--version` banner was not one of them, so it kept printing the old denominator for another twenty days.

Scoping a repair to where the defect was noticed is how it survives. This is a clean instance of that.

## The fix

```
Tests: 606 across 43 test-bearing modules (44 registered harnesses)
```

Both numbers stated, each labelled as what it is. `_test_bearing_modules()` derives from the same harness descriptions `_total_tests()` sums, so numerator and denominator cannot drift apart.

**The guard asserts the real subprocess output, not the helper** — the format string is the surface, and checking `_test_bearing_modules()` alone would pass while the banner still printed `len(HARNESSES)`. It pins all three figures against their sources:

| Figure | Pinned against |
|---|---|
| 606 | `count_tests.py` |
| 43 | `_harness_count` |
| 44 | `len(HARNESSES)` |

Proven in both directions: passes here, fails on line 186 with only `cli.py` reverted.

## What I deliberately did not do

**No release-claims manifest entry for this.** The module count is already bound by `_harness_count` and now by the banner guard. A parallel manifest claim would be a second guard on one fact — the duplication that makes a defect need fixing in more than one place to begin with. The manifest is for facts with *no* owner; this one now has one.

## Verification

```
testing/            454 passed, 182 subtests   (was 453)
ruff (both files)   39 findings, identical to main; none introduced
ruff --select F821  All checks passed
verify_release_claims.py   5 passed, 0 not reproduced
```

## Note on how it was found

The review that surfaced this recorded the banner output verbatim as a **passing** observation, in the same document that separately verified the README. Neither number was wrong where it was written — which is exactly why nobody had caught it.