### PR TITLE
fix(#351): guard return_channel and capability_profile. Both passed 100% at a dead host

### DIFF
--- a/protocol_tests/capability_profile_harness.py
+++ b/protocol_tests/capability_profile_harness.py
@@ -32,6 +32,8 @@ from datetime import datetime, timezone
 from enum import Enum
 import urllib.request
 
+from protocol_tests.http_helpers import inconclusive_detail
+
 
 # ---------------------------------------------------------------------------
 # Wilson score CI (inlined for zero-dep)
@@ -222,6 +224,19 @@ class CapabilityProfileTests:
         self.results: list[CapabilityProfileTestResult] = []
 
     def _record(self, result: CapabilityProfileTestResult):
+        # #348/#351: a result whose target never serviced the request is
+        # INCONCLUSIVE, never a pass. Enforced here rather than at each verdict
+        # so a new test cannot forget it.
+        #
+        # Before this guard, `cli test capability-profile --url <closed port>` reported
+        # 10/10 passed (100%) and exited 0, with a Wilson 95% interval of
+        # [0.7225, 1.0000] computed over a pass rate derived from zero
+        # serviced requests. A confidence interval on nothing is worse than a
+        # bare 100%: it presents the absence of a target as a measurement.
+        _d = inconclusive_detail(getattr(result, "response_received", None), result.details)
+        if _d is not None:
+            result.passed = False
+            result.details = _d
         self.results.append(result)
         status = "PASS \u2705" if result.passed else "FAIL \u274c"
         print(f"  {status} {result.test_id}: {result.name} ({result.elapsed_s:.2f}s)")

--- a/protocol_tests/return_channel_harness.py
+++ b/protocol_tests/return_channel_harness.py
@@ -34,6 +34,8 @@ from datetime import datetime, timezone
 from enum import Enum
 import urllib.request
 
+from protocol_tests.http_helpers import inconclusive_detail
+
 
 # ---------------------------------------------------------------------------
 # Wilson score CI (inlined for zero-dep)
@@ -232,6 +234,19 @@ class ReturnChannelTests:
         self.results: list[ReturnChannelTestResult] = []
 
     def _record(self, result: ReturnChannelTestResult):
+        # #348/#351: a result whose target never serviced the request is
+        # INCONCLUSIVE, never a pass. Enforced here rather than at each verdict
+        # so a new test cannot forget it.
+        #
+        # Before this guard, `cli test return-channel --url <closed port>` reported
+        # 8/8 passed (100%) and exited 0, with a Wilson 95% interval of
+        # [0.6756, 1.0000] computed over a pass rate derived from zero
+        # serviced requests. A confidence interval on nothing is worse than a
+        # bare 100%: it presents the absence of a target as a measurement.
+        _d = inconclusive_detail(getattr(result, "response_received", None), result.details)
+        if _d is not None:
+            result.passed = False
+            result.details = _d
         self.results.append(result)
         status = "PASS \u2705" if result.passed else "FAIL \u274c"
         print(f"  {status} {result.test_id}: {result.name} ({result.elapsed_s:.2f}s)")

--- a/testing/test_serviced_guard.py
+++ b/testing/test_serviced_guard.py
@@ -67,6 +67,15 @@ GUARDED = [
     # shared http_post_json shape, and a non-2xx is not A2A servicing the request, so all
     # three preconditions were clear.
     ("protocol_tests.jailbreak_harness", "JailbreakTests", "JailbreakTestResult"),
+    # #351, found by an independent-reviewer sweep 2026-08-29 as live CLI behaviour
+    # rather than static suspicion: both reported a perfect pass against a closed
+    # port, with a Wilson interval computed over it.
+    #   return-channel       8/8 passed (100%), exit 0, CI [0.6756, 1.0000]
+    #   capability-profile  10/10 passed (100%), exit 0, CI [0.7225, 1.0000]
+    ("protocol_tests.return_channel_harness", "ReturnChannelTests",
+     "ReturnChannelTestResult"),
+    ("protocol_tests.capability_profile_harness", "CapabilityProfileTests",
+     "CapabilityProfileTestResult"),
     # #351: guard on the shared ABC, so every adapter subclass inherits it. Blocked
     # on precondition 1 until its simulate mode marked synthesised responses
     # "_simulated" instead of "simulate"; the marker was write-only, so renaming it
@@ -138,7 +147,6 @@ UNREVIEWED = {
     "a2a_harness",
     "aiuc1_compliance_harness",
     "benchmark_integrity_harness",
-    "capability_profile_harness",
     "cbrn_harness",
     "crewai_cve_harness",
     "extended_thinking_harness",
@@ -151,7 +159,6 @@ UNREVIEWED = {
     "over_refusal_harness",
     "prompt_caching_harness",
     "ptc_harness",
-    "return_channel_harness",
     "skill_security_harness",
     "tool_search_harness",
     "watermark_harness",
@@ -337,7 +344,7 @@ class TestCoverageListIsDerived(unittest.TestCase):
     def test_unreviewed_does_not_grow(self) -> None:
         """A tripwire on the honest number, so the backlog cannot quietly expand."""
         self.assertLessEqual(
-            len(UNREVIEWED), 21,
+            len(UNREVIEWED), 19,
             "UNREVIEWED grew. A new module recording a response should be guarded or "
             "reviewed, not appended to the backlog.")
 


### PR DESCRIPTION
`UNREVIEWED` 21 → 19, shrunk by review. Refs #348, #350, #355, #374, #397.

Reported by an independent-reviewer sweep, 2026-08-29, as **live CLI behaviour rather than static suspicion**. Reproduced on main before any change:

```
cli test return-channel     --url http://127.0.0.1:9    8/8  passed (100%), exit 0
cli test capability-profile --url http://127.0.0.1:9   10/10 passed (100%), exit 0
```

Both wrote a report presenting a completed successful evaluation, each with a Wilson 95% interval over the pass rate — `[0.6756, 1.0000]` and `[0.7225, 1.0000]`. Nothing was listening on that port.

**The confidence interval is the part worth naming.** A bare 100% at least looks like something a reader might question. An interval presents the absence of a target as a *measurement*, with quantified uncertainty computed over no observations at all.

## Root cause

The class #348 and #350 already named. `return_channel_harness` states it outright:

```python
_poison_succeeded(resp):
    if resp.get("_error") or resp.get("error"):
        return False   # Error response = poison didn't work
```

An error response means the harness learned nothing about the control it came to test.

## Preconditions, checked before applying anything

| # | Precondition | Finding |
|---|---|---|
| 1 | Simulation marked | **No simulate mode in either module** — no fixture path to turn into a false negative |
| 2 | Response-key convention | **Verified, not assumed.** Each defines its *own local* `http_post_json` rather than importing the shared one. Both return `{"_error": True, "_status": …}` / `{"_error": True, "_exception": …}` on failure and `{…, "_status": …}` on success — exactly what `_serviced` reads |
| 3 | Non-2xx not normal servicing | Both A2A over HTTP. Unlike l402/x402, a non-2xx is not the protocol answering |

## The fix

Guards in `_record`, matching the already-guarded modules, so a new test cannot forget them.

**Written as a failing regression first** — adding both to `GUARDED` before touching either module failed all ten subtests (five unserviced conditions each).

After, same closed port:

```
return-channel      0/8  passed, exit 1
capability-profile  0/10 passed, exit 1
RCP-001: INCONCLUSIVE - target did not service the request; status=0. Original finding: ...
CP-001:  INCONCLUSIVE - target did not service the request; status=0. Original finding: ...
```

Original findings preserved in the detail. **No failures synthesised** — the count is unchanged, the verdicts simply are not passes.

## Known limit, not addressed here

The Wilson interval is still computed, now over 0/8 and 0/10. Reporting a confidence interval across results that are uniformly INCONCLUSIVE is the same category error one level up — and it lives in **shared summary machinery**, not in these two modules.

Fixing it here would be a partial repair of a shared surface, which is how #348 came to need fixing four times. It deserves its own issue.

## Verification

```
testing/            454 passed, 194 subtests   (was 454/182)
ruff --select F821  All checks passed
ruff (both modules) same count as main before this change
```

The twelve new subtests are five unserviced conditions plus a serviced control for each module — the serviced case proving the guards do not over-fire on a real answer.