### PR TITLE
fix(cli): refuse --json before dispatch on harnesses that do not declare it

### DIFF
--- a/protocol_tests/cli.py
+++ b/protocol_tests/cli.py
@@ -26,6 +26,7 @@ import os
 import re
 import sys
 import importlib
+import importlib.util  # `importlib` alone does not expose .util
 from datetime import datetime, timezone
 
 from protocol_tests.version import get_harness_version
@@ -360,6 +361,41 @@ def _total_tests() -> int:
     return total
 
 
+def _module_declares_flag(harness_name: str, flag: str) -> bool:
+    """Whether a harness module declares `flag` in its own argparse.
+
+    Derived from the module source, not from a maintained list. A maintained
+    list is the thing that drifts: the CLI already carried the comment "pass
+    --json through to harness modules that support it" directly above a line
+    that appended it unconditionally, so the intent was recorded and the
+    implementation did not match it.
+
+    Located through importlib rather than a relative path, so the answer does
+    not depend on the working directory the CLI was invoked from.
+    """
+    info = HARNESSES.get(harness_name)
+    if not info:
+        return False
+    try:
+        spec = importlib.util.find_spec(info["module"])
+        origin = spec.origin if spec else None
+        if not origin:
+            return False
+        with open(origin, encoding="utf-8") as fh:
+            src = fh.read()
+    except (ImportError, OSError, ValueError):
+        # Unreadable module: say the flag is absent rather than guess. The
+        # caller turns that into a clear refusal, which beats dispatching and
+        # letting argparse fail with "unrecognized arguments" from a submodule.
+        return False
+    return bool(re.search(r'add_argument\(\s*["\']' + re.escape(flag) + r'["\']', src))
+
+
+def _json_capable_count() -> int:
+    """How many registered harnesses declare --json. Derived, so it cannot drift."""
+    return sum(1 for name in HARNESSES if _module_declares_flag(name, "--json"))
+
+
 def _test_bearing_modules() -> int:
     """Registered harnesses that actually contribute tests. NOT len(HARNESSES).
 
@@ -593,9 +629,26 @@ def main():
             os.environ["AGENT_SECURITY_TELEMETRY"] = "off"
 
         # --json flag: tell harnesses to output JSON to stdout (#103)
+        #
+        # Only 11 of the 44 registered harnesses declare --json. This block
+        # appended it to all of them, so `test a2a --json` and 32 others died on
+        # "unrecognized arguments: --json" from inside the submodule, exit 2,
+        # after the CLI had already advertised the flag as common. Refuse before
+        # dispatch with an accurate message instead. Reported 2026-08-29.
         if json_output:
+            if not _module_declares_flag(harness_name, "--json"):
+                print(f"error: `{harness_name}` does not support --json.",
+                      file=sys.stderr)
+                print(file=sys.stderr)
+                print("--json is not yet a common contract across this CLI: "
+                      f"{_json_capable_count()} of {len(HARNESSES)} registered "
+                      "harnesses declare it.", file=sys.stderr)
+                if _module_declares_flag(harness_name, "--report"):
+                    print(f"\nUse:  agent-security test {harness_name} "
+                          "--report <path>\nwhich writes the same JSON to a file.",
+                          file=sys.stderr)
+                sys.exit(2)
             os.environ["AGENT_SECURITY_JSON_OUTPUT"] = "1"
-            # Also pass --json through to harness modules that support it
             filtered_args.append("--json")
 
         if delay_ms > 0:

--- a/testing/test_cli_json_capability.py
+++ b/testing/test_cli_json_capability.py
@@ -1,0 +1,115 @@
+"""`--json` must be refused before dispatch on harnesses that do not declare it.
+
+Reported 2026-08-29 by an independent-reviewer sweep, which hit it on two
+subcommands:
+
+    agent-security test a2a            --url ... --json
+    agent-security test return-channel --url ... --json
+    -> error: unrecognized arguments: --json     (exit 2, raised inside the submodule)
+
+Deriving the set rather than trusting the two reported instances put the real
+number at **33 of 44**. Only 11 registered harnesses declare `--json`, so the
+CLI was advertising a common flag that three quarters of its subcommands reject,
+and the failure surfaced as an argparse error from a module the user did not
+invoke by name.
+
+The CLI already carried the correct intent one line above the defect:
+
+    # Also pass --json through to harness modules that support it
+    filtered_args.append("--json")
+
+The comment described a capability check. The code appended unconditionally.
+
+## What this fixes and what it does not
+
+This does not make `--json` work everywhere. A common JSON contract across 44
+harnesses is a separate project, and pretending otherwise by scraping console
+output would be worse than the error it replaced -- the reviewer said so
+explicitly: "Do not silently fall back to human console parsing."
+
+It replaces a confusing failure with an accurate one, and points at `--report`,
+which 32 of the 33 unsupported harnesses do accept and which writes the same JSON
+to a file.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from protocol_tests.cli import (
+    HARNESSES,
+    _json_capable_count,
+    _module_declares_flag,
+)
+
+
+def _run(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "protocol_tests.cli", *args],
+        cwd=REPO_ROOT, capture_output=True, text=True, timeout=120, check=False,
+    )
+
+
+class TestJsonCapabilityIsDerived(unittest.TestCase):
+    def test_capability_is_read_from_the_module_not_a_list(self):
+        """A maintained list is the thing that drifts; assert the derived answer."""
+        self.assertTrue(_module_declares_flag("mcp", "--json"))
+        self.assertFalse(_module_declares_flag("a2a", "--json"))
+        self.assertTrue(_module_declares_flag("a2a", "--report"))
+
+    def test_unknown_harness_is_not_reported_as_capable(self):
+        self.assertFalse(_module_declares_flag("no-such-harness", "--json"))
+
+    def test_capable_count_is_positive_and_bounded(self):
+        """Assert a real range, so a lookup that silently fails everywhere fails here.
+
+        If _module_declares_flag started returning False for everything -- a bad
+        path, a changed argparse idiom -- every refusal below would still 'pass'
+        while the CLI refused every subcommand. Pin that it finds some and not all.
+        """
+        n = _json_capable_count()
+        self.assertGreater(n, 0, "no harness detected as --json capable; the "
+                                 "source lookup is probably broken")
+        self.assertLess(n, len(HARNESSES), "every harness reported capable; the "
+                                           "detection is probably matching too broadly")
+
+
+class TestUnsupportedJsonIsRefusedBeforeDispatch(unittest.TestCase):
+    def test_a2a_json_is_refused_with_an_accurate_message(self):
+        proc = _run("test", "a2a", "--url", "http://127.0.0.1:9", "--json")
+        self.assertEqual(proc.returncode, 2, f"expected exit 2, got {proc.returncode}")
+        err = proc.stderr
+        self.assertIn("does not support --json", err)
+        self.assertNotIn(
+            "unrecognized arguments", err,
+            "the submodule argparse error is what this replaces; it should no "
+            "longer reach the user")
+        self.assertIn("--report", err, "the message must name the alternative that works")
+
+    def test_the_message_states_the_real_ratio(self):
+        """The count in the message is derived, so it cannot go stale."""
+        proc = _run("test", "return-channel", "--url", "http://127.0.0.1:9", "--json")
+        m = re.search(r"(\d+) of (\d+) registered", proc.stderr)
+        self.assertIsNotNone(m, f"message no longer states the ratio:\n{proc.stderr}")
+        self.assertEqual(int(m.group(1)), _json_capable_count())
+        self.assertEqual(int(m.group(2)), len(HARNESSES))
+
+
+class TestSupportedJsonStillWorks(unittest.TestCase):
+    def test_mcp_json_is_not_refused(self):
+        """The guard must not over-refuse, or it is worse than the defect."""
+        proc = _run("test", "mcp", "--transport", "http",
+                    "--url", "http://127.0.0.1:9", "--json")
+        self.assertNotIn("does not support --json", proc.stderr)
+        self.assertIn('"suite"', proc.stdout, "mcp --json no longer emits its JSON report")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Reported 2026-08-29. Refs #369.

## The defect, and how much bigger it is than reported

```
cli test a2a            --url ... --json
cli test return-channel --url ... --json
-> error: unrecognized arguments: --json    exit 2, raised inside the submodule
```

Deriving the set instead of trusting the two reported instances put the real number at **33 of 44**. Only **11** registered harnesses declare `--json`.

So the CLI advertised a common flag that three quarters of its subcommands reject, and the failure surfaced as an argparse error naming a module the user never typed.

## The intent was already recorded, one line above the defect

```python
# Also pass --json through to harness modules that support it
filtered_args.append("--json")
```

The comment described a capability check. The code appended unconditionally.

## The fix

Capability is **derived from the module source**, not a maintained list — a maintained list is exactly what drifts — and located through `importlib.util` so the answer doesn't depend on the working directory. An unreadable module reports the flag absent, producing a clear refusal rather than a dispatch that fails later somewhere else.

**Checked before refusing anything:** every module that reads `AGENT_SECURITY_JSON_OUTPUT` also declares `--json`, so no currently working path breaks. Refusing without that check would have been a plausible way to introduce a regression while fixing a defect.

```
error: `a2a` does not support --json.

--json is not yet a common contract across this CLI: 11 of 44 registered harnesses declare it.

Use:  agent-security test a2a --report <path>
which writes the same JSON to a file.
```

The count is computed, so it cannot go stale as harnesses gain the flag. `--report` is a real alternative: **32 of the 33** unsupported harnesses accept it.

## What this does not do

Make `--json` work everywhere. A common JSON contract across 44 harnesses is a separate project. Scraping console output to fake one would be worse than the error it replaces — and the report that raised this said so explicitly: *"Do not silently fall back to human console parsing."*

## Tests

Six, covering three things:

| What | Why |
|---|---|
| derived capability, incl. a **range assertion** | if the lookup ever returned `False` for everything, every refusal test would still pass while the CLI refused *every* subcommand. Count pinned `> 0` and `< len(HARNESSES)` |
| refusal is accurate, submodule argparse error no longer reaches the user | that error is what this replaces |
| `mcp --json` still emits its report | a guard that over-refuses is worse than the defect |

```
testing/            460 passed, 194 subtests   (was 454)
ruff (new file)     All checks passed
ruff (cli.py)       16 findings, unchanged against main
ruff --select F821  All checks passed
```