### PR TITLE
fix(#404): INCONCLUSIVE is a result class, not the residual bucket

### DIFF
--- a/protocol_tests/capability_profile_harness.py
+++ b/protocol_tests/capability_profile_harness.py
@@ -32,7 +32,7 @@ from datetime import datetime, timezone
 from enum import Enum
 import urllib.request
 
-from protocol_tests.http_helpers import inconclusive_detail
+from protocol_tests.http_helpers import inconclusive_detail, run_summary, summary_lines
 
 
 # ---------------------------------------------------------------------------
@@ -709,17 +709,12 @@ class CapabilityProfileTests:
                         protocol="unknown",
                     ))
 
-        total = len(self.results)
-        passed = sum(1 for r in self.results if r.passed)
-        ci = wilson_ci(passed, total)
+        summary = run_summary(self.results)
 
-        print(f"\n{'='*60}")
-        if total:
-            print(f"RESULTS: {passed}/{total} passed ({passed/total*100:.0f}%)")
-            print(f"WILSON 95% CI for pass rate: [{ci[0]:.4f}, {ci[1]:.4f}]")
-        else:
-            print("No tests run")
-        print(f"{'='*60}\n")
+        print(f"\\n{'='*60}")
+        for _line in summary_lines(summary):
+            print(_line)
+        print(f"{'='*60}\\n")
 
         return self.results
 
@@ -729,9 +724,7 @@ class CapabilityProfileTests:
 # ---------------------------------------------------------------------------
 
 def generate_report(results: list[CapabilityProfileTestResult], output_path: str):
-    total = len(results)
-    passed = sum(1 for r in results if r.passed)
-    ci = wilson_ci(passed, total)
+    summary = run_summary(results)
 
     report = {
         "suite": "Capability Profile Validation Tests v3.6",
@@ -739,13 +732,7 @@ def generate_report(results: list[CapabilityProfileTestResult], output_path: str
         "owasp_mapping": ["ASI05", "ASI09"],
         "stride_mapping": ["Elevation of Privilege", "Tampering"],
         "github_issue": "#48",
-        "summary": {
-            "total": total,
-            "passed": passed,
-            "failed": total - passed,
-            "pass_rate": round(passed / total, 4) if total else 0,
-            "wilson_95_ci": {"lower": ci[0], "upper": ci[1]},
-        },
+        "summary": summary,
         "results": [asdict(r) for r in results],
     }
     with open(output_path, "w") as f:

--- a/protocol_tests/governance_modification_harness.py
+++ b/protocol_tests/governance_modification_harness.py
@@ -40,8 +40,8 @@ import uuid
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 
-from protocol_tests._utils import Severity, wilson_ci, jsonrpc_request, http_post_json
-from protocol_tests.http_helpers import inconclusive_detail
+from protocol_tests._utils import Severity, jsonrpc_request, http_post_json
+from protocol_tests.http_helpers import inconclusive_detail, run_summary, summary_lines
 
 
 @dataclass
@@ -831,15 +831,12 @@ class GovernanceModificationTests:
                     severity=Severity.HIGH.value, passed=False, details=str(e),
                 ))
 
-        total = len(self.results)
-        passed = sum(1 for r in self.results if r.passed)
-        ci = wilson_ci(passed, total)
+        summary = run_summary(self.results)
 
-        print(f"\n{'='*60}")
-        if total:
-            print(f"RESULTS: {passed}/{total} passed ({passed/total*100:.0f}%)")
-            print(f"WILSON 95% CI: [{ci[0]:.4f}, {ci[1]:.4f}]")
-        print(f"{'='*60}\n")
+        print(f"\\n{'='*60}")
+        for _line in summary_lines(summary):
+            print(_line)
+        print(f"{'='*60}\\n")
 
         return self.results
 
@@ -873,9 +870,7 @@ def main() -> None:
     results = suite.run_all()
 
     if args.report:
-        total = len(results)
-        passed = sum(1 for r in results if r.passed)
-        ci = wilson_ci(passed, total)
+        summary = run_summary(results)
         report = {
             "suite": "Governance Modification Tests",
             "hc_ref": "HC-12",
@@ -885,13 +880,7 @@ def main() -> None:
                 "gates within 48 hours of deployment for throughput gains."
             ),
             "timestamp": datetime.now(timezone.utc).isoformat(),
-            "summary": {
-                "total": total,
-                "passed": passed,
-                "failed": total - passed,
-                "pass_rate": round(passed / total, 4) if total else 0,
-                "wilson_95_ci": {"lower": ci[0], "upper": ci[1]},
-            },
+            "summary": summary,
             "results": [asdict(r) for r in results],
         }
         with open(args.report, "w") as f:

--- a/protocol_tests/http_helpers.py
+++ b/protocol_tests/http_helpers.py
@@ -123,6 +123,113 @@ def _err(resp: dict) -> bool:
     return resp.get("_error") or resp.get("_status", 200) >= 400
 
 
+#: The marker that makes a result INCONCLUSIVE rather than a pass or a failure.
+#:
+#: #404: this state has lived only as a prefix on a prose field. Nothing in the
+#: 35 result dataclasses carries it, so every summary could ask "passed?" and
+#: nothing else, and an inconclusive result fell into whichever bucket was
+#: residual -- which was `failed`. A run that established nothing was reported
+#: as a run in which the target failed everything.
+#:
+#: Defining it once is the smallest step that makes the third class countable.
+#: A field on the result classes would be better and is not blocked by this.
+INCONCLUSIVE_PREFIX = "INCONCLUSIVE - "
+
+
+def is_inconclusive(details: str | None) -> bool:
+    """True when `details` marks a result as INCONCLUSIVE.
+
+    The predicate exists so that callers stop matching the substring by hand.
+    When the state gains a structural home on the result classes, this is the
+    one place that has to learn about it.
+    """
+    return INCONCLUSIVE_PREFIX.strip(" -") in (details or "")
+
+
+def run_summary(results) -> dict:
+    """Summary counts that keep PASS, FAIL and INCONCLUSIVE distinct.
+
+    Every affected module computed this inline and identically::
+
+        total  = len(self.results)
+        passed = sum(1 for r in self.results if r.passed)
+        ci     = wilson_ci(passed, total)
+        "failed": total - passed
+
+    Three things are wrong with that once a guard can produce INCONCLUSIVE.
+
+    `failed` is a residual bucket, so an inconclusive result is counted as a
+    target failure. After #402, `return-channel` against a closed port reported
+    ``{total: 8, passed: 0, failed: 8}`` when the honest statement is that eight
+    tests established nothing.
+
+    `pass_rate` divides by `total`, so it answers "of everything attempted, how
+    much passed", when the question a reader has is "of what was actually
+    observed, how much passed".
+
+    The Wilson interval is computed over that same denominator, which is the
+    part the reviewer objected to: an interval over wholly unserviced
+    observations presents the absence of a target as a measurement, complete
+    with quantified uncertainty derived from nothing.
+
+    So the denominator here is `serviced`, and both `pass_rate` and
+    `wilson_95_ci` are ``None`` when nothing was serviced. None is deliberate
+    over 0.0: a rate of zero is a claim, and absence is not.
+
+    `total` still equals ``passed + failed + inconclusive``, so a consumer that
+    sums the buckets is not broken by this.
+    """
+    from protocol_tests.statistical import wilson_ci
+
+    results = list(results)
+    total = len(results)
+    inconclusive = sum(1 for r in results
+                       if is_inconclusive(getattr(r, "details", None)))
+    passed = sum(1 for r in results if getattr(r, "passed", False))
+    failed = total - passed - inconclusive
+    serviced = passed + failed
+
+    summary = {
+        "total": total,
+        "passed": passed,
+        "failed": failed,
+        "inconclusive": inconclusive,
+        "serviced": serviced,
+        "status": ("empty" if total == 0
+                   else "inconclusive" if serviced == 0
+                   else "completed"),
+    }
+    if serviced:
+        lo, hi = wilson_ci(passed, serviced)
+        summary["pass_rate"] = round(passed / serviced, 4)
+        summary["wilson_95_ci"] = {"lower": lo, "upper": hi}
+    else:
+        summary["pass_rate"] = None
+        summary["wilson_95_ci"] = None
+    return summary
+
+
+def summary_lines(summary: dict) -> list[str]:
+    """Console lines for a run summary, saying plainly when nothing was observed."""
+    if summary["total"] == 0:
+        return ["No tests run"]
+    if summary["serviced"] == 0:
+        return [
+            (f"RESULTS: 0/{summary['total']} passed - "
+             f"{summary['inconclusive']} INCONCLUSIVE, none serviced"),
+            ("Pass rate not computed: no request was serviced, so there is "
+             "nothing to compute it over."),
+        ]
+    pct = summary["passed"] / summary["serviced"] * 100
+    ci = summary["wilson_95_ci"]
+    lines = [(f"RESULTS: {summary['passed']}/{summary['serviced']} serviced tests "
+              f"passed ({pct:.0f}%)")]
+    if summary["inconclusive"]:
+        lines.append(f"{summary['inconclusive']} INCONCLUSIVE, excluded from the rate")
+    lines.append(f"WILSON 95% CI for pass rate: [{ci['lower']:.4f}, {ci['upper']:.4f}]")
+    return lines
+
+
 def inconclusive_detail(resp, details: str | None) -> str | None:
     """Replacement ``details`` when a result must be INCONCLUSIVE, else ``None``.
 
@@ -148,7 +255,7 @@ def inconclusive_detail(resp, details: str | None) -> str | None:
         return None
     if _serviced(resp):
         return None
-    if "INCONCLUSIVE" in (details or ""):
+    if is_inconclusive(details):
         return None
     # Read both status conventions, for the same reason _serviced does. Reading
     # only "_status" made this line report "status=0" for a harness that writes
@@ -158,7 +265,7 @@ def inconclusive_detail(resp, details: str | None) -> str | None:
     status = resp.get("_status")
     if status is None:
         status = resp.get("status", 0)
-    return ("INCONCLUSIVE - target did not service the request; "
+    return (f"{INCONCLUSIVE_PREFIX}target did not service the request; "
             f"status={status}. Original finding: {details}")
 
 

--- a/protocol_tests/intent_contract_harness.py
+++ b/protocol_tests/intent_contract_harness.py
@@ -33,7 +33,7 @@ from datetime import datetime, timezone
 from enum import Enum
 import urllib.request
 
-from protocol_tests.http_helpers import http_post_json, _err, _is_conn_error, _serviced, inconclusive_detail
+from protocol_tests.http_helpers import http_post_json, _err, _is_conn_error, _serviced, inconclusive_detail, run_summary, summary_lines
 
 
 # ---------------------------------------------------------------------------
@@ -572,17 +572,12 @@ class IntentContractTests:
                         protocol="unknown",
                     ))
 
-        total = len(self.results)
-        passed = sum(1 for r in self.results if r.passed)
-        ci = wilson_ci(passed, total)
+        summary = run_summary(self.results)
 
-        print(f"\n{'='*60}")
-        if total:
-            print(f"RESULTS: {passed}/{total} passed ({passed/total*100:.0f}%)")
-            print(f"WILSON 95% CI for pass rate: [{ci[0]:.4f}, {ci[1]:.4f}]")
-        else:
-            print("No tests run")
-        print(f"{'='*60}\n")
+        print(f"\\n{'='*60}")
+        for _line in summary_lines(summary):
+            print(_line)
+        print(f"{'='*60}\\n")
 
         return self.results
 
@@ -592,9 +587,7 @@ class IntentContractTests:
 # ---------------------------------------------------------------------------
 
 def generate_report(results: list[IntentContractTestResult], output_path: str):
-    total = len(results)
-    passed = sum(1 for r in results if r.passed)
-    ci = wilson_ci(passed, total)
+    summary = run_summary(results)
 
     report = {
         "suite": "Intent Contract Validation Tests v1.0",
@@ -602,13 +595,7 @@ def generate_report(results: list[IntentContractTestResult], output_path: str):
         "owasp_mapping": ["ASI02", "ASI09"],
         "stride_mapping": ["Tampering", "Elevation of Privilege"],
         "github_issue": "#116",
-        "summary": {
-            "total": total,
-            "passed": passed,
-            "failed": total - passed,
-            "pass_rate": round(passed / total, 4) if total else 0,
-            "wilson_95_ci": {"lower": ci[0], "upper": ci[1]},
-        },
+        "summary": summary,
         "results": [asdict(r) for r in results],
     }
     with open(output_path, "w") as f:

--- a/protocol_tests/jailbreak_harness.py
+++ b/protocol_tests/jailbreak_harness.py
@@ -44,7 +44,7 @@ from datetime import datetime, timezone
 from enum import Enum
 import urllib.request
 
-from protocol_tests.http_helpers import http_post_json, inconclusive_detail
+from protocol_tests.http_helpers import http_post_json, inconclusive_detail, run_summary, summary_lines
 from protocol_tests._utils import model_judge_compliance
 
 
@@ -1039,17 +1039,12 @@ class JailbreakTests:
         if self.use_judge:
             self._apply_model_judge_pass()
 
-        total = len(self.results)
-        passed = sum(1 for r in self.results if r.passed)
-        ci = wilson_ci(passed, total)
+        summary = run_summary(self.results)
 
-        print(f"\n{'='*60}")
-        if total:
-            print(f"RESULTS: {passed}/{total} passed ({passed/total*100:.0f}%)")
-            print(f"WILSON 95% CI for pass rate: [{ci[0]:.4f}, {ci[1]:.4f}]")
-        else:
-            print("No tests run")
-        print(f"{'='*60}\n")
+        print(f"\\n{'='*60}")
+        for _line in summary_lines(summary):
+            print(_line)
+        print(f"{'='*60}\\n")
 
         return self.results
 
@@ -1059,20 +1054,12 @@ class JailbreakTests:
 # ---------------------------------------------------------------------------
 
 def generate_report(results: list[JailbreakTestResult], output_path: str):
-    total = len(results)
-    passed = sum(1 for r in results if r.passed)
-    ci = wilson_ci(passed, total)
+    summary = run_summary(results)
 
     report = {
         "suite": "Expanded Jailbreak Corpus Tests v3.1",
         "timestamp": datetime.now(timezone.utc).isoformat(),
-        "summary": {
-            "total": total,
-            "passed": passed,
-            "failed": total - passed,
-            "pass_rate": round(passed / total, 4) if total else 0,
-            "wilson_95_ci": {"lower": ci[0], "upper": ci[1]},
-        },
+        "summary": summary,
         "results": [asdict(r) for r in results],
     }
     with open(output_path, "w") as f:

--- a/protocol_tests/memory_harness.py
+++ b/protocol_tests/memory_harness.py
@@ -42,7 +42,7 @@ from datetime import datetime, timezone
 from enum import Enum
 import urllib.request
 
-from protocol_tests.http_helpers import http_post_json, _err, _is_conn_error, _serviced, inconclusive_detail
+from protocol_tests.http_helpers import http_post_json, _err, _is_conn_error, _serviced, inconclusive_detail, run_summary, summary_lines
 
 
 # ---------------------------------------------------------------------------
@@ -774,17 +774,12 @@ class MemoryTests:
                         protocol="unknown",
                     ))
 
-        total = len(self.results)
-        passed = sum(1 for r in self.results if r.passed)
-        ci = wilson_ci(passed, total)
+        summary = run_summary(self.results)
 
-        print(f"\n{'='*60}")
-        if total:
-            print(f"RESULTS: {passed}/{total} passed ({passed/total*100:.0f}%)")
-            print(f"WILSON 95% CI for pass rate: [{ci[0]:.4f}, {ci[1]:.4f}]")
-        else:
-            print("No tests run")
-        print(f"{'='*60}\n")
+        print(f"\\n{'='*60}")
+        for _line in summary_lines(summary):
+            print(_line)
+        print(f"{'='*60}\\n")
 
         return self.results
 
@@ -794,9 +789,7 @@ class MemoryTests:
 # ---------------------------------------------------------------------------
 
 def generate_report(results: list[MemoryTestResult], output_path: str):
-    total = len(results)
-    passed = sum(1 for r in results if r.passed)
-    ci = wilson_ci(passed, total)
+    summary = run_summary(results)
 
     report = {
         "suite": "Memory & Continuity Security Tests v3.4",
@@ -804,13 +797,7 @@ def generate_report(results: list[MemoryTestResult], output_path: str):
         "owasp_mapping": ["ASI01", "ASI03", "ASI05", "ASI07"],
         "stride_mapping": ["Information Disclosure", "Tampering", "Elevation of Privilege"],
         "github_issue": "#119",
-        "summary": {
-            "total": total,
-            "passed": passed,
-            "failed": total - passed,
-            "pass_rate": round(passed / total, 4) if total else 0,
-            "wilson_95_ci": {"lower": ci[0], "upper": ci[1]},
-        },
+        "summary": summary,
         "results": [asdict(r) for r in results],
     }
     with open(output_path, "w") as f:

--- a/protocol_tests/multi_agent_harness.py
+++ b/protocol_tests/multi_agent_harness.py
@@ -54,7 +54,7 @@ from datetime import datetime, timezone
 from enum import Enum
 import urllib.request
 
-from protocol_tests.http_helpers import http_post_json, _err, _is_conn_error, _serviced, inconclusive_detail
+from protocol_tests.http_helpers import http_post_json, _err, _is_conn_error, _serviced, inconclusive_detail, run_summary, summary_lines
 
 
 # ---------------------------------------------------------------------------
@@ -1206,17 +1206,12 @@ class MultiAgentTests:
                         protocol="unknown",
                     ))
 
-        total = len(self.results)
-        passed = sum(1 for r in self.results if r.passed)
-        ci = wilson_ci(passed, total)
+        summary = run_summary(self.results)
 
-        print(f"\n{'='*60}")
-        if total:
-            print(f"RESULTS: {passed}/{total} passed ({passed/total*100:.0f}%)")
-            print(f"WILSON 95% CI for pass rate: [{ci[0]:.4f}, {ci[1]:.4f}]")
-        else:
-            print("No tests run")
-        print(f"{'='*60}\n")
+        print(f"\\n{'='*60}")
+        for _line in summary_lines(summary):
+            print(_line)
+        print(f"{'='*60}\\n")
 
         return self.results
 
@@ -1226,9 +1221,7 @@ class MultiAgentTests:
 # ---------------------------------------------------------------------------
 
 def generate_report(results: list[MultiAgentTestResult], output_path: str):
-    total = len(results)
-    passed = sum(1 for r in results if r.passed)
-    ci = wilson_ci(passed, total)
+    summary = run_summary(results)
 
     report = {
         "suite": "Multi-Agent Interaction Security Tests v3.5",
@@ -1236,13 +1229,7 @@ def generate_report(results: list[MultiAgentTestResult], output_path: str):
         "owasp_mapping": ["ASI01", "ASI02", "ASI03", "ASI06", "ASI07"],
         "stride_mapping": ["Spoofing", "Tampering", "Elevation of Privilege", "Denial of Service"],
         "github_issue": "#117",
-        "summary": {
-            "total": total,
-            "passed": passed,
-            "failed": total - passed,
-            "pass_rate": round(passed / total, 4) if total else 0,
-            "wilson_95_ci": {"lower": ci[0], "upper": ci[1]},
-        },
+        "summary": summary,
         "results": [asdict(r) for r in results],
     }
     with open(output_path, "w") as f:

--- a/protocol_tests/provenance_harness.py
+++ b/protocol_tests/provenance_harness.py
@@ -27,7 +27,7 @@ import math
 import sys
 import time
 import uuid
-from protocol_tests.http_helpers import inconclusive_detail
+from protocol_tests.http_helpers import inconclusive_detail, run_summary, summary_lines
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from enum import Enum
@@ -781,17 +781,12 @@ class ProvenanceTests:
                         protocol="unknown",
                     ))
 
-        total = len(self.results)
-        passed = sum(1 for r in self.results if r.passed)
-        ci = wilson_ci(passed, total)
+        summary = run_summary(self.results)
 
-        print(f"\n{'='*60}")
-        if total:
-            print(f"RESULTS: {passed}/{total} passed ({passed/total*100:.0f}%)")
-            print(f"WILSON 95% CI for pass rate: [{ci[0]:.4f}, {ci[1]:.4f}]")
-        else:
-            print("No tests run")
-        print(f"{'='*60}\n")
+        print(f"\\n{'='*60}")
+        for _line in summary_lines(summary):
+            print(_line)
+        print(f"{'='*60}\\n")
 
         return self.results
 
@@ -801,21 +796,13 @@ class ProvenanceTests:
 # ---------------------------------------------------------------------------
 
 def generate_report(results: list[ProvenanceTestResult], output_path: str):
-    total = len(results)
-    passed = sum(1 for r in results if r.passed)
-    ci = wilson_ci(passed, total)
+    summary = run_summary(results)
 
     report = {
         "suite": "Provenance & Tool Attestation Tests v3.0",
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "cve_reference": CVE_REF,
-        "summary": {
-            "total": total,
-            "passed": passed,
-            "failed": total - passed,
-            "pass_rate": round(passed / total, 4) if total else 0,
-            "wilson_95_ci": {"lower": ci[0], "upper": ci[1]},
-        },
+        "summary": summary,
         "results": [asdict(r) for r in results],
     }
     with open(output_path, "w") as f:

--- a/protocol_tests/return_channel_harness.py
+++ b/protocol_tests/return_channel_harness.py
@@ -34,7 +34,7 @@ from datetime import datetime, timezone
 from enum import Enum
 import urllib.request
 
-from protocol_tests.http_helpers import inconclusive_detail
+from protocol_tests.http_helpers import inconclusive_detail, run_summary, summary_lines
 
 
 # ---------------------------------------------------------------------------
@@ -646,17 +646,12 @@ class ReturnChannelTests:
                         protocol="unknown",
                     ))
 
-        total = len(self.results)
-        passed = sum(1 for r in self.results if r.passed)
-        ci = wilson_ci(passed, total)
+        summary = run_summary(self.results)
 
-        print(f"\n{'='*60}")
-        if total:
-            print(f"RESULTS: {passed}/{total} passed ({passed/total*100:.0f}%)")
-            print(f"WILSON 95% CI for pass rate: [{ci[0]:.4f}, {ci[1]:.4f}]")
-        else:
-            print("No tests run")
-        print(f"{'='*60}\n")
+        print(f"\\n{'='*60}")
+        for _line in summary_lines(summary):
+            print(_line)
+        print(f"{'='*60}\\n")
 
         return self.results
 
@@ -666,9 +661,7 @@ class ReturnChannelTests:
 # ---------------------------------------------------------------------------
 
 def generate_report(results: list[ReturnChannelTestResult], output_path: str):
-    total = len(results)
-    passed = sum(1 for r in results if r.passed)
-    ci = wilson_ci(passed, total)
+    summary = run_summary(results)
 
     report = {
         "suite": "Return Channel Poisoning Tests v3.4",
@@ -676,13 +669,7 @@ def generate_report(results: list[ReturnChannelTestResult], output_path: str):
         "owasp_mapping": ["ASI03", "ASI05"],
         "stride_mapping": ["Tampering", "Elevation of Privilege"],
         "github_issue": "#49",
-        "summary": {
-            "total": total,
-            "passed": passed,
-            "failed": total - passed,
-            "pass_rate": round(passed / total, 4) if total else 0,
-            "wilson_95_ci": {"lower": ci[0], "upper": ci[1]},
-        },
+        "summary": summary,
         "results": [asdict(r) for r in results],
     }
     with open(output_path, "w") as f:

--- a/testing/test_inconclusive_summary.py
+++ b/testing/test_inconclusive_summary.py
@@ -1,0 +1,190 @@
+"""INCONCLUSIVE is a result class, not a residual bucket (#404).
+
+After #402 stopped `return_channel` and `capability_profile` reporting a false
+PASS against a closed port, they reported this instead::
+
+    summary: {total: 8, passed: 0, failed: 8}
+    WILSON 95% CI for pass rate: [0.0000, 0.3244]
+
+Every one of those eight results was INCONCLUSIVE and none of them was a
+failure. Two things were wrong and they are opposite in direction to the defect
+#402 fixed:
+
+- `failed` was the residual bucket, so a run that established nothing was
+  reported as a run in which the target failed everything;
+- a Wilson interval was computed over a pass rate whose denominator included
+  observations that never happened, presenting the absence of a target as a
+  measurement with quantified uncertainty.
+
+The root cause was that INCONCLUSIVE had no structural existence. It was a
+prefix on a prose field, so a summary could ask `passed?` and nothing else.
+
+## Scope, and why it is eight modules rather than twenty-five
+
+Twenty-five modules emit a Wilson summary and eighteen can produce an
+INCONCLUSIVE result. Only the intersection can miscount one, and that is eight.
+The other seventeen summary sites are not wrong today; they are simply not
+reachable by this defect, and changing them would be churn.
+
+That intersection is derived below rather than listed, so a module that gains a
+guard tomorrow is caught the day it does.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import unittest
+
+from protocol_tests.http_helpers import (
+    INCONCLUSIVE_PREFIX,
+    is_inconclusive,
+    run_summary,
+    summary_lines,
+)
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+PROTOCOL_TESTS = REPO_ROOT / "protocol_tests"
+
+# The defect shape: a residual-bucket failed count.
+RESIDUAL_FAILED = re.compile(r'"failed":\s*total\s*-\s*passed')
+
+# "Emits a run summary", in EITHER idiom. Matching only the old one -- the
+# WILSON/wilson_95_ci literals -- was the first version of this file, and it was
+# useless: adopting run_summary() removes those literals, so the affected set
+# collapsed to nothing the moment the migration landed and the ratchet below
+# guarded an empty loop. A detector keyed to the thing being removed stops
+# detecting exactly when it starts mattering.
+EMITS_SUMMARY = re.compile(r"WILSON 95%|wilson_95_ci|run_summary|summary_lines")
+
+# http_helpers defines the guard and the shared summary, and quotes the defect
+# in run_summary's docstring as the thing it replaces. It is the fix, not a
+# harness, so it is not a candidate.
+NOT_A_HARNESS = {"http_helpers", "harness_base"}
+
+# Modules that can produce INCONCLUSIVE, emit a summary, and have NOT adopted
+# the shared one. May shrink. Must never grow -- a new entry means a module was
+# written against the pattern this issue exists to remove.
+GRANDFATHERED: set[str] = set()
+
+
+class _R:
+    """Minimal stand-in with the two attributes run_summary reads."""
+
+    def __init__(self, passed: bool, details: str):
+        self.passed = passed
+        self.details = details
+
+
+def _inconclusive(n: int) -> list[_R]:
+    return [_R(False, f"{INCONCLUSIVE_PREFIX}target did not service the request")
+            for _ in range(n)]
+
+
+class TestInconclusiveIsCountedSeparately(unittest.TestCase):
+    def test_a_wholly_unserviced_run_has_no_failures(self):
+        """The #404 headline: eight inconclusives are not eight failures."""
+        s = run_summary(_inconclusive(8))
+        self.assertEqual(s["inconclusive"], 8)
+        self.assertEqual(s["failed"], 0, "inconclusive results counted as failures")
+        self.assertEqual(s["passed"], 0)
+        self.assertEqual(s["status"], "inconclusive")
+
+    def test_no_pass_rate_or_interval_without_a_serviced_observation(self):
+        """None, not 0.0. A rate of zero is a claim; absence is not."""
+        s = run_summary(_inconclusive(8))
+        self.assertEqual(s["serviced"], 0)
+        self.assertIsNone(s["pass_rate"])
+        self.assertIsNone(s["wilson_95_ci"])
+
+    def test_buckets_still_sum_to_total(self):
+        """A consumer that adds the buckets must not be broken by the new class."""
+        results = [_R(True, "ok"), _R(False, "real failure")] + _inconclusive(3)
+        s = run_summary(results)
+        self.assertEqual(s["passed"] + s["failed"] + s["inconclusive"], s["total"])
+
+    def test_rate_is_over_serviced_observations_only(self):
+        """1 pass and 1 failure among 3 results is 50%, not 33%."""
+        s = run_summary([_R(True, "ok"), _R(False, "real failure")] + _inconclusive(1))
+        self.assertEqual(s["serviced"], 2)
+        self.assertEqual(s["pass_rate"], 0.5)
+        self.assertIsNotNone(s["wilson_95_ci"])
+        self.assertEqual(s["status"], "completed")
+
+    def test_a_clean_serviced_run_is_unaffected(self):
+        """The common case must not change, or the fix costs more than the defect."""
+        s = run_summary([_R(True, "ok"), _R(True, "ok"), _R(False, "real failure")])
+        self.assertEqual((s["passed"], s["failed"], s["inconclusive"]), (2, 1, 0))
+        self.assertEqual(s["pass_rate"], round(2 / 3, 4))
+        self.assertEqual(s["status"], "completed")
+
+    def test_empty_run_is_empty_not_inconclusive(self):
+        self.assertEqual(run_summary([])["status"], "empty")
+
+
+class TestSummaryLinesSayWhatHappened(unittest.TestCase):
+    def test_unserviced_run_states_it_plainly(self):
+        lines = "\n".join(summary_lines(run_summary(_inconclusive(8))))
+        self.assertIn("INCONCLUSIVE", lines)
+        self.assertIn("none serviced", lines)
+        self.assertNotIn("WILSON", lines,
+                         "an interval must not be printed over unserviced observations")
+
+    def test_serviced_run_still_reports_an_interval(self):
+        lines = "\n".join(summary_lines(run_summary([_R(True, "ok"), _R(False, "f")])))
+        self.assertIn("WILSON 95%", lines)
+
+
+class TestIsInconclusive(unittest.TestCase):
+    def test_detects_the_prefix_and_nothing_else(self):
+        self.assertTrue(is_inconclusive(f"{INCONCLUSIVE_PREFIX}whatever"))
+        self.assertFalse(is_inconclusive("the control held"))
+        self.assertFalse(is_inconclusive(None))
+        self.assertFalse(is_inconclusive(""))
+
+
+class TestNoModuleKeepsTheResidualBucket(unittest.TestCase):
+    """The ratchet. Derived, so module nine is caught the day it is written."""
+
+    def _affected(self) -> set[str]:
+        out = set()
+        for path in sorted(PROTOCOL_TESTS.glob("*.py")):
+            src = path.read_text(encoding="utf-8")
+            if path.stem in NOT_A_HARNESS:
+                continue
+            if "inconclusive_detail" in src and EMITS_SUMMARY.search(src):
+                out.add(path.stem)
+        return out
+
+    def test_the_affected_set_is_not_empty(self):
+        """Assert a positive expected set, so a broken scan cannot read as success.
+
+        If the detection stopped matching -- a renamed helper, a changed summary
+        idiom -- the residual-bucket assertion below would iterate nothing and
+        pass while every module carried the defect.
+        """
+        self.assertGreaterEqual(
+            len(self._affected()), 8,
+            "fewer affected modules found than the eight known at #404; the "
+            "detection is probably broken rather than the repo improved")
+
+    def test_no_affected_module_computes_failed_as_a_residual(self):
+        for name in sorted(self._affected() - GRANDFATHERED):
+            with self.subTest(module=name):
+                src = (PROTOCOL_TESTS / f"{name}.py").read_text(encoding="utf-8")
+                self.assertIsNone(
+                    RESIDUAL_FAILED.search(src),
+                    f"{name} can produce INCONCLUSIVE and still computes "
+                    f'"failed": total - passed, so an inconclusive result is '
+                    f"reported as a target failure. Use run_summary() from "
+                    f"protocol_tests.http_helpers.")
+
+    def test_grandfather_list_is_empty_and_may_only_shrink(self):
+        self.assertEqual(
+            GRANDFATHERED, set(),
+            "every affected module was migrated at #404. A non-empty list means "
+            "one regressed or a new one was added against the old pattern.")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #404. Refs #402, #403, #351.

## The defect

#402 stopped `return_channel` and `capability_profile` reporting a false PASS against a closed port. They then reported this instead:

```
summary: {total: 8, passed: 0, failed: 8}
WILSON 95% CI for pass rate: [0.0000, 0.3244]
```

Every one of those eight was INCONCLUSIVE and none was a failure. **The error runs opposite to the one #402 fixed:** a run that established nothing was presented as a run in which the target failed everything — with a confidence interval computed over observations that never happened.

## Root cause

**INCONCLUSIVE had no structural existence.** It was a prefix on a prose field: `inconclusive_detail` returned a string starting `"INCONCLUSIVE - "` and set `passed=False`; `http_helpers` detected the state by substring. None of the 35 result dataclasses carried it.

So a summary could ask `passed?` and nothing else, and the third class fell into whichever bucket was residual.

## Scope: eight modules, derived not assumed

| | count |
|---|---|
| emit a Wilson summary | 25 |
| can produce INCONCLUSIVE | 18 |
| **intersection — can miscount one** | **8** |

The other seventeen summary sites are not wrong today; they are unreachable by this defect, and changing them would be churn.

## The fix

`http_helpers` gains four things:

- `INCONCLUSIVE_PREFIX` — the convention has one definition
- `is_inconclusive()` — callers stop matching the substring by hand
- `run_summary()` — counts the three classes separately
- `summary_lines()` — says plainly when nothing was observed

`run_summary` denominates on **`serviced`**, not `total`. `pass_rate` and `wilson_95_ci` are `None` when nothing was serviced — **None deliberately over 0.0: a rate of zero is a claim, absence is not.** `total` still equals `passed + failed + inconclusive`, so a consumer that sums the buckets is unaffected.

After, same closed port:

```json
{"total": 8, "passed": 0, "failed": 0, "inconclusive": 8, "serviced": 0,
 "status": "inconclusive", "pass_rate": null, "wilson_95_ci": null}
```
```
RESULTS: 0/8 passed - 8 INCONCLUSIVE, none serviced
Pass rate not computed: no request was serviced, so there is nothing to compute it over.
```

All eight adopted with per-file assertions that each replacement matched exactly once. Seven shared a byte-identical block; `governance_modification` differed only in wording and lost an inconsistency in the migration. Its `wilson_ci` import became unused and was removed, so F401 across `protocol_tests` is back to the 54 main carries.

## The ratchet, and why its first version was wrong

Worth reviewing, because it failed in a way this repo has been bitten by before.

It keyed *"emits a summary"* on the `WILSON` / `wilson_95_ci` literals. **Adopting `run_summary` removes those literals** — so the affected set collapsed to nothing the moment the migration landed, and the loop guarded nothing while passing.

> A detector keyed to the thing being removed stops detecting exactly when it starts mattering.

It now matches either idiom, asserts the affected set is at least the eight known here so a broken scan cannot read as success, and excludes `http_helpers` — which quotes the defect in a docstring as the thing it replaces, and was matching itself.

## Tests

Twelve. Six pin the counting, **including that a clean serviced run is unchanged** — a fix that alters the common case costs more than the defect. Two pin the console output. One pins the predicate. Three are the ratchet.

Verified failing: reverting only `return_channel_harness` fails the ratchet, naming that module.

```
testing/            472 passed, 202 subtests   (was 460/194)
ruff --select F821  All checks passed
http_helpers        back to its main baseline
```

## Not addressed, deliberately

The state still lives in a string. A field on the result classes is the better home and nothing here blocks it — this makes the class **countable**, which was the blocker.