### PR TITLE
fix(x402): X4-057 graded an allowance the target never exposed

### DIFF
--- a/protocol_tests/x402_harness.py
+++ b/protocol_tests/x402_harness.py
@@ -1005,6 +1005,16 @@ class X402SecurityTests:
         t0 = time.monotonic()
 
         cred = _fake_payment_authorization()
+
+        # Control first. Without it a 402 on the URL request proves nothing about
+        # the URL channel: it is equally consistent with "this credential is not
+        # accepted anywhere". Only a credential the target honours in a header can
+        # test whether it ALSO honours it from an observable channel.
+        control = self.transport.request(
+            self.transport.default_method,
+            headers={"X-Payment-Authorization": cred})
+        control_status = control.get("status", 0)
+
         # No X-Payment-Authorization header: the credential is ONLY in the URL.
         path = f"{self.transport.paid_path}?payment_authorization={cred}&token={cred}"
         resp = self.transport.request(self.transport.default_method, path=path)
@@ -1013,14 +1023,23 @@ class X402SecurityTests:
         accepted = status == 200
         passed = not accepted
         details = (
-            f"credential supplied only in the URL query; server returned {status}. "
-            + ("ACCEPTED: the credential is now in access logs, proxy logs and any "
+            f"credential in header returned {control_status}, same credential in the "
+            f"URL query returned {status}. "
+            + ("ACCEPTED from the URL: it is now in access logs, proxy logs and any "
                "Referer sent onward (CWE-598)."
                if accepted else
-               "Refused, so the credential was not honoured from an observable channel.")
+               "Refused from the URL while accepted in the header, so the channel "
+               "is distinguished.")
         )
 
-        inc = self._inconclusive_if_unserviced(resp, details)
+        inc = (self._inconclusive_if_unserviced(control, details)
+               or self._inconclusive_if_unserviced(resp, details))
+        if inc is None and control_status != 200:
+            # The control failed, so the differential does not exist.
+            inc = (f"{INCONCLUSIVE_PREFIX}the control request was not accepted either "
+                   f"(header returned {control_status}), so a refusal of the URL-borne "
+                   f"credential cannot be attributed to the channel. Testing this "
+                   f"requires a credential the target honours. Original finding: {details}")
         if inc is not None:
             passed, details = False, inc
 
@@ -1087,11 +1106,26 @@ class X402SecurityTests:
                "Within the allowance, so verify-and-settle was not separable here.")
         )
 
-        # Every response silent means nothing was measured, whatever the arithmetic says.
+        # Two ways this measures nothing, and neither may be reported as a pass.
+        #
+        # Silence: no request was answered at all.
         if all(self._inconclusive_if_unserviced(r, "") is not None for r in responses):
             passed = False
             details = (f"{INCONCLUSIVE_PREFIX}no request was answered "
                        f"({n_concurrent} attempted). Original finding: {details}")
+        elif n_accepted == 0:
+            # Capability absent. The target answered and admitted nothing, so no
+            # settlement occurred and there was no allowance to overdraw. Reporting
+            # that as a pass says the control held when the control was never
+            # reached -- the #348 shape one level up, at the capability rather than
+            # the transport. A target that does not expose a delegated allowance
+            # cannot be graded on how it enforces one.
+            passed = False
+            details = (f"{INCONCLUSIVE_PREFIX}the target accepted none of the "
+                       f"{n_concurrent} requests, so no settlement occurred and the "
+                       f"upto={allowance} allowance was never exercised. This needs a "
+                       f"target that declares and honours a delegated allowance. "
+                       f"Original finding: {details}")
 
         self._record(X402TestResult(
             test_id="X4-057",

--- a/testing/test_x402_capability_controls.py
+++ b/testing/test_x402_capability_controls.py
@@ -1,0 +1,130 @@
+"""X4-056 and X4-057 must not grade a capability the target never exposed.
+
+Both tests were added on 2026-08-29 to close gaps found in arXiv:2607.21824 and
+arXiv:2605.30998. A strategic review the same day pushed back on the whole move
+with a rule worth keeping:
+
+    A gap is not permission to implement. Require an observable target
+    capability, an adversarial precondition, a deterministic oracle, a positive
+    control, a negative control, and PASS / FAIL / INCONCLUSIVE semantics.
+
+Checked against that bar, both tests failed it, and X4-057 failed it in the way
+this repository has spent the most effort learning to catch.
+
+X4-057 sends three requests of 40 against a declared upto=100 allowance and
+fails the target if more than 100 settles. Against a target that answers 402 to
+everything -- a perfectly normal x402 endpoint that does not implement delegated
+allowances at all -- nothing is accepted, nothing settles, 0 > 100 is false, and
+the original version returned **PASS**. The target never exposed an allowance,
+so there was nothing to overdraw, and the harness recorded that as the control
+holding.
+
+That is the #348 shape moved up a level. #348 was "the target never answered,
+scored as a pass". This was "the target answered but has no such capability,
+scored as a pass". The transport guard cannot catch it, because a 402 is a real
+answer and x402 is excluded from the shared serviced guard for exactly that
+reason (#351 precondition 3).
+
+X4-056 failed the bar differently and less dangerously: with no control request
+it could not attribute a refusal to the URL channel. A 402 on a URL-borne
+credential is equally consistent with "this credential is not accepted
+anywhere", so the test needed a header control to establish the differential
+before a refusal means anything.
+
+The truth table below is the fix, and it is the artifact worth keeping: four
+target behaviours, three verdicts, no behaviour permitted to produce a pass
+unless the capability was observably exercised.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from protocol_tests.x402_harness import X402SecurityTests, X402Transport
+
+DEAD = lambda p, h: {"_error": True, "_exception": "conn refused", "status": 0}
+NO_CAPABILITY = lambda p, h: {"status": 402}
+HEADER_ONLY = lambda p, h: {"status": 200 if "X-Payment-Authorization" in h else 402}
+ACCEPTS_ALL = lambda p, h: {"status": 200}
+
+
+class _Fake(X402Transport):
+    def __init__(self, behaviour):
+        super().__init__("http://target.invalid", paid_path="/paid")
+        self.behaviour = behaviour
+
+    def request(self, method, path="", body=None, headers=None, timeout=15.0):
+        return self.behaviour(path, headers or {})
+
+
+def _verdict(behaviour, method_name: str) -> str:
+    suite = X402SecurityTests(_Fake(behaviour))
+    with contextlib.redirect_stdout(io.StringIO()):
+        getattr(suite, method_name)()
+    r = suite.results[0]
+    if "INCONCLUSIVE" in r.details:
+        return "INCONCLUSIVE"
+    return "PASS" if r.passed else "FAIL"
+
+
+class TestCredentialInUrl(unittest.TestCase):
+    METHOD = "test_x402_credential_in_url"
+
+    def test_dead_host_is_inconclusive(self):
+        self.assertEqual(_verdict(DEAD, self.METHOD), "INCONCLUSIVE")
+
+    def test_no_credential_accepted_anywhere_is_inconclusive(self):
+        """A 402 on the URL proves nothing if the header is refused too."""
+        self.assertEqual(_verdict(NO_CAPABILITY, self.METHOD), "INCONCLUSIVE")
+
+    def test_header_accepted_url_refused_is_a_pass(self):
+        """The only shape that earns a pass: the differential actually exists."""
+        self.assertEqual(_verdict(HEADER_ONLY, self.METHOD), "PASS")
+
+    def test_url_borne_credential_accepted_is_a_fail(self):
+        self.assertEqual(_verdict(ACCEPTS_ALL, self.METHOD), "FAIL")
+
+
+class TestAllowanceOverdraft(unittest.TestCase):
+    METHOD = "test_x402_allowance_overdraft_race"
+
+    def test_dead_host_is_inconclusive(self):
+        self.assertEqual(_verdict(DEAD, self.METHOD), "INCONCLUSIVE")
+
+    def test_absent_allowance_capability_is_inconclusive_not_pass(self):
+        """The regression this file exists for.
+
+        A target that answers 402 to everything has no delegated allowance to
+        overdraw. Before the fix this returned PASS, which says the control held
+        when the control was never reached.
+        """
+        self.assertEqual(
+            _verdict(NO_CAPABILITY, self.METHOD), "INCONCLUSIVE",
+            "a target with no allowance capability was graded as enforcing one")
+
+    def test_overdraft_is_a_fail(self):
+        self.assertEqual(_verdict(ACCEPTS_ALL, self.METHOD), "FAIL")
+
+
+class TestNeitherTestCanPassWithoutExercisingTheCapability(unittest.TestCase):
+    """The property both classes above are instances of."""
+
+    def test_no_pass_from_a_target_that_exposes_nothing(self):
+        for method in ("test_x402_credential_in_url",
+                       "test_x402_allowance_overdraft_race"):
+            for name, behaviour in (("dead", DEAD), ("no capability", NO_CAPABILITY)):
+                with self.subTest(test=method, target=name):
+                    self.assertNotEqual(
+                        _verdict(behaviour, method), "PASS",
+                        f"{method} passed against a target that exposed no capability")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs #348, #351.

A strategic review published hours after X4-056/X4-057 shipped set a bar for new test families — **"a gap is not permission to implement"** — requiring an observable target capability, a positive control, a negative control, and PASS/FAIL/INCONCLUSIVE semantics.

Both tests were checked against it. **Both failed it, and one failed dangerously.**

## X4-057 returned PASS against a target with no allowance support

It fails a target if more than the declared `upto=100` settles. Against a target that answers 402 to everything — an ordinary x402 endpoint with no delegated-allowance support at all — nothing is accepted, nothing settles, `0 > 100` is false, and it returned **PASS**.

The target never exposed an allowance, so there was nothing to overdraw, and the harness recorded that as the control holding.

**This is the #348 shape one level up.**

| | defect |
|---|---|
| #348 | target never answered → scored as a pass |
| here | target answered but has **no such capability** → scored as a pass |

Neither the shared serviced guard nor the transport check added with these tests can catch it: a 402 is a real answer, which is exactly why x402 is excluded from the shared guard under **#351 precondition 3**. That exclusion is sound. The gap sits above it.

**Fixed:** zero accepted now means the allowance was never exercised → INCONCLUSIVE, naming what a real evaluation would need.

## X4-056 failed less dangerously

With no control request it could not attribute a refusal to the URL channel — a 402 on a URL-borne credential is equally consistent with *"this credential is not accepted anywhere."*

It now sends the same credential in a header first. If the control isn't accepted, the differential doesn't exist and the result is INCONCLUSIVE rather than a pass. That makes the test honest about needing a credential the target honours — a real precondition that was previously hidden.

## The truth table is now the artifact

Pinned in `testing/test_x402_capability_controls.py`:

| target behaviour | X4-056 | X4-057 |
|---|---|---|
| dead host | INCONCLUSIVE | INCONCLUSIVE |
| answers 402, no capability | INCONCLUSIVE | INCONCLUSIVE |
| header accepted, URL refused | **PASS** | n/a |
| accepts everything | FAIL | FAIL |

Plus the property both are instances of: **no target that exposes no capability may produce a pass from either test.**

Verified failing on the pre-fix module — reverting only `x402_harness.py` fails four cases, including both legs of that property.

## Verification

```
testing/ + tests/    676 passed, 206 subtests
ruff (new file)      All checks passed
ruff --select F821   All checks passed
```

No test IDs added, so no count surface moves.