### PR TITLE
docs: adopt the four usable items from the 2026-08-29 strategic review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,37 @@ These recur across rounds — always check:
    `inconclusive_detail()` in `http_helpers.py` understands both so individual
    modules do not have to.
 
+9. **A gap found in someone else's work is not permission to implement a test.**
+   Adopted 2026-08-29 from a strategic review, after it caught a defect in tests
+   written an hour earlier. Before adding a test family, require all six:
+
+   ```text
+   an observable target capability
+   an adversarial precondition
+   a deterministic oracle
+   a positive control      (a target shape that must PASS)
+   a negative control      (a target shape that must FAIL)
+   PASS / FAIL / INCONCLUSIVE semantics for each
+   ```
+
+   The positive control is the one that gets skipped, and skipping it is how
+   `X4-057` shipped returning PASS against a target with no delegated-allowance
+   support at all: nothing accepted, nothing settled, so nothing overdrawn, so
+   "the control held". That is item 8 one level up — not *the target never
+   answered*, but *the target answered and has no such capability*. The serviced
+   guard cannot catch it, because the answer was real. Write the truth table
+   before the test; see `testing/test_x402_capability_controls.py`.
+
+10. **The progress metric is the unclassified remainder, not the test count.**
+    Every module that records a target response must end up guarded, reviewed,
+    carrying a documented protocol-specific exception, or declared unsupported.
+    The number to move is `len(UNREVIEWED)` in `testing/test_serviced_guard.py`.
+
+    A rising test count is compatible with every verdict in the suite being
+    unsound, and this repository has shipped a released version where that was
+    partly true. Do not report coverage growth as progress while the remainder
+    is non-empty.
+
 ## Docker
 
 Docker is available. Ask to turn it on if not found.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,14 @@
 
 **Even if an agent is properly authenticated and authorized, can it still be manipulated into unsafe or policy-violating behavior?**
 
-608 executable security tests across 43 test-bearing modules on `main` (verified 2026-08-29 via `scripts/count_tests.py`; the v4.15.0 release carries 603). MCP + A2A + L402 + x402 wire-protocol testing, plus UCP/ACP merchant-journey, AP2 mandate-chain, Fireblocks x402 hardening, Visa TAP / Mastercard Agentic Token funding-instrument, and denial-of-settlement finality conformance across the full agentic-payments stack. Decision-layer attack scenarios. One `pip install` away.
+**A test that did not reach the target is not a passing security test.**
+
+This harness sends adversarial traffic at a live endpoint, records what the target actually
+serviced, and reports PASS, FAIL or **INCONCLUSIVE**. It will not convert a request the target
+never answered — or a capability the target never exposed — into evidence that a control held.
+That distinction is enforced by `testing/test_serviced_guard.py` and
+`testing/test_x402_capability_controls.py` rather than asserted here, and the repairs that put
+it there are in [CHANGELOG.md](CHANGELOG.md).
 
 ```
 $ agent-security test mcp --url http://localhost:8080/mcp
@@ -26,6 +33,8 @@ Results: 8/10 passed (80% pass rate) - see report.json
 > Illustrative output. A target the harness cannot reach, or that answers without
 > servicing the request, reports **INCONCLUSIVE** — never PASS. See
 > [v4.13.1](CHANGELOG.md) for why that distinction is enforced rather than assumed.
+
+608 executable security tests across 43 test-bearing modules on `main` (verified 2026-08-29 via `scripts/count_tests.py`; the v4.15.0 release carries 603). MCP + A2A + L402 + x402 wire-protocol testing, plus UCP/ACP merchant-journey, AP2 mandate-chain, Fireblocks x402 hardening, Visa TAP / Mastercard Agentic Token funding-instrument, and denial-of-settlement finality conformance across the full agentic-payments stack. Decision-layer attack scenarios. One `pip install` away.
 
 If this evidence discipline is useful in your agent-security work, **star this
 repository to follow releases**.

--- a/docs/RELATED-WORK.md
+++ b/docs/RELATED-WORK.md
@@ -2,6 +2,44 @@
 
 This harness performs executable adversarial testing at the implementation and evidence surface of agent protocols: it sends real adversarial payloads and negative vectors and checks whether an implementation makes the correct accept/reject decision. It is complementary to formal-conformance, capability-binding, and delegation-protocol research, not a substitute for it. This page cites the closest work and states, honestly, where this project overlaps and where it differs.
 
+## Where this sits
+
+Four bodies of work below occupy adjacent layers. Reading them as a stack is more
+useful than reading them as competitors, and it is the honest description:
+
+```text
+formal invariants          AgentThread / AgentRFC     prove and model protocol
+                                                      invariants, localise which
+                                                      party owns each control
+
+platform benchmark         AIP-Bench / PCAT           measure named platform
+                                                      implementations by
+                                                      attack-success rate
+
+endpoint execution         THIS HARNESS               assert protocol semantics
+                                                      against an arbitrary target
+                                                      and grade the retained
+                                                      execution evidence
+
+receipt conformance        Receipt Verifier           check that a verifier
+                           Conformance Corpus v0      reproduces expected verdicts
+                                                      over a portable corpus
+
+evidence sufficiency       DEMM-Bench                 determine whether retained
+                                                      records support the claims
+                                                      made from them
+```
+
+This project owns one row. It does not compete on formalisation, it is not first
+to deterministic agentic-commerce benchmarking, it does not hold the largest
+receipt-verifier corpus, and its evidence-class taxonomy is not the only
+evidence-sufficiency framework. What it does is send hostile traffic at a live
+endpoint and refuse to convert an unanswered request, or an unexposed capability,
+into a passing security result.
+
+Added 2026-08-29. If a claim anywhere in this repository reads as owning more than
+one row of that stack, it is wrong and should be corrected here first.
+
 ## This project's methodology note
 
 The receipt claim-level module (RCL-001..011) is described in a short position-and-methodology note, **"Claim-Level Negative Testing for Agent-Governance Evidence"** (Saleme, 2026): a four-property decomposition of an action receipt (integrity/provenance; execution occurrence and outcome; authorization; check execution and integrity), and executable negative vectors that construct correctly signed but semantically unsupported receipts and show a claim-level verifier rejecting them. Concept DOI: [10.5281/zenodo.21418701](https://doi.org/10.5281/zenodo.21418701). It positions this harness as the executable complement to the formal-conformance and capability-binding work below.


### PR DESCRIPTION
The review's commercial half is not actionable while Michael is employed at Salesforce, so Choice C, the go-to-market section, and the design-partner outcome are **rejected rather than deferred**. Four items change what the repository does.

## `CLAUDE.md` — two new conventions

Placed beside items 7 and 8, because they are the same kind of rule: things that stop a defect *class* rather than fix an instance.

**Item 9 — a gap is not permission to implement**, with the six preconditions a new test family must meet. It is recorded because it already earned its place: applied to X4-056 and X4-057 an hour after they merged, it found that **X4-057 returned PASS against a target with no delegated-allowance support at all**. Nothing accepted, nothing settled, nothing overdrawn, so "the control held."

The positive control is the precondition that gets skipped — and that is exactly what skipping it produces.

**Item 10 — the progress metric is the unclassified remainder.** The number to move is `len(UNREVIEWED)` in `testing/test_serviced_guard.py`, currently **19**, not the test count. A rising count is compatible with every verdict in the suite being unsound, and this repository has shipped a released version where that was partly true.

## `README.md` — stop leading with the count

Now leads with **"a test that did not reach the target is not a passing security test"**, which the repository has spent this week earning rather than asserting, and which points at the two suites that enforce it. Count and protocol breadth move below the sample output.

The INCONCLUSIVE note was already in the README, but sat *under* the illustrative output — the wrong order for the one claim that distinguishes this from a scanner.

## `docs/RELATED-WORK.md` — the stack, as a map not a matrix

```text
formal invariants      AgentThread / AgentRFC
platform benchmark     AIP-Bench / PCAT
endpoint execution     THIS HARNESS
receipt conformance    Receipt Verifier Conformance Corpus v0
evidence sufficiency   DEMM-Bench
```

**This project owns one row.** The section says so, and says that any claim elsewhere in the repository reading as more than one row is wrong and should be corrected there first.

## Verification

```
testing/ + tests/          676 passed, 206 subtests
verify_release_claims.py   5 passed, 0 not reproduced
validate_owasp_agentic_mapping.py   PASS
```

No test IDs added, no count surface moved.