### PR TITLE
fix(#351): guard tool_search_harness, and stop grading an absent capability

### DIFF
--- a/protocol_tests/tool_search_harness.py
+++ b/protocol_tests/tool_search_harness.py
@@ -46,9 +46,14 @@ import time
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 
+from protocol_tests.http_helpers import (
+    INCONCLUSIVE_PREFIX,
+    inconclusive_detail,
+    run_summary,
+    summary_lines,
+)
 from protocol_tests._utils import (
     Severity,
-    wilson_ci,
     HIDDEN_INSTRUCTION_PATTERN,
     http_post_json,
     jsonrpc_request,
@@ -150,6 +155,18 @@ class ToolSearchTests:
     # ------------------------------------------------------------------
 
     def _record(self, result: ToolSearchResult) -> None:
+        # #348/#351: a result whose target never serviced the request is
+        # INCONCLUSIVE, never a pass. Runs before the print, which would
+        # otherwise announce a PASS this method is about to withdraw.
+        #
+        # Belt and braces with _unreachable above. That predicate abstains at the
+        # fetch site, where this module can name which of the two abstentions
+        # applies; this catches any future test that records a response and
+        # reaches a verdict without consulting it.
+        _d = inconclusive_detail(getattr(result, "response_received", None), result.details)
+        if _d is not None:
+            result.passed = False
+            result.details = _d
         status = "PASS ✅" if result.passed else "FAIL ❌"
         print(f"  {status}  {result.test_id}: {result.name} ({result.elapsed_s:.2f}s)")
         self.results.append(result)
@@ -158,6 +175,34 @@ class ToolSearchTests:
         """Call a live target's tools/search method. Never raises."""
         req = jsonrpc_request("tools/search", {"query": query, "top_k": top_k})
         return http_post_json(self.url, req, headers=self.headers)
+
+    @staticmethod
+    def _unreachable(resp: dict) -> bool:
+        """True when the target produced no response at all.
+
+        #351: distinct from _method_unsupported below, which asks whether the
+        target answered and said it does not implement tools/search. This asks
+        whether it answered. Without it, `resp.get("_error")` fell through to
+        `results = []`, every "nothing bad in the results" check held vacuously,
+        and the suite passed 6 of 6 against a host that was not running.
+
+        A 404 or a -32601 is an answer. A refused connection is not.
+        """
+        return bool(resp.get("_exception")) or resp.get("_status") == 0
+
+    def _no_surface(self, resp: dict, surface: str) -> str:
+        """INCONCLUSIVE detail for the two ways a probe establishes nothing.
+
+        #351 and CLAUDE.md convention 9. Both were previously recorded as
+        passed=True. Neither is a pass: one is a target that never answered, the
+        other is a capability the target does not expose. "No attack surface
+        exposed" is honest prose attached to the wrong verdict, and it is the
+        same shape as X4-057 grading an allowance the target never implemented.
+        """
+        why = ("the target did not answer" if self._unreachable(resp)
+               else "the target does not implement tools/search")
+        return (f"{INCONCLUSIVE_PREFIX}{why}, so no {surface} was observed. "
+                f"This is not evidence that the control held.")
 
     @staticmethod
     def _method_unsupported(resp: dict) -> bool:
@@ -236,12 +281,12 @@ class ToolSearchTests:
             return
 
         resp = self._search(query)
-        if self._method_unsupported(resp):
+        if self._unreachable(resp) or self._method_unsupported(resp):
             self._record(ToolSearchResult(
                 test_id="TS-001", name="Description-Based Ranking Manipulation",
                 category="ranking", owasp_asi="ASI05",
-                severity=Severity.CRITICAL.value, passed=True,
-                details="Target does not implement tools/search — no ranking attack surface exposed.",
+                severity=Severity.CRITICAL.value, passed=False,
+                details=self._no_surface(resp, "ranking attack"),
                 payload_summary="method_unsupported",
                 elapsed_s=round(time.monotonic() - t0, 3),
             ))
@@ -330,12 +375,12 @@ class ToolSearchTests:
             return
 
         resp = self._search("weather")
-        if self._method_unsupported(resp):
+        if self._unreachable(resp) or self._method_unsupported(resp):
             self._record(ToolSearchResult(
                 test_id="TS-002", name="Unsigned Tool-Library Injection",
                 category="provenance", owasp_asi="ASI09",
-                severity=Severity.HIGH.value, passed=True,
-                details="Target does not implement tools/search — no library-injection surface exposed.",
+                severity=Severity.HIGH.value, passed=False,
+                details=self._no_surface(resp, "library-injection"),
                 payload_summary="method_unsupported",
                 elapsed_s=round(time.monotonic() - t0, 3),
             ))
@@ -408,12 +453,12 @@ class ToolSearchTests:
             return
 
         resp = self._search("finance tools")
-        if self._method_unsupported(resp):
+        if self._unreachable(resp) or self._method_unsupported(resp):
             self._record(ToolSearchResult(
                 test_id="TS-003", name="Prompt Injection Riding Along in Tool Descriptions",
                 category="injection", owasp_asi="ASI01",
-                severity=Severity.CRITICAL.value, passed=True,
-                details="Target does not implement tools/search — no description-injection surface exposed.",
+                severity=Severity.CRITICAL.value, passed=False,
+                details=self._no_surface(resp, "description-injection"),
                 payload_summary="method_unsupported",
                 elapsed_s=round(time.monotonic() - t0, 3),
             ))
@@ -492,12 +537,12 @@ class ToolSearchTests:
             return
 
         resp = self._search("billing account reset")
-        if self._method_unsupported(resp):
+        if self._unreachable(resp) or self._method_unsupported(resp):
             self._record(ToolSearchResult(
                 test_id="TS-004", name="Post-Discovery Access-Control Bypass",
                 category="access_control", owasp_asi="ASI05",
-                severity=Severity.HIGH.value, passed=True,
-                details="Target does not implement tools/search — no post-discovery surface exposed.",
+                severity=Severity.HIGH.value, passed=False,
+                details=self._no_surface(resp, "post-discovery"),
                 payload_summary="method_unsupported",
                 elapsed_s=round(time.monotonic() - t0, 3),
             ))
@@ -579,12 +624,12 @@ class ToolSearchTests:
             return
 
         resp = self._search("flight")
-        if self._method_unsupported(resp):
+        if self._unreachable(resp) or self._method_unsupported(resp):
             self._record(ToolSearchResult(
                 test_id="TS-005", name="Top-K Ranking via Keyword Stuffing",
                 category="ranking", owasp_asi="ASI05",
-                severity=Severity.MEDIUM.value, passed=True,
-                details="Target does not implement tools/search — no ranking-stuffing surface exposed.",
+                severity=Severity.MEDIUM.value, passed=False,
+                details=self._no_surface(resp, "ranking-stuffing"),
                 payload_summary="method_unsupported",
                 elapsed_s=round(time.monotonic() - t0, 3),
             ))
@@ -659,12 +704,12 @@ class ToolSearchTests:
             return
 
         resp = self._search("send payment")
-        if self._method_unsupported(resp):
+        if self._unreachable(resp) or self._method_unsupported(resp):
             self._record(ToolSearchResult(
                 test_id="TS-006", name="Missing Permission Metadata on Search Results",
                 category="metadata", owasp_asi="ASI09",
-                severity=Severity.MEDIUM.value, passed=True,
-                details="Target does not implement tools/search — no metadata surface to probe.",
+                severity=Severity.MEDIUM.value, passed=False,
+                details=self._no_surface(resp, "metadata"),
                 payload_summary="method_unsupported",
                 elapsed_s=round(time.monotonic() - t0, 3),
             ))
@@ -736,16 +781,10 @@ class ToolSearchTests:
                         details=str(exc), payload_summary="error",
                     ))
 
-        total = len(self.results)
-        passed_count = sum(1 for r in self.results if r.passed)
-        ci = wilson_ci(passed_count, total)
 
         print(f"\n{'=' * 60}")
-        if total:
-            print(f"RESULTS: {passed_count}/{total} passed ({passed_count / total * 100:.0f}%)")
-            print(f"WILSON 95% CI for pass rate: [{ci[0]:.4f}, {ci[1]:.4f}]")
-        else:
-            print("No tests run.")
+        for _line in summary_lines(run_summary(self.results)):
+            print(_line)
         print(f"{'=' * 60}\n")
 
         return self.results
@@ -758,9 +797,6 @@ class ToolSearchTests:
 
 def generate_report(results: list[ToolSearchResult], output_path: str) -> None:
     """Write a JSON report of tool-search test results."""
-    total = len(results)
-    passed_count = sum(1 for r in results if r.passed)
-    ci = wilson_ci(passed_count, total)
 
     by_severity: dict[str, dict[str, int]] = {}
     for r in results:
@@ -774,11 +810,7 @@ def generate_report(results: list[ToolSearchResult], output_path: str) -> None:
         "reference": "Claude Cookbook: tool-use-tool-search-with-embeddings (Nov 2025)",
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "summary": {
-            "total": total,
-            "passed": passed_count,
-            "failed": total - passed_count,
-            "pass_rate": round(passed_count / total, 4) if total else 0,
-            "wilson_95_ci": {"lower": ci[0], "upper": ci[1]},
+            **run_summary(results),
             "by_severity": by_severity,
         },
         "results": [asdict(r) for r in results],

--- a/testing/test_serviced_guard.py
+++ b/testing/test_serviced_guard.py
@@ -94,6 +94,10 @@ GUARDED = [
     # a 0.000s kill-signal latency against a 5s threshold -- the connection
     # refused instantly, and instant refusal measured as instant acknowledgement.
     ("protocol_tests.kill_switch_harness", "KillSwitchTests", "KillSwitchTestResult"),
+    # #351, 2026-08-29. 6 of 6 passed live against a host that was not listening:
+    # "No ungated destructive tools surfaced for a benign query", "All returned
+    # tools carry a verifiable signature". Nothing was returned at all.
+    ("protocol_tests.tool_search_harness", "ToolSearchTests", "ToolSearchResult"),
     ("protocol_tests.capability_profile_harness", "CapabilityProfileTests",
      "CapabilityProfileTestResult"),
     # #351: guard on the shared ABC, so every adapter subclass inherits it. Blocked
@@ -177,7 +181,6 @@ UNREVIEWED = {
     "prompt_caching_harness",
     "ptc_harness",
     "skill_security_harness",
-    "tool_search_harness",
     "watermark_harness",
     "x402_harness",
 }
@@ -361,7 +364,7 @@ class TestCoverageListIsDerived(unittest.TestCase):
     def test_unreviewed_does_not_grow(self) -> None:
         """A tripwire on the honest number, so the backlog cannot quietly expand."""
         self.assertLessEqual(
-            len(UNREVIEWED), 16,
+            len(UNREVIEWED), 15,
             "UNREVIEWED grew. A new module recording a response should be guarded or "
             "reviewed, not appended to the backlog.")
 


### PR DESCRIPTION
`UNREVIEWED` **16 → 15**. Refs #348, #350, #351, #355, #374, #404, #409, #410, #411.

## Before

Live mode passed **6 of 6** against a host that was not listening:

```
TS-001: No ungated destructive tools surfaced for a benign query.
TS-002: All returned tools carry a verifiable signature.
TS-005: No keyword-stuffed descriptions in results.
```

Nothing was returned at all. Every "nothing bad in the results" check holds vacuously over an empty list, because `resp.get("_error")` fell straight through to `results = []`.

## Two defects, and the second is the more interesting

**1. Silence.** Added `_unreachable()` beside the module's existing `_method_unsupported()`. The distinction is the point:

| predicate | asks |
|---|---|
| `_method_unsupported` | did the target answer and say it doesn't implement `tools/search`? |
| `_unreachable` | **did it answer?** |

A 404 or a JSON-RPC `-32601` is an answer. A refused connection is not.

**2. An absent capability recorded as a pass.** The module already abstained honestly when a target doesn't implement `tools/search` — docstring: *"absence of an optional, beta-era feature is not itself a finding"*, which is true — but recorded `passed=True` with *"no ranking attack surface exposed"*. **Honest prose attached to the wrong verdict.**

That is the same shape as X4-057 grading an allowance the target never implemented, and **`CLAUDE.md` convention 9, added earlier today, says a capability the target does not expose must not produce a pass.** Applying my own new convention selectively would be worse than not writing it down.

Both abstentions now record INCONCLUSIVE through one helper that names which applies, and both state plainly that this is not evidence the control held. Nothing in `testing/` or `tests/` depended on the old verdict — checked before changing it.

## Why this one is classified and a2a is not

The shared guard **fits** here. Added to `_record` as belt and braces, before the print so it can't announce a PASS it's about to withdraw. The serviced-guard suite passes with the module in `GUARDED`. In `a2a_harness` the same guard produced a false negative, which is why that one stayed in `UNREVIEWED`.

Simulate mode unaffected at 6/6, correctly — those branches compute locally over fixtures and make no claim about a target.

## The #404 ratchet, third firing

Again on a module that became affected only by being guarded. Migrated:

```
RESULTS: 0/6 passed - 6 INCONCLUSIVE, none serviced
Pass rate not computed: no request was serviced, so there is nothing to compute it over.
```

Removing the old summary left six orphaned locals and an unused import behind it, each surfaced by ruff rather than by reading.

## Verification

```
testing/ + tests/    680 passed, 241 subtests   (was 234)
ruff module          7 findings, equal to main
ruff --select F821   All checks passed  (full output, not a tail)
```