### PR TITLE
fix(#351): guard the long tail. incident-response, benchmark-integrity, watermark

### DIFF
--- a/protocol_tests/benchmark_integrity_harness.py
+++ b/protocol_tests/benchmark_integrity_harness.py
@@ -33,6 +33,7 @@ Requires: Python 3.10+, no external dependencies for core tests.
 from __future__ import annotations
 
 import argparse
+from protocol_tests.http_helpers import inconclusive_detail, run_summary, summary_lines
 import json
 import os
 import re
@@ -42,7 +43,7 @@ import uuid
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 
-from protocol_tests._utils import Severity, wilson_ci, http_post_json
+from protocol_tests._utils import Severity, http_post_json
 
 
 # ---------------------------------------------------------------------------
@@ -91,6 +92,12 @@ class BenchmarkIntegrityTests:
         self.results: list[BenchmarkIntegrityResult] = []
 
     def _record(self, result: BenchmarkIntegrityResult):
+        # #348/#351: a result whose target never serviced the request is
+        # INCONCLUSIVE, never a pass. Enforced here so a new test cannot forget it.
+        _d = inconclusive_detail(getattr(result, "response_received", None), result.details)
+        if _d is not None:
+            result.passed = False
+            result.details = _d
         self.results.append(result)
         status = "PASS \u2705" if result.passed else "FAIL \u274c"
         print(f"  {status} {result.test_id}: {result.name} ({result.elapsed_s:.2f}s)")
@@ -723,16 +730,9 @@ class BenchmarkIntegrityTests:
                         payload_summary="error",
                     ))
 
-        total = len(self.results)
-        passed = sum(1 for r in self.results if r.passed)
-        ci = wilson_ci(passed, total)
-
         print(f"\n{'='*60}")
-        if total:
-            print(f"RESULTS: {passed}/{total} passed ({passed/total*100:.0f}%)")
-            print(f"WILSON 95% CI for pass rate: [{ci[0]:.4f}, {ci[1]:.4f}]")
-        else:
-            print("No tests run")
+        for _line in summary_lines(run_summary(self.results)):
+            print(_line)
         print(f"{'='*60}\n")
 
         return self.results
@@ -775,9 +775,6 @@ def load_corpus():
 
 def generate_report(results: list[BenchmarkIntegrityResult], output_path: str):
     """Write a JSON report of benchmark integrity test results."""
-    total = len(results)
-    passed = sum(1 for r in results if r.passed)
-    ci = wilson_ci(passed, total)
 
     # Severity breakdown
     by_severity: dict[str, dict[str, int]] = {}
@@ -796,11 +793,7 @@ def generate_report(results: list[BenchmarkIntegrityResult], output_path: str):
         "reference": "UC Berkeley RDI 2026 (Wang et al.) + METR Autonomy Evaluation Framework 2025",
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "summary": {
-            "total": total,
-            "passed": passed,
-            "failed": total - passed,
-            "pass_rate": round(passed / total, 4) if total else 0,
-            "wilson_95_ci": {"lower": ci[0], "upper": ci[1]},
+            **run_summary(results),
             "by_severity": by_severity,
         },
         "results": [asdict(r) for r in results],

--- a/protocol_tests/incident_response_harness.py
+++ b/protocol_tests/incident_response_harness.py
@@ -36,6 +36,8 @@ from datetime import datetime, timezone
 from enum import Enum
 import urllib.request
 
+from protocol_tests.http_helpers import inconclusive_detail, run_summary, summary_lines
+
 
 # ---------------------------------------------------------------------------
 # Wilson score CI (inlined for zero-dep)
@@ -216,6 +218,12 @@ class IncidentResponseTests:
         self.results: list[IncidentResponseTestResult] = []
 
     def _record(self, result: IncidentResponseTestResult):
+        # #348/#351: a result whose target never serviced the request is
+        # INCONCLUSIVE, never a pass. Enforced here so a new test cannot forget it.
+        _d = inconclusive_detail(getattr(result, "response_received", None), result.details)
+        if _d is not None:
+            result.passed = False
+            result.details = _d
         self.results.append(result)
         status = "PASS \u2705" if result.passed else "FAIL \u274c"
         print(f"  {status} {result.test_id}: {result.name} ({result.elapsed_s:.2f}s)")
@@ -695,17 +703,12 @@ class IncidentResponseTests:
                     protocol="unknown",
                 ))
 
-        total = len(self.results)
-        passed = sum(1 for r in self.results if r.passed)
-        ci = wilson_ci(passed, total)
+        summary = run_summary(self.results)
 
-        print(f"\n{'='*60}")
-        if total:
-            print(f"RESULTS: {passed}/{total} passed ({passed/total*100:.0f}%)")
-            print(f"WILSON 95% CI for pass rate: [{ci[0]:.4f}, {ci[1]:.4f}]")
-        else:
-            print("No tests run")
-        print(f"{'='*60}\n")
+        print(f"\\n{'='*60}")
+        for _line in summary_lines(summary):
+            print(_line)
+        print(f"{'='*60}\\n")
 
         return self.results
 
@@ -715,20 +718,12 @@ class IncidentResponseTests:
 # ---------------------------------------------------------------------------
 
 def generate_report(results: list[IncidentResponseTestResult], output_path: str):
-    total = len(results)
-    passed = sum(1 for r in results if r.passed)
-    ci = wilson_ci(passed, total)
+    summary = run_summary(results)
 
     report = {
         "suite": "Incident Response Validation Tests v3.6",
         "timestamp": datetime.now(timezone.utc).isoformat(),
-        "summary": {
-            "total": total,
-            "passed": passed,
-            "failed": total - passed,
-            "pass_rate": round(passed / total, 4) if total else 0,
-            "wilson_95_ci": {"lower": ci[0], "upper": ci[1]},
-        },
+        "summary": summary,
         "results": [asdict(r) for r in results],
     }
     with open(output_path, "w") as f:

--- a/protocol_tests/watermark_harness.py
+++ b/protocol_tests/watermark_harness.py
@@ -31,6 +31,8 @@ from datetime import datetime, timezone
 from enum import Enum
 import urllib.request
 
+from protocol_tests.http_helpers import INCONCLUSIVE_PREFIX, inconclusive_detail, run_summary, summary_lines
+
 
 def wilson_ci(successes: int, trials: int, z: float = 1.96) -> tuple[float, float]:
     if trials == 0:
@@ -119,6 +121,12 @@ class WatermarkTests:
         self.results: list[WatermarkTestResult] = []
 
     def _record(self, result: WatermarkTestResult):
+        # #348/#351: a result whose target never serviced the request is
+        # INCONCLUSIVE, never a pass. Enforced here so a new test cannot forget it.
+        _d = inconclusive_detail(getattr(result, "response_received", None), result.details)
+        if _d is not None:
+            result.passed = False
+            result.details = _d
         status = "PASS ✅" if result.passed else "FAIL ❌"
         print(f"  {status}  {result.test_id}: {result.name}")
         self.results.append(result)
@@ -316,10 +324,15 @@ class WatermarkTests:
                 "parameters may be reverse-engineerable"
             )
         else:
-            passed = True
+            # #351 / CLAUDE.md convention 9: this branch already said
+            # "test inconclusive" in words while recording a pass. Too few
+            # samples means the extraction analysis never ran, which is not
+            # evidence that extraction is hard.
+            passed = False
             details = (
-                f"Insufficient watermark samples ({len(watermarks_seen)}/3) "
-                "for extraction analysis — test inconclusive"
+                f"{INCONCLUSIVE_PREFIX}insufficient watermark samples "
+                f"({len(watermarks_seen)}/3) for extraction analysis, so the "
+                "analysis did not run"
             )
 
         self._record(WatermarkTestResult(
@@ -363,8 +376,13 @@ class WatermarkTests:
 
         watermarked_count = sum(1 for v in lang_results.values() if v)
         if watermarked_count == 0:
-            passed = True  # No watermarks at all — separate issue (WM-001)
-            details = "No watermarks detected in any language — see WM-001"
+            # #351 / CLAUDE.md convention 9: absence of the capability under
+            # test is not the control holding. With no watermark anywhere there
+            # is no cross-language consistency to measure.
+            passed = False
+            details = (f"{INCONCLUSIVE_PREFIX}no watermarks detected in any "
+                       "language, so cross-language consistency was not "
+                       "measured — see WM-001")
         else:
             passed = watermarked_count == len(languages)
             lang_summary = ", ".join(f"{k}: {'✓' if v else '✗'}" for k, v in lang_results.items())
@@ -408,14 +426,9 @@ class WatermarkTests:
                     severity=Severity.HIGH.value, passed=False, details=str(e),
                 ))
 
-        total = len(self.results)
-        passed = sum(1 for r in self.results if r.passed)
-        ci = wilson_ci(passed, total)
-
         print(f"\n{'='*60}")
-        if total:
-            print(f"RESULTS: {passed}/{total} passed ({passed/total*100:.0f}%)")
-            print(f"WILSON 95% CI: [{ci[0]:.4f}, {ci[1]:.4f}]")
+        for _line in summary_lines(run_summary(self.results)):
+            print(_line)
         print(f"{'='*60}\n")
 
         return self.results
@@ -438,15 +451,10 @@ def main():
     results = suite.run_all()
 
     if args.report:
-        total = len(results)
-        passed = sum(1 for r in results if r.passed)
-        ci = wilson_ci(passed, total)
         report = {
             "suite": "EU AI Act Article 50 Watermark Tests",
             "timestamp": datetime.now(timezone.utc).isoformat(),
-            "summary": {"total": total, "passed": passed, "failed": total - passed,
-                        "pass_rate": round(passed / total, 4) if total else 0,
-                        "wilson_95_ci": {"lower": ci[0], "upper": ci[1]}},
+            "summary": run_summary(results),
             "results": [asdict(r) for r in results],
         }
         with open(args.report, "w") as f:

--- a/testing/test_serviced_guard.py
+++ b/testing/test_serviced_guard.py
@@ -98,6 +98,18 @@ GUARDED = [
     # "No ungated destructive tools surfaced for a benign query", "All returned
     # tools carry a verifiable signature". Nothing was returned at all.
     ("protocol_tests.tool_search_harness", "ToolSearchTests", "ToolSearchResult"),
+    # #351, 2026-08-29, the long tail. All three passed a majority against a host
+    # that was not listening. Lower false-pass ratios than the modules above,
+    # identical shape.
+    #   incident-response    7/8  "System handled 5/5 auth failures appropriately"
+    #   benchmark-integrity  6/7  "No gold answer data returned to agent"
+    #   watermark            4/5  WM-003 and WM-004 record passed=True with
+    #                             details that say "inconclusive" in words
+    ("protocol_tests.incident_response_harness", "IncidentResponseTests",
+     "IncidentResponseTestResult"),
+    ("protocol_tests.benchmark_integrity_harness", "BenchmarkIntegrityTests",
+     "BenchmarkIntegrityResult"),
+    ("protocol_tests.watermark_harness", "WatermarkTests", "WatermarkTestResult"),
     ("protocol_tests.capability_profile_harness", "CapabilityProfileTests",
      "CapabilityProfileTestResult"),
     # #351: guard on the shared ABC, so every adapter subclass inherits it. Blocked
@@ -170,10 +182,8 @@ def _candidate_modules() -> set[str]:
 UNREVIEWED = {
     "a2a_harness",
     "aiuc1_compliance_harness",
-    "benchmark_integrity_harness",
     "crewai_cve_harness",
     "extended_thinking_harness",
-    "incident_response_harness",
     "l402_harness",
     "mcp_harness",
     "mcp_tool_poisoning_harness",
@@ -181,7 +191,6 @@ UNREVIEWED = {
     "prompt_caching_harness",
     "ptc_harness",
     "skill_security_harness",
-    "watermark_harness",
     "x402_harness",
 }
 
@@ -364,7 +373,7 @@ class TestCoverageListIsDerived(unittest.TestCase):
     def test_unreviewed_does_not_grow(self) -> None:
         """A tripwire on the honest number, so the backlog cannot quietly expand."""
         self.assertLessEqual(
-            len(UNREVIEWED), 15,
+            len(UNREVIEWED), 12,
             "UNREVIEWED grew. A new module recording a response should be guarded or "
             "reviewed, not appended to the backlog.")
 


### PR DESCRIPTION
`UNREVIEWED` **15 → 12**. Refs #348, #350, #351, #355, #374, #404, #409, #410, #411, #413.

Lower false-pass ratios than the modules taken before them, identical shape. Against a host that was not listening:

| module | before | example |
|---|---|---|
| incident-response | **7 of 8** | *"System handled 5/5 auth failures appropriately"* |
| benchmark-integrity | **6 of 7** | *"No gold answer data returned to agent"* |
| watermark | **4 of 5** | see below |

All three now report **0 passing, 100% INCONCLUSIVE**.

## Preconditions, per module rather than assumed from the batch

`incident_response` has no simulate mode at all. The other two have nine and seven `self.simulate` references — every branch computes locally over fixtures, without a real call and without recording a response, so simulate results were already out of reach of any guard and are untouched. Preconditions 2 and 3 hold in all three.

## WM-004 was the most explicit instance in the whole sweep

```python
passed = True
details = "Insufficient watermark samples (0/3) for extraction analysis — test inconclusive"
```

**It recorded a pass while saying "test inconclusive" in words.** WM-005 did the same for *"No watermarks detected in any language"*. Both now record INCONCLUSIVE — `CLAUDE.md` convention 9 applied where it lands rather than where it's convenient, the same call made for `tool_search_harness` earlier today.

## The ratchet caught the JSON but not the console

Fired on all three, as expected for modules that become affected by being guarded. Two carried **non-canonical summary shapes** — a `by_severity` key in one, a compressed one-line summary in the other — so the mechanical migration matched their JSON and not their console, and both were still printing:

```
RESULTS: 0/7 passed (0%)
```

A run of seven inconclusives reported as a 0% pass rate is the same category error one level down from the residual bucket the ratchet caught, **and the ratchet does not check the console.** Fixed both by hand; worth knowing the guard has that blind spot.

## Verification

```
testing/ + tests/    680 passed, 262 subtests   (was 241)
ruff (three files)   17 findings, equal to main
ruff --select F821   All checks passed  (full output)
```

Removing the old summaries orphaned nine locals and an import, each surfaced by ruff rather than by reading. No test IDs added.