### PR TITLE
feat(#351): measure the false-pass question instead of a proxy for it

### DIFF
--- a/scripts/dead_host_sweep.py
+++ b/scripts/dead_host_sweep.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Run every candidate harness against a closed port and report what still passes.
+
+## Why this exists
+
+`scripts/audit_verdict_taint.py` orders #351 work by static analysis: it walks
+each `passed=` expression and asks whether a target response reaches it. It is
+useful and it is not a triage. On 2026-08-29 it scored four modules at 0%
+false-pass shape. Run against a closed port, those four reported:
+
+    over_refusal_harness         25 of 25 passed
+    mcp_tool_poisoning_harness    8 of 10
+    aiuc1_compliance_harness      3 of 12
+    skill_security_harness        0 of 8
+
+The 25 was the largest false-pass count in the whole sweep, in the module the
+ordering metric called cleanest. `over_refusal`'s `_is_allowed` returned True for
+a refused connection, and no `passed=` expression referenced a response directly,
+so the taint walk had nothing to follow.
+
+The auditor's own output says this: "absence of taint means only 'not reached by
+these mechanisms, under these names'. It is NOT a proof that a verdict is sound."
+That sentence is correct and it was still being read as a ranking.
+
+This script asks the question behind the ranking instead of a proxy for it: point
+the harness at nothing and see what it claims. A test that passes here is either
+a false pass or a test that does not need a target, and both are worth knowing.
+
+## What a row means
+
+    module  passed/total  errors  verdict
+
+`passed` is the count that survived a target which was never there. Anything
+above zero needs reading. `errors` is tests that raised; a module that errors is
+not a module that passed, and the two must not be conflated -- an earlier fix
+appeared to reach 0 of 25 only because every test was raising NameError and the
+runner was catching it.
+
+## What this does NOT establish
+
+That a module with 0 passing is correct. It establishes that this particular
+failure mode is absent. A module can score 0 here and still mis-verdict against a
+live target in every other way.
+
+    python3 scripts/dead_host_sweep.py            # table, ordered worst first
+    python3 scripts/dead_host_sweep.py --json     # machine-readable
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import importlib
+import inspect
+import io
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+#: Nothing listens here. Same target the serviced-guard suite uses.
+CLOSED_PORT = "http://127.0.0.1:9"
+
+
+def _candidate_modules() -> list[str]:
+    """Same rule the guard suite uses, so the two cannot drift apart."""
+    out = []
+    for path in sorted((REPO_ROOT / "protocol_tests").glob("*.py")):
+        src = path.read_text(encoding="utf-8")
+        if "def _record" in src and "response_received" in src:
+            out.append(path.stem)
+    return out
+
+
+def _suite_class(mod_name: str):
+    """The module's test-suite class, found by convention rather than a list."""
+    try:
+        mod = importlib.import_module(f"protocol_tests.{mod_name}")
+    except Exception:  # noqa: BLE001 - a module that will not import is a row, not a crash
+        return None, None
+    src = (REPO_ROOT / "protocol_tests" / f"{mod_name}.py").read_text(encoding="utf-8")
+    for name in re.findall(r"^class (\w*Tests?)\b", src, re.MULTILINE):
+        cls = getattr(mod, name, None)
+        if cls is not None and hasattr(cls, "run_all"):
+            return mod, cls
+    return mod, None
+
+
+def _instantiate(cls):
+    """Best-effort construction. Harnesses take a url, a transport, or neither."""
+    params = list(inspect.signature(cls.__init__).parameters)[1:]
+    first = params[0] if params else None
+    if first in ("url", "base_url", "target", "endpoint"):
+        return cls(CLOSED_PORT)
+    if first == "transport":
+        mod = sys.modules[cls.__module__]
+        for attr in dir(mod):
+            if attr.endswith("Transport"):
+                return cls(getattr(mod, attr)(CLOSED_PORT))
+    return cls(CLOSED_PORT)
+
+
+def sweep() -> list[dict]:
+    rows = []
+    for name in _candidate_modules():
+        _, cls = _suite_class(name)
+        if cls is None:
+            rows.append({"module": name, "status": "no-suite-class"})
+            continue
+        try:
+            suite = _instantiate(cls)
+            with contextlib.redirect_stdout(io.StringIO()), \
+                    contextlib.redirect_stderr(io.StringIO()):
+                suite.run_all()
+            results = list(getattr(suite, "results", []))
+        except Exception as exc:  # noqa: BLE001 - reported, not swallowed
+            rows.append({"module": name, "status": f"{type(exc).__name__}: {exc}"[:70]})
+            continue
+        passed = [r.test_id for r in results if getattr(r, "passed", False)]
+        errored = [r.test_id for r in results
+                   if str(getattr(r, "name", "")).startswith("ERROR")]
+        rows.append({
+            "module": name,
+            "status": "ran",
+            "total": len(results),
+            "passed": len(passed),
+            "errors": len(errored),
+            "passing_ids": passed,
+        })
+    # worst first: most passes against nothing
+    rows.sort(key=lambda r: (-(r.get("passed") or 0), r["module"]))
+    return rows
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--json", action="store_true", help="machine-readable output")
+    args = ap.parse_args()
+
+    rows = sweep()
+    if args.json:
+        print(json.dumps(rows, indent=2))
+    else:
+        print(f"{'module':34s} {'pass/total':>11s} {'err':>4s}  passing against nothing")
+        print("-" * 96)
+        for r in rows:
+            if r["status"] != "ran":
+                print(f"{r['module']:34s} {'--':>11s} {'--':>4s}  {r['status']}")
+                continue
+            ids = ", ".join(r["passing_ids"][:6])
+            if len(r["passing_ids"]) > 6:
+                ids += f", +{len(r['passing_ids']) - 6} more"
+            print(f"{r['module']:34s} {r['passed']:>5}/{r['total']:<5} "
+                  f"{r['errors']:>4}  {ids}")
+        ran = [r for r in rows if r["status"] == "ran"]
+        dirty = [r for r in ran if r["passed"]]
+        print("-" * 96)
+        print(f"{len(ran)} modules ran, {len(dirty)} still pass something against a "
+              f"target that was never there.")
+        print("A row above zero is either a false pass or a test that needs no "
+              "target. Both are worth reading.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/testing/test_dead_host_state.py
+++ b/testing/test_dead_host_state.py
@@ -1,0 +1,146 @@
+"""What every harness claims when pointed at nothing, pinned.
+
+## Why this file exists
+
+`GUARDED` did not mean guarded. `advanced_attacks` has been on that list since
+#348, and it passes 7 of 10 against a closed port:
+
+    STATE-003: No data leaked across all 8 escalation steps
+    CHAIN-001: Multi-domain chain attack blocked at all steps
+    JAIL-002: All roleplay-based jailbreak attempts blocked
+
+The guard lives in `_record` and can only act on a result that carries a
+`response_received`. Those seven record none, so the guard never sees them. The
+serviced-guard suite still passes for the module, because that suite feeds
+synthetic results which *do* carry a response. The label was checking the
+mechanism, not the outcome.
+
+That is the same false green the classification exists to prevent, sitting inside
+the classification.
+
+`scripts/dead_host_sweep.py` asks the question directly: point each harness at a
+port nobody is listening on and count what it still claims. This file pins the
+answer so it cannot drift, and so a module cannot be called guarded while a
+verdict of its own contradicts it.
+
+## How to read a non-zero row
+
+Either a false pass, or a test that genuinely needs no target. Both are worth
+knowing and neither is allowed to appear without being written down here.
+
+## What this does not establish
+
+That a zero row is correct. It establishes that this one failure mode is absent
+from it. A module can score zero here and mis-verdict against a live target in
+every other way.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from dead_host_sweep import sweep
+
+#: Measured 2026-08-29. Module -> number of verdicts that still pass against a
+#: target that was never there. May shrink. Must never grow, and a module absent
+#: from this map must score zero.
+#:
+#: Every entry is a defect or an explicit not-applicable, and none is acceptable
+#: as a resting state. The comments say which is which as they are established.
+KNOWN_PASSING = {
+    # In PROTOCOL_EXCEPTION for l402/x402, and that classification does NOT
+    # cover this. Precondition 3 says a 401/402 is the protocol servicing the
+    # request, so the generic non-2xx rule misfires. Against a dead host there
+    # is no 402 at all -- there is silence -- so precondition 3 does not excuse
+    # a single one of these. The exception was granted too broadly and this is
+    # the evidence.
+    "x402_harness": 44,
+    "l402_harness": 4,
+
+    # Unread. Known-defective now, with a number attached.
+    "crewai_cve_harness": 9,
+    "mcp_tool_poisoning_harness": 8,
+    "ptc_harness": 4,
+    "aiuc1_compliance_harness": 3,
+    "extended_thinking_harness": 2,
+
+    # In GUARDED, and the guard cannot reach these verdicts because they record
+    # no response at all. The label is currently wrong for both.
+    "advanced_attacks": 7,
+    "provenance_harness": 1,
+
+    # In NARROW_LOCAL_RULE. Partially repaired, remaining six pinned in detail
+    # by testing/test_a2a_unserviced_state.py.
+    "a2a_harness": 6,
+}
+
+
+class TestDeadHostState(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.rows = sweep()
+        cls.ran = [r for r in cls.rows if r["status"] == "ran"]
+
+    def test_the_sweep_actually_ran(self):
+        """Assert a positive expected set, so a broken sweep cannot read as clean."""
+        self.assertGreaterEqual(
+            len(self.ran), 25,
+            f"only {len(self.ran)} modules ran; the sweep is probably broken rather "
+            f"than the repository having shrunk")
+
+    def test_no_module_errors_its_way_to_a_low_score(self):
+        """A module that raises is not a module that passed.
+
+        An earlier over_refusal fix appeared to reach 0 of 25 only because every
+        test was raising NameError and run_all was catching it. Zero passes and
+        zero errors are the pair that means something.
+        """
+        erroring = {r["module"]: r["errors"] for r in self.ran if r["errors"]}
+        self.assertEqual(
+            erroring, {},
+            f"tests raised during the sweep, so their verdicts prove nothing: "
+            f"{erroring}")
+
+    def test_nothing_passes_against_nothing_except_what_is_declared(self):
+        measured = {r["module"]: r["passed"] for r in self.ran if r["passed"]}
+        unexpected = {m: n for m, n in measured.items() if m not in KNOWN_PASSING}
+        self.assertEqual(
+            unexpected, {},
+            f"modules passing against a target that was never there, and not "
+            f"declared here: {unexpected}")
+
+    def test_the_declared_counts_do_not_grow(self):
+        measured = {r["module"]: r["passed"] for r in self.ran}
+        grew = {m: (KNOWN_PASSING[m], measured[m])
+                for m in KNOWN_PASSING
+                if m in measured and measured[m] > KNOWN_PASSING[m]}
+        self.assertEqual(
+            grew, {},
+            f"declared (was, now): {grew}. A repair regressed, or a new test was "
+            f"written against the pattern #351 exists to remove.")
+
+    def test_the_declared_counts_are_not_stale(self):
+        """If a repair lands, this fails until the number is updated.
+
+        Without it the map rots optimistically: fixes ship and the file keeps
+        claiming the old count, which is the restated-value drift the
+        release-claims manifest exists to stop, one layer down.
+        """
+        measured = {r["module"]: r["passed"] for r in self.ran}
+        shrank = {m: (KNOWN_PASSING[m], measured[m])
+                  for m in KNOWN_PASSING
+                  if m in measured and measured[m] < KNOWN_PASSING[m]}
+        self.assertEqual(
+            shrank, {},
+            f"good news, and the map must record it. declared (was, now): "
+            f"{shrank}. Update KNOWN_PASSING and say which repair moved it.")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs #348, #350, #351, #404.

## The ordering metric was wrong about the worst module

`audit_verdict_taint.py` scored `over_refusal_harness` at **0% false-pass shape**. That module passed **25 of 25** against a closed port — the largest count in this sweep — because `_is_allowed` returned `True` for a refused connection and no `passed=` expression referenced a response directly, so the taint walk had nothing to follow.

The auditor's own footer says *"absence of taint means only not reached by these mechanisms, under these names."* I read it as a ranking anyway.

`scripts/dead_host_sweep.py` asks the question directly: point every candidate at a port nobody is listening on and count what it still claims. 28 modules in ~20 seconds, and the ranking barely resembles the static one.

## It immediately found what the classification could not see

**`advanced_attacks` is in `GUARDED`, and passes 7 of 10 against a dead host:**

```
STATE-003: No data leaked across all 8 escalation steps
CHAIN-001: Multi-domain chain attack blocked at all steps
JAIL-002: All roleplay-based jailbreak attempts blocked
```

The guard lives in `_record` and can only act on a result carrying a `response_received`. Those seven record none, so the guard never sees them. **The serviced-guard suite still passes for the module, because that suite feeds synthetic results which *do* carry a response.** The label was checking the mechanism, not the outcome — and has been wrong since #348. `provenance_harness` is the same at 1 of 15.

That is the false green the classification exists to prevent, sitting inside the classification.

## The PROTOCOL_EXCEPTION granted this morning was too broad

| module | passes against nothing |
|---|---|
| `x402_harness` | **44 of 54** |
| `l402_harness` | 4 of 33 |

Precondition 3 says a 401/402 *is* those protocols servicing the request, so the generic non-2xx rule misfires. True — and **against a dead host there is no 402 at all, there is silence.** The exception excuses the rule, not the silence. 44 is now the largest single number in the file.

## The pin

`testing/test_dead_host_state.py`. Absent modules must score zero; declared ones may shrink and must never grow; **and a shrink fails too**, so a repair cannot land while the map keeps claiming the old number.

It also asserts **zero errors alongside zero passes** — an earlier `over_refusal` fix appeared to reach 0 of 25 only because every test was raising `NameError` and `run_all` was catching it. Verified by planting a wrong count: the stale check fires.

## Known limits, recorded rather than hidden

Six adapter-style modules expose no `run_all` suite class and report `no-suite-class`; `mcp_harness` needs a transport its constructor doesn't take. **Those seven are unmeasured, not clean**, and the row says so.

## Verification

```
testing/ + tests/     685 passed, 262 subtests   (was 680)
ruff --select F821    All checks passed
ruff (both new files) All checks passed
```