### PR TITLE
fix(#351): silence is not an answer, in x402 and l402

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,15 @@ These recur across rounds — always check:
    `inconclusive_detail()` in `http_helpers.py` understands both so individual
    modules do not have to.
 
+   **An exemption from that guard is not an exemption from the rule.** x402 and
+   L402 are excluded from `_serviced` because a 402 IS the protocol servicing the
+   request, and applying it would invert both modules. That is correct, and it
+   was read as needing no instrument at all: against a closed port the two
+   returned PASS on 44 of 54 and 4 of 33. There is no 402 from a host that is not
+   running. Use `silence_detail()` where a non-2xx is a real answer -- it fires
+   only when a test issued requests and not one was answered -- and
+   `inconclusive_detail()` everywhere else. Never neither.
+
 9. **A gap found in someone else's work is not permission to implement a test.**
    Adopted 2026-08-29 from a strategic review, after it caught a defect in tests
    written an hour earlier. Before adding a test family, require all six:

--- a/protocol_tests/a2a_harness.py
+++ b/protocol_tests/a2a_harness.py
@@ -298,6 +298,7 @@ class A2ASecurityTests:
 
     def _record(self, result: A2ATestResult):
         # NO shared serviced guard here, deliberately. #351, 2026-08-29.
+        # Classified NARROW_LOCAL_RULE in testing/test_serviced_guard.py.
         #
         # Applying inconclusive_detail to this module downgrades a legitimate
         # active rejection to INCONCLUSIVE. http_helpers._serviced treats a 2xx
@@ -310,12 +311,17 @@ class A2ASecurityTests:
         # arriving through the response-convention door rather than the
         # simulate-fixture one.
         #
-        # So this module stays in UNREVIEWED. What IS fixed here is the counting:
-        # see _answered and _aggregate_evidence. A transport failure is no longer
-        # tallied as a blocked attack, which took the dead-host pass count from
-        # 11 of 13 to 4 of 13. The remaining four are recorded in
-        # testing/test_a2a_unserviced_state.py so the gap is visible and cannot
-        # silently regrow.
+        # What IS fixed here is the counting: see _answered and
+        # _aggregate_evidence. A transport failure is no longer tallied as a
+        # blocked attack. The remaining false passes are enumerated by ID in
+        # testing/test_a2a_unserviced_state.py, which fails if that set grows
+        # OR shrinks.
+        #
+        # No count is restated here on purpose. The first version of this comment
+        # said "from 11 of 13 to 4 of 13" while the enforced set held six, so a
+        # reader of the source got a number that no test could contradict. The
+        # only durable place for a measurement is somewhere that fails when it
+        # goes stale.
         # Narrow, module-local guard. Not the shared serviced guard: see the
         # comment above. This fires only on the marker _aggregate_evidence sets
         # when a multi-attempt test reached nobody, so a JSON-RPC error envelope

--- a/protocol_tests/http_helpers.py
+++ b/protocol_tests/http_helpers.py
@@ -269,6 +269,115 @@ def inconclusive_detail(resp, details: str | None) -> str | None:
             f"status={status}. Original finding: {details}")
 
 
+# ---------------------------------------------------------------------------
+# Silence, for the protocols where a non-2xx is a real answer
+# ---------------------------------------------------------------------------
+#
+# x402 and L402 are exempt from _serviced, and correctly: a 402 IS the protocol
+# servicing the request, and _serviced would read every payment challenge as an
+# unserviced one and invert both modules. The exemption was then read as needing
+# no instrument at all. Against a closed port those two returned PASS on 44 of 54
+# and 4 of 33 -- there is no 402 from a host that is not running, there is
+# nothing, and every verdict of the form "no bad payment was accepted" held.
+#
+# These three functions draw the one line the exemption does not cover. They
+# live here rather than in each harness because the package already learned that
+# lesson the expensive way: one verdict defect had 44 parallel homes and each
+# repair reached only the files someone opened (CLAUDE.md convention 7).
+
+_SINK_ATTR = "_response_sink"
+_WRAPPED_ATTR = "_response_logging_installed"
+
+
+def answered(resp) -> bool:
+    """True when the target sent something back, at any status.
+
+    Deliberately weaker than :func:`_serviced`. A 402, a 401, a 404 and a 500 are
+    all answers here; only silence is not. Use this where a non-2xx is the
+    protocol working, and :func:`_serviced` everywhere else.
+    """
+    if not isinstance(resp, dict):
+        return False
+    if resp.get("_error") and resp.get("_exception"):
+        return False
+    status = resp.get("status", resp.get("_status", 0))
+    return isinstance(status, int) and status > 0
+
+
+def instrument_transport(transport, sink: list) -> None:
+    """Append every response *transport* produces to *sink*.
+
+    Wraps ``request``, ``get`` and ``post`` -- whichever exist. Wrapping only
+    ``request`` was the first version, on the reasoning that the real transports
+    route ``get`` and ``post`` through it. True of the real ones, and false of
+    the test doubles: three fakes in testing/test_vsr03_verdict_correctness.py
+    implement ``get`` alone. That failed loudly with an AttributeError, which was
+    luck. A double implementing ``get`` *and* ``request`` would have been
+    instrumented on the path it does not use, and the guard would have gone
+    quiet with every test still green.
+
+    Responses are de-duplicated by identity, so a ``get`` that delegates to
+    ``request`` is one attempt rather than two.
+
+    The sink lives on the transport rather than in the closure so a transport
+    reused across two suites feeds the live one, instead of appending to the
+    first suite's list forever while the second sees nothing.
+    """
+    if not getattr(transport, _WRAPPED_ATTR, False):
+        for name in ("request", "get", "post"):
+            inner = getattr(transport, name, None)
+            if callable(inner):
+                setattr(transport, name, _logging(transport, inner))
+        setattr(transport, _WRAPPED_ATTR, True)
+    setattr(transport, _SINK_ATTR, sink)
+
+
+def _logging(transport, inner):
+    def wrapper(*args, **kwargs):
+        resp = inner(*args, **kwargs)
+        sink = getattr(transport, _SINK_ATTR, None)
+        if sink is not None:
+            if not isinstance(resp, dict):
+                sink.append({})          # an attempt, and not an answer
+            elif not any(r is resp for r in sink):
+                sink.append(resp)
+        return resp
+    return wrapper
+
+
+def silence_detail(seen: list, details: str | None) -> str | None:
+    """Replacement ``details`` when nothing answered, else ``None``.
+
+    Same shape as :func:`inconclusive_detail`, and a deliberately narrower rule.
+    An empty *seen* returns ``None``: a test that issued no requests has nothing
+    to be silent about, and the guard must not manufacture an INCONCLUSIVE for a
+    purely local verdict.
+    """
+    if not seen or is_inconclusive(details):
+        return None
+    if any(answered(r) for r in seen):
+        return None
+    return (f"{INCONCLUSIVE_PREFIX}none of {len(seen)} requests were answered. "
+            f"Original finding: {details}")
+
+
+def silence_evidence(seen: list, existing: dict | None) -> dict:
+    """Annotate the original evidence rather than replacing it.
+
+    The finding dict a test attached -- ``{"accepted_bad": []}`` -- is exactly
+    what a reader needs in order to see *why* it was empty.
+    """
+    evidence = dict(existing or {})
+    last = seen[-1] if seen and isinstance(seen[-1], dict) else {}
+    evidence.update({
+        "attempts": len(seen),
+        "answered": 0,
+        "_error": True,
+        "_exception": last.get("_exception") or "no response",
+    })
+    return evidence
+
+
 def _serviced(resp: dict) -> bool:
     """True when the target actually processed the request.
 

--- a/protocol_tests/l402_harness.py
+++ b/protocol_tests/l402_harness.py
@@ -66,6 +66,9 @@ from typing import Any
 import http.client
 import urllib.request
 
+from protocol_tests.http_helpers import (
+    instrument_transport, silence_detail, silence_evidence)
+
 
 # ---------------------------------------------------------------------------
 # L402 protocol primitives
@@ -246,8 +249,30 @@ class L402SecurityTests:
         self.results: list[L402TestResult] = []
         # Cache a challenge from the server for tests that need one
         self._cached_challenge: L402Challenge | None = None
+        # Every response the current test has received. Read by _record.
+        self._seen: list[dict] = []
+        instrument_transport(transport, self._seen)
 
     def _record(self, result: L402TestResult):
+        # #351. Measured against a closed port this module returned PASS on 4
+        # of 33 tests. Small next to x402's 44 and the same defect, granted by
+        # the same over-broad PROTOCOL_EXCEPTION: precondition 3 excuses the
+        # non-2xx rule, because a 402 challenge is the protocol working. It does
+        # not excuse silence. Against a dead host there is no challenge at all.
+        #
+        # This module already had the right vocabulary for the answer. It has
+        # carried `not_evaluated` since before #351, with `failed` computed as
+        # "not passed and not not_evaluated", so the third state is counted
+        # correctly in every summary here. It was simply never wired to the
+        # unreachable-target case, which is the largest source of it.
+        seen = list(self._seen)
+        self._seen.clear()          # in place: the transport holds this object
+        detail = None if result.not_evaluated else silence_detail(seen, result.details)
+        if detail is not None:
+            result.passed = False
+            result.not_evaluated = True
+            result.details = detail
+            result.response_received = silence_evidence(seen, result.response_received)
         self.results.append(result)
         status = "N/A \u2796" if result.not_evaluated else ("PASS \u2705" if result.passed else "FAIL \u274c")
         print(f"  {status} {result.test_id}: {result.name} ({result.elapsed_s:.2f}s)")
@@ -1988,6 +2013,9 @@ class L402SecurityTests:
             print(f"\n[{category.upper().replace('_', ' ')}]")
             for test_name in test_names:
                 test_fn = getattr(self, test_name)
+                # Scope the answer log to this test, so requests made by a test
+                # that raised cannot supply the next one an answer it never got.
+                self._seen.clear()
                 try:
                     test_fn()
                 except Exception as e:

--- a/protocol_tests/x402_harness.py
+++ b/protocol_tests/x402_harness.py
@@ -79,7 +79,8 @@ import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-from protocol_tests.http_helpers import INCONCLUSIVE_PREFIX
+from protocol_tests.http_helpers import (
+    INCONCLUSIVE_PREFIX, instrument_transport, silence_detail, silence_evidence)
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
@@ -323,8 +324,35 @@ class X402SecurityTests:
         self._cached_challenge: X402Challenge | None = None
         # Track data for autonomy risk scoring
         self._autonomy_signals: dict[str, bool] = {}
+        # Every response the current test has received. Read by _record.
+        self._seen: list[dict] = []
+        instrument_transport(transport, self._seen)
 
     def _record(self, result: X402TestResult):
+        # #351. x402 sat in PROTOCOL_EXCEPTION, and that classification was
+        # granted too broadly. It excuses the non-2xx rule. It does not excuse
+        # silence, and against a closed port this module returned PASS on 44 of
+        # 54 tests -- the largest count in the repository.
+        #
+        # Against a dead host there is no 402. There is nothing. Every verdict
+        # here has the shape "nothing bad was observed", so a target that
+        # answered nothing produces 44 controls reported as holding when not one
+        # of them was exercised:
+        #
+        #     X4-026: No malformed payment payloads accepted
+        #     X4-041: No SSRF via payment callback URLs
+        #     X4-047: Expired payment authorizations rejected
+        #
+        # Fires only when this test issued requests and not one was answered, so
+        # every 402/401/4xx path is untouched and the protocol exception stands
+        # for what it was actually granted for.
+        seen = list(self._seen)
+        self._seen.clear()          # in place: the transport holds this object
+        detail = silence_detail(seen, result.details)
+        if detail is not None:
+            result.passed = False
+            result.details = detail
+            result.response_received = silence_evidence(seen, result.response_received)
         self.results.append(result)
         status = "PASS \u2705" if result.passed else "FAIL \u274c"
         print(f"  {status} {result.test_id}: {result.name} ({result.elapsed_s:.2f}s)")
@@ -3423,6 +3451,10 @@ class X402SecurityTests:
             print(f"\n[{category.upper().replace('_', ' ')}]")
             for test_name in test_names:
                 test_fn = getattr(self, test_name)
+                # Scope the answer log to this test. Without the reset, requests
+                # made by a test that raised would carry into the next one and
+                # could supply it an answer it never received.
+                self._seen.clear()
                 try:
                     test_fn()
                 except Exception as e:

--- a/testing/test_dead_host_state.py
+++ b/testing/test_dead_host_state.py
@@ -54,14 +54,12 @@ from dead_host_sweep import sweep
 #: Every entry is a defect or an explicit not-applicable, and none is acceptable
 #: as a resting state. The comments say which is which as they are established.
 KNOWN_PASSING = {
-    # In PROTOCOL_EXCEPTION for l402/x402, and that classification does NOT
-    # cover this. Precondition 3 says a 401/402 is the protocol servicing the
-    # request, so the generic non-2xx rule misfires. Against a dead host there
-    # is no 402 at all -- there is silence -- so precondition 3 does not excuse
-    # a single one of these. The exception was granted too broadly and this is
-    # the evidence.
-    "x402_harness": 44,
-    "l402_harness": 4,
+    # x402_harness was here at 44, the largest count in the repository, and
+    # l402_harness at 4. Both were in PROTOCOL_EXCEPTION, and that classification
+    # did not cover this: precondition 3 excuses the non-2xx rule because a
+    # 401/402 is the protocol servicing the request, and against a dead host
+    # there is no 402 at all. Both now instrument the transport and record 0.
+    # They have left this map and moved to NARROW_LOCAL_RULE.
 
     # Unread. Known-defective now, with a number attached.
     "crewai_cve_harness": 9,

--- a/testing/test_payment_silence_guard.py
+++ b/testing/test_payment_silence_guard.py
@@ -1,0 +1,260 @@
+"""The payment protocols may treat a 402 as an answer. They may not treat silence as one.
+
+## What this pins
+
+`x402_harness` and `l402_harness` sat in `PROTOCOL_EXCEPTION` in
+test_serviced_guard.py, on a reason that is correct:
+
+    a 401/402 IS those protocols servicing the request, so their apparent
+    exposure in any triage is inflated relative to what is actionable
+
+The shared serviced guard would read every payment challenge as "the target did
+not service the request" and invert both modules. That is real, and it is why
+neither uses `inconclusive_detail`.
+
+The bucket was doing a second job it was never given. The exception excuses one
+rule -- that a non-2xx means the target did not service the request. It says
+nothing about silence. Against a closed port there is no 402; there is nothing,
+and both modules graded that nothing:
+
+    x402  44 of 54 PASS      l402  4 of 33 PASS
+
+    X4-026: No malformed payment payloads accepted
+    X4-041: No SSRF via payment callback URLs
+    L4-013: Preimage not leaked in error responses
+
+"The generic instrument does not fit" had been read as "no instrument is
+needed".
+
+## Both directions, because the danger runs both ways
+
+Over-applying a guard is how a2a_harness broke: `_serviced` turned an active
+rejection into INCONCLUSIVE, a false negative introduced by the fix for false
+positives. So this file asserts the silence rule fires on silence **and stays
+out of the way of a target answering 402 to everything** -- the shape that is
+normal operation for both protocols.
+
+The rule is derived, not enumerated. Both modules instrument the transport, so
+a test added tomorrow is covered without appearing on any list, and the
+mechanism itself lives once in `http_helpers` -- `answered`, `silence_detail`,
+`silence_evidence`, `instrument_transport` -- rather than twice in the two
+harnesses. Convention 7 exists because a verdict defect with 44 parallel homes
+had to be repaired four times.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from protocol_tests.l402_harness import L402SecurityTests, L402Transport
+from protocol_tests.x402_harness import X402SecurityTests, X402Transport
+
+CLOSED_PORT = "http://127.0.0.1:9"
+
+#: A challenge good enough for both parsers.
+_MACAROON = 'L402 macaroon="AGIAJEemVQUTEyNCR0exk7ek90Cg==", invoice="lnbc1500n1p"'
+_CHALLENGE_HEADERS = {
+    "www-authenticate": _MACAROON,
+    "x-payment-required": "true",
+    "x-payment-amount": "1000",
+    "x-payment-address": "0xabc",
+    "x-payment-network": "base",
+    "x-payment-currency": "USDC",
+}
+
+#: What a closed port produces, in the shape both transports emit for it.
+SILENCE = {"status": 0, "headers": {}, "body": "", "_error": True,
+           "_exception": "[Errno 111] Connection refused"}
+#: A server that is up and demanding payment for everything. Normal operation.
+CHALLENGE = {"status": 402, "headers": dict(_CHALLENGE_HEADERS),
+             "body": '{"error":"payment required"}'}
+
+
+def _fixed(base, response):
+    """A transport subclass answering every request with *response*.
+
+    Subclassing rather than substituting keeps `base_url`, `paid_path` and
+    `default_method` real, which several tests read directly.
+    """
+    class _Fixed(base):
+        def request(self, method, path="", body=None, headers=None, timeout=15.0):
+            return dict(response)
+    return _Fixed
+
+
+def _run(suite_cls, transport):
+    suite = suite_cls(transport)
+    with contextlib.redirect_stdout(io.StringIO()), \
+            contextlib.redirect_stderr(io.StringIO()):
+        suite.run_all()
+    return suite.results
+
+
+def _passing(results):
+    return [r.test_id for r in results if r.passed]
+
+
+def _erroring(results):
+    return [r.test_id for r in results if str(getattr(r, "name", "")).startswith("ERROR")]
+
+
+class TestX402(unittest.TestCase):
+    LIVE = _fixed(X402Transport, CHALLENGE)
+    DEAD = _fixed(X402Transport, SILENCE)
+
+    def test_nothing_passes_against_silence(self):
+        results = _run(X402SecurityTests, self.DEAD("http://target.invalid"))
+        self.assertEqual(
+            _passing(results), [],
+            "a verdict of the form 'nothing bad was observed' passed against a "
+            "target that answered nothing")
+
+    def test_the_suite_ran_rather_than_erroring_to_zero(self):
+        """Zero passes and zero errors are the pair that means something.
+
+        An earlier over_refusal repair appeared to reach 0 of 25 only because
+        every test was raising NameError and run_all was catching it.
+        """
+        results = _run(X402SecurityTests, self.DEAD("http://target.invalid"))
+        self.assertGreaterEqual(len(results), 54)
+        self.assertEqual(_erroring(results), [])
+
+    def test_a_402_to_everything_still_produces_real_verdicts(self):
+        """The false-negative direction. A challenge is an answer.
+
+        Two results are INCONCLUSIVE here and neither comes from the silence
+        rule: X4-056 and X4-057 require an observably exercised capability
+        (CLAUDE.md convention 9), and a target that challenges everything
+        exposes no URL-credential channel and no delegated allowance.
+        """
+        results = _run(X402SecurityTests, self.LIVE("http://target.invalid"))
+        self.assertEqual(_erroring(results), [])
+        self.assertGreater(
+            len(_passing(results)), 40,
+            "the silence rule is firing against a live 402 target; it has been "
+            "written too broadly and now inverts the protocol it was exempted for")
+        unanswered = [r.test_id for r in results
+                      if "requests were answered" in (r.details or "")]
+        self.assertEqual(
+            unanswered, [],
+            f"the silence rule fired on a target that answered every request: "
+            f"{unanswered}")
+
+
+class TestL402(unittest.TestCase):
+    LIVE = _fixed(L402Transport, CHALLENGE)
+    DEAD = _fixed(L402Transport, SILENCE)
+
+    def test_nothing_passes_against_silence(self):
+        results = _run(L402SecurityTests, self.DEAD("http://target.invalid"))
+        self.assertEqual(_passing(results), [])
+
+    def test_the_suite_ran_rather_than_erroring_to_zero(self):
+        results = _run(L402SecurityTests, self.DEAD("http://target.invalid"))
+        self.assertGreaterEqual(len(results), 33)
+        self.assertEqual(_erroring(results), [])
+
+    def test_silence_uses_the_third_state_this_module_already_had(self):
+        """`not_evaluated` predates #351 and was never wired to an unreachable target.
+
+        It is excluded from `failed` in every summary this module computes, so
+        setting it is what stops a run that established nothing from being
+        reported as a run in which the target failed everything.
+        """
+        results = _run(L402SecurityTests, self.DEAD("http://target.invalid"))
+        graded = [r.test_id for r in results if not r.not_evaluated]
+        self.assertEqual(
+            graded, [],
+            f"these were graded pass or fail against a target that never "
+            f"answered: {graded}")
+
+    def test_a_402_to_everything_still_produces_real_verdicts(self):
+        results = _run(L402SecurityTests, self.LIVE("http://target.invalid"))
+        self.assertEqual(_erroring(results), [])
+        self.assertGreater(len(_passing(results)), 25)
+        unanswered = [r.test_id for r in results
+                      if "requests were answered" in (r.details or "")]
+        self.assertEqual(unanswered, [], f"fired on a live target: {unanswered}")
+
+
+class TestTheInstrumentationItself(unittest.TestCase):
+    """The mechanism the guard depends on, tested apart from any verdict."""
+
+    def test_a_transport_that_only_implements_get_is_still_seen(self):
+        """The regression. Wrapping `request` alone was not enough.
+
+        The first version wrapped `request` only, reasoning that the real
+        transports route `get` and `post` through it. True of the real ones and
+        false of the doubles: three fakes in test_vsr03_verdict_correctness.py
+        implement `get` and nothing else. That raised AttributeError, which was
+        luck -- a double implementing `get` *and* `request` would have been
+        instrumented on the path it does not use, and the guard would have gone
+        quiet with every test in this file still green.
+        """
+        class GetOnly:
+            base_url = "http://target.invalid"
+            paid_path = ""
+            default_method = "GET"
+
+            def get(self, path="", headers=None, timeout=15.0):
+                return dict(SILENCE)
+
+        transport = GetOnly()
+        suite = X402SecurityTests(transport)
+        suite._seen.clear()
+        transport.get("/x")
+        self.assertEqual(
+            len(suite._seen), 1,
+            "a transport implementing only get() was not instrumented, so the "
+            "silence guard can never fire for it")
+
+    def test_get_delegating_to_request_counts_as_one_attempt(self):
+        """Both are wrapped, so the response must be de-duplicated by identity."""
+        transport = _fixed(X402Transport, CHALLENGE)("http://target.invalid")
+        suite = X402SecurityTests(transport)
+        suite._seen.clear()
+        transport.get("/x")
+        self.assertEqual(len(suite._seen), 1, f"double-counted: {suite._seen}")
+
+    def test_a_reused_transport_feeds_the_live_suite(self):
+        """Wrapping is idempotent and the sink follows the newest suite.
+
+        The first version kept the sink in the closure, so a transport reused
+        across two suites appended to the first suite's list forever while the
+        second saw nothing and could never downgrade anything.
+        """
+        transport = _fixed(X402Transport, CHALLENGE)("http://target.invalid")
+        first = X402SecurityTests(transport)
+        second = X402SecurityTests(transport)
+        first._seen.clear()
+        second._seen.clear()
+        transport.get("/x")
+        self.assertEqual(len(second._seen), 1, "the live suite saw nothing")
+        self.assertEqual(len(first._seen), 0, "the stale suite is still being fed")
+
+    def test_a_test_that_makes_no_request_is_not_downgraded(self):
+        """No attempts is not the same as no answers.
+
+        A purely local verdict has nothing to be silent about, and the guard
+        must not manufacture an INCONCLUSIVE for it.
+        """
+        from protocol_tests.x402_harness import X402TestResult
+        suite = X402SecurityTests(_fixed(X402Transport, SILENCE)("http://target.invalid"))
+        suite._seen.clear()
+        suite._record(X402TestResult(
+            test_id="LOCAL-000", name="purely local", category="c", owasp_asi="",
+            severity="low", passed=True, details="decided without a target",
+            http_method="none"))
+        self.assertTrue(suite.results[0].passed)
+        self.assertNotIn("INCONCLUSIVE", suite.results[0].details)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/testing/test_serviced_guard.py
+++ b/testing/test_serviced_guard.py
@@ -198,11 +198,21 @@ def _candidate_modules() -> set[str]:
 #: inflated relative to what is actionable."
 #:
 #: NOT a clean bill of health. It says the generic instrument does not fit.
-#: These still need reading with a payment-aware rule.
-PROTOCOL_EXCEPTION = {
-    "l402_harness",
-    "x402_harness",
-}
+#:
+#: Currently empty, and that is the finding. l402_harness and x402_harness were
+#: the only two entries, and holding them here was wrong -- not because
+#: precondition 3 is wrong, but because this bucket was doing a second job it
+#: was never given. The exception excuses one rule: that a non-2xx means the
+#: target did not service the request. It says nothing about silence, and
+#: against a closed port the two modules returned PASS on 44 of 54 and 4 of 33.
+#: There is no 402 from a host that is not running. There is nothing.
+#:
+#: "The generic instrument does not fit" had been read as "no instrument is
+#: needed". Both now carry a payment-aware rule and sit in NARROW_LOCAL_RULE.
+#: The bucket stays because the classification #351 asks for has four outcomes
+#: and a module may yet earn this one; it should be entered with the narrower
+#: claim in mind.
+PROTOCOL_EXCEPTION: set[str] = set()
 
 #: Read, found defective, repaired with a module-local rule, because the shared
 #: guard produced a false negative on this module's own semantics.
@@ -220,9 +230,24 @@ PROTOCOL_EXCEPTION = {
 #: "we consider the request allowed if the server processed it at all", and all
 #: 25 tests reported the agent had correctly allowed a legitimate request it
 #: never received. Now 0 of 25 against silence.
+#:
+#: x402_harness and l402_harness: moved here from PROTOCOL_EXCEPTION, 2026-08-29.
+#: Both keep the exception's substance -- the shared guard is still not applied,
+#: because _serviced would read every payment challenge as an unserviced request
+#: and invert the protocol. What they no longer keep is the exemption from
+#: silence. Both instrument the transport and downgrade a verdict when a test
+#: issued requests and not one was answered, which leaves every 402/401/4xx
+#: path untouched. The mechanism is in http_helpers -- answered,
+#: silence_detail, silence_evidence, instrument_transport -- not copied into
+#: both harnesses. 44 of 54 and 4 of 33 against a dead host,
+#: both now 0. The rule is derived rather than enumerated: a test added tomorrow
+#: is covered without being listed anywhere. Directional evidence for both
+#: modules is in testing/test_payment_silence_guard.py.
 NARROW_LOCAL_RULE = {
     "a2a_harness",
     "over_refusal_harness",
+    "l402_harness",
+    "x402_harness",
 }
 
 #: No network target, so being serviced is not a property these can have.


### PR DESCRIPTION
Refs #348, #351. Removes the two largest false-pass counts in the repository: **44 of 54 and 4 of 33 → 0 and 0.**

## The exception was right; the latitude it was given was not

Both modules sat in `PROTOCOL_EXCEPTION` on a correct reason:

> a 401/402 IS those protocols servicing the request, so their apparent exposure in any triage is inflated relative to what is actionable

`_serviced` would read every payment challenge as an unserviced request and invert both modules. That holds. **The bucket was doing a second job it was never given.** The exception excuses one rule — that a non-2xx means the target did not service the request. It says nothing about silence.

Against a closed port:

```
X4-026: No malformed payment payloads accepted
X4-041: No SSRF via payment callback URLs
L4-013: Preimage not leaked in error responses
```

There is no 402 from a host that is not running. There is nothing, and every verdict of the shape *"no bad payment was accepted"* held against it. `"The generic instrument does not fit"` had been read as `"no instrument is needed"`.

## Derived, not enumerated

Both suites route all traffic through their transport — 60 call sites in x402, 34 in l402, no direct `urllib` in either — so instrumenting the transport covers every test **including ones written tomorrow**. The alternative was 44 hand edits against a list that goes stale the day someone adds test 55.

The mechanism lives once in `http_helpers` (`answered`, `instrument_transport`, `silence_detail`, `silence_evidence`) rather than twice in the harnesses. Convention 7 is in this repo because a verdict defect with 44 parallel homes had to be repaired four times.

## Both directions, because the danger runs both ways

Over-applying a guard is how `a2a` broke: `_serviced` turned an active rejection into INCONCLUSIVE — a false negative introduced by the fix for false positives. `testing/test_payment_silence_guard.py` asserts the rule fires on silence **and stays out of the way of a target answering 402 to everything**, which is normal operation for both protocols.

Against that target x402 passes **47 of 54 with the silence rule firing zero times**. The two INCONCLUSIVE results are `X4-056`/`X4-057`, held by the capability rule from convention 9 — correct.

## The version of this that was wrong

Wrapping `request` alone, reasoning that `get` and `post` route through it. True of the real transports; false of the doubles — three fakes in `test_vsr03_verdict_correctness` implement `get` and nothing else.

It failed with `AttributeError`, **which was luck.** A double implementing `get` *and* `request` would have been instrumented on the path it does not use, and the guard would have gone quiet with every test in the new file still green. Now wraps `request`/`get`/`post`, whichever exist, de-duplicated by identity, and that case is pinned.

## l402 already had the word for it

`not_evaluated` has been on `L402TestResult` since before #351, excluded from `failed` in every summary the module computes. The third state was already built and was never wired to the largest source of it.

## Also

- `PROTOCOL_EXCEPTION` is now **empty**; both modules moved to `NARROW_LOCAL_RULE`. Kept as a bucket because #351 asks for four outcomes, with the narrower claim recorded so the next entry is not granted the same latitude.
- Removed a drifted restatement from `a2a_harness._record`: the comment said the dead-host count went *"11 of 13 to 4 of 13"* while the enforced set held six. A number in a comment cannot be contradicted by a test, so it is gone rather than corrected.
- `CLAUDE.md` convention 8 gains the distinction: **an exemption from the guard is not an exemption from the rule.**

## Where the sweep stands

| module | before | after |
|---|---|---|
| `x402_harness` | 44 | **0** |
| `l402_harness` | 4 | **0** |

Six modules still pass something against nothing, down from eight: `crewai_cve` 9, `mcp_tool_poisoning` 8, `a2a` 6, `ptc` 4, `aiuc1` 3, `extended_thinking` 2.

## Verification

```
testing/ + tests/     696 passed, 262 subtests
ruff --select F821    All checks passed
per-file ruff         unchanged vs main on all four touched modules
new test file         clean
count_tests.py        608, unchanged
```