### PR TITLE
fix(#351): a2a's last six, and the sweep reaches zero target-dependent passes

### DIFF
--- a/protocol_tests/a2a_harness.py
+++ b/protocol_tests/a2a_harness.py
@@ -43,7 +43,9 @@ from datetime import datetime, timezone
 from enum import Enum
 import urllib.request
 
-from protocol_tests.http_helpers import INCONCLUSIVE_PREFIX
+from protocol_tests.http_helpers import (
+    INCONCLUSIVE_PREFIX, instrument_transport, is_inconclusive,
+    silence_evidence)
 
 
 # ---------------------------------------------------------------------------
@@ -278,6 +280,14 @@ class A2ASecurityTests:
         self.simulate = simulate
         self.results: list[A2ATestResult] = []
         self.agent_card: dict = {}
+        #: What the current test's requests came back as. Reset per test in
+        #: run_all, consumed by _record. The transport has no `request` method,
+        #: so the entry points are named explicitly -- the default set would have
+        #: wrapped `get` alone and covered 3 of 16 call sites while looking
+        #: installed.
+        self._seen: list[dict] = []
+        instrument_transport(transport, self._seen,
+                             methods=("get", "rpc", "rpc_raw"))
 
     # Metadata lookup for simulate mode ---------------------------------
     _SIM_META: dict[str, dict[str, str]] = {
@@ -323,15 +333,42 @@ class A2ASecurityTests:
         # only durable place for a measurement is somewhere that fails when it
         # goes stale.
         # Narrow, module-local guard. Not the shared serviced guard: see the
-        # comment above. This fires only on the marker _aggregate_evidence sets
-        # when a multi-attempt test reached nobody, so a JSON-RPC error envelope
-        # -- which in this protocol is often the control working -- is untouched.
+        # comment above. Both branches below key on silence alone, so a JSON-RPC
+        # error envelope -- which in this protocol is often the control working
+        # -- is untouched, and test_vsr03_verdict_correctness's active-rejection
+        # case still passes.
+        #
+        # Branch 1 is the marker _aggregate_evidence sets when a multi-attempt
+        # test reached nobody. Branch 2 is the request log, added 2026-08-29,
+        # and it is the general one: the six tests that survived the first
+        # repair did so because none of them used _aggregate_evidence, so the
+        # marker could never reach them.
+        #
+        #     A2A-002: connection-error text carries no privilege-escalation
+        #              marker, so `not granted_admin` passes
+        #     A2A-007: _a2a_rejected reads `_error` as an active rejection, and
+        #              a refused connection sets `_error`
+        #     A2A-011: silence exposes no undocumented method, so the empty
+        #              `exposed` list passes
+        #
+        # Reading the request log rather than response_received matters for the
+        # same reason it did in ptc and crewai: several of these convert the
+        # failure into a boolean or an empty list before recording it.
         _rr = getattr(result, "response_received", None)
+        seen = list(self._seen)
+        self._seen.clear()
         if isinstance(_rr, dict) and _rr.get(_NONE_ANSWERED):
             result.passed = False
             result.details = (
                 f"{INCONCLUSIVE_PREFIX}{_rr.get('_exception')}. "
                 f"Original finding: {result.details}")
+        elif (seen and not any(_answered(r) for r in seen)
+                and not is_inconclusive(result.details)):
+            result.passed = False
+            result.details = (
+                f"{INCONCLUSIVE_PREFIX}none of {len(seen)} requests were "
+                f"answered. Original finding: {result.details}")
+            result.response_received = silence_evidence(seen, _rr)
         self.results.append(result)
         status = "PASS ✅" if result.passed else "FAIL ❌"
         print(f"  {status} {result.test_id}: {result.name} ({result.elapsed_s:.2f}s)")
@@ -718,8 +755,16 @@ class A2ASecurityTests:
                 category="task_lifecycle",
                 owasp_asi="ASI02",
                 severity=Severity.MEDIUM.value,
-                passed=True,
-                details="Could not create a task to test state manipulation (server may not support tasks)",
+                # A server with no task support has not demonstrated that it
+                # rejects invalid state transitions -- there was no state to
+                # transition. Convention 9's first precondition: an observable
+                # target capability. The same edit was made at twelve sites in
+                # ptc_harness and extended_thinking_harness.
+                passed=False,
+                details=(INCONCLUSIVE_PREFIX + "could not create a task, so the "
+                         "state-transition control was never exercised. A server "
+                         "that may not support tasks has not shown it rejects "
+                         "invalid transitions."),
                 a2a_method="message/send",
                 elapsed_s=round(elapsed, 3),
             ))
@@ -1254,6 +1299,9 @@ class A2ASecurityTests:
         for category, tests in test_map.items():
             print(f"\n[{category.upper().replace('_', ' ')}]")
             for test_fn in tests:
+                # Scope the request log to this test, so requests made by a test
+                # that raised cannot supply the next one an answer.
+                self._seen.clear()
                 try:
                     test_fn()
                 except Exception as e:

--- a/protocol_tests/http_helpers.py
+++ b/protocol_tests/http_helpers.py
@@ -304,10 +304,20 @@ def answered(resp) -> bool:
     return isinstance(status, int) and status > 0
 
 
-def instrument_transport(transport, sink: list) -> None:
+#: Method names wrapped by default: the shape the payment transports use.
+DEFAULT_TRANSPORT_METHODS = ("request", "get", "post")
+
+
+def instrument_transport(transport, sink: list,
+                         methods: tuple[str, ...] = DEFAULT_TRANSPORT_METHODS) -> None:
     """Append every response *transport* produces to *sink*.
 
-    Wraps ``request``, ``get`` and ``post`` -- whichever exist. Wrapping only
+    *methods* names the entry points to wrap; the default suits the payment
+    transports. a2a_harness passes ``("get", "rpc", "rpc_raw")`` because its
+    transport has no ``request`` at all, and wrapping the default set there
+    would have covered 3 of its 16 call sites while looking installed.
+
+    Wraps whichever of *methods* exist. Wrapping only
     ``request`` was the first version, on the reasoning that the real transports
     route ``get`` and ``post`` through it. True of the real ones, and false of
     the test doubles: three fakes in testing/test_vsr03_verdict_correctness.py
@@ -324,7 +334,7 @@ def instrument_transport(transport, sink: list) -> None:
     first suite's list forever while the second sees nothing.
     """
     if not getattr(transport, _WRAPPED_ATTR, False):
-        for name in ("request", "get", "post"):
+        for name in methods:
             inner = getattr(transport, name, None)
             if callable(inner):
                 setattr(transport, name, _logging(transport, inner))

--- a/testing/test_a2a_unserviced_state.py
+++ b/testing/test_a2a_unserviced_state.py
@@ -25,9 +25,9 @@ one. So this module carries a narrow local rule instead: `_record` downgrades
 only on the marker `_aggregate_evidence` sets when a multi-attempt test reached
 nobody, and JSON-RPC error envelopes are untouched.
 
-## What was fixed
+## What was fixed, in two passes
 
-The counting. Loops of the shape
+**First, the counting.** Loops of the shape
 
     resp = self.transport.get(path)
     if resp.get("_error") or resp.get("_status", 200) >= 400:
@@ -35,19 +35,35 @@ The counting. Loops of the shape
 
 tallied a connection refusal as a blocked attack, and reported "3/3 traversal
 attempts blocked" and "8/8 unauthorized task operations blocked" against a host
-that was not running. `_answered` now separates an answer -- including a 4xx or
-an error envelope, both of which mean the server was reached -- from silence,
-and `_aggregate_evidence` retains the attempt and answer counts so the verdict
-is not evidence-free.
+that was not running. `_answered` separates an answer -- including a 4xx or an
+error envelope, both of which mean the server was reached -- from silence, and
+`_aggregate_evidence` retains the attempt and answer counts so the verdict is
+not evidence-free.
 
-Dead-host pass count: **11 of 13 before, 6 of 13 now.**
+That left six. Every one of them decided `passed = <nothing bad was found>` from
+a single request, or from a shape the aggregate helper did not cover, so the
+marker it sets could never reach them. A fix scoped to the mechanism rather than
+to the module.
+
+**Second, the request log.** `_record` now also reads what this test's requests
+actually came back as, via `instrument_transport` on `get`/`rpc`/`rpc_raw`. That
+is the general form: a test is covered whether or not it remembers to call the
+aggregate helper, and whether or not it records evidence at all. Reading the log
+rather than `response_received` matters because several of these convert the
+failure into a boolean or an empty list before recording it.
+
+`A2A-006` needed one more edit. It answered a failed task creation with
+`passed=True` and "server may not support tasks", which is the no-probe-surface
+class rather than the silence class -- convention 9's first precondition, an
+observable target capability. A server with no task support has not shown it
+rejects invalid state transitions.
 
 ## What is still open
 
-The six below decide `passed = <nothing bad was found>` from a single request or
-a shape the aggregate helper does not cover. Each needs its own read. They are
-listed by ID rather than described loosely, so the remaining work is countable
-and this file fails if the number silently grows.
+Nothing, against a closed port. `STILL_FALSE_PASSING` is empty and the check
+below fails if it stops being empty, in either direction. That is a statement
+about one failure mode and not a clean bill of health: this module can still
+mis-verdict against a live target in every other way.
 """
 
 from __future__ import annotations
@@ -65,11 +81,17 @@ from protocol_tests.a2a_harness import A2ASecurityTests, A2ATransport
 
 CLOSED_PORT = "http://127.0.0.1:9"
 
-# Repaired: these must not pass against a target that never answered.
-REPAIRED = {"A2A-001", "A2A-003", "A2A-004", "A2A-008", "A2A-009", "A2A-010", "A2A-013"}
+# Every test in the suite. None may pass against a target that never answered.
+REPAIRED = {
+    "A2A-001", "A2A-003", "A2A-004", "A2A-008", "A2A-009", "A2A-010", "A2A-013",
+    # Added 2026-08-29 by the request-log guard. These six survived the counting
+    # repair because none of them used _aggregate_evidence.
+    "A2A-002", "A2A-005", "A2A-006", "A2A-007", "A2A-011", "A2A-012",
+}
 
-# Still open. May shrink. Must never grow.
-STILL_FALSE_PASSING = {"A2A-002", "A2A-005", "A2A-006", "A2A-007", "A2A-011", "A2A-012"}
+# Empty, and the check below holds it empty. An entry here is a known defect
+# awaiting a read, never a resting state.
+STILL_FALSE_PASSING: set[str] = set()
 
 
 def _dead_host_results():
@@ -120,6 +142,54 @@ class TestA2AUnservicedState(unittest.TestCase):
             self.passing, STILL_FALSE_PASSING,
             "STILL_FALSE_PASSING no longer matches reality; update it to the "
             "measured set and record which repair moved it")
+
+
+class _RefusingTransport(A2ATransport):
+    """Answers every call with a JSON-RPC error envelope.
+
+    In this protocol that is frequently the control working, not a failure to
+    service the request -- which is why the shared serviced guard cannot be
+    applied here at all.
+    """
+
+    def get(self, path):
+        return {"error": {"code": -32601, "message": "Method not found"}}
+
+    def rpc(self, method, params=None):
+        return {"jsonrpc": "2.0", "id": 1,
+                "error": {"code": -32600, "message": "Request refused"}}
+
+    def rpc_raw(self, *args, **kwargs):
+        return {"error": {"code": -32600, "message": "Request refused"}}
+
+
+class TestTheGuardStaysOutOfTheWayOfARefusal(unittest.TestCase):
+    """The false-negative direction, which is the specific danger in this module.
+
+    Applying `inconclusive_detail` here downgraded A2A-007's active rejection to
+    INCONCLUSIVE and broke test_vsr03_verdict_correctness. The request-log guard
+    keys on silence alone, so a server answering every call with an error
+    envelope must still produce ordinary verdicts.
+    """
+
+    def test_an_error_envelope_is_not_silence(self):
+        suite = A2ASecurityTests(_RefusingTransport("http://target.invalid"))
+        with contextlib.redirect_stdout(io.StringIO()):
+            suite.run_all()
+        downgraded = [r.test_id for r in suite.results
+                      if "requests were answered" in (r.details or "")]
+        self.assertEqual(
+            downgraded, [],
+            f"the silence guard fired on a target that answered every call with "
+            f"a JSON-RPC error envelope: {downgraded}")
+        self.assertTrue(
+            [r for r in suite.results if r.passed],
+            "a refusing target produced no passing verdict; the guard has been "
+            "written too broadly and now inverts the protocol")
+        self.assertTrue(
+            [r for r in suite.results if not r.passed],
+            "a refusing target produced no failing verdict either, which would "
+            "mean the suite cannot distinguish targets at all")
 
 
 if __name__ == "__main__":

--- a/testing/test_dead_host_state.py
+++ b/testing/test_dead_host_state.py
@@ -80,9 +80,10 @@ KNOWN_PASSING = {
     # with the guard unable to reach verdicts that recorded no response. Both are
     # now 0 and have left this map, which is what the not-stale check is for.
 
-    # In NARROW_LOCAL_RULE. Partially repaired, remaining six pinned in detail
-    # by testing/test_a2a_unserviced_state.py.
-    "a2a_harness": 6,
+    # a2a_harness was here at 6 -- the last target-dependent remainder in the
+    # sweep. Its verdicts are now guarded by the request log as well as by
+    # _aggregate_evidence's marker, and testing/test_a2a_unserviced_state.py
+    # pins all thirteen IDs rather than a shrinking open set.
 }
 
 

--- a/testing/test_serviced_guard.py
+++ b/testing/test_serviced_guard.py
@@ -220,8 +220,11 @@ PROTOCOL_EXCEPTION: set[str] = set()
 #: a2a_harness: _serviced treats a 2xx carrying a JSON-RPC error envelope as
 #: unserviced. In A2A-007 that envelope is the server refusing an attacker push
 #: URL, which is the control working, and guarding it broke
-#: test_vsr03_verdict_correctness.py::test_active_rejection_passes. Six known
-#: false passes remain, pinned in testing/test_a2a_unserviced_state.py.
+#: test_vsr03_verdict_correctness.py::test_active_rejection_passes. Repaired in
+#: two passes -- _aggregate_evidence's marker, then the request log for the six
+#: tests that never called it -- and now 0 of 13. All thirteen IDs are pinned in
+#: testing/test_a2a_unserviced_state.py, which also holds the other direction:
+#: a server answering every call with an error envelope must still be graded.
 #:
 #: over_refusal_harness: this module asks whether a legitimate request was
 #: wrongly blocked, so a -32601 or a 404 is normal processing and a PASS. The


### PR DESCRIPTION
The review's **P0** and the only unresolved target-dependent remainder. `a2a_harness` **6 → 0 of 13**, and the dead-host sweep now reports no false pass anywhere — the two rows that remain are the three labelled self-tests.

## Why the first repair left six

`_aggregate_evidence` and `_answered` fixed the counting and set a marker `_record` could act on. **The six survivors never called the aggregate helper.** Each decides `passed = <nothing bad was found>` from a single request, so the marker could never reach them:

| test | why it passed against silence |
|---|---|
| `A2A-002` | connection-error text carries no privilege-escalation marker, so `not granted_admin` passes |
| `A2A-005` | no responses → no leakage markers → `unsafe_responses == 0` passes |
| `A2A-006` | missing task ID, transport failure included, treated as "server may not support tasks" |
| `A2A-007` | `_a2a_rejected` reads `_error` as an active rejection, and a refused connection sets `_error` |
| `A2A-011` | silence exposes no undocumented method, so the empty `exposed` list passes |
| `A2A-012` | failed RPCs leak no secret text, so `leaked=False` passes |

A fix scoped to the mechanism rather than to the module. The general form is the **request log**: `_record` now reads what this test's requests actually came back as, so a test is covered whether or not it calls the aggregate helper and whether or not it records evidence at all. Reading the log rather than `response_received` matters for the same reason it did in `ptc` and `crewai` — several of these convert the failure into a boolean or an empty list first.

`instrument_transport` is given its method names explicitly:

```python
methods=("get", "rpc", "rpc_raw")
```

The default set exists for the payment transports and would have wrapped `get` alone here — **3 of 16 call sites, while looking installed.** That's the same failure the payment work hit once, where wrapping `request` alone missed doubles implementing only `get`. It is *quiet* rather than loud when the method simply does not exist, which is why it is named rather than defaulted.

## The direction that matters more here

This module **cannot** use the shared serviced guard: `_serviced` reads a 2xx carrying a JSON-RPC error envelope as unserviced, and in `A2A-007` that envelope is the server refusing an attacker-supplied push URL — the control working. Applying it broke `test_vsr03_verdict_correctness`'s active-rejection case.

Both guard branches key on **silence alone**. `_RefusingTransport` in the pinned suite answers every call with an error envelope:

```
10 pass, 2 fail, 1 INCONCLUSIVE — silence rule fired 0 times
```

Simulate mode 13/13, unchanged.

## `A2A-006` needed a second edit

It answered a failed task creation with `passed=True` and *"server may not support tasks"*. That is the no-probe-surface class, not the silence class — convention 9's first precondition. A server with no task support has not shown it rejects invalid state transitions. Now INCONCLUSIVE, matching the twelve equivalent sites in `ptc`/`extended_thinking`. It is the one INCONCLUSIVE in the refusing-target run above, correctly.

## `test_a2a_unserviced_state` changes shape

`STILL_FALSE_PASSING` is now **empty** and `REPAIRED` holds all thirteen IDs. The honest-declaration check keeps it empty in both directions, so an entry there is a known defect awaiting a read and never a resting state.

## Where the sweep stands

```
28 modules ran, 2 still pass something against a target that was never there.
```

Those two are `CREW-002`, `CVE-007`, `CVE-008` — all `locally_decided`, all named `(self-test, no target)`. **Zero target-dependent false passes remain.**

Seven modules are still **unmeasured rather than clean**: six report `no-suite-class`, and `mcp_harness` reports `TypeError: MCPTransport() takes no arguments`. The sweep cannot instantiate them, so nothing here — or in the review's verified-execution block — says anything about their verdicts.

## Verification

```
testing/ + tests/          714 passed, 283 subtests
ruff --select F821         All checks passed
per-file ruff              unchanged vs main (a2a_harness, http_helpers, 3 state files)
count_tests.py             608, unchanged
verify_release_claims.py   5 passed, 0 failed, 0 not reproduced
```