### PR TITLE
fix(#351): the sweep's finder was a naming convention, and 34 suites were invisible

### DIFF
--- a/scripts/dead_host_sweep.py
+++ b/scripts/dead_host_sweep.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Run every candidate harness against a closed port and report what still passes.
+r"""Run every candidate harness against a closed port and report what still passes.
 
 ## Why this exists
 
@@ -28,7 +28,27 @@ a false pass or a test that does not need a target, and both are worth knowing.
 
 ## What a row means
 
-    module  passed/total  errors  verdict
+    module[::Class]  passed/total  errors  verdict
+
+A module holding several suites -- the adapter families -- gets one row per
+concrete adapter. Single-suite modules keep the bare module name, because the
+pins in testing/test_dead_host_state.py refer to them by it.
+
+Three statuses are not the same thing and used to look the same:
+
+    ran                 produced verdicts; the count is a measurement
+    ran-no-verdicts     ran and produced nothing; NOT a clean row
+    <exception>         could not be run at all
+
+`mcp_harness` is the second kind. It aborts with
+
+    if not self.initialize():
+        return self.results
+
+which is the correct behaviour -- it refuses to emit verdicts it cannot ground
+-- and it rendered as `0/0`, indistinguishable from a suite that ran everything
+and found nothing. No failures is not the same as passing, one level up from the
+rule this script exists to enforce.
 
 `passed` is the count that survived a target which was never there. Anything
 above zero needs reading. `errors` is tests that raised; a module that errors is
@@ -42,6 +62,32 @@ That a module with 0 passing is correct. It establishes that this particular
 failure mode is absent. A module can score 0 here and still mis-verdict against a
 live target in every other way.
 
+## The finder was a naming convention
+
+Until 2026-08-29 this script looked for a class matching `^class (\w*Tests?)`
+that had `run_all`. Both halves were conventions dressed as a discovery rule,
+and eight modules came back `no-suite-class` -- a row that reads as a fact about
+the module when it was a fact about the finder:
+
+    autogen_harness, gtg1002_simulation      class name lacks "Tests"
+    cloud_agent_harness                      6 adapters, run_tests not run_all
+    enterprise_adapters                     10 adapters, run_tests not run_all
+    extended_enterprise_adapters            12 adapters, run_tests not run_all
+    framework_adapters                       7 adapters, run_tests not run_all
+
+The summary line counted modules it could construct and said nothing at all
+about the rest, which is the failure this script exists to catch, aimed at
+itself. No count is restated here; testing/test_dead_host_state.py asserts a
+floor and fails if discovery narrows back to a naming convention.
+
+The adapters turned out to be guarded already, at the base class -- but that was an
+argument ("every subclass inherits it") and the guard suite verified it for four
+of them with synthetic fixtures. It is now measured for all of them.
+
+Discovery is by capability: a non-abstract class defined in the module with a
+callable `run_all` or `run_tests`. `harness_base` legitimately has neither; that
+row now means what it says.
+
     python3 scripts/dead_host_sweep.py            # table, ordered worst first
     python3 scripts/dead_host_sweep.py --json     # machine-readable
 """
@@ -54,7 +100,6 @@ import importlib
 import inspect
 import io
 import json
-import re
 import sys
 from pathlib import Path
 
@@ -75,64 +120,129 @@ def _candidate_modules() -> list[str]:
     return out
 
 
-def _suite_class(mod_name: str):
-    """The module's test-suite class, found by convention rather than a list."""
+def _suites(mod_name: str):
+    r"""Every runnable suite in a module, found by capability rather than by name.
+
+    The first version of this asked for a class whose name matched
+    ``^class (\w*Tests?)`` and which had ``run_all``. Both halves were naming
+    conventions dressed as a discovery rule, and eight modules came back as
+    ``no-suite-class`` -- a row that reads as a fact about the module when it was
+    a fact about the finder:
+
+        autogen_harness         AutoGenHarness       (no "Tests" suffix)
+        gtg1002_simulation      GTG1002Simulation    (no "Tests" suffix)
+        cloud_agent_harness     6 adapters           (run_tests, not run_all)
+        enterprise_adapters     10 adapters          (run_tests, not run_all)
+        extended_enterprise_adapters  12 adapters    (run_tests, not run_all)
+        framework_adapters      7 adapters           (run_tests, not run_all)
+
+    That is 34 suites the sweep reported nothing about while reporting 28
+    modules clean. "No failures" was not the same as "passing", one level up
+    from the rule this whole script exists to enforce.
+
+    A module may still legitimately have none: ``harness_base`` is the shared
+    ABC and defines no tests of its own. That row now means what it says.
+    """
     try:
         mod = importlib.import_module(f"protocol_tests.{mod_name}")
     except Exception:  # noqa: BLE001 - a module that will not import is a row, not a crash
-        return None, None
-    src = (REPO_ROOT / "protocol_tests" / f"{mod_name}.py").read_text(encoding="utf-8")
-    for name in re.findall(r"^class (\w*Tests?)\b", src, re.MULTILINE):
-        cls = getattr(mod, name, None)
-        if cls is not None and hasattr(cls, "run_all"):
-            return mod, cls
-    return mod, None
+        return None, []
+    found = []
+    for name, obj in vars(mod).items():
+        if not (inspect.isclass(obj) and obj.__module__ == mod.__name__):
+            continue
+        if getattr(obj, "__abstractmethods__", ()):
+            continue                      # an ABC is a base, not a suite
+        runner = next((r for r in ("run_all", "run_tests")
+                       if callable(getattr(obj, r, None))), None)
+        if runner:
+            found.append((name, obj, runner))
+    return mod, found
+
+
+def _transport_for(cls):
+    """A concrete transport from the suite's own module, for suites that take one."""
+    mod = sys.modules[cls.__module__]
+    for name, obj in vars(mod).items():
+        if not (inspect.isclass(obj) and name.endswith("Transport")):
+            continue
+        if getattr(obj, "__abstractmethods__", ()):
+            continue
+        params = list(inspect.signature(obj.__init__).parameters)[1:]
+        # Named parameters only. MCPTransport takes (*args, **kwargs), which
+        # accepts a URL and does nothing with it -- a candidate that constructs
+        # successfully and cannot talk to anything, which is the worst kind.
+        if not params or params[0] not in ("url", "base_url", "target", "endpoint"):
+            continue
+        try:
+            return obj(CLOSED_PORT)
+        except Exception:  # noqa: BLE001,S112 - a bad candidate is not an error
+            continue
+    return None
 
 
 def _instantiate(cls):
-    """Best-effort construction. Harnesses take a url, a transport, or neither."""
+    """Best-effort construction. Suites take a url, a transport, or neither."""
     params = list(inspect.signature(cls.__init__).parameters)[1:]
     first = params[0] if params else None
-    if first in ("url", "base_url", "target", "endpoint"):
-        return cls(CLOSED_PORT)
     if first == "transport":
-        mod = sys.modules[cls.__module__]
-        for attr in dir(mod):
-            if attr.endswith("Transport"):
-                return cls(getattr(mod, attr)(CLOSED_PORT))
+        transport = _transport_for(cls)
+        if transport is None:
+            raise TypeError(f"no concrete transport found for {cls.__name__}")
+        return cls(transport)
+    if first is None:
+        return cls()
     return cls(CLOSED_PORT)
 
 
 def sweep() -> list[dict]:
     rows = []
     for name in _candidate_modules():
-        _, cls = _suite_class(name)
-        if cls is None:
+        _, suites = _suites(name)
+        if not suites:
             rows.append({"module": name, "status": "no-suite-class"})
             continue
-        try:
-            suite = _instantiate(cls)
-            with contextlib.redirect_stdout(io.StringIO()), \
-                    contextlib.redirect_stderr(io.StringIO()):
-                suite.run_all()
-            results = list(getattr(suite, "results", []))
-        except Exception as exc:  # noqa: BLE001 - reported, not swallowed
-            rows.append({"module": name, "status": f"{type(exc).__name__}: {exc}"[:70]})
-            continue
-        passed = [r.test_id for r in results if getattr(r, "passed", False)]
-        errored = [r.test_id for r in results
-                   if str(getattr(r, "name", "")).startswith("ERROR")]
-        rows.append({
-            "module": name,
-            "status": "ran",
-            "total": len(results),
-            "passed": len(passed),
-            "errors": len(errored),
-            "passing_ids": passed,
-        })
+        for cls_name, cls, runner in suites:
+            # Label by class only where a module holds more than one, so the
+            # single-suite rows keep the names every existing pin refers to.
+            label = name if len(suites) == 1 else f"{name}::{cls_name}"
+            try:
+                suite = _instantiate(cls)
+                with contextlib.redirect_stdout(io.StringIO()), \
+                        contextlib.redirect_stderr(io.StringIO()):
+                    returned = getattr(suite, runner)()
+                results = list(getattr(suite, "results", None) or returned or [])
+            except Exception as exc:  # noqa: BLE001 - reported, not swallowed
+                rows.append({"module": label,
+                             "status": f"{type(exc).__name__}: {exc}"[:70]})
+                continue
+            if not results:
+                # Distinct from "ran, everything zero". mcp_harness aborts with
+                # `if not self.initialize(): return self.results`, which is the
+                # right behaviour and produces a 0/0 row that reads exactly like
+                # a clean sweep. No failures is not the same as passing.
+                rows.append({"module": label, "status": "ran-no-verdicts",
+                             "total": 0, "passed": 0, "errors": 0,
+                             "passing_ids": []})
+                continue
+            passed = [_test_id(r) for r in results if getattr(r, "passed", False)]
+            errored = [_test_id(r) for r in results
+                       if str(getattr(r, "name", "")).startswith("ERROR")]
+            rows.append({
+                "module": label,
+                "status": "ran",
+                "total": len(results),
+                "passed": len(passed),
+                "errors": len(errored),
+                "passing_ids": passed,
+            })
     # worst first: most passes against nothing
     rows.sort(key=lambda r: (-(r.get("passed") or 0), r["module"]))
     return rows
+
+
+def _test_id(result) -> str:
+    return str(getattr(result, "test_id", None) or getattr(result, "name", "?"))
 
 
 def main() -> int:
@@ -147,6 +257,10 @@ def main() -> int:
         print(f"{'module':34s} {'pass/total':>11s} {'err':>4s}  passing against nothing")
         print("-" * 96)
         for r in rows:
+            if r["status"] == "ran-no-verdicts":
+                print(f"{r['module']:34s} {'0/0':>11s} {'--':>4s}  "
+                      f"produced no verdicts -- nothing measured, not clean")
+                continue
             if r["status"] != "ran":
                 print(f"{r['module']:34s} {'--':>11s} {'--':>4s}  {r['status']}")
                 continue
@@ -156,12 +270,20 @@ def main() -> int:
             print(f"{r['module']:34s} {r['passed']:>5}/{r['total']:<5} "
                   f"{r['errors']:>4}  {ids}")
         ran = [r for r in rows if r["status"] == "ran"]
+        silent = [r for r in rows if r["status"] == "ran-no-verdicts"]
+        skipped = [r for r in rows if r["status"] not in ("ran", "ran-no-verdicts")]
         dirty = [r for r in ran if r["passed"]]
         print("-" * 96)
-        print(f"{len(ran)} modules ran, {len(dirty)} still pass something against a "
-              f"target that was never there.")
+        print(f"{len(ran)} suites produced verdicts, {len(dirty)} still pass "
+              f"something against a target that was never there.")
         print("A row above zero is either a false pass or a test that needs no "
               "target. Both are worth reading.")
+        if silent:
+            print(f"{len(silent)} produced no verdicts at all "
+                  f"({', '.join(r['module'] for r in silent)}) -- unmeasured, not clean.")
+        if skipped:
+            print(f"{len(skipped)} could not be run "
+                  f"({', '.join(r['module'] for r in skipped)}).")
     return 0
 
 

--- a/testing/test_dead_host_state.py
+++ b/testing/test_dead_host_state.py
@@ -87,6 +87,16 @@ KNOWN_PASSING = {
 }
 
 
+#: Ran, and deliberately emitted nothing. mcp_harness aborts before its first
+#: test when the MCP handshake fails, which is the behaviour #351 asks for. The
+#: row is here so the abort stays visible instead of reading as a clean 0/0.
+SILENT_BY_DESIGN = {"mcp_harness"}
+
+#: No runnable suite at all. harness_base is the shared ABC and defines no tests
+#: of its own, so this is a correct row rather than a gap.
+UNRUNNABLE = {"harness_base"}
+
+
 class TestDeadHostState(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -94,11 +104,43 @@ class TestDeadHostState(unittest.TestCase):
         cls.ran = [r for r in cls.rows if r["status"] == "ran"]
 
     def test_the_sweep_actually_ran(self):
-        """Assert a positive expected set, so a broken sweep cannot read as clean."""
+        r"""Assert a positive expected set, so a broken sweep cannot read as clean.
+
+        The floor was 25 while the finder matched class names against
+        `^class (\w*Tests?)` and required `run_all`. Both were conventions
+        dressed as a discovery rule, so every adapter -- plus two modules whose
+        class name lacks the suffix -- was reported as `no-suite-class` and the
+        summary counted only what it could construct.
+
+        The floor is asserted rather than restated in prose, so it cannot go
+        stale the way the sentence it replaced did.
+        """
         self.assertGreaterEqual(
-            len(self.ran), 25,
-            f"only {len(self.ran)} modules ran; the sweep is probably broken rather "
-            f"than the repository having shrunk")
+            len(self.ran), 60,
+            f"only {len(self.ran)} suites produced verdicts; the sweep is probably "
+            f"broken, or its discovery has narrowed back to a naming convention")
+
+    def test_a_suite_that_produced_nothing_is_declared(self):
+        """Ran and emitted no verdicts is not the same as ran and found nothing.
+
+        mcp_harness aborts with `if not self.initialize(): return self.results`,
+        which is correct -- it refuses to emit verdicts it cannot ground -- and
+        it rendered as `0/0`, indistinguishable from a clean sweep. Anything
+        else landing in this state is a suite that silently stopped testing.
+        """
+        silent = {r["module"] for r in self.rows if r["status"] == "ran-no-verdicts"}
+        self.assertEqual(
+            silent, SILENT_BY_DESIGN,
+            f"declared {sorted(SILENT_BY_DESIGN)}, measured {sorted(silent)}. A "
+            f"suite producing no verdicts is unmeasured, not clean.")
+
+    def test_nothing_is_unrunnable_except_what_is_declared(self):
+        cannot_run = {r["module"]: r["status"] for r in self.rows
+                      if r["status"] not in ("ran", "ran-no-verdicts")}
+        self.assertEqual(
+            set(cannot_run), UNRUNNABLE,
+            f"declared {sorted(UNRUNNABLE)}, measured {cannot_run}. A suite the "
+            f"sweep cannot construct is a suite nothing here says anything about.")
 
     def test_no_module_errors_its_way_to_a_low_score(self):
         """A module that raises is not a module that passed.

--- a/testing/test_serviced_guard.py
+++ b/testing/test_serviced_guard.py
@@ -274,6 +274,15 @@ NARROW_LOCAL_RULE = {
     "aiuc1_compliance_harness",
 }
 
+#: ADAPTER_CASES below verifies the base-class guard for one adapter per module
+#: using synthetic results. That is the mechanism; it is not the outcome. As of
+#: 2026-08-29 scripts/dead_host_sweep.py constructs and runs every concrete
+#: adapter against a closed port, so "every subclass inherits it" is measured
+#: rather than argued. All of them score zero. The distinction matters here
+#: because it is exactly how advanced_attacks kept a GUARDED label while
+#: false-passing 7 of 10: the guard suite fed it synthetic results that carried
+#: a response, and the module's own tests recorded none.
+
 #: No network target, so being serviced is not a property these can have.
 #: skill_security_harness makes no HTTP calls; its verdicts read a local skill
 #: path and it already fails closed when that path is empty (0 of 8, all with


### PR DESCRIPTION
`dead_host_sweep.py` looked for a class matching `^class (\w*Tests?)` that had `run_all`. **Both halves were conventions dressed as a discovery rule**, and eight modules came back `no-suite-class` — a row that reads as a fact about the module when it was a fact about the finder:

| module | why it was invisible |
|---|---|
| `autogen_harness`, `gtg1002_simulation` | class name lacks the `Tests` suffix |
| `cloud_agent_harness` | 6 adapters, `run_tests` not `run_all` |
| `enterprise_adapters` | 10 adapters, `run_tests` not `run_all` |
| `extended_enterprise_adapters` | 12 adapters, `run_tests` not `run_all` |
| `framework_adapters` | 7 adapters, `run_tests` not `run_all` |

The summary line counted what it could construct and said nothing about the rest. **That is the rule this script exists to enforce — no failures is not the same as passing — aimed at the script itself.**

Discovery is now by capability: a non-abstract class defined in the module with a callable `run_all` or `run_tests`. **28 modules → 61 suites producing verdicts.**

## The adapters were already right, and that had never been measured

All 34 score zero, because the guard lives on the adapter base class and every subclass inherits it. That was true, and it was *an argument*. `ADAPTER_CASES` verified it for four adapters using **synthetic results** — the mechanism, not the outcome.

That is the same gap that let `advanced_attacks` hold a `GUARDED` label while false-passing 7 of 10: the guard suite fed it synthetic results carrying a response, and its own tests recorded none. Now measured for all of them.

## `mcp_harness` is correct and its row was not

```python
if not self.initialize():
    return self.results
```

It refuses to emit verdicts it cannot ground — precisely what #351 asks for. It rendered as `0/0`, **indistinguishable from a suite that ran everything and found nothing.**

`ran-no-verdicts` is now a distinct status, printed as *"produced no verdicts — nothing measured, not clean"*, declared in `SILENT_BY_DESIGN`, and asserted.

`_transport_for` also has to skip `MCPTransport`, whose `__init__` takes `(*args, **kwargs)`: **it accepts a URL and does nothing with it**, so it constructs successfully and cannot talk to anything. Candidates now need a named url parameter. Against this target it changed no verdict, because the suite aborts either way; against a live one it would have silently tested nothing.

## Three statuses that used to look like one

```
ran                 produced verdicts; the count is a measurement
ran-no-verdicts     ran and produced nothing; NOT a clean row
<exception>         could not be run at all
```

`harness_base` is the third kind and correctly so — it is the shared ABC and defines no tests. Both non-`ran` states are declared and asserted, so a suite that silently stops testing fails the state file rather than reading as clean.

## The repo's own drift check caught me

`test_no_stale_module_count_anywhere` failed on two sentences I had **just written** that said "28 modules". The fix is not to update the number to 43 — it is that a count in prose has no test that can contradict it. Both restatements are gone; the floor is asserted in `test_the_sweep_actually_ran` instead, and it fails if discovery narrows back to a naming convention.

## Where this leaves the sweep

```
61 suites produced verdicts, 2 still pass something against a target that was never there.
1 produced no verdicts at all (mcp_harness) -- unmeasured, not clean.
1 could not be run (harness_base).
```

The 2 are `CREW-002`, `CVE-007`, `CVE-008` — all `locally_decided`, all named `(self-test, no target)`. **Zero target-dependent false passes, now across 61 suites rather than 28.**

## Verification

```
testing/ + tests/          716 passed, 283 subtests
ruff --select F821         All checks passed
dead_host_sweep.py         lint clean (was 0 findings, still 0)
test_dead_host_state.py    lint clean
count_tests.py             608, unchanged
verify_release_claims.py   5 passed, 0 failed, 0 not reproduced
```