### PR TITLE
fix: --json must put exactly one JSON document on stdout

### DIFF
--- a/protocol_tests/_utils.py
+++ b/protocol_tests/_utils.py
@@ -9,7 +9,9 @@ harness files.  Import from here instead of copy-pasting implementations.
 
 from __future__ import annotations
 
+import contextlib
 import json
+import sys
 import math
 import os
 import re
@@ -281,3 +283,30 @@ def http_post_json(
         return {"_error": True, "_status": e.code, "_body": body_text}
     except Exception as e:
         return {"_error": True, "_exception": type(e).__name__, "_message": str(e)[:300]}
+
+
+@contextlib.contextmanager
+def json_stdout_only(active: bool):
+    """In ``--json`` mode, send progress output to stderr.
+
+    A machine consumer of ``--json`` gets exactly one document on stdout. Six
+    CLIs violated that: five print a run banner from ``run_all`` and every one
+    of them printed "Report written to ..." after the JSON.
+
+    Found 2026-08-29 by an independent reviewer running
+
+        python -m protocol_tests.mcp_harness --transport http --url ... \
+            --json --report /tmp/report.json
+
+    and getting stdout that ``json.loads`` refuses. Not a false verdict, and
+    still a defect: it breaks CI and any downstream evidence tooling that reads
+    the documented interface.
+
+    The notice itself belongs on stderr in every mode, JSON or not -- it is
+    progress, not output -- so it is moved unconditionally rather than guarded.
+    """
+    if not active:
+        yield
+        return
+    with contextlib.redirect_stdout(sys.stderr):
+        yield

--- a/protocol_tests/a2a_harness.py
+++ b/protocol_tests/a2a_harness.py
@@ -1344,7 +1344,7 @@ def generate_report(results: list[A2ATestResult], output_path: str):
     }
     with open(output_path, "w") as f:
         json.dump(report, f, indent=2, default=str)
-    print(f"Report written to {output_path}")
+    print(f"Report written to {output_path}", file=sys.stderr)
 
 
 # ---------------------------------------------------------------------------
@@ -1389,7 +1389,7 @@ def main():
         if args.report:
             with open(args.report, "w") as f:
                 json.dump(merged, f, indent=2, default=str)
-            print(f"Report written to {args.report}")
+            print(f"Report written to {args.report}", file=sys.stderr)
         results = merged.get("results", [])
     else:
         suite = A2ASecurityTests(transport, agent_card_path=args.agent_card,

--- a/protocol_tests/advanced_attacks.py
+++ b/protocol_tests/advanced_attacks.py
@@ -713,7 +713,7 @@ def generate_report(results, output_path):
     }
     with open(output_path, "w") as f:
         json.dump(report, f, indent=2, default=str)
-    print(f"Report written to {output_path}")
+    print(f"Report written to {output_path}", file=sys.stderr)
 
 
 def main():
@@ -747,7 +747,7 @@ def main():
             if args.report:
                 with open(args.report, "w") as f:
                     json.dump(merged, f, indent=2, default=str)
-                print(f"Report written to {args.report}")
+                print(f"Report written to {args.report}", file=sys.stderr)
             results = merged.get("results", [])
         else:
             suite = AdvancedAttackTests(args.url, headers=headers)

--- a/protocol_tests/ap2_harness.py
+++ b/protocol_tests/ap2_harness.py
@@ -96,7 +96,7 @@ import uuid
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 
-from protocol_tests._utils import Severity, wilson_ci, http_post_json
+from protocol_tests._utils import Severity, wilson_ci, http_post_json, json_stdout_only
 
 
 # ---------------------------------------------------------------------------
@@ -909,7 +909,11 @@ def main() -> None:
 
     simulate = args.simulate or not args.url
     suite = AP2MandateTests(url=args.url, headers=headers, simulate=simulate)
-    results = suite.run_all()
+    # The suite prints a run banner as it goes. In --json mode that lands
+    # on stdout ahead of the document, so a consumer gets a header and
+    # then JSON. Progress belongs on stderr; see _utils.json_stdout_only.
+    with json_stdout_only(args.json):
+        results = suite.run_all()
 
     total = len(results)
     passed = sum(1 for r in results if r.passed)
@@ -931,7 +935,7 @@ def main() -> None:
     if args.report:
         with open(args.report, "w") as f:
             json.dump(report, f, indent=2, default=str)
-        print(f"Report written to {args.report}")
+        print(f"Report written to {args.report}", file=sys.stderr)
 
     sys.exit(1 if any(not r.passed for r in results) else 0)
 

--- a/protocol_tests/autogen_harness.py
+++ b/protocol_tests/autogen_harness.py
@@ -708,7 +708,7 @@ def main() -> None:
     if args.output:
         with open(args.output, "w") as f:
             f.write(report_json)
-        print(f"\nReport written to {args.output}")
+        print(f"\nReport written to {args.output}", file=sys.stderr)
     else:
         print(f"\n{report_json}")
 

--- a/protocol_tests/benchmark_integrity_harness.py
+++ b/protocol_tests/benchmark_integrity_harness.py
@@ -801,7 +801,7 @@ def generate_report(results: list[BenchmarkIntegrityResult], output_path: str):
 
     with open(output_path, "w") as f:
         json.dump(report, f, indent=2, default=str)
-    print(f"Report written to {output_path}")
+    print(f"Report written to {output_path}", file=sys.stderr)
 
 
 # ---------------------------------------------------------------------------

--- a/protocol_tests/capability_profile_harness.py
+++ b/protocol_tests/capability_profile_harness.py
@@ -737,7 +737,7 @@ def generate_report(results: list[CapabilityProfileTestResult], output_path: str
     }
     with open(output_path, "w") as f:
         json.dump(report, f, indent=2, default=str)
-    print(f"Report written to {output_path}")
+    print(f"Report written to {output_path}", file=sys.stderr)
 
 
 # ---------------------------------------------------------------------------
@@ -775,7 +775,7 @@ def main():
         if args.report:
             with open(args.report, "w") as f:
                 json.dump(merged, f, indent=2, default=str)
-            print(f"Report written to {args.report}")
+            print(f"Report written to {args.report}", file=sys.stderr)
         results = merged.get("results", [])
     else:
         suite = CapabilityProfileTests(args.url, headers=headers)

--- a/protocol_tests/card_token_harness.py
+++ b/protocol_tests/card_token_harness.py
@@ -64,12 +64,13 @@ import argparse
 import base64
 import hashlib
 import json
+import sys
 import time
 import uuid
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 
-from protocol_tests._utils import Severity, wilson_ci, http_post_json
+from protocol_tests._utils import Severity, wilson_ci, http_post_json, json_stdout_only
 
 
 # ---------------------------------------------------------------------------
@@ -666,7 +667,11 @@ def main() -> None:
 
     simulate = args.simulate or not args.url
     suite = CardTokenTests(url=args.url, headers=headers, simulate=simulate)
-    results = suite.run_all()
+    # The suite prints a run banner as it goes. In --json mode that lands
+    # on stdout ahead of the document, so a consumer gets a header and
+    # then JSON. Progress belongs on stderr; see _utils.json_stdout_only.
+    with json_stdout_only(args.json):
+        results = suite.run_all()
 
     total = len(results)
     passed = sum(1 for r in results if r.passed)
@@ -688,7 +693,7 @@ def main() -> None:
     if args.report:
         with open(args.report, "w") as f:
             json.dump(report, f, indent=2, default=str)
-        print(f"Report written to {args.report}")
+        print(f"Report written to {args.report}", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/protocol_tests/cbrn_harness.py
+++ b/protocol_tests/cbrn_harness.py
@@ -622,7 +622,7 @@ def generate_report(results: list[CBRNTestResult], output_path: str):
     }
     with open(output_path, "w") as f:
         json.dump(report, f, indent=2, default=str)
-    print(f"Report written to {output_path}")
+    print(f"Report written to {output_path}", file=sys.stderr)
 
 
 # ---------------------------------------------------------------------------
@@ -661,7 +661,7 @@ def main():
             import json as _json
             with open(args.report, "w") as f:
                 _json.dump(merged, f, indent=2, default=str)
-            print(f"Report written to {args.report}")
+            print(f"Report written to {args.report}", file=sys.stderr)
         results = merged.get("results", [])
     else:
         suite = CBRNTests(args.url, headers=headers)

--- a/protocol_tests/community_runner.py
+++ b/protocol_tests/community_runner.py
@@ -1108,7 +1108,7 @@ Examples:
     if args.report:
         with open(args.report, "w", encoding="utf-8") as f:
             json.dump(summary, f, indent=2)
-        print(f"\nReport written to {args.report}")
+        print(f"\nReport written to {args.report}", file=sys.stderr)
 
     # Exit code: 0 if all passed, 1 if any failed
     if "failed" in summary and summary["failed"] > 0:

--- a/protocol_tests/enterprise_adapters.py
+++ b/protocol_tests/enterprise_adapters.py
@@ -971,7 +971,7 @@ def generate_report(results: list[EnterpriseTestResult], output_path: str):
     }
     with open(output_path, "w") as f:
         json.dump(report, f, indent=2, default=str)
-    print(f"\nReport written to {output_path}")
+    print(f"\nReport written to {output_path}", file=sys.stderr)
 
 
 def main():
@@ -1017,7 +1017,7 @@ def main():
             if args.report:
                 with open(args.report, "w") as f:
                     json.dump(merged, f, indent=2, default=str)
-                print(f"Report written to {args.report}")
+                print(f"Report written to {args.report}", file=sys.stderr)
             results = merged.get("results", [])
         else:
             print(f"\n{'='*60}")

--- a/protocol_tests/extended_enterprise_adapters.py
+++ b/protocol_tests/extended_enterprise_adapters.py
@@ -814,7 +814,7 @@ def generate_report(results, output_path):
     }
     with open(output_path, "w") as f:
         json.dump(report, f, indent=2, default=str)
-    print(f"\nReport written to {output_path}")
+    print(f"\nReport written to {output_path}", file=sys.stderr)
 
 
 def main():
@@ -866,7 +866,7 @@ def main():
                 import json as _json
                 with open(args.report, "w") as f:
                     _json.dump(merged, f, indent=2, default=str)
-                print(f"Report written to {args.report}")
+                print(f"Report written to {args.report}", file=sys.stderr)
             results = merged.get("results", [])
         else:
             adapter = cls(args.url, headers=headers)

--- a/protocol_tests/extended_thinking_harness.py
+++ b/protocol_tests/extended_thinking_harness.py
@@ -764,7 +764,7 @@ def generate_report(results: list[ExtendedThinkingResult], output_path: str) -> 
 
     with open(output_path, "w") as f:
         json.dump(report, f, indent=2, default=str)
-    print(f"Report written to {output_path}")
+    print(f"Report written to {output_path}", file=sys.stderr)
 
 
 # ---------------------------------------------------------------------------
@@ -810,7 +810,7 @@ def main() -> None:
         if args.report:
             with open(args.report, "w") as f:
                 json.dump(merged, f, indent=2, default=str)
-            print(f"Report written to {args.report}")
+            print(f"Report written to {args.report}", file=sys.stderr)
         results = merged.get("results", [])
     else:
         suite = ExtendedThinkingTests(url=args.url, headers=headers, simulate=args.simulate)

--- a/protocol_tests/framework_adapters.py
+++ b/protocol_tests/framework_adapters.py
@@ -1160,7 +1160,7 @@ def generate_report(results: list[AdapterTestResult], output_path: str):
     }
     with open(output_path, "w") as f:
         json.dump(report, f, indent=2, default=str)
-    print(f"\nReport written to {output_path}")
+    print(f"\nReport written to {output_path}", file=sys.stderr)
 
 
 # ---------------------------------------------------------------------------
@@ -1239,7 +1239,7 @@ def main():
             if args.report:
                 with open(args.report, "w") as f:
                     json.dump(merged, f, indent=2, default=str)
-                print(f"Report written to {args.report}")
+                print(f"Report written to {args.report}", file=sys.stderr)
             results = merged.get("results", [])
         else:
             print(f"\n{'='*60}")

--- a/protocol_tests/governance_modification_harness.py
+++ b/protocol_tests/governance_modification_harness.py
@@ -971,7 +971,7 @@ def main() -> None:
         }
         with open(args.report, "w") as f:
             json.dump(report, f, indent=2, default=str)
-        print(f"Report written to {args.report}")
+        print(f"Report written to {args.report}", file=sys.stderr)
 
     sys.exit(1 if any(not r.passed for r in results) else 0)
 

--- a/protocol_tests/gtg1002_simulation.py
+++ b/protocol_tests/gtg1002_simulation.py
@@ -914,7 +914,7 @@ def main():
             if args.report:
                 with open(args.report, "w") as f:
                     json.dump(merged, f, indent=2, default=str)
-                print(f"Report written to {args.report}")
+                print(f"Report written to {args.report}", file=sys.stderr)
             results = merged.get("results", [])
         else:
             results = sim.run_all(phases=phases, full_campaign=args.full_campaign)

--- a/protocol_tests/harmful_output_harness.py
+++ b/protocol_tests/harmful_output_harness.py
@@ -712,7 +712,7 @@ def generate_report(results: list[HarmfulOutputTestResult], output_path: str):
     }
     with open(output_path, "w") as f:
         json.dump(report, f, indent=2, default=str)
-    print(f"Report written to {output_path}")
+    print(f"Report written to {output_path}", file=sys.stderr)
 
 
 # ---------------------------------------------------------------------------
@@ -750,7 +750,7 @@ def main():
         if args.report:
             with open(args.report, "w") as f:
                 json.dump(merged, f, indent=2, default=str)
-            print(f"Report written to {args.report}")
+            print(f"Report written to {args.report}", file=sys.stderr)
         results = merged.get("results", [])
     else:
         suite = HarmfulOutputTests(args.url, headers=headers)

--- a/protocol_tests/identity_harness.py
+++ b/protocol_tests/identity_harness.py
@@ -1100,7 +1100,7 @@ def main():
             if args.report:
                 with open(args.report, "w") as f:
                     json.dump(merged, f, indent=2, default=str)
-                print(f"Report written to {args.report}")
+                print(f"Report written to {args.report}", file=sys.stderr)
             results = merged.get("results", [])
         else:
             suite = IdentitySecurityTests(args.url, headers=headers)

--- a/protocol_tests/incident_response_harness.py
+++ b/protocol_tests/incident_response_harness.py
@@ -780,7 +780,7 @@ def generate_report(results: list[IncidentResponseTestResult], output_path: str)
     }
     with open(output_path, "w") as f:
         json.dump(report, f, indent=2, default=str)
-    print(f"Report written to {output_path}")
+    print(f"Report written to {output_path}", file=sys.stderr)
 
 
 # ---------------------------------------------------------------------------
@@ -819,7 +819,7 @@ def main():
             import json as _json
             with open(args.report, "w") as f:
                 _json.dump(merged, f, indent=2, default=str)
-            print(f"Report written to {args.report}")
+            print(f"Report written to {args.report}", file=sys.stderr)
         results = merged.get("results", [])
     else:
         suite = IncidentResponseTests(args.url, headers=headers)

--- a/protocol_tests/intent_contract_harness.py
+++ b/protocol_tests/intent_contract_harness.py
@@ -600,7 +600,7 @@ def generate_report(results: list[IntentContractTestResult], output_path: str):
     }
     with open(output_path, "w") as f:
         json.dump(report, f, indent=2, default=str)
-    print(f"Report written to {output_path}")
+    print(f"Report written to {output_path}", file=sys.stderr)
 
 
 # ---------------------------------------------------------------------------
@@ -638,7 +638,7 @@ def main():
         if args.report:
             with open(args.report, "w") as f:
                 json.dump(merged, f, indent=2, default=str)
-            print(f"Report written to {args.report}")
+            print(f"Report written to {args.report}", file=sys.stderr)
         results = merged.get("results", [])
     else:
         suite = IntentContractTests(args.url, headers=headers)

--- a/protocol_tests/jailbreak_harness.py
+++ b/protocol_tests/jailbreak_harness.py
@@ -1106,7 +1106,7 @@ def generate_report(results: list[JailbreakTestResult], output_path: str):
     }
     with open(output_path, "w") as f:
         json.dump(report, f, indent=2, default=str)
-    print(f"Report written to {output_path}")
+    print(f"Report written to {output_path}", file=sys.stderr)
 
 
 # ---------------------------------------------------------------------------
@@ -1149,7 +1149,7 @@ def main():
         if args.report:
             with open(args.report, "w") as f:
                 json.dump(merged, f, indent=2, default=str)
-            print(f"Report written to {args.report}")
+            print(f"Report written to {args.report}", file=sys.stderr)
         results = merged.get("results", [])
     else:
         suite = JailbreakTests(args.url, headers=headers, use_judge=args.judge)

--- a/protocol_tests/kill_switch_harness.py
+++ b/protocol_tests/kill_switch_harness.py
@@ -564,7 +564,7 @@ def main():
         }
         with open(args.report, "w") as f:
             json.dump(report, f, indent=2, default=str)
-        print(f"Report written to {args.report}")
+        print(f"Report written to {args.report}", file=sys.stderr)
 
     sys.exit(1 if any(not r.passed for r in results) else 0)
 

--- a/protocol_tests/l402_harness.py
+++ b/protocol_tests/l402_harness.py
@@ -2129,7 +2129,7 @@ def generate_report(results: list[L402TestResult], output_path: str):
     }
     with open(output_path, "w") as f:
         json.dump(report, f, indent=2, default=str)
-    print(f"Report written to {output_path}")
+    print(f"Report written to {output_path}", file=sys.stderr)
 
 
 # ---------------------------------------------------------------------------

--- a/protocol_tests/mcp_harness.py
+++ b/protocol_tests/mcp_harness.py
@@ -3358,7 +3358,7 @@ def generate_report(
     report = build_report(results, error=error, protocol_version=protocol_version)
     with open(output_path, "w") as f:
         json.dump(report, f, indent=2, default=str)
-    print(f"Report written to {output_path}")
+    print(f"Report written to {output_path}", file=sys.stderr)
 
 
 # ---------------------------------------------------------------------------
@@ -3691,7 +3691,7 @@ def main():
             with open(args.report, "w") as f:
                 json.dump(differential, f, indent=2, default=str)
             if not json_output:
-                print(f"Report written to {args.report}")
+                print(f"Report written to {args.report}", file=sys.stderr)
         if json_output:
             print(json.dumps(differential, indent=2, default=str))
         failed = any(report_has_failure(report) for report in (
@@ -3734,7 +3734,7 @@ def main():
             with open(args.report, "w") as f:
                 json.dump(merged, f, indent=2, default=str)
             if not json_output:
-                print(f"Report written to {args.report}")
+                print(f"Report written to {args.report}", file=sys.stderr)
         if json_output:
             print(json.dumps(merged, indent=2, default=str))
         results = merged.get("results", [])

--- a/protocol_tests/mcp_supplychain.py
+++ b/protocol_tests/mcp_supplychain.py
@@ -614,7 +614,7 @@ def main() -> None:
         with open(args.report, "w") as f:
             json.dump(report, f, indent=2, default=str)
         if not json_output:
-            print(f"Report written to {args.report}")
+            print(f"Report written to {args.report}", file=sys.stderr)
 
     if json_output:
         print(json.dumps(report, indent=2, default=str))

--- a/protocol_tests/memory_harness.py
+++ b/protocol_tests/memory_harness.py
@@ -863,7 +863,7 @@ def generate_report(results: list[MemoryTestResult], output_path: str):
     }
     with open(output_path, "w") as f:
         json.dump(report, f, indent=2, default=str)
-    print(f"Report written to {output_path}")
+    print(f"Report written to {output_path}", file=sys.stderr)
 
 
 # ---------------------------------------------------------------------------
@@ -901,7 +901,7 @@ def main():
         if args.report:
             with open(args.report, "w") as f:
                 json.dump(merged, f, indent=2, default=str)
-            print(f"Report written to {args.report}")
+            print(f"Report written to {args.report}", file=sys.stderr)
         results = merged.get("results", [])
     else:
         suite = MemoryTests(args.url, headers=headers)

--- a/protocol_tests/multi_agent_harness.py
+++ b/protocol_tests/multi_agent_harness.py
@@ -1282,7 +1282,7 @@ def generate_report(results: list[MultiAgentTestResult], output_path: str):
     }
     with open(output_path, "w") as f:
         json.dump(report, f, indent=2, default=str)
-    print(f"Report written to {output_path}")
+    print(f"Report written to {output_path}", file=sys.stderr)
 
 
 # ---------------------------------------------------------------------------
@@ -1320,7 +1320,7 @@ def main():
         if args.report:
             with open(args.report, "w") as f:
                 json.dump(merged, f, indent=2, default=str)
-            print(f"Report written to {args.report}")
+            print(f"Report written to {args.report}", file=sys.stderr)
         results = merged.get("results", [])
     else:
         suite = MultiAgentTests(args.url, headers=headers)

--- a/protocol_tests/over_refusal_harness.py
+++ b/protocol_tests/over_refusal_harness.py
@@ -942,7 +942,7 @@ def generate_report(results: list[OverRefusalTestResult], output_path: str):
     }
     with open(output_path, "w") as f:
         json.dump(report, f, indent=2, default=str)
-    print(f"Report written to {output_path}")
+    print(f"Report written to {output_path}", file=sys.stderr)
 
 
 # ---------------------------------------------------------------------------
@@ -980,7 +980,7 @@ def main():
         if args.report:
             with open(args.report, "w") as f:
                 json.dump(merged, f, indent=2, default=str)
-            print(f"Report written to {args.report}")
+            print(f"Report written to {args.report}", file=sys.stderr)
         results = merged.get("results", [])
     else:
         suite = OverRefusalTests(args.url, headers=headers)

--- a/protocol_tests/prompt_caching_harness.py
+++ b/protocol_tests/prompt_caching_harness.py
@@ -723,7 +723,7 @@ def generate_report(results: list[PromptCachingResult], output_path: str) -> Non
 
     with open(output_path, "w") as f:
         json.dump(report, f, indent=2, default=str)
-    print(f"Report written to {output_path}")
+    print(f"Report written to {output_path}", file=sys.stderr)
 
 
 # ---------------------------------------------------------------------------
@@ -769,7 +769,7 @@ def main() -> None:
         if args.report:
             with open(args.report, "w") as f:
                 json.dump(merged, f, indent=2, default=str)
-            print(f"Report written to {args.report}")
+            print(f"Report written to {args.report}", file=sys.stderr)
         results = merged.get("results", [])
     else:
         suite = PromptCachingTests(url=args.url, headers=headers, simulate=args.simulate)

--- a/protocol_tests/provenance_harness.py
+++ b/protocol_tests/provenance_harness.py
@@ -872,7 +872,7 @@ def generate_report(results: list[ProvenanceTestResult], output_path: str):
     }
     with open(output_path, "w") as f:
         json.dump(report, f, indent=2, default=str)
-    print(f"Report written to {output_path}")
+    print(f"Report written to {output_path}", file=sys.stderr)
 
 
 # ---------------------------------------------------------------------------
@@ -910,7 +910,7 @@ def main():
         if args.report:
             with open(args.report, "w") as f:
                 json.dump(merged, f, indent=2, default=str)
-            print(f"Report written to {args.report}")
+            print(f"Report written to {args.report}", file=sys.stderr)
         results = merged.get("results", [])
     else:
         suite = ProvenanceTests(args.url, headers=headers)

--- a/protocol_tests/ptc_harness.py
+++ b/protocol_tests/ptc_harness.py
@@ -809,7 +809,7 @@ def generate_report(results: list[PTCResult], output_path: str) -> None:
 
     with open(output_path, "w") as f:
         json.dump(report, f, indent=2, default=str)
-    print(f"Report written to {output_path}")
+    print(f"Report written to {output_path}", file=sys.stderr)
 
 
 # ---------------------------------------------------------------------------
@@ -855,7 +855,7 @@ def main() -> None:
         if args.report:
             with open(args.report, "w") as f:
                 json.dump(merged, f, indent=2, default=str)
-            print(f"Report written to {args.report}")
+            print(f"Report written to {args.report}", file=sys.stderr)
         results = merged.get("results", [])
     else:
         suite = PTCTests(url=args.url, headers=headers, simulate=args.simulate)

--- a/protocol_tests/return_channel_harness.py
+++ b/protocol_tests/return_channel_harness.py
@@ -674,7 +674,7 @@ def generate_report(results: list[ReturnChannelTestResult], output_path: str):
     }
     with open(output_path, "w") as f:
         json.dump(report, f, indent=2, default=str)
-    print(f"Report written to {output_path}")
+    print(f"Report written to {output_path}", file=sys.stderr)
 
 
 # ---------------------------------------------------------------------------
@@ -712,7 +712,7 @@ def main():
         if args.report:
             with open(args.report, "w") as f:
                 json.dump(merged, f, indent=2, default=str)
-            print(f"Report written to {args.report}")
+            print(f"Report written to {args.report}", file=sys.stderr)
         results = merged.get("results", [])
     else:
         suite = ReturnChannelTests(args.url, headers=headers)

--- a/protocol_tests/settlement_finality_harness.py
+++ b/protocol_tests/settlement_finality_harness.py
@@ -56,11 +56,12 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 import time
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 
-from protocol_tests._utils import Severity, wilson_ci, http_post_json
+from protocol_tests._utils import Severity, wilson_ci, http_post_json, json_stdout_only
 
 
 @dataclass
@@ -493,7 +494,11 @@ def main() -> None:
 
     simulate = args.simulate or not args.url
     suite = SettlementFinalityTests(url=args.url, headers=headers, simulate=simulate)
-    results = suite.run_all()
+    # The suite prints a run banner as it goes. In --json mode that lands
+    # on stdout ahead of the document, so a consumer gets a header and
+    # then JSON. Progress belongs on stderr; see _utils.json_stdout_only.
+    with json_stdout_only(args.json):
+        results = suite.run_all()
 
     total = len(results)
     passed = sum(1 for r in results if r.passed)
@@ -514,7 +519,7 @@ def main() -> None:
     if args.report:
         with open(args.report, "w") as f:
             json.dump(report, f, indent=2, default=str)
-        print(f"Report written to {args.report}")
+        print(f"Report written to {args.report}", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/protocol_tests/skill_security_harness.py
+++ b/protocol_tests/skill_security_harness.py
@@ -1235,7 +1235,7 @@ def generate_report(results: list[SkillSecurityResult], output_path: str) -> Non
 
     with open(output_path, "w") as f:
         json.dump(report, f, indent=2, default=str)
-    print(f"Report written to {output_path}")
+    print(f"Report written to {output_path}", file=sys.stderr)
 
 
 # ---------------------------------------------------------------------------

--- a/protocol_tests/tool_search_harness.py
+++ b/protocol_tests/tool_search_harness.py
@@ -818,7 +818,7 @@ def generate_report(results: list[ToolSearchResult], output_path: str) -> None:
 
     with open(output_path, "w") as f:
         json.dump(report, f, indent=2, default=str)
-    print(f"Report written to {output_path}")
+    print(f"Report written to {output_path}", file=sys.stderr)
 
 
 # ---------------------------------------------------------------------------
@@ -864,7 +864,7 @@ def main() -> None:
         if args.report:
             with open(args.report, "w") as f:
                 json.dump(merged, f, indent=2, default=str)
-            print(f"Report written to {args.report}")
+            print(f"Report written to {args.report}", file=sys.stderr)
         results = merged.get("results", [])
     else:
         suite = ToolSearchTests(url=args.url, headers=headers, simulate=args.simulate)

--- a/protocol_tests/ucp_acp_harness.py
+++ b/protocol_tests/ucp_acp_harness.py
@@ -74,12 +74,13 @@ import argparse
 import base64
 import hashlib
 import json
+import sys
 import time
 import uuid
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 
-from protocol_tests._utils import Severity, wilson_ci, http_post_json
+from protocol_tests._utils import Severity, wilson_ci, http_post_json, json_stdout_only
 
 
 # ---------------------------------------------------------------------------
@@ -697,7 +698,11 @@ def main() -> None:
 
     simulate = args.simulate or not args.url
     suite = UCPACPJourneyTests(url=args.url, headers=headers, simulate=simulate)
-    results = suite.run_all()
+    # The suite prints a run banner as it goes. In --json mode that lands
+    # on stdout ahead of the document, so a consumer gets a header and
+    # then JSON. Progress belongs on stderr; see _utils.json_stdout_only.
+    with json_stdout_only(args.json):
+        results = suite.run_all()
 
     total = len(results)
     passed = sum(1 for r in results if r.passed)
@@ -719,7 +724,7 @@ def main() -> None:
     if args.report:
         with open(args.report, "w") as f:
             json.dump(report, f, indent=2, default=str)
-        print(f"Report written to {args.report}")
+        print(f"Report written to {args.report}", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/protocol_tests/watermark_harness.py
+++ b/protocol_tests/watermark_harness.py
@@ -459,7 +459,7 @@ def main():
         }
         with open(args.report, "w") as f:
             json.dump(report, f, indent=2, default=str)
-        print(f"Report written to {args.report}")
+        print(f"Report written to {args.report}", file=sys.stderr)
 
     sys.exit(1 if any(not r.passed for r in results) else 0)
 

--- a/protocol_tests/x402_fireblocks_harness.py
+++ b/protocol_tests/x402_fireblocks_harness.py
@@ -95,7 +95,7 @@ import uuid
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 
-from protocol_tests._utils import Severity, wilson_ci, http_post_json
+from protocol_tests._utils import Severity, wilson_ci, http_post_json, json_stdout_only
 
 
 # ---------------------------------------------------------------------------
@@ -973,7 +973,11 @@ def main() -> None:
 
     simulate = args.simulate or not args.url
     suite = X402FireblocksTests(url=args.url, headers=headers, simulate=simulate)
-    results = suite.run_all()
+    # The suite prints a run banner as it goes. In --json mode that lands
+    # on stdout ahead of the document, so a consumer gets a header and
+    # then JSON. Progress belongs on stderr; see _utils.json_stdout_only.
+    with json_stdout_only(args.json):
+        results = suite.run_all()
 
     total = len(results)
     passed = sum(1 for r in results if r.passed)
@@ -995,7 +999,7 @@ def main() -> None:
     if args.report:
         with open(args.report, "w") as f:
             json.dump(report, f, indent=2, default=str)
-        print(f"Report written to {args.report}")
+        print(f"Report written to {args.report}", file=sys.stderr)
 
     sys.exit(1 if any(not r.passed for r in results) else 0)
 

--- a/protocol_tests/x402_harness.py
+++ b/protocol_tests/x402_harness.py
@@ -3604,7 +3604,7 @@ def generate_report(results: list[X402TestResult], output_path: str,
     }
     with open(output_path, "w") as f:
         json.dump(report, f, indent=2, default=str)
-    print(f"Report written to {output_path}")
+    print(f"Report written to {output_path}", file=sys.stderr)
 
 
 # ---------------------------------------------------------------------------

--- a/testing/test_json_stdout_purity.py
+++ b/testing/test_json_stdout_purity.py
@@ -1,0 +1,129 @@
+"""``--json`` must put exactly one JSON document on stdout, and nothing else.
+
+Raised by an independent review of the live-calibration work, running
+
+    python -m protocol_tests.mcp_harness --transport http --url ... \
+        --json --report /tmp/report.json
+
+and getting stdout that ``json.loads`` refuses, because ``generate_report``
+printed "Report written to ..." ahead of the document.
+
+Not a false verdict, and still a defect. ``--json`` is a machine interface, and
+a consumer that reads the documented contract gets a parse error rather than a
+result. It breaks CI and any downstream evidence tooling.
+
+## It was a class, not an instance
+
+The report named one module. Sixty print sites across the package had the same
+notice on stdout, and five CLIs additionally print a run banner from
+``run_all`` before the document:
+
+    ============================================================
+    AP2 MANDATE-CHAIN CONFORMANCE SUITE
+    ============================================================
+    {
+      "suite": ...
+
+The notice moved to stderr unconditionally -- it is progress, not output, in
+every mode -- and the five banner CLIs wrap their run in
+``_utils.json_stdout_only``.
+
+## Why this test invokes subprocesses
+
+The defect lives in the boundary between the module and its caller. Importing
+``main()`` and capturing ``sys.stdout`` would not have caught it: the notice is
+emitted by a helper several frames down, and the banner by the suite itself. The
+only faithful check is the one the reviewer ran.
+
+The module list is derived from source rather than written down, so a CLI added
+tomorrow is covered without being listed anywhere.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+#: These take a subcommand or a mode flag before any target, so the bare
+#: invocation below is a usage error rather than a run. Their JSON paths are not
+#: exercised here; they are excluded by name so the exclusion is visible.
+NOT_A_BARE_CLI = {"cli", "community_runner", "mcp_supplychain"}
+
+#: Nothing is listening here.
+CLOSED_PORT = "http://127.0.0.1:9"
+
+
+def _json_cli_modules() -> list[str]:
+    """Every protocol_tests module whose CLI accepts both --json and --report."""
+    out = []
+    for path in sorted((REPO_ROOT / "protocol_tests").glob("*.py")):
+        if path.stem in NOT_A_BARE_CLI:
+            continue
+        src = path.read_text(encoding="utf-8")
+        if '"--json"' in src and '"--report"' in src:
+            out.append(path.stem)
+    return out
+
+
+class TestJsonStdoutPurity(unittest.TestCase):
+    def test_the_module_list_is_not_empty(self):
+        """Assert a positive expected set, so a broken finder cannot read as clean."""
+        mods = _json_cli_modules()
+        self.assertGreaterEqual(
+            len(mods), 6,
+            f"only {len(mods)} modules found with both flags; the source scan is "
+            f"probably broken rather than the package having shrunk")
+
+    def test_stdout_is_exactly_one_json_document(self):
+        for mod in _json_cli_modules():
+            with self.subTest(module=mod), \
+                    tempfile.NamedTemporaryFile(suffix=".json") as report:
+                proc = subprocess.run(
+                    [sys.executable, "-m", f"protocol_tests.{mod}",
+                     "--json", "--report", report.name, "--url", CLOSED_PORT],
+                    capture_output=True, text=True, timeout=180, cwd=REPO_ROOT,
+                    # A harness exits non-zero when its own tests fail, which
+                    # is the normal path here. The exit code is not the subject.
+                    check=False)
+                stdout = proc.stdout.strip()
+                if not stdout:
+                    continue          # this CLI writes nothing on this path
+                try:
+                    json.loads(stdout)
+                except json.JSONDecodeError as exc:
+                    first = stdout.split("\n", 1)[0][:70]
+                    self.fail(
+                        f"{mod} --json emitted non-JSON on stdout: {exc}. "
+                        f"First line: {first!r}. Progress and notices belong on "
+                        f"stderr; see _utils.json_stdout_only.")
+
+    def test_the_report_notice_is_not_on_stdout(self):
+        """The specific line the reviewer hit, asserted directly.
+
+        The check above would also catch it, but only while the document
+        happens to be the thing it breaks. If a future CLI emitted the notice
+        and no JSON at all, stdout would be non-empty prose and this names why.
+        """
+        for mod in _json_cli_modules():
+            with self.subTest(module=mod), \
+                    tempfile.NamedTemporaryFile(suffix=".json") as report:
+                proc = subprocess.run(
+                    [sys.executable, "-m", f"protocol_tests.{mod}",
+                     "--json", "--report", report.name, "--url", CLOSED_PORT],
+                    capture_output=True, text=True, timeout=180, cwd=REPO_ROOT,
+                    # A harness exits non-zero when its own tests fail, which
+                    # is the normal path here. The exit code is not the subject.
+                    check=False)
+                self.assertNotIn(
+                    "Report written to", proc.stdout,
+                    f"{mod} printed the report notice to stdout in --json mode")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Raised by the independent review of the live-calibration work, running

```
python -m protocol_tests.mcp_harness --transport http --url ... --json --report /tmp/report.json
```

and getting stdout that `json.loads` refuses, because `generate_report` printed `Report written to ...` ahead of the document. Cited to `mcp_harness.py:3762`.

Not a false verdict, and still a defect: **`--json` is a machine interface**, and a consumer reading the documented contract gets a parse error instead of a result.

## It was a class, not an instance

The report named one module. Measuring found the notice on stdout at **sixty print sites**, and five CLIs additionally printing a run banner ahead of the document:

```
============================================================
AP2 MANDATE-CHAIN CONFORMANCE SUITE
============================================================
{
  "suite": ...
```

**Seven of eleven** CLIs accepting both flags emitted unparseable stdout.

Worth noting how narrowly this was nearly missed: `mcp_harness` is **clean against a closed port**, because the run aborts before the report is written. It only breaks on the live path — which is where the reviewer was.

## The repair

The notice moves to stderr **unconditionally**, in every mode. It is progress, not output, and guarding it on `--json` would leave the next author free to add a sixty-first site that forgets. The five banner CLIs wrap their run in `_utils.json_stdout_only`.

## The test

`testing/test_json_stdout_purity.py` runs each CLI as a **subprocess** with `--json --report` and asserts `json.loads(stdout)`.

Subprocesses because the defect lives in the boundary between the module and its caller: importing `main()` and capturing `sys.stdout` would not have caught it, since the notice comes from a helper several frames down and the banner from the suite itself. **The only faithful check is the one the reviewer ran.**

The module list is derived from source, so a CLI added tomorrow is covered without being listed. The three that take a subcommand are excluded by name so the exclusion is visible rather than implied.

## Verified live

`mcp_harness` against the official reference server now yields valid JSON on stdout: `total=32 passed=16`.

```
testing/ + tests/          730 passed, 282 subtests
ruff --select F821         All checks passed
per-file ruff              unchanged vs main across all seven touched modules (50 before, 50 after)
new test file              clean
count_tests.py             608, unchanged
verify_release_claims.py   5 passed, 0 failed, 0 not reproduced
```