### PR TITLE
release: 4.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.16.0] - 2026-08-29
+
 ### Changed — expect results to move in BOTH directions
 
 Two kinds of verdict change, and the second is new. **More results will report

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you cite this work in research, please use this metadata."
 title: "Agent Security Harness"
-version: "4.15.0"
+version: "4.16.0"
 abstract: "Multi-protocol agent security testing framework. 608 executable security tests across 43 test-bearing modules covering MCP, A2A, L402, and x402 wire protocols. Decision-layer attack scenarios, AIUC-1 pre-certification mapping, NIST AI 800-2 aligned."
 type: software
 authors:
@@ -11,7 +11,7 @@ authors:
 repository-code: "https://github.com/msaleme/red-team-blue-team-agent-fabric"
 url: "https://pypi.org/project/agent-security-harness/"
 license: Apache-2.0
-date-released: "2026-08-07"
+date-released: "2026-08-29"
 keywords:
   - agent-security
   - mcp

--- a/EVALUATION_PROTOCOL.md
+++ b/EVALUATION_PROTOCOL.md
@@ -288,4 +288,4 @@ Per NIST AI 800-2, we distinguish:
 
 _Document version: 1.0_
 _NIST AI 800-2 alignment date: March 21, 2026_
-_Framework version: 4.15.0 (608 tests)_
+_Framework version: 4.16.0 (608 tests)_

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ harness already expected.
 
 ```
 $ agent-security test mcp --url http://localhost:8080/mcp
-Running MCP Protocol Security Tests v4.15.0...
+Running MCP Protocol Security Tests v4.16.0...
  MCP-001: Tool List Integrity Check [PASS] (0.234s)
  MCP-002: Tool Registration via Call Injection [PASS] (0.412s)
  MCP-003: Capability Escalation via Initialize [FAIL] (0.156s)
@@ -295,12 +295,12 @@ The [constitutional-agent](https://github.com/CognitiveThoughtEngine/constitutio
 
 ## Roadmap
 
-**Current: v4.15.0** (2026-08-07). Recent shipped work — v4.5 skill supply chain and governance
+**Current: v4.16.0** (2026-08-29). Recent shipped work — v4.5 skill supply chain and governance
 modification · v4.6–v4.9 payment-stack depth (AP2 mandate chain, UCP/ACP merchant journey, card-network
 agentic tokens, settlement finality, Fireblocks x402) · v4.10 benchmark integrity · v4.11–v4.12
 decision-governance corpus currency and provenance repair · **v4.13 OWASP Agentic v1.1 T1–T17 coverage
 mapping and the human-in-the-loop harness** · v4.13.1 a correctness fix to that harness · v4.14.0
-endpoint provenance · **v4.15.0 unserviced requests are no longer recorded as passes** (see
+endpoint provenance · **v4.16.0 three target shapes: a verdict must be able to be wrong AND to be right** · v4.15.0 unserviced requests are no longer recorded as passes (see
 [CHANGELOG.md](CHANGELOG.md)).
 
 The release carries **603** tests; `main` is at **608** — MAG-019, MEM-011 and MEM-012, then X4-056 and

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -56,6 +56,7 @@ Dates and themes below are reconciled against `CHANGELOG.md`, which is authorita
 | **v4.13.0 — OWASP Agentic v1.1** | 2026-08-02 | T1–T17 commit-pinned coverage mapping, selector tooling, HITL harness (T10/T15) | Shipped |
 | **v4.13.1 — HITL correctness** | 2026-08-02 | All 8 HITL tests could record a verdict against a target that never serviced the request; `_serviced()` guard added | Shipped |
 | **v4.14.0 — Endpoint provenance** | 2026-08-05 | Removed fabricated default registry/telemetry endpoints pointing at domains this project never owned; both env vars now required; attestation independence claim corrected to "tested with" | Shipped |
+| **v4.16.0 — Three target shapes** | 2026-08-29 | A verdict must be able to be wrong AND to be right. Two sweeps join the closed-port one: a permissive sentinel that grants everything and a refusing one that denies everything. Ten modules could not pass a target that refused every request. No test added or removed, count 608 | Shipped |
 | **v4.15.0 — Unserviced requests are not passes** | 2026-08-07 | Seven modules recorded a `PASS` when the target never serviced the request; guard promoted to `http_helpers` and applied at each recording path. No test added or removed, count unchanged at 603 | Shipped |
 | **Next — Standards & Evidence** | — | Reproducible settlement-time payment evidence; methodology paper; schema as a standards-body informational draft | In progress |
 

--- a/docs/OWASP-AGENTIC-T1-T15-SUBMISSION-COVERAGE.md
+++ b/docs/OWASP-AGENTIC-T1-T15-SUBMISSION-COVERAGE.md
@@ -11,7 +11,7 @@
 | Report view | Submission (T1–T15) |
 | Report version | 1.0 |
 | Project | Agent Security Harness |
-| Harness version | `4.15.0` |
+| Harness version | `4.16.0` |
 | Assessed commit | [`19dbfb871d1379a42bbfa22fa06bb2edda58a2c0`](https://github.com/msaleme/red-team-blue-team-agent-fabric/commit/19dbfb871d1379a42bbfa22fa06bb2edda58a2c0) |
 | Assessed at | 2026-08-02T18:30:00Z |
 | Repository tests | 608 (`python scripts/count_tests.py`) |
@@ -752,6 +752,7 @@ Per-test rerun commands are in the `Rerun` column of each evidence table.
 | 1.1 | v1.1 `65e3bd59f99c` | 4.13.1 | `19dbfb871d13` | 2026-08-03 | Re-pinned after the v4.13.1 HITL correctness fix. No threat, scenario or control verdict changed; the T10/T15 limitations now state the corrected guard. The adjudication itself was performed at the 1.0 commit and was not redone. |
 | 1.2 | v1.1 `65e3bd59f99c` | 4.14.0 | `19dbfb871d13` | 2026-08-05 | Re-pinned to the v4.14.0 release. No threat, scenario or control verdict changed, and no test was added or removed. v4.14.0 removes fabricated default network endpoints and corrects an attestation independence claim; the harness exercises neither. commit and assessed_at are deliberately unchanged from 1.1, because the adjudication was not redone. |
 | 1.3 | v1.1 `65e3bd59f99c` | 4.15.0 | `19dbfb871d13` | 2026-08-07 | Re-pinned to the v4.15.0 release. No threat, scenario or control verdict changed, and no test was added or removed. Unlike 1.2, this release does change runtime behaviour. Issues 348 and 350 stop seven modules recording a pass when the target never serviced the request, so those results now read INCONCLUSIVE. This mapping adjudicates coverage rather than run output, so its verdicts are unaffected and were not redone. Stated plainly for readers who rely on run output instead. Any earlier run of multi_agent_harness, identity_harness, advanced_attacks, memory_harness, intent_contract_harness, enterprise_adapters or extended_enterprise_adapters against an unresponsive target reported more passes than it measured. commit and assessed_at are deliberately unchanged from 1.1. |
+| 1.4 | v1.1 `65e3bd59f99c` | 4.16.0 | `19dbfb871d13` | 2026-08-29 | Re-pinned to the v4.16.0 release. No threat, scenario or control verdict changed, and no test was added or removed. Like 4.15.0, this release changes runtime behaviour, and in both directions. More verdicts report INCONCLUSIVE, and some that previously reported FAIL now report PASS because ten modules could not recognise a target visibly refusing an attack. This mapping adjudicates coverage rather than run output, so its verdicts are unaffected and were not redone. Stated plainly for readers who rely on run output instead. commit and assessed_at are deliberately unchanged from 1.1. |
 
 A status changes only through a reviewed mapping change.
 

--- a/docs/OWASP-AGENTIC-V1.1-COVERAGE.md
+++ b/docs/OWASP-AGENTIC-V1.1-COVERAGE.md
@@ -9,7 +9,7 @@
 | Report view | Complete (T1–T17) |
 | Report version | 1.0 |
 | Project | Agent Security Harness |
-| Harness version | `4.15.0` |
+| Harness version | `4.16.0` |
 | Assessed commit | [`19dbfb871d1379a42bbfa22fa06bb2edda58a2c0`](https://github.com/msaleme/red-team-blue-team-agent-fabric/commit/19dbfb871d1379a42bbfa22fa06bb2edda58a2c0) |
 | Assessed at | 2026-08-02T18:30:00Z |
 | Repository tests | 608 (`python scripts/count_tests.py`) |
@@ -1001,6 +1001,7 @@ Recorded for source fidelity, not as criticism of OWASP. Inconsistencies in the 
 | 1.1 | v1.1 `65e3bd59f99c` | 4.13.1 | `19dbfb871d13` | 2026-08-03 | Re-pinned after the v4.13.1 HITL correctness fix. No threat, scenario or control verdict changed; the T10/T15 limitations now state the corrected guard. The adjudication itself was performed at the 1.0 commit and was not redone. |
 | 1.2 | v1.1 `65e3bd59f99c` | 4.14.0 | `19dbfb871d13` | 2026-08-05 | Re-pinned to the v4.14.0 release. No threat, scenario or control verdict changed, and no test was added or removed. v4.14.0 removes fabricated default network endpoints and corrects an attestation independence claim; the harness exercises neither. commit and assessed_at are deliberately unchanged from 1.1, because the adjudication was not redone. |
 | 1.3 | v1.1 `65e3bd59f99c` | 4.15.0 | `19dbfb871d13` | 2026-08-07 | Re-pinned to the v4.15.0 release. No threat, scenario or control verdict changed, and no test was added or removed. Unlike 1.2, this release does change runtime behaviour. Issues 348 and 350 stop seven modules recording a pass when the target never serviced the request, so those results now read INCONCLUSIVE. This mapping adjudicates coverage rather than run output, so its verdicts are unaffected and were not redone. Stated plainly for readers who rely on run output instead. Any earlier run of multi_agent_harness, identity_harness, advanced_attacks, memory_harness, intent_contract_harness, enterprise_adapters or extended_enterprise_adapters against an unresponsive target reported more passes than it measured. commit and assessed_at are deliberately unchanged from 1.1. |
+| 1.4 | v1.1 `65e3bd59f99c` | 4.16.0 | `19dbfb871d13` | 2026-08-29 | Re-pinned to the v4.16.0 release. No threat, scenario or control verdict changed, and no test was added or removed. Like 4.15.0, this release changes runtime behaviour, and in both directions. More verdicts report INCONCLUSIVE, and some that previously reported FAIL now report PASS because ten modules could not recognise a target visibly refusing an attack. This mapping adjudicates coverage rather than run output, so its verdicts are unaffected and were not redone. Stated plainly for readers who rely on run output instead. commit and assessed_at are deliberately unchanged from 1.1. |
 
 A status changes only through a reviewed mapping change.
 

--- a/docs/coverage/owasp-agentic-v1.1.json
+++ b/docs/coverage/owasp-agentic-v1.1.json
@@ -34,7 +34,7 @@
   "assessment": {
     "project": "Agent Security Harness",
     "repository": "https://github.com/msaleme/red-team-blue-team-agent-fabric",
-    "harness_version": "4.15.0",
+    "harness_version": "4.16.0",
     "git_commit": "19dbfb871d1379a42bbfa22fa06bb2edda58a2c0",
     "assessed_at": "2026-08-02T18:30:00Z",
     "reverified_at": "2026-08-03T01:05:00Z",
@@ -66,6 +66,13 @@
         "harness": "4.15.0",
         "date": "2026-08-07",
         "change": "Re-pinned to the v4.15.0 release. No threat, scenario or control verdict changed, and no test was added or removed. Unlike 1.2, this release does change runtime behaviour. Issues 348 and 350 stop seven modules recording a pass when the target never serviced the request, so those results now read INCONCLUSIVE. This mapping adjudicates coverage rather than run output, so its verdicts are unaffected and were not redone. Stated plainly for readers who rely on run output instead. Any earlier run of multi_agent_harness, identity_harness, advanced_attacks, memory_harness, intent_contract_harness, enterprise_adapters or extended_enterprise_adapters against an unresponsive target reported more passes than it measured. commit and assessed_at are deliberately unchanged from 1.1."
+      },
+      {
+        "report": "1.4",
+        "commit": "19dbfb871d1379a42bbfa22fa06bb2edda58a2c0",
+        "harness": "4.16.0",
+        "date": "2026-08-29",
+        "change": "Re-pinned to the v4.16.0 release. No threat, scenario or control verdict changed, and no test was added or removed. Like 4.15.0, this release changes runtime behaviour, and in both directions. More verdicts report INCONCLUSIVE, and some that previously reported FAIL now report PASS because ten modules could not recognise a target visibly refusing an attack. This mapping adjudicates coverage rather than run output, so its verdicts are unaffected and were not redone. Stated plainly for readers who rely on run output instead. commit and assessed_at are deliberately unchanged from 1.1."
       }
     ],
     "total_repository_tests": 608,

--- a/docs/coverage/owasp-agentic-v1.1.yaml
+++ b/docs/coverage/owasp-agentic-v1.1.yaml
@@ -52,7 +52,7 @@ framework:
 assessment:
   project: Agent Security Harness
   repository: https://github.com/msaleme/red-team-blue-team-agent-fabric
-  harness_version: 4.15.0
+  harness_version: 4.16.0
   git_commit: 19dbfb871d1379a42bbfa22fa06bb2edda58a2c0
   assessed_at: '2026-08-02T18:30:00Z'
   reverified_at: '2026-08-03T01:05:00Z'
@@ -94,6 +94,18 @@ assessment:
       or extended_enterprise_adapters against an unresponsive target reported more
       passes than it measured. commit and assessed_at are deliberately unchanged from
       1.1.
+  - report: '1.4'
+    commit: 19dbfb871d1379a42bbfa22fa06bb2edda58a2c0
+    harness: 4.16.0
+    date: '2026-08-29'
+    change: Re-pinned to the v4.16.0 release. No threat, scenario or control
+      verdict changed, and no test was added or removed. Like 4.15.0, this release
+      changes runtime behaviour, and in both directions. More verdicts report
+      INCONCLUSIVE, and some that previously reported FAIL now report PASS because
+      ten modules could not recognise a target visibly refusing an attack. This
+      mapping adjudicates coverage rather than run output, so its verdicts are
+      unaffected and were not redone. Stated plainly for readers who rely on run
+      output instead. commit and assessed_at are deliberately unchanged from 1.1.
 
   total_repository_tests: 608
   total_tests_command: python scripts/count_tests.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-security-harness"
-version = "4.15.0"
+version = "4.16.0"
 description = "608 security tests for AI agent systems - MCP, A2A, L402, x402, UCP/ACP merchant-journey, AP2 mandate + Fireblocks x402 hardening + Visa TAP / Mastercard Agentic Tokens + denial-of-settlement finality, decision governance, AIUC-1 compliance, NIST AI 800-2 aligned"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
126 commits since v4.15.0. The release-facing change is that **verdicts move in both directions**: more report INCONCLUSIVE, and some that previously reported FAIL now report PASS, because ten modules could not recognise a target visibly refusing an attack. No test added or removed; the count is 608.

**Minor, not patch**, on this project's own application of semver: 4.15.0 was cut for exactly this class of change, and consumers' results move.

Bumped: `pyproject.toml`, `CITATION.cff` (with `date-released`), `EVALUATION_PROTOCOL.md`, README current-version and sample output, `ROADMAP.md` row, `CHANGELOG.md` heading.

## The OWASP mapping is re-pinned, not re-adjudicated

`r15_version` requires `assessment.harness_version` to equal `pyproject`, so the mapping moves with every release. `report_history` gains `1.4` recording why: this release changes runtime behaviour in both directions, the mapping adjudicates **coverage** rather than run output, so no threat, scenario or control verdict was redone. `commit` and `assessed_at` are deliberately unchanged, matching the 1.1–1.3 pattern.

The JSON and both markdown crosswalks are **regenerated**, not hand-edited. A first attempt bumped `harness_version` directly in the generated JSON and broke `test_reports_match_freshly_generated_output` — the generator's guard doing its job.

## What is deliberately not here

`docs/release-claims.json` and the README count sentence still describe v4.15.0 carrying 603. **Both are true right now**, and the manifest is what makes them checkable: `test_release_claims.py` failed the moment the README wording moved ahead of it.

They move in a follow-up, once the release commit exists to pin them to. A claim that *"the v4.16.0 release carries 608"* needs a commit where that is reproducible, and **inventing one before the tag exists is the restatement problem wearing a manifest.**

```
testing/ + tests/          730 passed, 282 subtests
ruff --select F821         All checks passed
count_tests.py             608
verify_release_claims.py   5 passed, 0 failed, 0 not reproduced
```