### PR TITLE
release: pin the 4.16.0 claims to the release commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Results: 8/10 passed (80% pass rate) - see report.json
 > servicing the request, reports **INCONCLUSIVE** — never PASS. See
 > [v4.13.1](CHANGELOG.md) for why that distinction is enforced rather than assumed.
 
-608 executable security tests across 43 test-bearing modules on `main` (verified 2026-08-29 via `scripts/count_tests.py`; the v4.15.0 release carries 603). MCP + A2A + L402 + x402 wire-protocol testing, plus UCP/ACP merchant-journey, AP2 mandate-chain, Fireblocks x402 hardening, Visa TAP / Mastercard Agentic Token funding-instrument, and denial-of-settlement finality conformance across the full agentic-payments stack. Decision-layer attack scenarios. One `pip install` away.
+608 executable security tests across 43 test-bearing modules on `main` (verified 2026-08-29 via `scripts/count_tests.py`; the v4.16.0 release carries 608). MCP + A2A + L402 + x402 wire-protocol testing, plus UCP/ACP merchant-journey, AP2 mandate-chain, Fireblocks x402 hardening, Visa TAP / Mastercard Agentic Token funding-instrument, and denial-of-settlement finality conformance across the full agentic-payments stack. Decision-layer attack scenarios. One `pip install` away.
 
 If this evidence discipline is useful in your agent-security work, **star this
 repository to follow releases**.
@@ -303,10 +303,13 @@ mapping and the human-in-the-loop harness** · v4.13.1 a correctness fix to that
 endpoint provenance · **v4.16.0 three target shapes: a verdict must be able to be wrong AND to be right** · v4.15.0 unserviced requests are no longer recorded as passes (see
 [CHANGELOG.md](CHANGELOG.md)).
 
-The release carries **603** tests; `main` is at **608** — MAG-019, MEM-011 and MEM-012, then X4-056 and
-X4-057 (URL-borne payment credentials and delegated-allowance overdraft), all landing after the tag. Both
-are correct for their own ref, and `scripts/check_public_metadata.py` compares public claims against
-the release rather than against `main` for exactly that reason.
+The release carries **608** tests; `main` is at **608**. They agree at v4.16.0 because the tag was cut
+from `main` with no test added or removed since. They do not always agree: at v4.15.0 the release carried
+603 while `main` was at 608, the difference being MAG-019, MEM-011, MEM-012, X4-056 and X4-057, all
+landing after the tag. Both numbers were correct for their own ref, which is why
+`scripts/check_public_metadata.py` compares public claims against the release rather than against `main`,
+and why `docs/release-claims.json` pins the release count to a commit where re-running the command
+reproduces it.
 
 **Next — Standards & Evidence.** Reproducible settlement-time payment evidence, a methodology paper,
 and the attestation/evidence schema submitted to a standards venue. Coverage breadth and test count are

--- a/docs/release-claims.json
+++ b/docs/release-claims.json
@@ -5,10 +5,10 @@
   "claims": [
     {
       "id": "release-test-count",
-      "fact": "The v4.15.0 release carries 603 unique test IDs.",
-      "value": "603",
-      "release_tag": "v4.15.0",
-      "commit": "90f552baae65e33f83201e4a95e2c4d3ed249c6e",
+      "fact": "The v4.16.0 release carries 608 unique test IDs.",
+      "value": "608",
+      "release_tag": "v4.16.0",
+      "commit": "52a06fed481014d2059adc10412d458db091d551",
       "command": "python3 scripts/count_tests.py",
       "value_extraction": "Definitive count:\\s*(\\d+)",
       "generated_on": "2026-08-29",
@@ -19,7 +19,7 @@
       "surfaces": [
         {
           "path": "README.md",
-          "pattern": "the v4\\.15\\.0 release carries (\\d+)"
+          "pattern": "the v4\\.16\\.0 release carries (\\d+)"
         },
         {
           "path": "README.md",


### PR DESCRIPTION
The follow-up #434 said it would leave. `docs/release-claims.json` now states that the v4.16.0 release carries **608** unique test IDs, pinned to `52a06fed`, and the README surfaces it declares move with it.

```
[PASS] release-test-count surface README.md: states 608
[PASS] release-test-count regenerate @ v4.16.0: reproduced 608
[PASS] main-test-count regenerate @ HEAD: reproduced 608
```

REGENERATE runs the declared command at the declared **commit**, so the claim is checkable before the tag object exists. That is why the commit and not just the tag name is pinned.

## One paragraph had to be rewritten rather than renumbered

README carried an explanation of why the release and main counts *differed* at v4.15.0: 603 against 608, the difference being `MAG-019`, `MEM-011`, `MEM-012`, `X4-056` and `X4-057` landing after the tag.

At v4.16.0 they agree, because the tag is cut from `main` with no test added or removed since.

Changing 603 to 608 would have left a paragraph explaining a divergence that no longer exists. Deleting it would have lost the reason the manifest is there at all. It now states the agreement, keeps v4.15.0 as the worked example of when that is **not** true, and names both mechanisms that exist because of it.

```
testing/ + tests/          730 passed, 282 subtests
verify_release_claims.py   5 passed, 0 failed, 0 not reproduced
count_tests.py             608
```