### PR TITLE
fix(release): dist/ must contain exactly the distributions

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -68,13 +68,34 @@ jobs:
       - name: Build package
         run: python -m build
 
-      - name: Upload build artifacts
+      # Two artifacts, not one path list. upload-artifact@v4 roots a multi-path
+      # artifact at the least common ancestor of its paths, so `dist/` plus a
+      # file at the workspace root produced an artifact containing
+      # `dist/<wheel>` AND `build-environment.txt`. Downloading that into
+      # `path: dist/` yields `dist/dist/<wheel>` and `dist/build-environment.txt`,
+      # and twine then reports
+      #
+      #     no Python distribution packages to publish in the directory 'dist/'
+      #     Checking dist/build-environment.txt: InvalidDistribution
+      #
+      # which is exactly how v4.16.0 failed to publish on 2026-08-30.
+      #
+      # The recording step landed 2026-08-28 and every publish before it
+      # succeeded, so this workflow shipped broken and stayed broken through one
+      # release. It only runs on `release: published`, so no push, no PR and no
+      # scheduled job could have exercised it. Infrequent automation is
+      # unverified automation.
+      - name: Upload distributions
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: dist
-          path: |
-            dist/
-            build-environment.txt
+          path: dist/
+
+      - name: Upload the build-environment record
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: build-environment
+          path: build-environment.txt
 
   publish:
     name: Publish to PyPI
@@ -89,6 +110,28 @@ jobs:
         with:
           name: dist
           path: dist/
+
+      # A malformed dist/ made twine emit a WARNING and then fail on the first
+      # non-distribution file it met. Assert the positive expected set instead,
+      # so the next shape of this defect names itself rather than arriving as an
+      # InvalidDistribution on an unrelated filename.
+      - name: Assert dist/ holds exactly the distributions
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          wheels=(dist/*.whl); sdists=(dist/*.tar.gz)
+          others=()
+          for f in dist/*; do
+            case "$f" in *.whl|*.tar.gz) ;; *) others+=("$f") ;; esac
+          done
+          echo "wheels: ${#wheels[@]}  sdists: ${#sdists[@]}  other: ${#others[@]}"
+          ls -la dist/
+          [ "${#wheels[@]}" -ge 1 ] || { echo "::error::no wheel in dist/"; exit 1; }
+          [ "${#sdists[@]}" -ge 1 ] || { echo "::error::no sdist in dist/"; exit 1; }
+          if [ "${#others[@]}" -gt 0 ]; then
+            echo "::error::dist/ contains non-distribution files: ${others[*]}"
+            exit 1
+          fi
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@v1.13.0 # Docker-based action requires tag ref, not SHA


### PR DESCRIPTION
**v4.16.0 tagged and released cleanly and did not reach PyPI.** The publish job failed with:

```
##[warning] It looks like there are no Python distribution packages to publish in the directory 'dist/'
Checking dist/build-environment.txt: InvalidDistribution: Unknown distribution format: 'build-environment.txt'
```

`upload-artifact@v4` roots a multi-path artifact at the **least common ancestor** of its paths. `dist/` plus a file at the workspace root gave an artifact holding `dist/<wheel>` **and** `build-environment.txt`. Downloading that into `path: dist/` produced `dist/dist/<wheel>` beside `dist/build-environment.txt` — twine found no distribution where it looks, and one file it could not parse.

## This workflow shipped broken and stayed broken through a release

The build-environment recording step landed **2026-08-28** in `44f09ce`. Every publish before it succeeded: 08-02, 08-03, 08-05, 08-07. **v4.16.0 was the first release after it.**

The workflow triggers only on `release: published`, so no push, no pull request and no scheduled run could have exercised the change. **It was a hardening commit that broke the pipeline it was hardening**, and the feedback arrived one release later.

> Infrequent automation is unverified automation.

## The repair

Two artifacts rather than one path list, so `dist/` carries only what twine should see and the provenance record still ships as `build-environment`.

And a **positive assertion** before publishing: at least one wheel, at least one sdist, and nothing else. twine's own failure was a warning followed by an error on whichever non-distribution filename it happened to meet first — that names the symptom, not the shape. The next occurrence will say what is actually wrong.

That mirrors the check already in this file for the build backend, whose comment applies here too: *a recorded environment that nobody checks is a log, not a control.*

## Impact

PyPI is at **4.15.0**. Nothing was published under 4.16.0, so **no consumer saw a partial release.**