### PR TITLE
fix: 4.16.0 released 2026-08-30 UTC, not 08-29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [4.16.0] - 2026-08-29
+## [4.16.0] - 2026-08-30
 
 ### Changed — expect results to move in BOTH directions
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,7 +11,7 @@ authors:
 repository-code: "https://github.com/msaleme/red-team-blue-team-agent-fabric"
 url: "https://pypi.org/project/agent-security-harness/"
 license: Apache-2.0
-date-released: "2026-08-29"
+date-released: "2026-08-30"
 keywords:
   - agent-security
   - mcp

--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ The [constitutional-agent](https://github.com/CognitiveThoughtEngine/constitutio
 
 ## Roadmap
 
-**Current: v4.16.0** (2026-08-29). Recent shipped work — v4.5 skill supply chain and governance
+**Current: v4.16.0** (2026-08-30). Recent shipped work — v4.5 skill supply chain and governance
 modification · v4.6–v4.9 payment-stack depth (AP2 mandate chain, UCP/ACP merchant journey, card-network
 agentic tokens, settlement finality, Fireblocks x402) · v4.10 benchmark integrity · v4.11–v4.12
 decision-governance corpus currency and provenance repair · **v4.13 OWASP Agentic v1.1 T1–T17 coverage

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -56,7 +56,7 @@ Dates and themes below are reconciled against `CHANGELOG.md`, which is authorita
 | **v4.13.0 — OWASP Agentic v1.1** | 2026-08-02 | T1–T17 commit-pinned coverage mapping, selector tooling, HITL harness (T10/T15) | Shipped |
 | **v4.13.1 — HITL correctness** | 2026-08-02 | All 8 HITL tests could record a verdict against a target that never serviced the request; `_serviced()` guard added | Shipped |
 | **v4.14.0 — Endpoint provenance** | 2026-08-05 | Removed fabricated default registry/telemetry endpoints pointing at domains this project never owned; both env vars now required; attestation independence claim corrected to "tested with" | Shipped |
-| **v4.16.0 — Three target shapes** | 2026-08-29 | A verdict must be able to be wrong AND to be right. Two sweeps join the closed-port one: a permissive sentinel that grants everything and a refusing one that denies everything. Ten modules could not pass a target that refused every request. No test added or removed, count 608 | Shipped |
+| **v4.16.0 — Three target shapes** | 2026-08-30 | A verdict must be able to be wrong AND to be right. Two sweeps join the closed-port one: a permissive sentinel that grants everything and a refusing one that denies everything. Ten modules could not pass a target that refused every request. No test added or removed, count 608 | Shipped |
 | **v4.15.0 — Unserviced requests are not passes** | 2026-08-07 | Seven modules recorded a `PASS` when the target never serviced the request; guard promoted to `http_helpers` and applied at each recording path. No test added or removed, count unchanged at 603 | Shipped |
 | **Next — Standards & Evidence** | — | Reproducible settlement-time payment evidence; methodology paper; schema as a standards-body informational draft | In progress |
 


### PR DESCRIPTION
`check_public_metadata` reported:

```
CITATION.cff: date-released says 2026-08-29, v4.16.0 was published 2026-08-30
```

And it is right. The release published at `2026-08-30T00:29:27Z`. The version bump was authored a few minutes earlier — on the other side of the UTC rollover and on the local calendar day — so every date surface said 08-29.

`CITATION.cff`, the CHANGELOG heading, the ROADMAP row and the README current-version line now say **2026-08-30**, which is what a reader comparing the citation to the GitHub release will see.

Small, and this check exists because it was not always small: the header of `check_public_metadata.py` records `date-released` once being **thirteen days** off the actual release. A date that only a human remembers to set is a date that drifts — the same argument `release-claims.json` makes for counts.

## The tag is deliberately not re-pointed

The v4.16.0 tag still carries 08-29 in `CITATION.cff`. PyPI published `agent-security-harness 4.16.0` from `17dcdca` and **the artifact is immutable**, so moving the tag now would break the correspondence between what shipped and what the tag says shipped.

A one-day authored-versus-published gap inside the tag is a smaller inaccuracy than a tag that does not match the wheel.