### PR TITLE
fix(mcp): a missing response is three findings, and stdio knows which

### DIFF
--- a/protocol_tests/mcp_harness.py
+++ b/protocol_tests/mcp_harness.py
@@ -302,6 +302,15 @@ class MCPTransport:
     # to exercise it over stdio.
     supports_header_overrides = False
 
+    def is_alive(self) -> bool | None:
+        """Is the server still running? None when the transport cannot know.
+
+        Only a transport that owns the server process can answer this. Over
+        HTTP there is nothing to inspect, and a verdict that needs the answer
+        must say so rather than assume one. See StdioTransport.is_alive.
+        """
+        return None
+
     def send(self, message: dict) -> dict | None:
         raise NotImplementedError
 
@@ -508,6 +517,27 @@ class StdioTransport(MCPTransport):
             stderr=subprocess.PIPE,
             env={**os.environ, **(env or {})},
         )
+
+    def is_alive(self) -> bool | None:
+        """True if the server process is still running, None if unknowable.
+
+        Added 2026-08-30 during the first calibration of this transport against
+        a real MCP implementation. Several verdicts read a missing response and
+        reported "server may have crashed or hung" -- a disjunction the harness
+        was asserting rather than observing.
+
+        Over stdio it IS observable: the harness owns the process. Measured
+        against the official reference server, the two cases genuinely differ.
+        After seven malformed messages the process was alive and still answering
+        tools/list. After an oversized body it was alive and answering nothing.
+        Same missing response, different findings, and only one of them is a
+        denial of service.
+
+        The HTTP transport returns None from its own override: it has no process
+        to inspect, and inventing a liveness answer there would be worse than
+        admitting the limit.
+        """
+        return self.proc.poll() is None
 
     def send(self, message: dict) -> dict | None:
         line = json.dumps(message) + "\n"
@@ -1986,7 +2016,14 @@ class MCPSecurityTests:
             ))
             return
 
+        # Three outcomes, not two. Against the official reference server over
+        # stdio this reported "0/7 malformed messages handled gracefully", and
+        # the process was alive and still answering tools/list afterwards: it
+        # survived all seven and kept serving. Silence is not a rejection, and
+        # it is not a crash either. Counting only rejections and calling the
+        # rest unhandled overstates what was observed.
         handled_count = 0
+        ignored_count = 0
         for raw in malformed_messages:
             resp_bytes = self.transport.send_raw(raw, mcp_method="tools/list")
             if resp_bytes:
@@ -1999,11 +2036,38 @@ class MCPSecurityTests:
                     # Non-JSON response is acceptable for garbage input
                     handled_count += 1
             else:
-                # No response — inconclusive, don't count as handled
-                pass
+                # Silence. Counted separately from a rejection, because the two
+                # are different observations and the verdict now says which.
+                ignored_count += 1
 
         elapsed = time.monotonic() - t0
-        passed = handled_count == len(malformed_messages)
+        n = len(malformed_messages)
+        alive = self.transport.is_alive()
+        passed = handled_count == n
+
+        # A pass still requires an explicit rejection for every message, which
+        # is what the MCP spec asks for. What changes is the wording of a
+        # non-pass: silence with the server still serving is a different
+        # observation from silence with the server gone, and the old string
+        # reported both as "not handled gracefully".
+        if passed:
+            m008_detail = f"{handled_count}/{n} malformed messages handled gracefully"
+        elif ignored_count and alive is True:
+            m008_detail = (
+                f"{handled_count}/{n} rejected explicitly; {ignored_count} drew no "
+                f"response. The server process is still running and still serving, "
+                f"so it survived them without reporting a parse error.")
+        elif ignored_count and alive is False:
+            m008_detail = (
+                f"{handled_count}/{n} rejected explicitly; {ignored_count} drew no "
+                f"response and the server process has exited.")
+        elif ignored_count:
+            m008_detail = (
+                f"{handled_count}/{n} rejected explicitly; {ignored_count} drew no "
+                f"response. This transport cannot inspect the server process, so "
+                f"whether it survived them is not established here.")
+        else:
+            m008_detail = f"{handled_count}/{n} malformed messages handled gracefully"
 
         self._record(MCPTestResult(
             test_id="MCP-008",
@@ -2012,7 +2076,7 @@ class MCPSecurityTests:
             owasp_asi="ASI08",
             severity=Severity.MEDIUM.value,
             passed=passed,
-            details=f"{handled_count}/{len(malformed_messages)} malformed messages handled gracefully",
+            details=m008_detail,
             mcp_method="various",
             request_sent={"n_malformed": len(malformed_messages)},
             elapsed_s=round(elapsed, 3),
@@ -3114,6 +3178,27 @@ class MCPSecurityTests:
         responded = resp_bytes is not None
         rejected = responded and _mcp_rejected_text(resp_preview)
         passed = responded and elapsed < 30.0 and rejected
+        # "server may have crashed or hung" was a disjunction the harness
+        # asserted from a missing response. Where the transport owns the
+        # process it can resolve it, and against the official reference server
+        # over stdio the two cases are genuinely different findings: after this
+        # payload the process was alive and answering nothing, which is a hang,
+        # not a crash. Reported as what was observed.
+        alive = self.transport.is_alive() if not responded else None
+        if alive is True:
+            no_response_detail = (
+                f"No response after {elapsed:.1f}s. The server process is still "
+                f"running and stopped answering, so the request wedged the "
+                f"session rather than terminating the server.")
+        elif alive is False:
+            no_response_detail = (
+                f"No response after {elapsed:.1f}s and the server process has "
+                f"exited. The request terminated the server.")
+        else:
+            no_response_detail = (
+                f"No response after {elapsed:.1f}s. This transport cannot "
+                f"inspect the server process, so whether it crashed, hung or is "
+                f"still working is not established here.")
 
         self._record(MCPTestResult(
             test_id="MCP-018",
@@ -3128,7 +3213,7 @@ class MCPSecurityTests:
                 else (
                     f"Server did not reject oversized body in {elapsed:.1f}s — "
                     f"response: {resp_preview[:200]!r}" if responded
-                    else f"No response after {elapsed:.1f}s — server may have crashed or hung"
+                    else no_response_detail
                 )
             ),
             mcp_method="tools/call",

--- a/testing/test_mcp_liveness_grounded_verdicts.py
+++ b/testing/test_mcp_liveness_grounded_verdicts.py
@@ -1,0 +1,137 @@
+"""A missing response is three different findings, and the transport knows which.
+
+Two verdicts in mcp_harness read a missing response and asserted a cause:
+
+    MCP-018  "No response after 5.6s -- server may have crashed or hung"
+    MCP-008  "0/7 malformed messages handled gracefully"
+
+Both were written before this harness had ever been run over stdio. The first
+calibration of that transport, against the official
+`@modelcontextprotocol/server-everything` on 2026-08-30, showed the two cases
+are genuinely different and that the harness owns the evidence to tell them
+apart:
+
+    after seven malformed messages   process alive, still answering tools/list
+    after a 10 MB body               process alive, answering nothing
+
+Same missing response. One server survived an attack; the other was denied
+service. "crashed or hung" describes neither, and "0/7 handled gracefully"
+describes a server that survived all seven and kept serving.
+
+## Why the transport and not the test
+
+Only a transport that owns the server process can answer "is it still running".
+StdioTransport launches it, so `proc.poll()` is the answer. StreamableHTTPTransport
+has nothing to inspect, so `MCPTransport.is_alive` returns None and both verdicts
+say so rather than picking a cause. Admitting the limit is the point: over HTTP
+this reads "this transport cannot inspect the server process, so whether it
+survived them is not established here."
+
+## What did not change
+
+A pass still requires an explicit rejection for every message, which is what the
+spec asks for. Only the wording of a non-pass moved, from an asserted cause to
+an observed one.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from protocol_tests.mcp_harness import MCPSecurityTests, MCPTransport
+
+
+class _Silent(MCPTransport):
+    """Answers nothing, and reports a liveness the test chooses."""
+
+    def __init__(self, alive):
+        self._alive = alive
+
+    def is_alive(self):
+        return self._alive
+
+    def send(self, message, **kwargs):
+        return None
+
+    def send_raw(self, raw, mcp_method=None, **kwargs):
+        return None
+
+
+def _run(alive, method):
+    suite = MCPSecurityTests(_Silent(alive), json_output=True)
+    with contextlib.redirect_stdout(io.StringIO()), \
+            contextlib.redirect_stderr(io.StringIO()):
+        getattr(suite, method)()
+    return suite.results[0]
+
+
+class TestTheBaseTransportAdmitsItCannotKnow(unittest.TestCase):
+    def test_default_is_none_not_a_guess(self):
+        self.assertIsNone(
+            MCPTransport().is_alive(),
+            "a transport that does not own the server process must return None; "
+            "returning True or False there invents the evidence two verdicts rely on")
+
+
+class TestOversizedBodyReportsWhatWasObserved(unittest.TestCase):
+    METHOD = "test_mcp_unbounded_request_body_dos"
+
+    def test_alive_is_a_wedged_session_not_a_crash(self):
+        d = _run(True, self.METHOD).details
+        self.assertIn("still running", d)
+        self.assertIn("wedged", d)
+        self.assertNotIn("crashed", d)
+
+    def test_exited_says_the_server_terminated(self):
+        d = _run(False, self.METHOD).details
+        self.assertIn("exited", d)
+        self.assertIn("terminated the server", d)
+
+    def test_unknowable_says_so(self):
+        d = _run(None, self.METHOD).details
+        self.assertIn("cannot inspect", d)
+        self.assertIn("not established", d)
+
+    def test_no_response_is_never_a_pass(self):
+        """The #351 rule still holds underneath all three wordings."""
+        for alive in (True, False, None):
+            with self.subTest(alive=alive):
+                self.assertFalse(_run(alive, self.METHOD).passed)
+
+
+class TestMalformedHandlingSeparatesIgnoredFromDead(unittest.TestCase):
+    METHOD = "test_mcp_malformed_jsonrpc"
+
+    def test_alive_says_it_survived_them(self):
+        d = _run(True, self.METHOD).details
+        self.assertIn("drew no response", d)
+        self.assertIn("still serving", d)
+
+    def test_exited_says_the_process_is_gone(self):
+        self.assertIn("has exited", _run(False, self.METHOD).details)
+
+    def test_unknowable_says_so(self):
+        self.assertIn("not established", _run(None, self.METHOD).details)
+
+    def test_silence_is_still_not_graceful_handling(self):
+        """The verdict did not soften, only the description.
+
+        The spec asks for a parse error. A server that ignores malformed input
+        and keeps serving has not done that, and this must keep failing.
+        """
+        for alive in (True, False, None):
+            with self.subTest(alive=alive):
+                r = _run(alive, self.METHOD)
+                self.assertFalse(r.passed)
+                self.assertNotIn("handled gracefully", r.details)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
First calibration of `StdioTransport` against a real MCP implementation. **It had never been run** — `MCP-017` requires stdio and reported INCONCLUSIVE on every HTTP run, so an entire transport shipped uncalibrated.

`MCP-017` now passes for the first time against the official `@modelcontextprotocol/server-everything`:

```
Canary file was not created; no pre-handshake command execution detected
```

**A P0 control that had never once been exercised.**

## Two verdicts were asserting a cause they could observe

```
MCP-018  "No response after 5.6s — server may have crashed or hung"
MCP-008  "0/7 malformed messages handled gracefully"
```

Over stdio the harness owns the server process, and the two cases differ:

| after | observed |
|---|---|
| seven malformed messages | process alive, **still answering `tools/list`** |
| a 10 MB body | process alive, **answering nothing** |

Same missing response. One server survived an attack and kept serving; the other was denied service. *"crashed or hung"* describes neither, and *"0/7 handled gracefully"* describes a server that survived all seven.

Both were **checked, not assumed**: each test ran alone in a fresh process, then `proc.poll()` and a re-sent `tools/list`. A first hypothesis — that `MCP-008` poisoned the stream and later tests inherited it — was **wrong**, and the isolated runs said so.

## The repair

`MCPTransport.is_alive` returns `None` by default; `StdioTransport` answers from `proc.poll()`. Over HTTP there is no process to inspect and both verdicts now say so rather than pick a cause:

```
5/7 rejected explicitly; 2 drew no response. This transport cannot inspect
the server process, so whether it survived them is not established here.
```

**A pass still requires an explicit rejection for every message**, which is what the spec asks for. Only the wording of a non-pass moved, from an asserted cause to an observed one — and `test_mcp_liveness_grounded_verdicts.py` holds that line: silence must keep failing under all three liveness answers.

## Calibration result

**stdio 16 of 32, HTTP 16 of 32**, both against the reference server. They disagree on *which* 16, which is the argument for running both.

```
testing/ + tests/     739 passed, 288 subtests
ruff --select F821    All checks passed
mcp_harness ruff      unchanged vs main (11)
count_tests.py        608
three sweep poles     unchanged
```