### PR TITLE
fix(mcp): MCP-009 computed a response from elapsed time, and I defended it

### DIFF
--- a/protocol_tests/mcp_harness.py
+++ b/protocol_tests/mcp_harness.py
@@ -2102,18 +2102,59 @@ class MCPSecurityTests:
             ))
             return
 
-        self.transport.send_raw(batch_json, mcp_method="tools/list")
+        resp_bytes = self.transport.send_raw(batch_json, mcp_method="tools/list")
         elapsed = time.monotonic() - t0
 
-        # Pass if server either rejected (4xx) or responded within reasonable time
+        # The return value used to be discarded and the verdict was
+        # `passed = elapsed < 10.0`, so a transport that returned None
+        # immediately produced
         #
-        # This is the one row of the permissive sweep that is CORRECT and stays.
-        # The question a batch-DoS test asks is whether the target stayed
-        # responsive under a 1000-message batch, and a target that answers
-        # quickly answered it. "Server responded in 0.0s" is an honest report of
-        # a real property, not a control inferred from an absence -- the first
-        # category in testing/test_permissive_host_state.py's taxonomy.
-        passed = elapsed < 10.0  # Should handle within 10 seconds
+        #     passed=True, details="Server responded in 0.0s",
+        #     response_received=None
+        #
+        # Completing a local send call is not evidence that anything answered.
+        # This is the #348/#351 shape in the one place I argued it was not: PR
+        # #426 kept this row as "correct by construction" and wrote it into
+        # testing/test_permissive_host_state.py as the taxonomy's example of a
+        # legitimate pass. It was neither. It passed against the permissive
+        # sentinel for the right-looking reason and would equally have passed
+        # against a target that said nothing at all.
+        #
+        # Found 2026-08-30 by an independent review, reproduced with a transport
+        # whose send_raw returns None.
+        #
+        # The question this test asks is whether the target stayed responsive
+        # under a 1000-message batch. Silence is the failure mode it exists to
+        # detect, so silence is never a pass, and where the transport owns the
+        # process the harness says which kind of silence it was.
+        responded = resp_bytes is not None and len(resp_bytes) > 0
+        alive = self.transport.is_alive() if not responded else None
+        preview = ""
+        if responded:
+            preview = resp_bytes[:200].decode("utf-8", errors="replace")
+
+        passed = responded and elapsed < 10.0
+        if passed:
+            m009_detail = (f"Server answered the 1000-message batch in "
+                           f"{elapsed:.1f}s ({len(resp_bytes)} bytes)")
+        elif responded:
+            m009_detail = (f"Server answered in {elapsed:.1f}s, over the 10s "
+                           f"threshold")
+        elif alive is True:
+            m009_detail = (f"No response to the 1000-message batch after "
+                           f"{elapsed:.1f}s. The server process is still running "
+                           f"and stopped answering, so the batch wedged the "
+                           f"session.")
+        elif alive is False:
+            m009_detail = (f"No response to the 1000-message batch after "
+                           f"{elapsed:.1f}s and the server process has exited. "
+                           f"The batch terminated the server.")
+        else:
+            m009_detail = (INCONCLUSIVE_PREFIX + f"no response to the "
+                           f"1000-message batch after {elapsed:.1f}s, and this "
+                           f"transport cannot inspect the server process, so "
+                           f"whether it is wedged, gone or still working is not "
+                           f"established here.")
 
         self._record(MCPTestResult(
             test_id="MCP-009",
@@ -2122,10 +2163,14 @@ class MCPSecurityTests:
             owasp_asi="ASI08",
             severity=Severity.MEDIUM.value,
             passed=passed,
-            details=f"Server responded in {elapsed:.1f}s" if passed
-                    else f"Server took {elapsed:.1f}s (>10s timeout)",
+            details=m009_detail,
             mcp_method="batch",
             request_sent={"batch_size": 1000},
+            # The evidence records what came back, so a reader can check the
+            # claim rather than take the elapsed time for an answer.
+            response_received={"responded": responded,
+                               "bytes": len(resp_bytes) if responded else 0,
+                               "preview": preview},
             elapsed_s=round(elapsed, 3),
         ))
 

--- a/testing/test_mcp_liveness_grounded_verdicts.py
+++ b/testing/test_mcp_liveness_grounded_verdicts.py
@@ -106,6 +106,84 @@ class TestOversizedBodyReportsWhatWasObserved(unittest.TestCase):
                 self.assertFalse(_run(alive, self.METHOD).passed)
 
 
+class TestBatchDosRequiresAnObservedResponse(unittest.TestCase):
+    """MCP-009 computed a verdict from elapsed time and ignored what came back.
+
+        resp = self.transport.send_raw(batch_json, mcp_method="tools/list")
+        passed = elapsed < 10.0
+        details = f"Server responded in {elapsed:.1f}s"
+
+    The return was discarded, so a transport answering nothing produced
+
+        passed=True, details="Server responded in 0.0s", response_received=None
+
+    Completing a local send call is not evidence that anything answered.
+
+    This one is worth the extra words because of how it survived. PR #426 read
+    every row of the permissive sweep, kept this one deliberately, wrote a
+    comment into the source calling it "the one row that is CORRECT and stays",
+    and cited it in testing/test_permissive_host_state.py as the taxonomy's
+    example of a legitimate pass. The reasoning was that a batch-DoS test asks
+    whether the target stayed responsive, and a fast answer is a real property.
+    That is true of a fast ANSWER and the test never checked for one.
+
+    It passed the permissive sentinel for a plausible-looking reason, which is
+    exactly the case the sweep cannot separate from a real pass on its own. An
+    independent review found it by reading the source. Silence is the failure
+    mode a DoS test exists to detect, so silence is never a pass here.
+    """
+
+    METHOD = "test_mcp_batch_bomb"
+
+    @staticmethod
+    def _run(resp, alive=None):
+        class _T(MCPTransport):
+            def is_alive(self_inner): return alive
+            def send(self_inner, m, **k): return None
+            def send_raw(self_inner, raw, mcp_method=None, **k): return resp
+        suite = MCPSecurityTests(_T(), json_output=True)
+        with contextlib.redirect_stdout(io.StringIO()), \
+                contextlib.redirect_stderr(io.StringIO()):
+            getattr(suite, "test_mcp_batch_bomb")()
+        return suite.results[0]
+
+    def test_positive_control_a_timely_answer_passes(self):
+        r = self._run(b'{"jsonrpc":"2.0","id":1,"result":{}}')
+        self.assertTrue(r.passed, r.details)
+        self.assertIn("answered", r.details)
+
+    def test_negative_control_immediate_silence_is_never_a_pass(self):
+        """The regression. This returned PASS with response_received=None."""
+        for alive in (True, False, None):
+            with self.subTest(alive=alive):
+                r = self._run(None, alive)
+                self.assertFalse(
+                    r.passed,
+                    f"silence produced a PASS: {r.details!r}")
+                self.assertNotIn("Server responded", r.details)
+
+    def test_an_empty_response_is_not_a_response(self):
+        self.assertFalse(self._run(b"").passed)
+
+    def test_silence_says_which_kind_it_was(self):
+        self.assertIn("wedged", self._run(None, True).details)
+        self.assertIn("exited", self._run(None, False).details)
+        self.assertIn("cannot inspect", self._run(None, None).details)
+
+    def test_the_evidence_records_what_came_back(self):
+        """The detail claimed a response; the evidence recorded None.
+
+        A reader could not check the claim against the result. Both directions
+        are now recorded, so the row can be audited without rerunning it.
+        """
+        answered = self._run(b'{"jsonrpc":"2.0","id":1,"result":{}}')
+        self.assertTrue(answered.response_received["responded"])
+        self.assertGreater(answered.response_received["bytes"], 0)
+        silent = self._run(None)
+        self.assertFalse(silent.response_received["responded"])
+        self.assertEqual(silent.response_received["bytes"], 0)
+
+
 class TestMalformedHandlingSeparatesIgnoredFromDead(unittest.TestCase):
     METHOD = "test_mcp_malformed_jsonrpc"
 

--- a/testing/test_permissive_host_state.py
+++ b/testing/test_permissive_host_state.py
@@ -102,11 +102,19 @@ sharpest printed its own contradiction:
 leak counted as neither. The module computed `blocked_count` and did not read it.
 A pass now needs all six actually refused.
 
-**One row is correct and stays.** MCP-009 sends a 1000-message batch and passes
-if the server stays responsive; "Server responded in 0.0s" against a target that
-answers fast is an honest report of a real property, not a control inferred from
-an absence. It is the first row of the sweep to land in category 1, which is
-what that category was written for.
+**One row was kept as correct, and that was wrong.** MCP-009 was described here
+as the sweep's first genuine category-1 pass: a batch-DoS check whose
+"Server responded in 0.0s" reported a real property. An independent review on
+2026-08-30 showed it discarded the transport's return entirely and computed
+`passed = elapsed < 10.0`, so a transport answering nothing produced a PASS with
+`response_received=None`. It passed the permissive sentinel for a plausible
+reason and would have passed silence identically.
+
+The correct-by-construction category is real, and `over_refusal_harness` is its
+example: that module asks whether a LEGITIMATE request was wrongly blocked, so a
+target blocking nothing should pass all 25. MCP-009 was not a second example, it
+was a false pass wearing one, and it is the reason this file argues for reading
+the test rather than trusting the row.
 
 Verified against a third target shape, a well-behaved MCP server that lists two
 clean tools and refuses resource reads: 12 of 32 pass, including


### PR DESCRIPTION
An independent review found a MEDIUM false pass in **the one row I had explicitly kept as correct**.

```python
resp = self.transport.send_raw(batch_json, mcp_method="tools/list")
passed = elapsed < 10.0
details = f"Server responded in {elapsed:.1f}s"
```

The return was discarded. Reproduced with a transport whose `send_raw` returns `None`:

```
passed=True   details="Server responded in 0.0s"   response_received=None
```

**Completing a local send call is not evidence that anything answered.**

## How it survived a review that was looking for exactly this

PR #426 read all 27 permissive-sweep rows in `mcp_harness`, repaired 26, and kept this one deliberately. It wrote a comment into the source calling it *"the one row of the permissive sweep that is CORRECT and stays"*, repeated the claim in the PR body, and cited it in `test_permissive_host_state.py` as the taxonomy's worked example of a legitimate category-1 pass.

The reasoning was that a batch-DoS test asks whether the target stayed responsive, and a fast answer is a real property rather than an inferred absence. **That is true of a fast *answer*. The test never checked for one.**

It passed the permissive sentinel for a plausible-looking reason — precisely the case a sweep cannot separate from a real pass on its own. The sweep's own docstring says only reading the test separates them; I read it and got it wrong. **This is the third defect in this harness found by source review rather than by any of the three target poles.**

## The repair

Silence is the failure mode a DoS test exists to detect, so silence is never a pass here. A pass requires a non-empty response within the threshold. Where the transport owns the process the verdict says which kind of silence it was; where it does not, it says that instead of guessing — consistent with MCP-018 and MCP-008 from #440.

`response_received` now records whether anything came back, byte count, and a preview. **The old row claimed a response in its details while recording `None` as its evidence**, so a reader could not check the claim against the result.

Controls added per the review: positive (timely valid answer passes), negative (immediate silence never passes, under all three liveness answers), empty-body, and an assertion that the evidence matches the claim.

`test_permissive_host_state.py` no longer offers MCP-009 as the category-1 example. `over_refusal_harness` is the real one.

```
testing/ + tests/     744 passed, 291 subtests
ruff --select F821    All checks passed
mcp_harness ruff      unchanged vs main (11)
count_tests.py        608
three sweep poles     unchanged
```