### PR TITLE
feat: pin the review baseline, and keep the reference server as a job

### DIFF
--- a/protocol_tests/mcp_harness.py
+++ b/protocol_tests/mcp_harness.py
@@ -2128,33 +2128,51 @@ class MCPSecurityTests:
         # detect, so silence is never a pass, and where the transport owns the
         # process the harness says which kind of silence it was.
         responded = resp_bytes is not None and len(resp_bytes) > 0
-        alive = self.transport.is_alive() if not responded else None
-        preview = ""
-        if responded:
-            preview = resp_bytes[:200].decode("utf-8", errors="replace")
+        preview = resp_bytes[:200].decode("utf-8", errors="replace") if responded else ""
 
-        passed = responded and elapsed < 10.0
-        if passed:
+        # The oracle is RESPONSIVENESS, and a missing answer to the batch is not
+        # the same as a target that stopped answering. Against the pinned
+        # reference server over stdio the batch draws no reply and `tools/list`
+        # answers immediately afterwards: the server ignored the batch and
+        # survived it, which is the control holding.
+        #
+        # A first version of this repair called that case "the batch wedged the
+        # session", borrowing MCP-018's wording. MCP-018 had earned it -- there
+        # the follow-up probe genuinely goes unanswered -- and this had not. It
+        # is the same overclaim this test was just repaired for, one branch
+        # over, so the responsiveness claim is now made from a probe rather than
+        # from the batch reply alone.
+        still_serving = None
+        alive = None
+        if not responded:
+            probe = self.transport.send(jsonrpc_request("tools/list", {}))
+            still_serving = bool(probe) and "result" in probe
+            alive = self.transport.is_alive()
+
+        passed = elapsed < 10.0 and (responded or still_serving is True)
+        if passed and responded:
             m009_detail = (f"Server answered the 1000-message batch in "
                            f"{elapsed:.1f}s ({len(resp_bytes)} bytes)")
+        elif passed:
+            m009_detail = ("Server sent no reply to the 1000-message batch and "
+                           "answered a normal request immediately afterwards, "
+                           "so it ignored the batch and stayed responsive")
         elif responded:
             m009_detail = (f"Server answered in {elapsed:.1f}s, over the 10s "
                            f"threshold")
-        elif alive is True:
-            m009_detail = (f"No response to the 1000-message batch after "
-                           f"{elapsed:.1f}s. The server process is still running "
-                           f"and stopped answering, so the batch wedged the "
-                           f"session.")
         elif alive is False:
-            m009_detail = (f"No response to the 1000-message batch after "
-                           f"{elapsed:.1f}s and the server process has exited. "
-                           f"The batch terminated the server.")
+            m009_detail = ("No reply to the 1000-message batch and the server "
+                           "process has exited. The batch terminated the server.")
+        elif alive is True:
+            m009_detail = ("No reply to the 1000-message batch and no answer to "
+                           "a normal request afterwards, with the process still "
+                           "running. The batch wedged the session.")
         else:
-            m009_detail = (INCONCLUSIVE_PREFIX + f"no response to the "
-                           f"1000-message batch after {elapsed:.1f}s, and this "
-                           f"transport cannot inspect the server process, so "
-                           f"whether it is wedged, gone or still working is not "
-                           f"established here.")
+            m009_detail = (INCONCLUSIVE_PREFIX + "no reply to the 1000-message "
+                           "batch and no answer to a normal request afterwards. "
+                           "This transport cannot inspect the server process, so "
+                           "whether it is wedged, gone, or was never reachable is "
+                           "not established here.")
 
         self._record(MCPTestResult(
             test_id="MCP-009",
@@ -2170,7 +2188,8 @@ class MCPSecurityTests:
             # claim rather than take the elapsed time for an answer.
             response_received={"responded": responded,
                                "bytes": len(resp_bytes) if responded else 0,
-                               "preview": preview},
+                               "preview": preview,
+                               "still_serving_after": still_serving},
             elapsed_s=round(elapsed, 3),
         ))
 

--- a/scripts/mcp_reference_calibration.py
+++ b/scripts/mcp_reference_calibration.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+r"""Run mcp_harness against a pinned upstream MCP reference server, locally.
+
+## Why this exists as a job rather than a one-off
+
+The three target sweeps use fixtures this repository wrote. They cannot falsify
+the assumptions the harness already holds, because the same author wrote both.
+Every defect found on 2026-08-29/30 that the sweeps could NOT reach came from a
+real implementation or from someone reading the source:
+
+    MCP-002/008/018   the protocol's in-band result.isError rejection idiom
+    MCP-003           an error envelope read as absence of capabilities
+    MCP-017           a P0 control never exercised, because stdio never ran
+    MCP-009           a response claimed from elapsed time
+
+Keeping one real implementation in the loop is the cheapest correction for that,
+and an independent review asked for it to become a retained job rather than an
+afternoon.
+
+## What it reports, and why not a boolean
+
+    16 PASS   2 FAIL   14 INCONCLUSIVE / not-applicable
+
+Collapsing that to green/red loses the thing worth watching. The 14 are controls
+whose preconditions the reference server does not meet -- twelve modern-MCP RC
+checks with no authorized probe material, MCP-007 with no sampling capability,
+MCP-011 whose defined outcomes were not observed. If a future change quietly
+promoted any of those to PASS, a boolean would not notice. The class split is
+the signal.
+
+The two FAILs are findings about the reference server in this configuration, not
+about the harness and not a security assessment of the package.
+
+## The version is pinned on purpose
+
+Upstream behaviour and version can both move, which is the standing uncertainty
+in this job. A floating `@latest` would turn every upstream release into an
+unexplained diff in our own regression state. REFERENCE_SERVER pins it; bumping
+it is a deliberate edit that should come with a re-read of the class split.
+
+    python3 scripts/mcp_reference_calibration.py           # table
+    python3 scripts/mcp_reference_calibration.py --json    # machine-readable
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import json
+import shutil
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+#: Pinned. See the docstring: a floating tag makes upstream releases look like
+#: regressions in this repository.
+REFERENCE_SERVER = "@modelcontextprotocol/server-everything@2026.8.18"
+
+
+def server_command(offline_first: bool = True) -> list[str] | None:
+    """The npx invocation, or None when the server cannot be launched here.
+
+    Tries the local npm cache first so a normal run needs no network. Returns
+    None rather than raising, because "the fixture is unavailable" is a state
+    this job must report as unmeasured, never as success.
+    """
+    if shutil.which("npx") is None:
+        return None
+    return ["npx", "--offline", "-y", REFERENCE_SERVER, "stdio"] if offline_first \
+        else ["npx", "-y", REFERENCE_SERVER, "stdio"]
+
+
+def calibrate(command: list[str]) -> dict:
+    """Run the full MCP suite over stdio against *command* and classify."""
+    from protocol_tests.http_helpers import is_inconclusive
+    from protocol_tests.mcp_harness import MCPSecurityTests, StdioTransport
+
+    transport = StdioTransport(command)
+    suite = MCPSecurityTests(transport)
+    try:
+        with contextlib.redirect_stdout(io.StringIO()), \
+                contextlib.redirect_stderr(io.StringIO()):
+            suite.run_all()
+    finally:
+        with contextlib.suppress(Exception):
+            transport.proc.kill()
+
+    results = list(suite.results)
+    rows = []
+    for r in results:
+        detail = r.details or ""
+        if r.passed:
+            cls = "PASS"
+        elif is_inconclusive(detail) or "Not applicable" in detail \
+                or "not applicable" in detail:
+            cls = "INCONCLUSIVE"
+        else:
+            cls = "FAIL"
+        rows.append({"test_id": r.test_id, "class": cls, "details": detail[:160]})
+
+    counts = {c: sum(1 for x in rows if x["class"] == c)
+              for c in ("PASS", "FAIL", "INCONCLUSIVE")}
+    return {"server": REFERENCE_SERVER, "total": len(rows),
+            "counts": counts, "rows": rows}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--json", action="store_true", help="machine-readable output")
+    ap.add_argument("--network", action="store_true",
+                    help="allow npx to fetch the pinned server if not cached")
+    args = ap.parse_args()
+
+    cmd = server_command(offline_first=not args.network)
+    if cmd is None:
+        print("npx is not available; the reference server cannot be launched.",
+              file=sys.stderr)
+        print("UNMEASURED, not clean.", file=sys.stderr)
+        return 2
+    try:
+        report = calibrate(cmd)
+    except Exception as exc:  # noqa: BLE001 - reported, never swallowed into a pass
+        print(f"reference server did not run: {type(exc).__name__}: {exc}",
+              file=sys.stderr)
+        print("UNMEASURED, not clean. Retry with --network if it is not cached.",
+              file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+        return 0
+
+    c = report["counts"]
+    print(f"{report['server']}  (stdio, loopback child process)")
+    print("-" * 78)
+    for row in report["rows"]:
+        print(f"  {row['class']:13} {row['test_id']:12} {row['details'][:52]}")
+    print("-" * 78)
+    print(f"  {c['PASS']} PASS   {c['FAIL']} FAIL   {c['INCONCLUSIVE']} "
+          f"INCONCLUSIVE / not applicable   of {report['total']}")
+    print("The class split is the signal. A boolean would hide an INCONCLUSIVE")
+    print("quietly becoming a PASS, which is what this job exists to watch.")
+    print("FAILs are findings about this reference server in this configuration,")
+    print("not a security assessment of the package.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/testing/CRITICAL_EVALUATION_R36_2026-08-30.md
+++ b/testing/CRITICAL_EVALUATION_R36_2026-08-30.md
@@ -1,0 +1,117 @@
+# CRITICAL EVALUATION — Round 36
+
+**Date:** 2026-08-30
+**Round:** 36
+**Reviewed commit:** `1814e95aec1e968300e7ef7db3aa9f2c5a20e629`
+**Reviewed range:** `bfdc8cc04cb4894def5bc1b51f2bce75f34eeb3e..1814e95aec1e968300e7ef7db3aa9f2c5a20e629` (199 commits)
+**Prior baseline:** R35 (2026-07-25) named a date and a PR list but no commit, so
+its boundary had to be reconstructed. `bfdc8cc04cb4894def5bc1b51f2bce75f34eeb3e` is the last commit on or before
+that date and is recorded here as the reconstructed lower bound. **From this
+round on, every evaluation report pins both ends.**
+**Test count:** 608 across 43 test-bearing modules (`scripts/count_tests.py`)
+**Version:** 4.16.0 (released 2026-08-30, PyPI wheel + sdist)
+**Evaluator:** Session round plus four independent I0 reviews from the Hermes
+agent, pinned at `033a537`, `c593346`, `fbdad1b` and `bc9759c`
+
+---
+
+## 1. Why this header changed
+
+An independent review could not determine a "since prior review" boundary,
+because R35 identifies its scope by date and PR numbers rather than by commit.
+Reconstructing it from dates is guesswork that gets more expensive every round.
+
+Two lines fix it, and they are the first recommendation this round adopts:
+**Reviewed commit** and **Reviewed range**. The next round inspects a bounded
+delta from `1814e95aec1e968300e7ef7db3aa9f2c5a20e629` instead of re-deriving scope.
+
+## 2. What changed
+
+Twenty-five merged PRs, #417 through #441, all at 7/7 CI. The theme is one
+issue, #351, and its generalisation.
+
+| Area | Result |
+|---|---|
+| Dead-host false passes | 88 across ten modules, now 3, all declared local self-tests |
+| Two new target poles | `permissive_host_sweep.py`, `refusing_host_sweep.py`, each with a pinned state file |
+| Sweep discovery | class-name convention replaced by capability; 28 modules became 61 suites |
+| Live calibration | first runs against a real MCP implementation, HTTP and stdio |
+| Release | v4.16.0 shipped; `publish-pypi.yml` repaired |
+| Machine interface | `--json` now emits exactly one document on stdout |
+
+## 3. Prior fix verification
+
+| Issue | Severity | Status | Evidence |
+|---|---|---|---|
+| #348/#350/#351 unserviced-request passes | CRITICAL | FIXED | `dead_host_sweep`: 3 of 500, all declared self-tests, 0 errors |
+| `_serviced` non-2xx rule wrong for refusal-subject harnesses | HIGH | FIXED (10 modules) | `refusing_host_sweep`: 5 suites recognise a refusal where none did |
+| `--json` stdout impurity | MEDIUM | FIXED | `test_json_stdout_purity.py`, subprocess, source-derived module list |
+| MCP in-band `result.isError` idiom unrecognised | MEDIUM | FIXED | live reference server, MCP-002/008/018 |
+| MCP-009 response claimed from elapsed time | MEDIUM | FIXED | `test_mcp_liveness_grounded_verdicts.py`, five branches |
+
+## 4. New issues found this round
+
+**None open.** Both MEDIUM findings raised by external review were closed in the
+round that raised them (#432, #441).
+
+The MCP-009 finding is worth recording in full because of how it survived. PR
+#426 read all 27 permissive-sweep rows in `mcp_harness`, repaired 26, and kept
+one deliberately, writing into the source that it was "the one row that is
+CORRECT and stays" and citing it in `test_permissive_host_state.py` as the
+taxonomy's example of a legitimate pass. It discarded the transport's return and
+computed `passed = elapsed < 10.0`.
+
+The first repair was then also wrong, in the opposite direction: it called a
+server that ignores the batch and keeps serving "wedged", borrowing MCP-018's
+wording where MCP-018 had earned it and this had not. That was caught by running
+the new calibration job, not by review.
+
+## 5. What is good
+
+- Three target poles, each pinning measurements rather than asserting zero.
+- `ran-no-verdicts` is a distinct sweep status; `mcp_harness` at the dead host
+  is visibly unmeasured rather than a clean 0/0.
+- Reference-server calibration retains classes: 16 PASS / 2 FAIL / 14
+  INCONCLUSIVE, with the server version pinned.
+- Public metadata reconciles across four surfaces at 608 / 43 / v4.16.0.
+
+## 6. Methods
+
+Behaviour-first. Three synthetic sentinels, then a real implementation over both
+transports. Every claim in this report is reproducible from
+`1814e95aec1e968300e7ef7db3aa9f2c5a20e629` with the scripts named above.
+
+**The limit, stated plainly:** every defect the sentinels could not reach was
+found by a live target or by source review. Three of them. Synthetic fixtures
+encode the same assumptions as the harness that ships with them.
+
+## 7. Self-test suite
+
+`testing/` + `tests/`: 750 passed, 305 subtests. `ruff --select F821` clean.
+`count_tests.py` 608. `verify_release_claims.py` 5 passed, 0 failed, 0 not
+reproduced.
+
+## 8. Score
+
+**9/10.** No open MEDIUM or above. Not 10: two MEDIUMs reached `main` this round
+and both were found by an external reviewer rather than by this repository's own
+checks, one of them in a row this repository had explicitly examined and
+defended.
+
+## 9. Recommendations
+
+1. Bounded, no-semantic-change lint cleanup, separate from verdict repairs.
+2. Read the permissive and refusing backlogs one family at a time. They are
+   reading lists, not defect counts.
+3. Keep `mcp_harness`'s dead-host `0/0` visible as unmeasured; do not fabricate
+   per-test failures to give the sweep a count.
+4. A second real implementation, chosen for a different protocol idiom.
+
+## 10. Cumulative assessment
+
+#351 is closed for the dead-host pole and open as a reading list for the other
+two. The instruments are in place and pinned; what remains is reading, and one
+more real target.
+
+None of this establishes that any agent, gateway, MCP server or payment endpoint
+is secure. It establishes what this harness claims when it has nothing to go on.

--- a/testing/test_mcp_liveness_grounded_verdicts.py
+++ b/testing/test_mcp_liveness_grounded_verdicts.py
@@ -144,7 +144,7 @@ class TestBatchDosRequiresAnObservedResponse(unittest.TestCase):
         suite = MCPSecurityTests(_T(), json_output=True)
         with contextlib.redirect_stdout(io.StringIO()), \
                 contextlib.redirect_stderr(io.StringIO()):
-            getattr(suite, "test_mcp_batch_bomb")()
+            suite.test_mcp_batch_bomb()
         return suite.results[0]
 
     def test_positive_control_a_timely_answer_passes(self):
@@ -164,6 +164,30 @@ class TestBatchDosRequiresAnObservedResponse(unittest.TestCase):
 
     def test_an_empty_response_is_not_a_response(self):
         self.assertFalse(self._run(b"").passed)
+
+    def test_ignoring_the_batch_while_still_serving_is_a_pass(self):
+        """The branch a blunter repair got wrong.
+
+        The pinned reference server sends no reply to the batch and answers a
+        normal request immediately afterwards. The oracle is responsiveness, so
+        that is the control holding, and calling it "wedged" -- which a first
+        version of this repair did, borrowing MCP-018's wording -- is the same
+        overclaim MCP-009 was being repaired for, one branch over.
+        """
+        class _Serving(MCPTransport):
+            def is_alive(self_inner): return True
+            def send(self_inner, m, **k): return {"result": {"tools": []}}
+            def send_raw(self_inner, raw, mcp_method=None, **k): return None
+
+        suite = MCPSecurityTests(_Serving(), json_output=True)
+        with contextlib.redirect_stdout(io.StringIO()), \
+                contextlib.redirect_stderr(io.StringIO()):
+            suite.test_mcp_batch_bomb()
+        r = suite.results[0]
+        self.assertTrue(r.passed, r.details)
+        self.assertIn("stayed responsive", r.details)
+        self.assertNotIn("wedged", r.details)
+        self.assertTrue(r.response_received["still_serving_after"])
 
     def test_silence_says_which_kind_it_was(self):
         self.assertIn("wedged", self._run(None, True).details)

--- a/testing/test_mcp_reference_calibration.py
+++ b/testing/test_mcp_reference_calibration.py
@@ -1,0 +1,100 @@
+"""The pinned upstream MCP reference server, and what the harness claims about it.
+
+Every defect the three synthetic sweeps could NOT reach came from a real
+implementation or from reading the source. An independent review asked for the
+reference-server run to become a retained job rather than an afternoon, and to
+keep the result CLASSES rather than collapsing them to a boolean.
+
+    16 PASS   2 FAIL   14 INCONCLUSIVE / not applicable
+
+The 14 are the signal a boolean would lose. Twelve are modern-MCP RC checks with
+no authorized probe material, one is MCP-007 with no sampling capability, one is
+MCP-011 whose defined outcomes were not observed. If a change quietly promoted
+any of those to PASS, a green/red job would not notice.
+
+## Unmeasured is not clean
+
+This job needs `npx` and the pinned package in the local npm cache. When it
+cannot run it skips, and a skip here means the calibration did not happen. It is
+NOT evidence that the class split still holds.
+`test_the_pin_is_a_fixed_version` runs regardless, so something is always
+asserted even when the fixture is missing.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from mcp_reference_calibration import REFERENCE_SERVER, calibrate, server_command
+
+#: Measured 2026-08-30 against @modelcontextprotocol/server-everything@2026.8.18
+#: over stdio. Independently reproduced by a reviewer on the same day.
+EXPECTED = {"PASS": 16, "FAIL": 2, "INCONCLUSIVE": 14}
+
+#: The two FAILs are findings about this reference server in this configuration.
+#: MCP-008: it ignores malformed messages without reporting a parse error.
+#: MCP-018: a 10 MB body leaves the process alive and the session unanswerable.
+EXPECTED_FAILS = {"MCP-008", "MCP-018"}
+
+
+class TestThePinItself(unittest.TestCase):
+    """Runs even when the server cannot be launched."""
+
+    def test_the_pin_is_a_fixed_version(self):
+        """A floating tag turns every upstream release into a local regression."""
+        self.assertNotIn("@latest", REFERENCE_SERVER)
+        self.assertRegex(
+            REFERENCE_SERVER, r"@\d{4}\.\d{1,2}\.\d{1,2}$",
+            f"{REFERENCE_SERVER!r} is not pinned to a specific version. Bumping "
+            f"it is a deliberate edit and should come with a re-read of the "
+            f"class split in EXPECTED.")
+
+
+class TestReferenceCalibration(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cmd = server_command()
+        if cmd is None:
+            raise unittest.SkipTest(
+                "npx unavailable; reference calibration UNMEASURED, not clean")
+        try:
+            cls.report = calibrate(cmd)
+        except Exception as exc:  # noqa: BLE001
+            raise unittest.SkipTest(
+                f"pinned reference server did not launch ({exc}); calibration "
+                f"UNMEASURED, not clean. Populate the npm cache to run it.")
+
+    def test_the_suite_actually_produced_results(self):
+        self.assertEqual(
+            self.report["total"], sum(EXPECTED.values()),
+            "result count moved; the suite or the server changed")
+
+    def test_the_class_split_holds(self):
+        self.assertEqual(
+            self.report["counts"], EXPECTED,
+            "the class split moved. This is the check that exists so an "
+            "INCONCLUSIVE cannot quietly become a PASS. Read the diff before "
+            "updating EXPECTED, and say which change moved it.")
+
+    def test_the_failures_are_the_declared_ones(self):
+        got = {r["test_id"] for r in self.report["rows"] if r["class"] == "FAIL"}
+        self.assertEqual(
+            got, EXPECTED_FAILS,
+            f"different tests are failing against the reference server: {got}")
+
+    def test_no_inconclusive_row_claims_a_pass(self):
+        """The specific way this job earns its keep."""
+        for row in self.report["rows"]:
+            if row["class"] == "INCONCLUSIVE":
+                with self.subTest(test_id=row["test_id"]):
+                    self.assertNotIn("PASS", row["details"].upper()[:12])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Both remaining recommendations from the 2026-08-30 independent review.

## 1. The review baseline is pinned

R35 named a date and a PR list, so a reviewer could not determine a "since prior review" boundary and had to reconstruct scope from dates. R36 pins both ends, and records `bfdc8cc` as a **reconstructed** lower bound rather than presenting it as something R35 stated. Every report from here pins both.

## 2. The reference-server calibration is a retained job

`scripts/mcp_reference_calibration.py` runs the MCP suite over stdio against a **pinned** upstream server and reports classes, not a boolean:

```
16 PASS   2 FAIL   14 INCONCLUSIVE / not applicable
```

**The 14 are the point.** Twelve modern-MCP RC checks have no authorized probe material, MCP-007 has no sampling capability, MCP-011 did not observe its defined outcomes. A green/red job would not notice one of those quietly becoming a PASS.

The version is pinned because upstream behaviour and version can both move, and a floating tag turns every upstream release into an unexplained regression here.

When `npx` or the cached package is missing, the job **skips and says the calibration is UNMEASURED, not clean**. `test_the_pin_is_a_fixed_version` runs regardless, so a missing fixture cannot leave the file asserting nothing.

## The job found a defect in its first run, in code an hour old

`MCP-009` was repaired in #441 to require an observed response. Run against the pinned server it then **failed**, reporting *"the batch wedged the session"*.

The probe said otherwise: the process was alive **and** `tools/list` answered immediately afterwards. The server ignored the batch and stayed fully responsive — the control holding.

That wording was borrowed from MCP-018, where the follow-up probe genuinely goes unanswered and the claim is earned. Here it was **the same overclaim MCP-009 had just been repaired for, one branch over.**

The oracle is responsiveness, so it is now measured by a probe rather than inferred from the batch reply. Answered in time, or unanswered but still serving: both pass. Unanswered and not serving is a FAIL that says which kind, and a transport that cannot tell says so. Five branches, all pinned.

Calibration returns to **16/2/14**, matching the reviewer's measurement — now because the server is *observed* to stay responsive rather than because elapsed time was small.

```
testing/ + tests/     750 passed, 305 subtests
ruff --select F821    All checks passed
mcp_harness ruff      unchanged vs main (11); all new/changed files clean
count_tests.py        608
three sweep poles     unchanged
```