### PR TITLE
fix(ci): the calibration job turned UNMEASURED into a wrong failure

### DIFF
--- a/scripts/mcp_reference_calibration.py
+++ b/scripts/mcp_reference_calibration.py
@@ -103,8 +103,19 @@ def calibrate(command: list[str]) -> dict:
 
     counts = {c: sum(1 for x in rows if x["class"] == c)
               for c in ("PASS", "FAIL", "INCONCLUSIVE")}
+    # Zero results means the MCP session never initialised, which in practice
+    # means the server never started: `npx` exists but the pinned package is not
+    # in the local cache, so `--offline` cannot resolve it. Popen still succeeds,
+    # nothing answers, and run_all returns empty.
+    #
+    # This has to be its own state. The first version of this job only caught an
+    # exception, so on a machine without the cache the caller received
+    # {"PASS": 0, "FAIL": 0, "INCONCLUSIVE": 0} and the state test read it as
+    # "the class split moved" -- turning UNMEASURED into a confident and wrong
+    # failure message. That is the defect this whole job exists to catch, in the
+    # job itself.
     return {"server": REFERENCE_SERVER, "total": len(rows),
-            "counts": counts, "rows": rows}
+            "launched": bool(rows), "counts": counts, "rows": rows}
 
 
 def main() -> int:
@@ -126,6 +137,14 @@ def main() -> int:
         print(f"reference server did not run: {type(exc).__name__}: {exc}",
               file=sys.stderr)
         print("UNMEASURED, not clean. Retry with --network if it is not cached.",
+              file=sys.stderr)
+        return 2
+
+    if not report["launched"]:
+        print(f"{REFERENCE_SERVER} produced no results: the MCP session never "
+              f"initialised, so the server almost certainly did not start.",
+              file=sys.stderr)
+        print("UNMEASURED, not clean. Retry with --network to populate the cache.",
               file=sys.stderr)
         return 2
 

--- a/testing/test_mcp_reference_calibration.py
+++ b/testing/test_mcp_reference_calibration.py
@@ -69,6 +69,16 @@ class TestReferenceCalibration(unittest.TestCase):
             raise unittest.SkipTest(
                 f"pinned reference server did not launch ({exc}); calibration "
                 f"UNMEASURED, not clean. Populate the npm cache to run it.")
+        if not cls.report["launched"]:
+            # The failure mode this file nearly shipped with. On a machine
+            # without the pinned package cached, npx exists so Popen succeeds,
+            # nothing answers, and the suite returns zero results. Comparing
+            # those zeros to EXPECTED produced "the class split moved", which is
+            # a confident and wrong description of a fixture that never started.
+            raise unittest.SkipTest(
+                "the MCP session never initialised, so the pinned reference "
+                "server did not start (npx present, package not cached). "
+                "Calibration UNMEASURED, not clean.")
 
     def test_the_suite_actually_produced_results(self):
         self.assertEqual(


### PR DESCRIPTION
`main` went red on #442. Four Tests jobs failed with:

```
AssertionError: {'PASS': 0, 'FAIL': 0, 'INCONCLUSIVE': 0} != {'PASS': 16, ...}
: the class split moved. ... say which change moved it.
```

**The class split had not moved.** On a CI runner `npx` exists but the pinned package is not in the local npm cache, so `--offline` cannot resolve it. `Popen` still succeeds, the MCP session never initialises, `run_all` returns zero results, and `calibrate()` returned three zeros **without raising**.

The skip guard only caught an exception, so it never fired. The state test compared zeros to `EXPECTED` and produced a confident, specific, **wrong** diagnosis of a fixture that had not started.

> That is exactly the defect class this job was built to catch, in the job itself, written into the same commit as a docstring saying "unmeasured is not clean".

## The repair

`calibrate()` returns `launched`, decided by whether any result was produced at all. **Zero results is its own state, not a measurement of zero.** The CLI exits 2 and says the session never initialised; the state test skips with the same reason instead of comparing.

Verified against a deliberately unresolvable package name:

```
launched=False  total=0  counts={'PASS': 0, 'FAIL': 0, 'INCONCLUSIVE': 0}
```

`test_the_pin_is_a_fixed_version` still runs unconditionally, so a machine without the cache asserts something rather than nothing.

## On how this reached main

The merge gate waited for checks to **complete** and then merged, without gating on their **conclusion**. Completion is not success — the same confusion this issue has spent 26 PRs removing from the harness's own verdicts. The check count was printed and not read.

```
testing/ + tests/     750 passed, 305 subtests
both files            lint clean
```