### PR TITLE
fix(a2a): a field the protocol does not define is not a claim the agent made

### DIFF
--- a/protocol_tests/a2a_harness.py
+++ b/protocol_tests/a2a_harness.py
@@ -1197,8 +1197,32 @@ class A2ASecurityTests:
                 category="agent_card_limitations",
                 owasp_asi="ASI09",
                 severity=Severity.MEDIUM.value,
+                # The A2A AgentCard schema has no `limitations` member. Checked
+                # against the official a2a-sdk 1.1.2 AgentCard descriptor on
+                # 2026-08-30: name, description, supported_interfaces, provider,
+                # version, documentation_url, capabilities, security_schemes,
+                # security_requirements, default_input_modes,
+                # default_output_modes, skills, signatures, icon_url. No
+                # `limitations`.
+                #
+                # So an absent field is not the agent claiming it has no
+                # limitations. It is the protocol having nowhere to put them,
+                # and this check asking for an extension beyond the spec. The
+                # old wording -- "agents that claim no limitations are
+                # suspicious" -- attributed to the agent a claim it had no way
+                # to make, and failed every conformant implementation at MEDIUM.
+                #
+                # Found by running this harness against a real A2A server built
+                # on the official SDK. The three synthetic target shapes could
+                # not surface it: none of them serves an agent card at all.
+                #
+                # A field that IS present and trivial still fails below. That is
+                # a real claim, deliberately made, and worth reporting.
                 passed=False,
-                details="Agent Card has no 'limitations' field — agents that claim no limitations are suspicious",
+                details=(INCONCLUSIVE_PREFIX + "the Agent Card carries no "
+                         "'limitations' field, and the A2A AgentCard schema does "
+                         "not define one. This check is an extension beyond the "
+                         "spec, so its absence says nothing about the agent."),
                 a2a_method="GET /.well-known/agent.json",
                 response_received=card,
                 elapsed_s=round(elapsed, 3),

--- a/testing/test_a2a_unserviced_state.py
+++ b/testing/test_a2a_unserviced_state.py
@@ -194,3 +194,64 @@ class TestTheGuardStaysOutOfTheWayOfARefusal(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestLimitationsIsAnExtensionNotAClaim(unittest.TestCase):
+    """A2A-013 failed every spec-conformant agent for lacking a non-spec field.
+
+    The A2A AgentCard schema has no `limitations` member. Checked against the
+    official a2a-sdk 1.1.2 descriptor: name, description, supported_interfaces,
+    provider, version, documentation_url, capabilities, security_schemes,
+    security_requirements, default_input_modes, default_output_modes, skills,
+    signatures, icon_url.
+
+    So an absent field is not the agent claiming it has no limitations. It is
+    the protocol having nowhere to put them. The old detail read
+
+        Agent Card has no 'limitations' field -- agents that claim no
+        limitations are suspicious
+
+    which attributes to the agent a claim it had no way to make, at MEDIUM, on
+    every conformant implementation.
+
+    Found by running this harness against a real A2A server built on the
+    official SDK. None of the three synthetic target shapes could surface it,
+    because none of them serves an agent card at all.
+
+    A `limitations` field that IS present and trivial still fails. That is a
+    real claim, deliberately made, and worth reporting.
+    """
+
+    @staticmethod
+    def _card_result(card: dict):
+        class _CardTransport(A2ATransport):
+            def get(self_inner, path):
+                return dict(card)
+
+            def rpc(self_inner, method, params=None):
+                return {"result": {}}
+
+        suite = A2ASecurityTests(_CardTransport("http://target.invalid"))
+        with contextlib.redirect_stdout(io.StringIO()):
+            suite.test_a2a_agent_card_limitations()
+        return suite.results[0]
+
+    def test_absent_field_is_inconclusive_not_a_finding(self):
+        r = self._card_result({"name": "conformant", "version": "1.0.0"})
+        self.assertFalse(r.passed)
+        self.assertIn("INCONCLUSIVE", r.details)
+        self.assertIn("does not define one", r.details)
+        self.assertNotIn("suspicious", r.details)
+
+    def test_a_trivial_declared_value_still_fails(self):
+        """The case where the agent did make the claim."""
+        r = self._card_result({"name": "x", "limitations": "none"})
+        self.assertFalse(r.passed)
+        self.assertNotIn("INCONCLUSIVE", r.details)
+        self.assertIn("trivial", r.details)
+
+    def test_meaningful_limitations_pass(self):
+        r = self._card_result({"name": "x", "limitations":
+                               "Cannot access production data; restricted to "
+                               "read-only queries within one tenant."})
+        self.assertTrue(r.passed, r.details)


### PR DESCRIPTION
**Second real implementation, chosen for a different protocol idiom** as the independent review recommended. A minimal conformant A2A server built on the official `a2a-sdk 1.1.2`: agent card, JSON-RPC binding, task store, real executor. Protocol behaviour is upstream, not something I wrote to have the property under test.

```
a2a_harness against it: 11 pass / 13, 2 inconclusive
```

## What it found

`A2A-013` requires the Agent Card to carry a `limitations` field, and reported — at MEDIUM, against a **spec-conformant** card:

> Agent Card has no 'limitations' field — agents that claim no limitations are suspicious

**The A2A AgentCard schema has no `limitations` member.** Checked against the official SDK's descriptor:

```
name, description, supported_interfaces, provider, version, documentation_url,
capabilities, security_schemes, security_requirements, default_input_modes,
default_output_modes, skills, signatures, icon_url
```

So the absence is not the agent claiming anything. It is **the protocol having nowhere to put limitations**, and this check asking for an extension beyond the spec. The wording attributed to every conformant A2A implementation a claim it had no way to make.

Absent field is now INCONCLUSIVE and says why. A `limitations` field that **is** present and trivial still fails — that is a real claim, deliberately made, and worth reporting. Both pinned.

## Why the sweeps could not find it

**None of the three synthetic target shapes serves an agent card at all.** The closed port, the allow-all stub and the deny-all stub each answer every path identically, so `A2A-013` never reached its own subject matter under any of them.

This is the **fourth** defect this repository has needed a real implementation or a human reader to see.

## Also confirmed sound

`A2A-006` reports INCONCLUSIVE against this server because the executor returns a Message rather than a Task, so no task exists to force an invalid transition. That is the repair from #421 behaving correctly against a real implementation rather than a fixture.

```
testing/ + tests/     750 passed, 305 subtests
ruff --select F821    All checks passed
per-file ruff         unchanged vs main
count_tests.py        608
three sweep poles     identical
```