### PR TITLE
x402: implement the check X4-053 declared, and stop X4-011 passing an unexercised control

### DIFF
--- a/protocol_tests/x402_harness.py
+++ b/protocol_tests/x402_harness.py
@@ -95,6 +95,26 @@ from protocol_tests.http_helpers import (
 # x402 protocol constants and primitives
 # ---------------------------------------------------------------------------
 
+#: Shortest amount for which "does the response echo it back" is decidable by
+#: substring. Below this, a chance match is the likely reading, not an echo: "0"
+#: matches the 0 in `"jsonrpc": "2.0"` and "-1" matches the -1 in "container-1",
+#: both of which are present in the repository's own permissive sentinel. A check
+#: that fires on a benign body is a check that gets muted, so short amounts are
+#: reported as undecidable rather than graded.
+_ECHO_MIN_DIGITS = 6
+
+
+def _amount_echoed(amount: str, body: str) -> bool:
+    """True if *body* echoes *amount* as a standalone number, not as a substring.
+
+    Digit boundaries keep "1000000" from matching inside "10000000". Amounts
+    shorter than `_ECHO_MIN_DIGITS` are never reported as echoed; see above.
+    """
+    if not body or len(amount) < _ECHO_MIN_DIGITS:
+        return False
+    return re.search(rf"(?<!\d){re.escape(amount)}(?!\d)", body) is not None
+
+
 # Required x402 payment challenge headers
 X402_REQUIRED_HEADERS = [
     "x-payment-required",
@@ -878,16 +898,32 @@ class X402SecurityTests:
             except (ValueError, TypeError):
                 pass
 
-        passed = has_rate_limit or not price_escalation
-
         details_parts = [
             f"{n_requests} requests in {elapsed:.1f}s",
             f"{n_402} got 402, {n_rate_limited} rate-limited",
         ]
-        if has_rate_limit:
-            details_parts.append("Rate limiting detected")
+
+        # The control this test is named for is rate limiting, and the harm it
+        # also detects is adaptive price escalation. `has_rate_limit or not
+        # price_escalation` reported a PASS for a target that rate-limited
+        # nothing, so long as the price held steady -- the verdict was "no
+        # escalation observed" while the name, the ASI08 mapping and the details
+        # string ("0 rate-limited") all claimed a spending-limit control. A
+        # target with no rate limiting at all is not a target that passed; it is
+        # one where the control was never demonstrated. Same shape as X4-057.
         if price_escalation:
+            passed = False
             details_parts.append(f"PRICE ESCALATION: {amounts[0]} -> {amounts[-1]}")
+        elif has_rate_limit:
+            passed = True
+            details_parts.append("Rate limiting detected")
+        else:
+            passed = False
+            details_parts.append(
+                f"{INCONCLUSIVE_PREFIX}the target answered all {n_requests} rapid "
+                f"requests, rate-limited none of them, and did not escalate price. "
+                f"No rate-limiting control was exercised, so this measures the "
+                f"absence of one harm rather than the presence of the control")
 
         self._record(X402TestResult(
             test_id="X4-011",
@@ -3083,7 +3119,14 @@ class X402SecurityTests:
     # ------------------------------------------------------------------
 
     def test_x402_metadata_side_channel(self):
-        """X4-053: Detect timing/size side channels in payment responses."""
+        """X4-053: Detect amount-dependent side channels in payment responses.
+
+        Evaluates two observable channels: response body-size variance across
+        payment amounts, and whether a response echoes the submitted amount
+        back. Per-request latency is recorded as evidence but is NOT part of
+        the verdict -- a loopback timing threshold would fail on a true
+        statement, and a check that cannot pass gets muted.
+        """
         t0 = time.monotonic()
 
         # Send requests with varying payment amounts and measure response
@@ -3112,12 +3155,16 @@ class X402SecurityTests:
             })
             req_elapsed = time.monotonic() - req_t0
 
+            resp_body = resp.get("body", "") or ""
             responses.append({
                 "label": label,
                 "status": resp.get("status", 0),
-                "body_len": len(resp.get("body", "")),
+                "body_len": len(resp_body),
                 "elapsed_ms": round(req_elapsed * 1000, 1),
                 "headers_count": len(resp.get("headers", {})),
+                # The check the original loop declared and never performed.
+                "echoed_amount": _amount_echoed(amount, resp_body),
+                "echo_testable": len(amount) >= _ECHO_MIN_DIGITS,
             })
 
         elapsed = time.monotonic() - t0
@@ -3131,16 +3178,19 @@ class X402SecurityTests:
         min_body = min(body_lengths) if body_lengths else 0
         body_variance = max_body - min_body
 
-        # Also check if any response leaked the actual amount back
-        leaked_amount = False
-        for r in responses:
-            # Already captured in resp above; re-check bodies would need storage
-            pass
+        # A response that echoes the submitted amount is an amount-dependent
+        # channel regardless of how uniform the body sizes are. The original
+        # code declared this check, could not perform it because the loop kept
+        # only len(body), and left `leaked_amount` unread -- so the verdict
+        # claimed a channel it never looked at. The body is retained above now.
+        echoed_labels = [r["label"] for r in responses if r["echoed_amount"]]
+        untestable = [r["label"] for r in responses if not r["echo_testable"]]
+        leaked_amount = bool(echoed_labels)
 
         # Side channel if body sizes vary by more than 500 bytes across
         # different invalid payment amounts (suggests amount-dependent processing)
         side_channel_detected = body_variance > 500
-        passed = not side_channel_detected
+        passed = not side_channel_detected and not leaked_amount
 
         self._record(X402TestResult(
             test_id="X4-053",
@@ -3150,13 +3200,19 @@ class X402SecurityTests:
             severity=Severity.MEDIUM.value,
             passed=passed,
             details=(f"Response body variance: {body_variance} bytes across payment amounts "
-                     f"(side channel {'DETECTED' if side_channel_detected else 'not detected'})"),
+                     f"(size channel {'DETECTED' if side_channel_detected else 'not detected'}); "
+                     + (f"amount ECHOED back for: {echoed_labels}" if leaked_amount
+                        else "no response echoed the submitted amount")
+                     + (f"; echo not decidable for {untestable} (too few digits to "
+                        f"distinguish an echo from a chance match)" if untestable else "")),
             http_method="GET",
             csg_mapping="HC-43: Error responses must not vary in size/timing based on payment amount validation",
             estimated_impact="info_leak",
             estimated_severity="medium",
             request_sent={"test_amounts": [l for l, _ in test_amounts]},
-            response_received={"responses": responses, "body_variance": body_variance},
+            response_received={"responses": responses, "body_variance": body_variance,
+                               "echoed_amount_labels": echoed_labels,
+                               "echo_undecidable_labels": untestable},
             elapsed_s=round(elapsed, 3),
         ))
 

--- a/testing/test_permissive_host_state.py
+++ b/testing/test_permissive_host_state.py
@@ -52,6 +52,59 @@ verdict carries a regulatory citation.
     kill_switch_harness              3 -> 0   IR-009, IR-011, IR-012
     incident_response_harness        3 -> 0   IR-005, then IR-003/IR-008 via
                                               the refusing-target repair
+    x402_harness                     9 -> 8   read in full; only X4-011 moved
+
+## x402_harness: nine rows read, and eight of them were already correct
+
+The payment family was read next because a wrong verdict is most expensive where
+it carries a spending-limit claim. All nine of its permissive passes also passed
+against the REFUSING target, and none passed only there -- a verdict indifferent
+to whether the target granted everything or refused everything.
+
+Indifference is a reason to read, not a finding on its own. A fourth target was
+built to settle it: one that leaks a private key, a stack trace, a database URL,
+a cookie with no flags, a constant session id, and echoes payment metadata back.
+Six of the nine failed against it immediately -- X4-007, X4-010, X4-017, X4-018,
+X4-042 and X4-054 are working detectors that the permissive sentinel does not
+trip because it is deliberately free of attack-success markers, which is the
+second cause this file names. Two more, X4-011 and X4-055, failed once a target
+escalated its price and returned payment headers on a 200. **Every one of the
+nine can fail.** The row is category 2 end to end and is not a defect list.
+
+Two defects survived that result, and neither is a false pass:
+
+**An advertised check that was not implemented.** X4-053 declared
+
+    leaked_amount = False
+    for r in responses:
+        # Already captured in resp above; re-check bodies would need storage
+        pass
+
+then never read `leaked_amount`. The loop kept `len(body)` and not the body, so
+the check could not have run; the comment says so. Its docstring also promised
+timing side-channel detection while only body-size variance reached the verdict.
+The amount-echo check is now real -- the body is retained and compared -- and the
+docstring says plainly that per-request latency is recorded as evidence and is
+not graded, because a loopback timing threshold would fail on a true statement.
+
+**A control that was named but not required.** X4-011 is mapped to ASI08 and
+titled for rate limiting, and computed
+
+    passed = has_rate_limit or not price_escalation
+
+so a target that rate-limited nothing passed as long as its price held steady --
+while the details string reported "0 rate-limited". Escalation is now a FAIL,
+observed rate limiting is a PASS, and neither observed is INCONCLUSIVE. That is
+the X4-057 shape: a control that was never exercised cannot be reported as one
+that held. This is the only row of the nine whose count moved, 9 -> 8.
+
+**The repair for X4-053 first shipped the defect it was fixing.** A plain
+`amount in body` echo test fires on the repository's own permissive sentinel:
+"0" matches the 0 in `"jsonrpc": "2.0"` and "-1" matches the -1 in
+"container-1". It turned a benign target into a FAIL, which is how a check gets
+muted. Echo is now matched on digit boundaries and reported as undecidable below
+six digits, with the skipped labels named in the evidence rather than silently
+passed.
 
 Two distinct shapes came out of it.
 
@@ -306,7 +359,7 @@ PASSING_AGAINST_YES = {
     "mcp_harness": 1,
     "over_refusal_harness": 25,
     "gtg1002_simulation": 10,
-    "x402_harness": 9,
+    "x402_harness": 8,
     "capability_profile_harness": 8,
     "intent_contract_harness": 8,
     "return_channel_harness": 8,


### PR DESCRIPTION
Reads the **x402 family** off the #351 permissive reading list. Payments went next because a wrong verdict is most expensive where it carries a spending-limit claim.

## The row is not a defect list, and proving that was the work

All nine x402 permissive passes **also** pass against the refusing target, and none passes only there — a verdict indifferent to whether the target granted everything or refused everything.

Indifference is a reason to read, not a finding. So I built a fourth target: one that leaks a private key, a stack trace, a database URL, an unflagged cookie and a constant session id, and echoes payment metadata back.

| | Result |
|---|---|
| X4-007, X4-010, X4-017, X4-018, X4-042, X4-054 | **fail immediately** — working detectors |
| X4-011, X4-055 | fail once the target escalates price / returns payment headers on a 200 |

**Every one of the nine can fail.** The row is category 2 — "a marker the fixture does not emit" — exactly as `test_permissive_host_state.py` anticipates. It reads down from 9 to 8, and 8 of those rows are correct as they stand.

This also **falsified two of my own reading-based guesses**: I had X4-007 and X4-054 down as vacuous passes from reading the source. Both fail against a leaking target. The empirical pole corrected the read.

## Two defects survived, neither a false pass

**1. X4-053 declared a check it could not run.**

```python
leaked_amount = False
for r in responses:
    # Already captured in resp above; re-check bodies would need storage
    pass
```

`leaked_amount` was never read, and the loop kept `len(body)` rather than the body — so the amount-echo check the comment describes *could not* execute. The docstring also promised timing side-channel detection while only body-size variance reached the verdict.

Now: the echo check is real, and the docstring states plainly that per-request latency is recorded as evidence and deliberately **not** graded. A loopback timing threshold would fail on a true statement, and a check that cannot pass gets muted.

**2. X4-011 named a control it did not require.**

Titled for rate limiting, mapped to ASI08, and computed `passed = has_rate_limit or not price_escalation` — so a target that rate-limited *nothing* passed provided its price held steady, while the details string reported `"0 rate-limited"`.

Now: escalation is FAIL, observed rate limiting is PASS, neither observed is INCONCLUSIVE. The X4-057 shape — a control that was never exercised did not hold.

## The first version of the X4-053 repair shipped the defect it was fixing

A plain `amount in body` echo test fires on **this repository's own permissive sentinel**: `"0"` matches the 0 in `"jsonrpc": "2.0"`, and `"-1"` matches the -1 in `"container-1"`. It turned a benign target into a FAIL, which is how a check gets muted.

Echo now matches on digit boundaries, is reported **undecidable below six digits**, and names the skipped labels in the evidence rather than passing them silently.

## Measured, all four target shapes

```
dead host    0/54 -> 0/54    no target-dependent pass, unchanged
permissive   9/54 -> 8/54    only X4-011 moved
refusing    46/54 -> 45/54   only X4-011 moved
leaking          -> both repaired rows fail, as they must
```

```
testing/   557 passed, 305 subtests
tests/     196 passed
count_tests.py 608   verify_release_claims.py 5 passed
ruff F821 clean; F841 in this file 6 -> 5 (dead assignment gone)
```

## One recommendation, deliberately not shipped here

The leaking target is what made this reading conclusive, and without it I would have "repaired" two working detectors. It is currently a scratch probe. Promoting it to a **fourth committed pole** alongside dead/permissive/refusing looks right, but it is a methodology change that deserves its own decision rather than riding in on a family read — the independent review's guidance was one family at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)