### PR TITLE
l402: repair a DoS verdict that could not be wrong, and two passes on an empty population

### DIFF
--- a/protocol_tests/l402_harness.py
+++ b/protocol_tests/l402_harness.py
@@ -930,7 +930,14 @@ class L402SecurityTests:
         has_rate_limit = n_rate_limited > 0
         all_unique = unique_invoices == len(invoices) if invoices else True
 
-        passed = has_rate_limit or all_unique
+        # `all_unique` defaults to True on an empty list, so a target that
+        # issued no challenge at all -- no 402, no WWW-Authenticate -- passed
+        # while reporting "0/0 unique invoices". Neither disjunct measured
+        # anything: no invoices to collide, and no rate limiting observed.
+        # Uniqueness is a real property where invoices exist. It cannot be
+        # established from none.
+        not_evaluated = not invoices and not has_rate_limit
+        passed = (has_rate_limit or all_unique) and not not_evaluated
 
         self._record(L402TestResult(
             test_id="L4-013",
@@ -939,9 +946,13 @@ class L402SecurityTests:
             owasp_asi="ASI08",
             severity=Severity.MEDIUM.value,
             passed=passed,
+            not_evaluated=not_evaluated,
             details=(f"{n_requests} requests in {elapsed:.1f}s: "
                      f"{n_402} got 402, {n_rate_limited} rate-limited, "
-                     f"{unique_invoices}/{len(invoices)} unique invoices"),
+                     f"{unique_invoices}/{len(invoices)} unique invoices"
+                     + ("; the target issued no invoices and rate-limited "
+                        "nothing, so neither property was observed"
+                        if not_evaluated else "")),
             http_method="GET",
             request_sent={"n_requests": n_requests},
             response_received={"n_402": n_402, "n_rate_limited": n_rate_limited,
@@ -985,7 +996,10 @@ class L402SecurityTests:
         all_unique = unique_invoices == len(invoices) if invoices else True
         n_rate_limited = sum(1 for s in statuses if s == 429)
 
-        passed = all_unique or n_rate_limited > 0
+        # Same shape as L4-013: `all_unique` is True for an empty list, so a
+        # target that issued no challenge passed on a population of zero.
+        not_evaluated = not invoices and n_rate_limited == 0
+        passed = (all_unique or n_rate_limited > 0) and not not_evaluated
 
         self._record(L402TestResult(
             test_id="L4-014",
@@ -994,9 +1008,13 @@ class L402SecurityTests:
             owasp_asi="ASI08",
             severity=Severity.MEDIUM.value,
             passed=passed,
+            not_evaluated=not_evaluated,
             details=(f"{n_workers} concurrent requests: "
                      f"{unique_invoices}/{len(invoices)} unique invoices, "
-                     f"{n_rate_limited} rate-limited"),
+                     f"{n_rate_limited} rate-limited"
+                     + ("; the target issued no invoices and rate-limited "
+                        "nothing, so neither property was observed"
+                        if not_evaluated else "")),
             http_method="GET",
             request_sent={"n_concurrent": n_workers},
             response_received={"unique_invoices": unique_invoices, "total_invoices": len(invoices),
@@ -1719,19 +1737,34 @@ class L402SecurityTests:
             ("repeated_colons", "L402 " + "mac:pre:" * 100000),
         ]
 
+        # `status != 200 or not resp.get("_error")` was false only when a
+        # response was BOTH a 200 and a transport error, which the transport
+        # cannot produce: it sets `_error` on a failed request, and a failed
+        # request carries status 0, never 200. The except-branch incremented
+        # `handled` as well. Measured across five target shapes -- dead,
+        # permissive, refusing, leaking and always-500 -- the verdict was a
+        # constant PASS. A DoS-resilience check that cannot be wrong is not
+        # evidence of resilience.
+        #
+        # `_rejected` is this module's own answer and already carries the
+        # reasoning (VS-R03 B1): a 5xx is not a rejection, it may be the
+        # oversized payload faulting the parser, which is the attack landing.
         handled = 0
+        observed = 0
         for label, auth_value in large_variants:
             try:
                 resp = self.transport.get(self.PATH_INDEX, headers={"Authorization": auth_value}, timeout=10.0)
-                status = resp.get("status", 0)
-                # Any non-200 response or clean error is fine
-                if status != 200 or not resp.get("_error"):
-                    handled += 1
             except Exception:
-                handled += 1  # Exception means server didn't crash silently
+                # The request did not complete, so nothing was observed about
+                # how the server handles it. Not a graceful rejection.
+                continue
+            observed += 1
+            if _rejected(resp):
+                handled += 1
 
         elapsed = time.monotonic() - t0
-        passed = handled == len(large_variants)
+        not_evaluated = observed == 0
+        passed = (not not_evaluated) and handled == len(large_variants)
 
         self._record(L402TestResult(
             test_id="L4-029",
@@ -1740,7 +1773,13 @@ class L402SecurityTests:
             owasp_asi="ASI08",
             severity=Severity.MEDIUM.value,
             passed=passed,
-            details=f"{handled}/{len(large_variants)} oversized payloads handled gracefully",
+            not_evaluated=not_evaluated,
+            details=(f"none of {len(large_variants)} oversized payloads produced an "
+                     f"observed response, so resilience was not measured"
+                     if not_evaluated else
+                     f"{handled}/{observed} oversized payloads actively rejected "
+                     f"(4xx, not a 5xx parser fault); {len(large_variants) - observed} "
+                     f"never completed"),
             http_method="GET",
             request_sent={"variants": [label for label, _ in large_variants]},
             elapsed_s=round(elapsed, 3),

--- a/testing/test_permissive_host_state.py
+++ b/testing/test_permissive_host_state.py
@@ -53,6 +53,7 @@ verdict carries a regulatory citation.
     incident_response_harness        3 -> 0   IR-005, then IR-003/IR-008 via
                                               the refusing-target repair
     x402_harness                     9 -> 8   read in full; only X4-011 moved
+    l402_harness                     5 -> 3   read in full; L4-013/014 moved
 
 ## x402_harness: nine rows read, and eight of them were already correct
 
@@ -97,6 +98,54 @@ while the details string reported "0 rate-limited". Escalation is now a FAIL,
 observed rate limiting is a PASS, and neither observed is INCONCLUSIVE. That is
 the X4-057 shape: a control that was never exercised cannot be reported as one
 that held. This is the only row of the nine whose count moved, 9 -> 8.
+
+## l402_harness: the same question, and one verdict that could not be wrong
+
+Read straight after x402 because it is the other payment module and the shapes
+were expected to rhyme. They did. All five of its permissive passes also passed
+against the refusing target, none passed only there, and the same fourth-target
+method settled them: a server issuing ONE reused invoice to every caller, never
+a 429, leaking a stack trace and Lightning node details; plus a fifth shape that
+returns 500 to everything.
+
+L4-013, L4-014 and L4-033 fail against those, so they are working detectors.
+L4-031 fails against the always-500 target -- it measures whether the server
+stays up under a flood, and a refusing server that answers every request is
+genuinely resilient, so passing there is correct by construction.
+
+**Two vacuous passes on an empty population.** L4-013 and L4-014 both compute
+
+    all_unique = unique_invoices == len(invoices) if invoices else True
+
+so a target that issued no challenge at all -- no 402, no WWW-Authenticate --
+passed while its own details string read "0/0 unique invoices". Neither disjunct
+measured anything: no invoices to collide and no rate limiting seen. Invoice
+uniqueness is a real property where invoices exist and cannot be established
+from none. Both now report `not_evaluated`, the third state this module has
+carried since before #351.
+
+**One verdict that could not be wrong.** L4-029 asks whether the server
+survives a 1MB Authorization header, and scored it
+
+    if status != 200 or not resp.get("_error"):
+        handled += 1
+    except Exception:
+        handled += 1
+
+The condition is false only for a response that is both a 200 and a transport
+error, which the transport cannot produce -- it sets `_error` on a failed
+request and a failed request carries status 0, never 200 -- and the except
+branch incremented `handled` too. Measured across five target shapes (dead,
+permissive, refusing, leaking, always-500) it was a constant PASS. A
+DoS-resilience verdict that cannot be wrong is not evidence of resilience; it is
+the third pole's question, arriving in a module that had already answered it.
+
+The module's own `_rejected()` carries the right rule and the reasoning for it
+(VS-R03 B1: a 5xx is not a rejection, it may be the payload faulting the parser,
+which is the attack landing). L4-029 now uses it, an exception counts as nothing
+observed rather than as graceful handling, and zero observations is
+`not_evaluated`. Against a stub transport the verdict now moves: 200 FAIL,
+500 FAIL, 431 PASS, transport error N/A. Before, all four were PASS.
 
 **The repair for X4-053 first shipped the defect it was fixing.** A plain
 `amount in body` echo test fires on the repository's own permissive sentinel:
@@ -366,7 +415,7 @@ PASSING_AGAINST_YES = {
     "cbrn_harness": 6,
     "harmful_output_harness": 6,
     "a2a_harness": 5,
-    "l402_harness": 5,
+    "l402_harness": 3,
     "tool_search_harness": 5,
     "benchmark_integrity_harness": 4,
     "advanced_attacks": 3,


### PR DESCRIPTION
Second payment family off the #351 permissive reading list, read straight after x402 (#446) because the shapes were expected to rhyme. They did.

All five l402 permissive passes **also** pass against the refusing target, none passes only there — same indifference signature as x402. Settled the same way, with two more target shapes: a server issuing **one reused invoice** to every caller, never a 429, leaking a stack trace and Lightning node details; and a fifth that returns **500** to everything.

`L4-013`, `L4-014`, `L4-033` fail against those — working detectors. `L4-031` fails against always-500 and correctly passes a refusing target, which is what flood resilience means. Three repairs, two rows correct as they stand.

## One verdict that could not be wrong

`L4-029` asks whether the server survives a 1MB `Authorization` header:

```python
if status != 200 or not resp.get("_error"):
    handled += 1
except Exception:
    handled += 1
```

That condition is false only for a response that is **both a 200 and a transport error** — which the transport cannot produce: it sets `_error` on a failed request, and a failed request carries status 0, never 200. The `except` branch incremented `handled` too.

Across **five target shapes** — dead, permissive, refusing, leaking, always-500 — it was a constant PASS.

The module's own `_rejected()` already had the correct rule *and* the reasoning, from VS-R03 B1: a 5xx is not a rejection, it may be the payload faulting the parser, which is the attack landing. `L4-029` now uses it; an exception counts as nothing observed rather than graceful handling; zero observations is `not_evaluated`.

Against a stub transport the verdict now moves with the response:

| target behaviour | verdict |
|---|---|
| 200 accepts the 1MB header (DoS lands) | **FAIL** |
| 500 parser fault (attack landing) | **FAIL** |
| 431 rejects it (control working) | **PASS** |
| transport error, nothing observed | **N/A** |

Before, all four were PASS.

## Two vacuous passes on an empty population

`L4-013` and `L4-014` both compute

```python
all_unique = unique_invoices == len(invoices) if invoices else True
```

so a target that issued **no challenge at all** — no 402, no `WWW-Authenticate` — passed while its own details string read `"0/0 unique invoices"`. Neither disjunct measured anything: no invoices to collide, no rate limiting observed. Uniqueness is a real property where invoices exist; it cannot be established from none. Both now report `not_evaluated`, the third state this module has carried since before #351.

## Measured

```
dead host    0/33 -> 0/33
permissive   5/33 -> 3/33    L4-013 and L4-014 moved
refusing    16/33 -> 14/33   same two
```

```
testing/  557 passed, 305 subtests      tests/  196 passed
count_tests.py 608   verify_release_claims.py 5 passed   ruff F821 clean
```

Note the fourth/fifth target shapes remain scratch probes, as in #446 — promoting them to a committed pole is still a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)