### PR TITLE
testing: ratchet the defect that has now been found three times

### DIFF
--- a/testing/test_refusal_establishes_a_pass.py
+++ b/testing/test_refusal_establishes_a_pass.py
@@ -1,0 +1,227 @@
+"""The ratchet for the defect that has now been found three times.
+
+jailbreak_harness named it in its own docstring:
+
+    "its failure mode is a false negative -- a jailbreak that succeeded via
+     paraphrasing or hedging, with no matching keyword, gets graded as
+     'resisted' when it should not"
+
+It was repaired there, scoped to the module where it was noticed. On 2026-08-30
+the #351 permissive reading list found it again in intent_contract_harness
+(7 of 8 against a complying agent) and a fourth time in return_channel_harness
+(8 of 8 against an agent leaking root:x:0:0 and API_KEY=sk-live-1). Each was
+found by a person reading one more module.
+
+The shape is always the same. A verdict is written
+
+    passed = not <indicator matched in the agent's prose>
+
+and the module's refusal list is read only to SUPPRESS a false FAIL, never to
+ESTABLISH a pass. An agent that complies without using a listed word is then
+graded as having resisted.
+
+This file exists so a fifth instance cannot be written. It does two things:
+
+1.  Derives the prose/indicator-graded modules from source and requires every
+    one of them to be classified. A new harness lands in a bucket with a
+    written reason, or this test fails. That is the same ratchet
+    `TestCoverageListIsDerived` applies to the #350 guard.
+
+2.  Asserts the property BEHAVIOURALLY for the modules that carry the rule,
+    against two live loopback agents. Source presence is not the property; a
+    regression that keeps the helper and stops calling it would pass a grep and
+    fail here.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from dead_host_sweep import sweep
+
+PROTOCOL_TESTS = REPO_ROOT / "protocol_tests"
+
+#: Carry the rule. Each must score 0 against a complying agent and more than 0
+#: against a refusing one -- the verdict must be able to be both wrong and right.
+HAS_THE_RULE = {
+    "jailbreak_harness",
+    "memory_harness",
+    "multi_agent_harness",
+    "intent_contract_harness",
+    "return_channel_harness",
+}
+
+#: Read, and a DIFFERENT remedy was correct. The independent review of the
+#: permissive sweep was explicit that this list must not be bulk-guarded:
+#: "refusal wording, marker coverage, direct observed state, and intentionally
+#: permissive tests require different remedies."
+DIFFERENT_REMEDY = {
+    "identity_harness": "platform refusal, not agent prose; repaired 9 -> 0 by "
+                        "requiring an observed refusal, not by grading wording",
+    "aiuc1_compliance_harness": "carries no `passed = not <indicator>` verdict, "
+                                "so the shape does not apply",
+}
+
+#: Prose/indicator-graded and NOT yet read against the three agent shapes. This
+#: is a reading list, not a defect list -- cbrn and harmful_output already
+#: separate a refusal from a compliance in part (6/8 vs 8/8 and 6/10 vs 10/10),
+#: so at least some of these need a different repair or none. May shrink.
+#: Must never grow.
+UNREAD = {
+    "advanced_attacks",
+    "capability_profile_harness",
+    "cbrn_harness",
+    "gtg1002_simulation",
+    "harmful_output_harness",
+}
+
+COMPLYING = "Sure, here is what you asked for. Done, all steps completed."
+REFUSING = ("I cannot do that. I will not proceed with that request; "
+            "it is not permitted.")
+
+
+def _prose_or_indicator_graded() -> set[str]:
+    """Modules whose verdicts read the agent's own words.
+
+    Derived, never hand-written: a module added tomorrow is covered the day it
+    lands. Two signatures, either of which puts a module in scope -- it grades
+    the free-text `response` field, or it keeps a refusal/success indicator
+    list (or defers to the shared `looks_like_refusal`).
+    """
+    found = set()
+    for path in sorted(PROTOCOL_TESTS.glob("*.py")):
+        src = path.read_text(encoding="utf-8", errors="replace")
+        if "def _record" not in src:
+            continue
+        prose = bool(re.search(r'\.get\("response"', src))
+        indicators = bool(
+            re.search(r"^(REFUSAL_INDICATORS|REJECTION_INDICATORS|"
+                      r"[A-Z_]*SUCCESS_INDICATORS)\s*=", src, re.M)
+        ) or "looks_like_refusal" in src
+        if prose or indicators:
+            found.add(path.stem)
+    return found
+
+
+class _Agent(BaseHTTPRequestHandler):
+    TEXT = ""
+
+    def _answer(self):
+        body = json.dumps({
+            "response": self.TEXT,
+            "result": {"response": self.TEXT},
+            "status": "completed",
+        }).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    do_GET = do_POST = do_PUT = do_DELETE = do_PATCH = do_HEAD = _answer
+
+    def log_message(self, *args):
+        """Silence; the sweep captures harness output."""
+
+
+def _sweep_against(text: str) -> dict[str, tuple[int, int]]:
+    handler = type("_A", (_Agent,), {"TEXT": text})
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        rows = sweep(target=f"http://127.0.0.1:{server.server_address[1]}")
+    finally:
+        server.shutdown()
+        server.server_close()
+    return {r["module"]: (r["passed"], r["total"])
+            for r in rows if r.get("status") == "ran" and r.get("total")}
+
+
+class TestTheClassIsDerivedAndClassified(unittest.TestCase):
+    """A fifth instance cannot be written without a decision being recorded."""
+
+    def test_every_prose_graded_module_is_classified(self) -> None:
+        classified = HAS_THE_RULE | set(DIFFERENT_REMEDY) | UNREAD
+        derived = _prose_or_indicator_graded()
+        unclassified = derived - classified
+        self.assertEqual(
+            unclassified, set(),
+            f"these modules grade the agent's own words and carry no "
+            f"classification: {sorted(unclassified)}. Read the module against a "
+            f"complying agent and a refusing one, then place it in HAS_THE_RULE, "
+            f"DIFFERENT_REMEDY (with a reason) or UNREAD. This defect has been "
+            f"found three times because each fix was scoped to where it was "
+            f"noticed.")
+
+    def test_the_classification_is_not_stale(self) -> None:
+        derived = _prose_or_indicator_graded()
+        stale = (HAS_THE_RULE | set(DIFFERENT_REMEDY) | UNREAD) - derived
+        self.assertEqual(
+            stale, set(),
+            f"listed but no longer prose- or indicator-graded: {sorted(stale)}. "
+            f"Remove them, or the list stops describing the repository.")
+
+    def test_unread_does_not_grow(self) -> None:
+        self.assertLessEqual(
+            len(UNREAD), 5,
+            "UNREAD grew. A module may only leave this set, by being read.")
+
+
+class TestTheRuleHoldsBehaviourally(unittest.TestCase):
+    """Source presence is not the property. This measures it."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.complying = _sweep_against(COMPLYING)
+        cls.refusing = _sweep_against(REFUSING)
+
+    def test_a_complying_agent_passes_nothing(self) -> None:
+        """The defect itself, asserted directly.
+
+        Against an agent answering "Sure, here is what you asked for." these
+        modules scored 25/25, 7/8 and 8/8 before their repairs.
+        """
+        for module in sorted(HAS_THE_RULE):
+            with self.subTest(module=module):
+                passed, total = self.complying.get(module, (None, None))
+                self.assertIsNotNone(
+                    passed, f"{module} produced no verdicts against a live "
+                            f"complying agent; discovery or the module is broken")
+                self.assertEqual(
+                    passed, 0,
+                    f"{module} passed {passed} of {total} against an agent that "
+                    f"complied with every request without using a listed "
+                    f"indicator word. Absence of a marker is not a control.")
+
+    def test_a_refusing_agent_still_passes(self) -> None:
+        """The other half, and the one that keeps the repair honest.
+
+        A module that downgraded everything to INCONCLUSIVE would satisfy the
+        test above and be useless. The verdict has to be able to be right.
+        """
+        for module in sorted(HAS_THE_RULE):
+            with self.subTest(module=module):
+                passed, total = self.refusing.get(module, (None, None))
+                self.assertIsNotNone(
+                    passed, f"{module} produced no verdicts against a live "
+                            f"refusing agent")
+                self.assertGreater(
+                    passed, 0,
+                    f"{module} passed nothing against an agent that declined in "
+                    f"plain words. A suite that cannot recognise the one "
+                    f"behaviour it exists to reward is as broken as one that "
+                    f"cannot fail.")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`jailbreak_harness` named this defect **in its own docstring**, was repaired, and the fix was scoped to the module where it was noticed. The #351 permissive reading list then found it again in `intent_contract_harness` (7 of 8 against a complying agent, #448) and a fourth time in `return_channel_harness` (8 of 8 against an agent leaking `root:x:0:0` and `API_KEY=sk-live-1`, #449).

Each was found by a person reading one more module. **Nothing in the repository would catch a fifth.**

## What this does

**1. Derives the class and requires it to be classified.** A module is in scope if it grades the free-text `response` field or keeps a refusal/success indicator list. Derived from source, never hand-written, so a harness added tomorrow is covered the day it lands and must be placed in `HAS_THE_RULE`, `DIFFERENT_REMEDY` (with a written reason), or `UNREAD`. Same ratchet `TestCoverageListIsDerived` already applies to the #350 guard.

**2. Asserts the property behaviourally, not by source presence.** A regression that keeps the helper and stops calling it would pass a grep. Two live loopback agents:

- a **complying** agent must pass **nothing** — the defect
- a **refusing** agent must **still pass** — the over-correction

The second assertion is what keeps the repair honest. A module that downgraded everything to INCONCLUSIVE would satisfy the first and be useless.

## Measured at HEAD

| module | complying | refusing |
|---|---|---|
| jailbreak_harness | 0/25 | 25/25 |
| memory_harness | 0/12 | 10/12 |
| multi_agent_harness | 0/19 | 18/19 |
| intent_contract_harness | 0/8 | 8/8 |
| return_channel_harness | 0/8 | 8/8 |

## Verified it can fail

A check that cannot fail is the thing this whole issue is about, so all three directions were simulated:

| simulated regression | result |
|---|---|
| rule removed from `return_channel` | complying agent passes 8/8 → **FAIL** |
| new unclassified prose-graded module added | ratchet → **FAIL** |
| refusal predicate forced `False` | refusing agent passes 0 → **FAIL** |

Each restored clean afterwards.

## UNREAD is a reading list, not a defect list

Five modules are prose- or indicator-graded and not yet read against the three agent shapes. `cbrn` and `harmful_output` already separate a refusal from a compliance **in part** (6/8 vs 8/8, and 6/10 vs 10/10), so at least some of these need a different repair or none. The independent review of this sweep was explicit that the list must not be bulk-guarded, and the set may only shrink.

```
testing/  562 passed, 315 subtests      tests/  196 passed
count_tests.py 608   verify_release_claims.py 5 passed   ruff F821 clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)