### PR TITLE
docs: name the external implementer, consent granted in #304

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,10 +332,12 @@ explicitly *not* goals. Full detail and the anti-goals in [ROADMAP.md](ROADMAP.m
 
 ### Independent reproduction
 
-The only external check this project has received. [@VrtxOmega](https://github.com/msaleme/red-team-blue-team-agent-fabric/issues/304)
-wrote a **separate Node verifier** for the portable receipt-claim oracle fixtures and ran it against a
-pinned commit and fixture hash, matching all 11 RCL results including both acceptance controls — so it
-did not pass by rejecting everything.
+The only external check this project has received. [@VrtxOmega](https://github.com/VrtxOmega), in
+[veritas-agent-trust-lab](https://github.com/VrtxOmega/veritas-agent-trust-lab), wrote a **separate Node
+verifier** for the portable receipt-claim oracle fixtures and ran it against a pinned commit and fixture
+hash, matching all 11 RCL results including both acceptance controls — so it did not pass by rejecting
+everything. Reported in [#304](https://github.com/msaleme/red-team-blue-team-agent-fabric/issues/304);
+named here with their consent, granted 2026-08-31.
 
 The exchange also produced two corrections to this repository: `signature_algorithm` now names the
 actual encoding and states plainly that it is **not** RFC 8785 JCS, and `coverage_gaps` now declares

--- a/docs/RCL-CROSS-IMPLEMENTATION-INTEROP.md
+++ b/docs/RCL-CROSS-IMPLEMENTATION-INTEROP.md
@@ -70,22 +70,32 @@ tested only the stale direction.
 
 ## Attribution
 
-**The implementer is not named here.** They published their report themselves,
-under their own account, in [issue #304](https://github.com/msaleme/red-team-blue-team-agent-fabric/issues/304),
-which is public and linked above. A reader who wants to know who ran it can
-follow the link.
+**The implementer is named with their consent.** The cross-implementation was
+written and run by **[@VrtxOmega](https://github.com/VrtxOmega)** in
+**[VrtxOmega/veritas-agent-trust-lab](https://github.com/VrtxOmega/veritas-agent-trust-lab)**,
+whose own report and verifier runner are the primary artifacts:
 
-Permission to cite them by name in a citable artifact was requested on
-2026-08-26 with the explicit statement that no obligation was attached, and that
-if they would rather not be named, this note would record only that an external
-implementation exists. No reply was received. **That is not a refusal and is not
-recorded as one.** It is the default branch of a promise that was made when the
-question was asked, and it stays available to revise if they would prefer to be
-cited.
+| | |
+|---|---|
+| Cross-evaluation report | [`evidence/EXTERNAL_RCL_CROSS_EVALUATION.md`](https://github.com/VrtxOmega/veritas-agent-trust-lab/blob/main/evidence/EXTERNAL_RCL_CROSS_EVALUATION.md) |
+| Verifier runner | [`scripts/verify-external-rcl.mjs`](https://github.com/VrtxOmega/veritas-agent-trust-lab/blob/main/scripts/verify-external-rcl.mjs) |
+| Report as filed | [issue #304](https://github.com/msaleme/red-team-blue-team-agent-fabric/issues/304) |
 
-Citing the public issue is a reference to a public primary source. Naming a
-party as a co-signer of one's own claim is a different act and needs their
-affirmative agreement, which is why this note does the first and not the second.
+**How the consent was obtained, because the sequence matters.** Permission to
+cite them by name was requested on 2026-08-26 with the explicit statement that
+no obligation was attached, and that if they would rather not be named, this
+note would record only that an external implementation exists. No reply had
+arrived by 2026-08-30, so this note was published on that default branch, with
+the silence recorded as silence and **not** as a refusal. They replied on
+2026-08-31 granting the request; the note was then revised. A request that
+carries a real default costs nothing to decline, which is the only reason the
+answer to it means anything.
+
+**Naming them is still not a co-sign.** They reproduced a pinned artifact and
+reported the result. They have not reviewed this repository, do not vouch for
+it, and their own report says so first: it is filed as *not a contribution*, and
+it disclaims independent validation of either project. Their words on the scope
+govern over any summary of them here.
 
 ## What this does not establish
 

--- a/fixtures/rcl/CONFORMANCE.md
+++ b/fixtures/rcl/CONFORMANCE.md
@@ -152,11 +152,13 @@ implementation exists.
 | Implementation | Language | Corpus ref | Verdicts | Acceptance controls | Notes |
 |---|---|---|---|---|---|
 | Reference (`ClaimLevelVerifier`, this repo) | Python | `1.0` @ `4164151383…` | 11/11 | preserved | expectations are executed at export, not hand-written |
-| Independent implementation (unnamed pending consent) | Node | `1.0` @ `0bc47dab…` | 11/11 | preserved | written from the published contract alone; surfaced two contract-description defects, corrected in #307 |
+| Independent implementation ([VrtxOmega/veritas-agent-trust-lab](https://github.com/VrtxOmega/veritas-agent-trust-lab)) | Node | `1.0` @ `0bc47dab…` | 11/11 | preserved | written from the published contract alone; surfaced two contract-description defects, corrected in #307 |
 
-**The second row is deliberately unnamed.** The implementer scoped their own result conservatively
-and has not consented to being cited. Do not add their name, repository, or a link to this table
-without that consent. If it is granted, the row may name them and nothing else about it changes.
+**The second row is named because consent was granted**, on 2026-08-31, in
+[#304](https://github.com/msaleme/red-team-blue-team-agent-fabric/issues/304). Nothing else about
+the row changed when the name was added, which was the standing commitment. The implementer scoped
+their own result conservatively; a name in this table is attribution, not a co-sign. The rule above
+still governs any *future* row: do not add a name, repository, or link without that party's consent.
 
 The second row's result was obtained against the historical hash; see §1 for why that is the same
 eleven vectors.


### PR DESCRIPTION
`@VrtxOmega` replied on #304 on 2026-08-31 granting permission to be cited by name. This applies it.

**Why this is three files and not one.** All three carried the pending-consent state, and each made a specific promise about what would happen if consent arrived:

| File | The promise it made | What this PR does |
|---|---|---|
| `docs/RCL-CROSS-IMPLEMENTATION-INTEROP.md` | "it stays available to revise if they would prefer to be cited" | names them, links their report and runner, keeps the consent sequence on the record |
| `fixtures/rcl/CONFORMANCE.md` | "If it is granted, the row may name them and nothing else about it changes" | names the row; nothing else about it changed |
| `README.md` | handle linked to the issue, not the person | links to the person, names the repo, dates the consent |

**What did not change.** Naming is attribution, not a co-sign. Their report is filed as *NOT A CONTRIBUTION* and disclaims independent validation of either project; that scope is preserved. The E2/I1 claim still attaches to the fixture corpus and not to the harness, and the remaining 608 tests stay I0. `CONFORMANCE.md`'s general rule — do not name an implementer without consent — still governs any future row.

**Both external links were retrieved, not assumed**: `evidence/EXTERNAL_RCL_CROSS_EVALUATION.md` (3472B) and `scripts/verify-external-rcl.mjs` (6528B) both resolve in `VrtxOmega/veritas-agent-trust-lab`.

A derived sweep for the pending-consent language across every `.md`/`.py`/`.json`/`.yml` in the repo returns only the general rule, which is correct to keep.

`testing/`: 581 passed, 473 subtests. `verify_release_claims.py`: 6 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
