### PR TITLE
docs: the README section on external validation now asks for one

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,26 @@ It is a reproduction of a pinned artifact by one external party, submitted as a 
 **not** as a contribution, endorsement, certification, or adoption. It is not a substitute for
 independent review of the harness as a whole, which this project still does not have.
 
+**"A third independent implementation is worth more to this corpus than any additional vector."**
+That is [`fixtures/rcl/CONFORMANCE.md`](fixtures/rcl/CONFORMANCE.md) §7, verbatim, and it is not
+modesty. Two implementations agreeing establishes that they share a reading; only a third can tell
+you whether that reading is the contract or a coincidence.
+
+The bar is lower than it sounds. The corpus is eleven vectors, one fixture file, and a pinned hash;
+the run above was a single Node script written against the published format.
+[`docs/REPRODUCING.md`](docs/REPRODUCING.md) has the pin, the canonical byte basis that is the most
+common reason a correct implementation computes a different digest, and the table of what does and
+does not count as independent. §7 of `CONFORMANCE.md` adds the one rule that decides whether your
+result counts at all: **write the verifier from the published contract, not from
+`protocol_tests/receipt_claim_harness.py`.** Reading our implementation first turns an independent
+result into a port, and the value is entirely in the independence. File it with the
+[reproduction report template](https://github.com/msaleme/red-team-blue-team-agent-fabric/issues/new?template=reproduction-report.yml).
+
+**A result that contradicts ours gets published too.** #304 is the precedent for that as well: it
+matched 11 of 11 and *still* surfaced two defects in our own contract description, both corrected
+above. Disagreement is the more useful outcome, not the awkward one — a reproduction that only
+agrees may just mean two implementations share the same wrong assumption.
+
 *Using the harness? Open a PR to add yourself, or tag us in your project.*
 
 ---


### PR DESCRIPTION
The `### Independent reproduction` section is the one place in the README a reader learns this project has an outside check. It ended on a disclaimer — *"not a substitute for independent review of the harness as a whole, which this project still does not have"* — and stopped there. No invitation.

Meanwhile all three pieces of the ask already existed and nothing pointed at them:

| Asset | Says | Linked from |
|---|---|---|
| `fixtures/rcl/CONFORMANCE.md` §7 | "A third independent implementation is worth more to this corpus than any additional vector." | nowhere in the README |
| `docs/REPRODUCING.md` | the pin, the canonical byte basis, what counts as I1 | one row in a documentation table at README:285 |
| `.github/ISSUE_TEMPLATE/reproduction-report.yml` | the intake, incl. "we will publish it either way" | nowhere in the README |

**That is an unexercised path, not a failed one.** Nobody declined the ask; nobody arrived at it.

This puts the ask where the proof is — which only became worth doing once the proof had a name attached (#462, merged this morning). A named precedent is the difference between "please reimplement this" and "here is what that looked like when someone did."

**What it adds:** §7 quoted verbatim; the actual size of the job (eleven vectors, one fixture file, one pinned hash, one Node script); the write-from-the-contract rule; a direct link to the issue template; and the standing commitment to publish a contradicting result — for which #304 is itself the precedent, having matched 11/11 and *still* surfaced two defects in our own contract description.

**Attribution checked, not paraphrased.** The §7 sentence is quoted rather than restated, and the do-not-read-our-code rule is credited to `CONFORMANCE.md` §7 where it lives — a first draft of this attributed it to `REPRODUCING.md`, where it does not.

No claim about evidence class changed. The harness still has no independent review as a whole, and the section still says so.

`testing/`: 581 passed, 473 subtests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
