### PR TITLE
fix: INCONCLUSIVE gets a structural home, not just a prose prefix

### DIFF
--- a/protocol_tests/a2a_harness.py
+++ b/protocol_tests/a2a_harness.py
@@ -365,7 +365,7 @@ class A2ASecurityTests:
                 f"{INCONCLUSIVE_PREFIX}{_rr.get('_exception')}. "
                 f"Original finding: {result.details}")
         elif (seen and not any(_answered(r) for r in seen)
-                and not is_inconclusive(result.details)):
+                and not is_inconclusive(result)):
             result.passed = False
             result.details = (
                 f"{INCONCLUSIVE_PREFIX}none of {len(seen)} requests were "

--- a/protocol_tests/http_helpers.py
+++ b/protocol_tests/http_helpers.py
@@ -137,14 +137,55 @@ def _err(resp: dict) -> bool:
 INCONCLUSIVE_PREFIX = "INCONCLUSIVE - "
 
 
-def is_inconclusive(details: str | None) -> bool:
-    """True when `details` marks a result as INCONCLUSIVE.
+#: The structural home #404 said would be better and did not block on.
+#:
+#: A prose prefix is a display artifact. It survives `asdict()` only as English,
+#: so a consumer reading a serialised report has to re-implement the substring
+#: match to recover a state the harness already knew -- which is the predicate
+#: duplication #460 guards against internally, exported across the boundary.
+#:
+#: `l402_harness` and `x402_harness` reached this conclusion first and carry
+#: `not_evaluated: bool` on their result classes. Their own report writers count
+#: it. Nothing shared knew about it, so the two vocabularies described the same
+#: state in disjoint code paths -- which is why `run_summary` below would have
+#: miscounted a field-only result as a target failure had one ever reached it.
+#: That was latent, not live. It is closed here rather than left to be found.
+#:
+#: `identity_harness` independently arrived at a third name, `informational`,
+#: and its comment is careful that the two are not synonyms: `not_evaluated`
+#: means a required PRECONDITION was missing, `informational` means the check
+#: ran fine and there is nothing to assert. That distinction is real and worth
+#: keeping on the result. It is not a distinction the *summary* can act on --
+#: as that same comment says, "Both are excluded from pass and fail counts for
+#: the same reason: an unevaluated result must not be scored as secure."
+#:
+#: So both fields are read here, and neither is renamed. A module keeps the word
+#: that says what happened to it; the shared bucket asks only whether a verdict
+#: was ever serviced.
+#:
+#: The field is the canonical marker on a *result*; `inconclusive` stays the
+#: bucket name in a *summary*. Those are different objects and the names are
+#: not redundant.
+INCONCLUSIVE_FIELDS = ("not_evaluated", "informational")
 
-    The predicate exists so that callers stop matching the substring by hand.
-    When the state gains a structural home on the result classes, this is the
-    one place that has to learn about it.
+
+def is_inconclusive(subject) -> bool:
+    """True when `subject` is INCONCLUSIVE.
+
+    Accepts either a result object or its `details` string, because this is the
+    one predicate and callers should not have to know which form they hold. On
+    a result it reads the structural field first and falls back to the prefix,
+    so a module that has not migrated yet is counted exactly as before.
+
+    The docstring this replaces promised that when the state gained a
+    structural home, this would be the one place that had to learn about it.
+    This is that.
     """
-    return INCONCLUSIVE_PREFIX.strip(" -") in (details or "")
+    if subject is None or isinstance(subject, str):
+        return INCONCLUSIVE_PREFIX.strip(" -") in (subject or "")
+    if any(getattr(subject, f, False) for f in INCONCLUSIVE_FIELDS):
+        return True
+    return is_inconclusive(getattr(subject, "details", None))
 
 
 def run_summary(results) -> dict:
@@ -184,8 +225,7 @@ def run_summary(results) -> dict:
 
     results = list(results)
     total = len(results)
-    inconclusive = sum(1 for r in results
-                       if is_inconclusive(getattr(r, "details", None)))
+    inconclusive = sum(1 for r in results if is_inconclusive(r))
     passed = sum(1 for r in results if getattr(r, "passed", False))
     failed = total - passed - inconclusive
     serviced = passed + failed

--- a/protocol_tests/return_channel_harness.py
+++ b/protocol_tests/return_channel_harness.py
@@ -130,6 +130,9 @@ class ReturnChannelTestResult:
     passed: bool
     details: str
     protocol: str
+    #: INCONCLUSIVE as a field rather than only as a prefix on `details`.
+    #: `asdict()` carries this; it does not carry the meaning of English.
+    not_evaluated: bool = False
     request_sent: dict | None = None
     response_received: dict | None = None
     elapsed_s: float = 0.0
@@ -316,13 +319,15 @@ class ReturnChannelTests:
             # Third instance of the shape jailbreak_harness named in its own
             # docstring, after intent_contract_harness. Same rule, same place.
             result.passed = False
+            result.not_evaluated = True
             result.details = (
                 f"{INCONCLUSIVE_PREFIX}the agent answered without declining and "
                 f"without a POISON_SUCCESS_INDICATORS match. Substring grading "
                 f"cannot separate sanitised output from a paraphrased compliance "
                 f"here. Original finding: {result.details}")
         self.results.append(result)
-        status = "PASS \u2705" if result.passed else "FAIL \u274c"
+        status = ("N/A \u2796" if result.not_evaluated
+                  else "PASS \u2705" if result.passed else "FAIL \u274c")
         print(f"  {status} {result.test_id}: {result.name} ({result.elapsed_s:.2f}s)")
 
     def _send_poison(self, text: str) -> dict:

--- a/protocol_tests/tool_search_harness.py
+++ b/protocol_tests/tool_search_harness.py
@@ -169,7 +169,7 @@ class ToolSearchTests:
         if _d is not None:
             result.passed = False
             result.details = _d
-        elif is_inconclusive(result.details):
+        elif is_inconclusive(result):
             # A site that abstained by wording must not also report a pass.
             # Enforced here so a seventh test cannot set one without the other.
             result.passed = False

--- a/testing/test_inconclusive_is_structural.py
+++ b/testing/test_inconclusive_is_structural.py
@@ -1,0 +1,236 @@
+"""INCONCLUSIVE must be a field on a result, not only English in `details`.
+
+#404 defined `INCONCLUSIVE_PREFIX` so the third class became countable, and said
+in the same comment that a field on the result classes would be better and was
+not blocked by that step. This is that step, plus the ratchet that finishes it.
+
+Why a prefix is not enough. `asdict(result)` carries fields; it does not carry
+the meaning of a sentence. A consumer reading a serialised report sees
+`passed: false` for a control that failed and `passed: false` for a control that
+was never exercised, and can only tell them apart by re-implementing the
+substring match. That is the predicate duplication `test_no_duplicate_refusal_
+predicate.py` guards against inside this repository, exported across the API
+boundary where no guard can see it.
+
+Three vocabularies existed for this, in disjoint code paths. `l402_harness` and
+`x402_harness` carry `not_evaluated: bool` -- a required precondition was
+missing. `identity_harness` carries `informational: bool` -- the check ran fine
+and there is nothing to assert. Everything else says it in English. The first
+two are a real distinction and are kept; what they are not is a distinction the
+*summary* can act on, and `identity_harness` says so itself: "Both are excluded
+from pass and fail counts for the same reason: an unevaluated result must not be
+scored as secure."
+
+Nothing shared knew about either field, so `run_summary` -- which counted by
+prose -- would have scored a field-only result as a target failure, because
+`failed` is its residual bucket. No module fed it one, so that never fired.
+`test_field_only_result_is_not_counted_as_a_failure` and
+`test_informational_result_is_not_counted_as_a_failure` are the negative
+controls that keep it from firing later.
+"""
+from __future__ import annotations
+
+import ast
+import pathlib
+from dataclasses import asdict, dataclass
+
+import pytest
+
+from protocol_tests.http_helpers import (
+    INCONCLUSIVE_FIELDS,
+    INCONCLUSIVE_PREFIX,
+    is_inconclusive,
+    run_summary,
+)
+
+PROTOCOL_TESTS = pathlib.Path(__file__).resolve().parents[1] / "protocol_tests"
+
+#: Modules whose result dataclasses still carry INCONCLUSIVE only as a prefix on
+#: `details`. **This list may shrink as modules migrate, and must never grow.**
+#:
+#: Adding a module here is not a way to pass this test. A new result class that
+#: can be INCONCLUSIVE gets the field; the list is for the ones that predate it.
+PREFIX_ONLY = {
+    "a2a_harness",
+    "capability_profile_harness",
+    "cloud_agent_harness",
+    "enterprise_adapters",
+    "extended_enterprise_adapters",
+    "extended_thinking_harness",
+    "framework_adapters",
+    "governance_modification_harness",
+    "gtg1002_simulation",
+    "incident_response_harness",
+    "intent_contract_harness",
+    "jailbreak_harness",
+    "kill_switch_harness",
+    "mcp_harness",
+    "memory_harness",
+    "multi_agent_harness",
+    "over_refusal_harness",
+    "provenance_harness",
+    "ptc_harness",
+    "tool_search_harness",
+    "watermark_harness",
+}
+
+
+def _modules_that_can_be_inconclusive() -> dict[str, bool]:
+    """Every module with a result dataclass that can report INCONCLUSIVE.
+
+    Derived from source rather than listed, so a module added tomorrow is
+    covered without anyone remembering to add it here.
+    """
+    found: dict[str, bool] = {}
+    for path in sorted(PROTOCOL_TESTS.glob("*.py")):
+        text = path.read_text(encoding="utf-8")
+        if "@dataclass" not in text:
+            continue
+        if ("INCONCLUSIVE_PREFIX" not in text
+                and not any(f in text for f in INCONCLUSIVE_FIELDS)):
+            continue
+        tree = ast.parse(text)
+        carries = any(
+            isinstance(node, ast.ClassDef)
+            and any(
+                isinstance(stmt, ast.AnnAssign)
+                and isinstance(stmt.target, ast.Name)
+                and stmt.target.id in INCONCLUSIVE_FIELDS
+                for stmt in node.body
+            )
+            for node in ast.walk(tree)
+        )
+        found[path.stem] = carries
+    return found
+
+
+def test_the_prefix_only_list_may_shrink_and_must_never_grow():
+    surveyed = _modules_that_can_be_inconclusive()
+    assert surveyed, "no modules surveyed -- the derivation is broken, not the repo"
+
+    still_prefix_only = {name for name, carries in surveyed.items() if not carries}
+    grew = still_prefix_only - PREFIX_ONLY
+    assert not grew, (
+        "these modules can report INCONCLUSIVE but carry none of "
+        f"{list(INCONCLUSIVE_FIELDS)} as a field, and are not on the list: "
+        f"{sorted(grew)}. "
+        "A result class that can be inconclusive gets the field. Do not add the "
+        "module to PREFIX_ONLY to make this pass."
+    )
+
+    stale = PREFIX_ONLY - still_prefix_only
+    assert not stale, (
+        f"{sorted(stale)} have migrated -- remove them from PREFIX_ONLY. The list "
+        "is a debt register; leaving a paid entry on it overstates the debt."
+    )
+
+
+def test_modules_that_led_the_way_still_carry_the_field():
+    """l402 and x402 had this right before anything shared did."""
+    surveyed = _modules_that_can_be_inconclusive()
+    for name in ("l402_harness", "x402_harness", "identity_harness",
+                 "return_channel_harness"):
+        assert surveyed.get(name) is True, (
+            f"{name} lost its structural INCONCLUSIVE field. It is the "
+            "home for this state, not an implementation detail of one module."
+        )
+
+
+@dataclass
+class _FieldOnly:
+    passed: bool = False
+    details: str = "the control was never exercised"
+    not_evaluated: bool = True
+
+
+@dataclass
+class _PrefixOnly:
+    passed: bool = False
+    details: str = INCONCLUSIVE_PREFIX + "the control was never exercised"
+
+
+@dataclass
+class _InformationalOnly:
+    passed: bool = False
+    details: str = "recorded a finding; this check has no pass/fail criterion"
+    informational: bool = True
+
+
+@dataclass
+class _GenuineFailure:
+    passed: bool = False
+    details: str = "the target granted an unauthorised transfer"
+
+
+def test_field_only_result_is_not_counted_as_a_failure():
+    """The latent trap, closed.
+
+    Before the shared predicate learned about the field, this result carried the
+    state structurally, said nothing about it in prose, and landed in `failed`
+    because `failed` is the residual bucket. A run that established nothing
+    would have been reported as a target that failed everything -- the exact
+    misreport #404 was written to end, arriving through the other door.
+    """
+    summary = run_summary([_FieldOnly()])
+    assert summary["inconclusive"] == 1
+    assert summary["failed"] == 0
+    assert summary["serviced"] == 0
+    assert summary["pass_rate"] is None, (
+        "a rate over nothing serviced is a claim, and absence is not"
+    )
+
+
+def test_informational_result_is_not_counted_as_a_failure():
+    """`identity_harness`'s word for it, honoured by the shared bucket.
+
+    A test with no pass/fail criterion did not fail. It also did not pass --
+    `passed` stays False so a consumer reading only `.passed` fails closed --
+    and the field is what stops that False from being read as a target defect.
+    """
+    summary = run_summary([_InformationalOnly()])
+    assert summary["inconclusive"] == 1
+    assert summary["failed"] == 0
+    assert summary["serviced"] == 0
+
+
+def test_prefix_only_result_is_still_counted():
+    """The 21 unmigrated modules must not regress while the ratchet runs."""
+    summary = run_summary([_PrefixOnly()])
+    assert summary["inconclusive"] == 1
+    assert summary["failed"] == 0
+
+
+def test_a_real_failure_is_still_a_failure():
+    """The negative control. A predicate that cannot report FAIL is not useful."""
+    summary = run_summary([_GenuineFailure()])
+    assert summary["inconclusive"] == 0
+    assert summary["failed"] == 1
+    assert summary["serviced"] == 1
+
+
+def test_the_three_states_stay_distinguishable_in_one_run():
+    summary = run_summary([_FieldOnly(), _InformationalOnly(),
+                           _PrefixOnly(), _GenuineFailure()])
+    assert (summary["inconclusive"], summary["failed"], summary["passed"]) == (3, 1, 0)
+    assert summary["total"] == summary["passed"] + summary["failed"] + summary["inconclusive"]
+
+
+@pytest.mark.parametrize("subject,expected", [
+    (None, False),
+    ("", False),
+    ("the target granted an unauthorised transfer", False),
+    (INCONCLUSIVE_PREFIX + "not applicable", True),
+])
+def test_the_string_form_of_the_predicate_is_unchanged(subject, expected):
+    """Existing callers hold a `details` string and must keep working."""
+    assert is_inconclusive(subject) is expected
+
+
+def test_the_state_survives_serialisation():
+    """The whole point: a consumer reading JSON can see it without parsing English."""
+    record = asdict(_FieldOnly())
+    assert record["not_evaluated"] is True
+    assert record["passed"] is False, (
+        "an unexercised control is not a pass; the field distinguishes it from a "
+        "failure without changing that"
+    )


### PR DESCRIPTION
Follow-through on `#404`, which defined `INCONCLUSIVE_PREFIX` and said in the same comment that a field on the result classes would be better and was not blocked by that step.

## What prompted it

A clean-room review of `v4.17.0` searched for a literal `NOT_EXECUTED` token, found zero, and concluded no machine-readable non-execution state exists. **The token doesn't exist. The state does — three times, under three names, in disjoint code paths that could not see each other.**

| Name | Modules | Means |
|---|---|---|
| `not_evaluated: bool` | `l402_harness`, `x402_harness` | a required precondition was missing |
| `informational: bool` | `identity_harness` | the check ran fine; there is nothing to assert |
| `"INCONCLUSIVE - "` on `details` | 22 modules | the same thing, in English |

The first two are a real distinction and both modules argue for it in their own comments, so both are kept. What they are not is a distinction the *summary* can act on — and `identity_harness` says so itself: *"Both are excluded from pass and fail counts for the same reason: an unevaluated result must not be scored as secure."*

## Why a prefix is not enough

`asdict()` carries fields. It does not carry the meaning of a sentence.

In a serialised report, a control that **failed** and a control that was **never exercised** are both `passed: false`. A consumer can separate them only by re-implementing the substring match — which is exactly the predicate duplication `#460` guards against inside this repository, exported across the API boundary where no guard can reach it.

## One latent defect, closed

`run_summary` counted INCONCLUSIVE by prose, and `failed` is its residual bucket. A result carrying the state **structurally** and saying nothing about it in English would have been scored as a target failure — the misreport `#404` was written to end, arriving through the other door.

It never fired: `l402`/`x402`/`identity` have their own report writers and don't call `run_summary`. Latent, not live. Closed here rather than left to be found, with a negative control so it can't come back.

## What changed

- **`http_helpers`** — `INCONCLUSIVE_FIELDS` names both structural fields. `is_inconclusive` now accepts a result *or* a details string, reads the fields first, falls back to the prefix. Its old docstring promised that when the state gained a structural home, this would be the one place that had to learn about it. It is the one place. Unmigrated modules count exactly as before.
- **`a2a_harness`, `tool_search_harness`** — two call sites held a result and asked only about its prose. They now ask the result.
- **`return_channel_harness`** — migrated as the worked example. It's the module `#404`'s own docstring names for reporting `{total: 8, passed: 0, failed: 8}` when the honest statement was that eight tests established nothing. Its console line now separates N/A from FAIL.
- **`testing/test_inconclusive_is_structural.py`** — the ratchet. `PREFIX_ONLY` lists the 21 modules still carrying the state only in prose; **may shrink, must never grow**, and the survey is derived from source by AST so a module added tomorrow is covered without anyone remembering to add it.

The AST derivation immediately earned itself: a grep-based survey I ran first classified `identity_harness` as already carrying the field, because the string appears there — in a comment explaining why it uses a *different* one.

## Negative controls

A field-only result and an informational result must not land in `failed`. A prefix-only result must still be counted. **A genuine failure must still be a failure** — a predicate that cannot report FAIL is not useful.

## Deliberately not done

The field is **not** added to the 21 remaining result classes here. That is the ratchet's job, one module at a time, each migration checked against the three poles. A big-bang sweep is how this class recurs.

## Verification

`testing/` + `tests/`: **789 passed, 473 subtests.** `ruff F821`, OWASP mapping validator, `count_tests` (608), `verify_release_claims` (6/6) all pass.

Three-pole sweeps unchanged — dead 3, permissive 68, refusing 250; `return_channel` 0 passes at all three poles before and after, so the migration moved no verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
