### PR TITLE
fix: the INCONCLUSIVE ratchet paid out — all 21 modules carry the field

### DIFF
--- a/protocol_tests/a2a_harness.py
+++ b/protocol_tests/a2a_harness.py
@@ -230,8 +230,15 @@ class A2ATestResult:
     response_received: dict | None = None
     elapsed_s: float = 0.0
     timestamp: str = ""
+    #: INCONCLUSIVE as a field, not only as a prefix on `details`.
+    #: `asdict()` carries this; it does not carry the meaning of English.
+    not_evaluated: bool = False
 
     def __post_init__(self):
+        # A prefix written into `details` is the state too, not only a
+        # guard's decision. Derived here so both paths are structural.
+        if is_inconclusive(self.details):
+            self.not_evaluated = True
         if not self.timestamp:
             self.timestamp = datetime.now(timezone.utc).isoformat()
 

--- a/protocol_tests/capability_profile_harness.py
+++ b/protocol_tests/capability_profile_harness.py
@@ -35,6 +35,7 @@ from enum import Enum
 from protocol_tests.http_helpers import (
     INCONCLUSIVE_PREFIX,
     inconclusive_detail,
+    is_inconclusive,
     looks_like_refusal,
     run_summary,
     summary_lines,
@@ -137,8 +138,15 @@ class CapabilityProfileTestResult:
     #: Such a row is not prose-graded and the permissive-half rule below must
     #: not downgrade it. Same flag and same reason as memory_harness MEM-011/012.
     directly_observed: bool = False
+    #: INCONCLUSIVE as a field, not only as a prefix on `details`.
+    #: `asdict()` carries this; it does not carry the meaning of English.
+    not_evaluated: bool = False
 
     def __post_init__(self):
+        # A prefix written into `details` is the state too, not only a
+        # guard's decision. Derived here so both paths are structural.
+        if is_inconclusive(self.details):
+            self.not_evaluated = True
         if not self.timestamp:
             self.timestamp = datetime.now(timezone.utc).isoformat()
 
@@ -265,6 +273,7 @@ class CapabilityProfileTests:
         _d = inconclusive_detail(_rr, result.details)
         if _d is not None:
             result.passed = False
+            result.not_evaluated = True
             result.details = _d
         elif (result.passed and not result.directly_observed
                 and isinstance(_rr, dict) and not _capability_refused(_rr)):

--- a/protocol_tests/cloud_agent_harness.py
+++ b/protocol_tests/cloud_agent_harness.py
@@ -50,6 +50,7 @@ from datetime import datetime, timezone
 
 from protocol_tests.http_helpers import (
     INCONCLUSIVE_PREFIX,
+    is_inconclusive,
     refused,
     silence_detail,
     silence_evidence,
@@ -73,8 +74,15 @@ class CloudAgentTestResult:
     response_received: dict | None = None
     elapsed_s: float = 0.0
     timestamp: str = ""
+    #: INCONCLUSIVE as a field, not only as a prefix on `details`.
+    #: `asdict()` carries this; it does not carry the meaning of English.
+    not_evaluated: bool = False
 
     def __post_init__(self):
+        # A prefix written into `details` is the state too, not only a
+        # guard's decision. Derived here so both paths are structural.
+        if is_inconclusive(self.details):
+            self.not_evaluated = True
         if not self.timestamp:
             self.timestamp = datetime.now(timezone.utc).isoformat()
 
@@ -156,6 +164,7 @@ class CloudAgentAdapter(ABC):
             result.response_received = silence_evidence(seen, _rr)
         if _d is not None:
             result.passed = False
+            result.not_evaluated = True
             result.details = _d
         elif result.passed and isinstance(_rr, dict) and not refused(_rr):
             # #351, permissive half. The dominant verdict shapes in this family

--- a/protocol_tests/enterprise_adapters.py
+++ b/protocol_tests/enterprise_adapters.py
@@ -41,6 +41,7 @@ from datetime import datetime, timezone
 
 from protocol_tests.http_helpers import (
     INCONCLUSIVE_PREFIX,
+    is_inconclusive,
     refused,
     silence_detail,
     silence_evidence,
@@ -64,8 +65,15 @@ class EnterpriseTestResult:
     response_received: dict | None = None
     elapsed_s: float = 0.0
     timestamp: str = ""
+    #: INCONCLUSIVE as a field, not only as a prefix on `details`.
+    #: `asdict()` carries this; it does not carry the meaning of English.
+    not_evaluated: bool = False
 
     def __post_init__(self):
+        # A prefix written into `details` is the state too, not only a
+        # guard's decision. Derived here so both paths are structural.
+        if is_inconclusive(self.details):
+            self.not_evaluated = True
         if not self.timestamp:
             self.timestamp = datetime.now(timezone.utc).isoformat()
 
@@ -156,6 +164,7 @@ class EnterprisePlatformAdapter(ABC):
             result.response_received = silence_evidence(seen, _rr)
         if _d is not None:
             result.passed = False
+            result.not_evaluated = True
             result.details = _d
         elif result.passed and isinstance(_rr, dict) and not refused(_rr):
             # #351, permissive half. The dominant verdict shapes in this family

--- a/protocol_tests/extended_enterprise_adapters.py
+++ b/protocol_tests/extended_enterprise_adapters.py
@@ -39,6 +39,7 @@ from datetime import datetime, timezone
 
 from protocol_tests.http_helpers import (
     INCONCLUSIVE_PREFIX,
+    is_inconclusive,
     refused,
     silence_detail,
     silence_evidence,
@@ -62,7 +63,14 @@ class ExtTestResult:
     response_received: dict | None = None
     elapsed_s: float = 0.0
     timestamp: str = ""
+    #: INCONCLUSIVE as a field, not only as a prefix on `details`.
+    #: `asdict()` carries this; it does not carry the meaning of English.
+    not_evaluated: bool = False
     def __post_init__(self):
+        # A prefix written into `details` is the state too, not only a
+        # guard's decision. Derived here so both paths are structural.
+        if is_inconclusive(self.details):
+            self.not_evaluated = True
         if not self.timestamp:
             self.timestamp = datetime.now(timezone.utc).isoformat()
 
@@ -126,6 +134,7 @@ class ExtAdapter(ABC):
             r.response_received = silence_evidence(seen, _rr)
         if _d is not None:
             r.passed = False
+            r.not_evaluated = True
             r.details = _d
         elif r.passed and isinstance(_rr, dict) and not refused(_rr):
             # #351, permissive half. The dominant verdict shapes in this family

--- a/protocol_tests/extended_thinking_harness.py
+++ b/protocol_tests/extended_thinking_harness.py
@@ -51,6 +51,7 @@ from datetime import datetime, timezone
 from protocol_tests._utils import Severity, http_post_json, jsonrpc_request, wilson_ci
 from protocol_tests.http_helpers import (
     INCONCLUSIVE_PREFIX,
+    is_inconclusive,
     silence_detail,
     silence_evidence,
 )
@@ -74,8 +75,15 @@ class ExtendedThinkingResult:
     response_received: dict | None = None
     elapsed_s: float = 0.0
     timestamp: str = ""
+    #: INCONCLUSIVE as a field, not only as a prefix on `details`.
+    #: `asdict()` carries this; it does not carry the meaning of English.
+    not_evaluated: bool = False
 
     def __post_init__(self):
+        # A prefix written into `details` is the state too, not only a
+        # guard's decision. Derived here so both paths are structural.
+        if is_inconclusive(self.details):
+            self.not_evaluated = True
         if not self.timestamp:
             self.timestamp = datetime.now(timezone.utc).isoformat()
 
@@ -137,6 +145,7 @@ class ExtendedThinkingTests:
         detail = silence_detail(seen, result.details)
         if detail is not None:
             result.passed = False
+            result.not_evaluated = True
             result.details = detail
             result.response_received = silence_evidence(
                 seen, getattr(result, "response_received", None))

--- a/protocol_tests/framework_adapters.py
+++ b/protocol_tests/framework_adapters.py
@@ -50,6 +50,7 @@ from urllib.parse import urlparse, urlunparse
 
 from protocol_tests.http_helpers import (
     INCONCLUSIVE_PREFIX,
+    is_inconclusive,
     refused,
     silence_detail,
     silence_evidence,
@@ -73,8 +74,15 @@ class AdapterTestResult:
     response_received: dict | None = None
     elapsed_s: float = 0.0
     timestamp: str = ""
+    #: INCONCLUSIVE as a field, not only as a prefix on `details`.
+    #: `asdict()` carries this; it does not carry the meaning of English.
+    not_evaluated: bool = False
 
     def __post_init__(self):
+        # A prefix written into `details` is the state too, not only a
+        # guard's decision. Derived here so both paths are structural.
+        if is_inconclusive(self.details):
+            self.not_evaluated = True
         if not self.timestamp:
             self.timestamp = datetime.now(timezone.utc).isoformat()
 
@@ -180,6 +188,7 @@ class FrameworkAdapter(ABC):
             result.response_received = silence_evidence(seen, _rr)
         if _d is not None:
             result.passed = False
+            result.not_evaluated = True
             result.details = _d
         elif result.passed and isinstance(_rr, dict) and not refused(_rr):
             # #351, permissive half. The dominant verdict shapes in this family

--- a/protocol_tests/governance_modification_harness.py
+++ b/protocol_tests/governance_modification_harness.py
@@ -42,6 +42,7 @@ from datetime import datetime, timezone
 
 from protocol_tests._utils import Severity, http_post_json, jsonrpc_request
 from protocol_tests.http_helpers import (
+    is_inconclusive,
     INCONCLUSIVE_PREFIX,
     run_summary,
     silence_detail,
@@ -65,6 +66,15 @@ class GovernanceModTestResult:
     request_sent: dict | None = None
     response_received: dict | None = None
     elapsed_s: float = 0.0
+    #: INCONCLUSIVE as a field, not only as a prefix on `details`.
+    #: `asdict()` carries this; it does not carry the meaning of English.
+    not_evaluated: bool = False
+
+    def __post_init__(self):
+        # A prefix written into `details` is the state too, not only a
+        # guard's decision. Derived here so both paths are structural.
+        if is_inconclusive(self.details):
+            self.not_evaluated = True
 
 
 def _explicitly_rejected(resp: dict) -> bool:
@@ -213,6 +223,7 @@ class GovernanceModificationTests:
                 seen, getattr(result, "response_received", None))
         if _d is not None:
             result.passed = False
+            result.not_evaluated = True
             result.details = _d
         status = "PASS ✅" if result.passed else "FAIL ❌"
         print(f"  {status}  {result.test_id}: {result.name}")

--- a/protocol_tests/gtg1002_simulation.py
+++ b/protocol_tests/gtg1002_simulation.py
@@ -56,6 +56,7 @@ from protocol_tests.http_helpers import (
     _is_conn_error,
     http_post,
     inconclusive_detail,
+    is_inconclusive,
     looks_like_refusal,
 )
 
@@ -79,7 +80,14 @@ class GTGTestResult:
     response_received: dict | None = None
     elapsed_s: float = 0.0
     timestamp: str = ""
+    #: INCONCLUSIVE as a field, not only as a prefix on `details`.
+    #: `asdict()` carries this; it does not carry the meaning of English.
+    not_evaluated: bool = False
     def __post_init__(self):
+        # A prefix written into `details` is the state too, not only a
+        # guard's decision. Derived here so both paths are structural.
+        if is_inconclusive(self.details):
+            self.not_evaluated = True
         if not self.timestamp:
             self.timestamp = datetime.now(timezone.utc).isoformat()
 
@@ -247,6 +255,7 @@ class GTG1002Simulation:
         _d = inconclusive_detail(_rr, r.details)
         if _d is not None:
             r.passed = False
+            r.not_evaluated = True
             r.details = _d
         elif r.passed and isinstance(_rr, dict) and not _gtg_refused(_rr):
             # #351, permissive half, and the docstring above already names why:

--- a/protocol_tests/identity_harness.py
+++ b/protocol_tests/identity_harness.py
@@ -43,6 +43,7 @@ from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 
 from protocol_tests.http_helpers import (
+    is_inconclusive,
     looks_like_refusal,
     INCONCLUSIVE_PREFIX,
     _err,
@@ -136,6 +137,10 @@ class IdentityTestResult:
     elapsed_s: float = 0.0
     timestamp: str = ""
     def __post_init__(self):
+        # A prefix written into `details` is the state too, not only a
+        # guard's decision. Derived here so both paths are structural.
+        if is_inconclusive(self.details):
+            self.not_evaluated = True
         if not self.timestamp:
             self.timestamp = datetime.now(timezone.utc).isoformat()
 

--- a/protocol_tests/incident_response_harness.py
+++ b/protocol_tests/incident_response_harness.py
@@ -38,6 +38,7 @@ from enum import Enum
 
 from protocol_tests.http_helpers import (
     INCONCLUSIVE_PREFIX,
+    is_inconclusive,
     run_summary,
     silence_detail,
     silence_evidence,
@@ -136,8 +137,15 @@ class IncidentResponseTestResult:
     response_received: dict | None = None
     elapsed_s: float = 0.0
     timestamp: str = ""
+    #: INCONCLUSIVE as a field, not only as a prefix on `details`.
+    #: `asdict()` carries this; it does not carry the meaning of English.
+    not_evaluated: bool = False
 
     def __post_init__(self):
+        # A prefix written into `details` is the state too, not only a
+        # guard's decision. Derived here so both paths are structural.
+        if is_inconclusive(self.details):
+            self.not_evaluated = True
         if not self.timestamp:
             self.timestamp = datetime.now(timezone.utc).isoformat()
 
@@ -253,6 +261,7 @@ class IncidentResponseTests:
                 seen, getattr(result, "response_received", None))
         if _d is not None:
             result.passed = False
+            result.not_evaluated = True
             result.details = _d
         self.results.append(result)
         status = "PASS \u2705" if result.passed else "FAIL \u274c"

--- a/protocol_tests/intent_contract_harness.py
+++ b/protocol_tests/intent_contract_harness.py
@@ -37,6 +37,7 @@ from protocol_tests.http_helpers import (
     _err,
     http_post_json,
     inconclusive_detail,
+    is_inconclusive,
     looks_like_refusal,
     run_summary,
     summary_lines,
@@ -101,8 +102,15 @@ class IntentContractTestResult:
     response_received: dict | None = None
     elapsed_s: float = 0.0
     timestamp: str = ""
+    #: INCONCLUSIVE as a field, not only as a prefix on `details`.
+    #: `asdict()` carries this; it does not carry the meaning of English.
+    not_evaluated: bool = False
 
     def __post_init__(self):
+        # A prefix written into `details` is the state too, not only a
+        # guard's decision. Derived here so both paths are structural.
+        if is_inconclusive(self.details):
+            self.not_evaluated = True
         if not self.timestamp:
             self.timestamp = datetime.now(timezone.utc).isoformat()
 
@@ -197,6 +205,7 @@ class IntentContractTests:
         _d = inconclusive_detail(_rr, result.details)
         if _d is not None:
             result.passed = False
+            result.not_evaluated = True
             result.details = _d
         elif result.passed and isinstance(_rr, dict) and not _intent_refused(_rr):
             # #351, permissive half. Seven of the eight verdicts here are

--- a/protocol_tests/jailbreak_harness.py
+++ b/protocol_tests/jailbreak_harness.py
@@ -48,6 +48,7 @@ from protocol_tests.http_helpers import (
     INCONCLUSIVE_PREFIX,
     http_post_json,
     inconclusive_detail,
+    is_inconclusive,
     looks_like_refusal,
     run_summary,
     summary_lines,
@@ -125,8 +126,15 @@ class JailbreakTestResult:
     response_received: dict | None = None
     elapsed_s: float = 0.0
     timestamp: str = ""
+    #: INCONCLUSIVE as a field, not only as a prefix on `details`.
+    #: `asdict()` carries this; it does not carry the meaning of English.
+    not_evaluated: bool = False
 
     def __post_init__(self):
+        # A prefix written into `details` is the state too, not only a
+        # guard's decision. Derived here so both paths are structural.
+        if is_inconclusive(self.details):
+            self.not_evaluated = True
         if not self.timestamp:
             self.timestamp = datetime.now(timezone.utc).isoformat()
 
@@ -192,6 +200,7 @@ class JailbreakTests:
         _d = inconclusive_detail(_rr, result.details)
         if _d is not None:
             result.passed = False
+            result.not_evaluated = True
             result.details = _d
         elif result.passed and isinstance(_rr, dict) and not _jailbreak_refused(_rr):
             # #351, permissive half, and this module's own docstring named the

--- a/protocol_tests/kill_switch_harness.py
+++ b/protocol_tests/kill_switch_harness.py
@@ -33,6 +33,7 @@ from datetime import datetime, timezone
 from enum import Enum
 
 from protocol_tests.http_helpers import (
+    is_inconclusive,
     INCONCLUSIVE_PREFIX,
     run_summary,
     silence_detail,
@@ -76,6 +77,15 @@ class KillSwitchTestResult:
     request_sent: dict | None = None
     response_received: dict | None = None
     elapsed_s: float = 0.0
+    #: INCONCLUSIVE as a field, not only as a prefix on `details`.
+    #: `asdict()` carries this; it does not carry the meaning of English.
+    not_evaluated: bool = False
+
+    def __post_init__(self):
+        # A prefix written into `details` is the state too, not only a
+        # guard's decision. Derived here so both paths are structural.
+        if is_inconclusive(self.details):
+            self.not_evaluated = True
 
 
 def jsonrpc_request(method: str, params: dict | None = None, id: str | None = None) -> dict:
@@ -165,6 +175,7 @@ class KillSwitchTests:
                 seen, getattr(result, "response_received", None))
         if _d is not None:
             result.passed = False
+            result.not_evaluated = True
             result.details = _d
         status = "PASS ✅" if result.passed else "FAIL ❌"
         print(f"  {status}  {result.test_id}: {result.name}")

--- a/protocol_tests/l402_harness.py
+++ b/protocol_tests/l402_harness.py
@@ -65,6 +65,7 @@ from datetime import datetime, timezone
 from enum import Enum
 
 from protocol_tests.http_helpers import (
+    is_inconclusive,
     instrument_transport,
     silence_detail,
     silence_evidence,
@@ -228,6 +229,10 @@ class L402TestResult:
     timestamp: str = ""
 
     def __post_init__(self):
+        # A prefix written into `details` is the state too, not only a
+        # guard's decision. Derived here so both paths are structural.
+        if is_inconclusive(self.details):
+            self.not_evaluated = True
         if not self.timestamp:
             self.timestamp = datetime.now(timezone.utc).isoformat()
 

--- a/protocol_tests/mcp_harness.py
+++ b/protocol_tests/mcp_harness.py
@@ -58,6 +58,7 @@ from protocol_tests._utils import (
     URL_PATTERN,
 )
 from protocol_tests.http_helpers import (
+    is_inconclusive,
     INCONCLUSIVE_PREFIX,
     # Shared 2026-08-30: tool_search_harness had the same shape. Kept under
     # the local name so the fourteen call sites below are unchanged.
@@ -611,8 +612,15 @@ class MCPTestResult:
     response_received: dict | None = None
     elapsed_s: float = 0.0
     timestamp: str = ""
+    #: INCONCLUSIVE as a field, not only as a prefix on `details`.
+    #: `asdict()` carries this; it does not carry the meaning of English.
+    not_evaluated: bool = False
 
     def __post_init__(self):
+        # A prefix written into `details` is the state too, not only a
+        # guard's decision. Derived here so both paths are structural.
+        if is_inconclusive(self.details):
+            self.not_evaluated = True
         if not self.timestamp:
             self.timestamp = datetime.now(timezone.utc).isoformat()
 

--- a/protocol_tests/memory_harness.py
+++ b/protocol_tests/memory_harness.py
@@ -42,6 +42,7 @@ from datetime import datetime, timezone
 from enum import Enum
 
 from protocol_tests.http_helpers import (
+    is_inconclusive,
     INCONCLUSIVE_PREFIX,
     _err,
     _is_conn_error,
@@ -133,8 +134,15 @@ class MemoryTestResult:
     #: _record must not touch them; testing/test_memory_namespace_boundary.py
     #: caught it doing so.
     directly_observed: bool = False
+    #: INCONCLUSIVE as a field, not only as a prefix on `details`.
+    #: `asdict()` carries this; it does not carry the meaning of English.
+    not_evaluated: bool = False
 
     def __post_init__(self):
+        # A prefix written into `details` is the state too, not only a
+        # guard's decision. Derived here so both paths are structural.
+        if is_inconclusive(self.details):
+            self.not_evaluated = True
         if not self.timestamp:
             self.timestamp = datetime.now(timezone.utc).isoformat()
 
@@ -231,6 +239,7 @@ class MemoryTests:
         _d = inconclusive_detail(_rr, result.details)
         if _d is not None:
             result.passed = False
+            result.not_evaluated = True
             result.details = _d
         elif (result.passed and not result.directly_observed
                 and isinstance(_rr, dict) and not _memory_refused(_rr)):

--- a/protocol_tests/multi_agent_harness.py
+++ b/protocol_tests/multi_agent_harness.py
@@ -54,6 +54,7 @@ from datetime import datetime, timezone
 from enum import Enum
 
 from protocol_tests.http_helpers import (
+    is_inconclusive,
     INCONCLUSIVE_PREFIX,
     _err,
     _is_conn_error,
@@ -124,8 +125,15 @@ class MultiAgentTestResult:
     response_received: dict | None = None
     elapsed_s: float = 0.0
     timestamp: str = ""
+    #: INCONCLUSIVE as a field, not only as a prefix on `details`.
+    #: `asdict()` carries this; it does not carry the meaning of English.
+    not_evaluated: bool = False
 
     def __post_init__(self):
+        # A prefix written into `details` is the state too, not only a
+        # guard's decision. Derived here so both paths are structural.
+        if is_inconclusive(self.details):
+            self.not_evaluated = True
         if not self.timestamp:
             self.timestamp = datetime.now(timezone.utc).isoformat()
 
@@ -276,6 +284,7 @@ class MultiAgentTests:
         _d = inconclusive_detail(_rr, result.details)
         if _d is not None:
             result.passed = False
+            result.not_evaluated = True
             result.details = _d
         elif result.passed and isinstance(_rr, dict) and not _multi_agent_refused(_rr):
             # #351, permissive-target half. Every verdict in this module is
@@ -293,6 +302,7 @@ class MultiAgentTests:
             _, _inc = _multi_agent_verdict(_rr, succeeded=False)
             if _inc is not None:
                 result.passed = False
+                result.not_evaluated = True
                 result.details = _inc
         self.results.append(result)
         status = "PASS \u2705" if result.passed else "FAIL \u274c"

--- a/protocol_tests/over_refusal_harness.py
+++ b/protocol_tests/over_refusal_harness.py
@@ -30,7 +30,10 @@ from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from enum import Enum
 
-from protocol_tests.http_helpers import INCONCLUSIVE_PREFIX
+from protocol_tests.http_helpers import (
+    is_inconclusive,
+    INCONCLUSIVE_PREFIX,
+)
 
 # ---------------------------------------------------------------------------
 # Wilson score CI (inlined from statistical.py for zero-dep)
@@ -147,8 +150,15 @@ class OverRefusalTestResult:
     response_received: dict | None = None
     elapsed_s: float = 0.0
     timestamp: str = ""
+    #: INCONCLUSIVE as a field, not only as a prefix on `details`.
+    #: `asdict()` carries this; it does not carry the meaning of English.
+    not_evaluated: bool = False
 
     def __post_init__(self):
+        # A prefix written into `details` is the state too, not only a
+        # guard's decision. Derived here so both paths are structural.
+        if is_inconclusive(self.details):
+            self.not_evaluated = True
         if not self.timestamp:
             self.timestamp = datetime.now(timezone.utc).isoformat()
 

--- a/protocol_tests/provenance_harness.py
+++ b/protocol_tests/provenance_harness.py
@@ -33,6 +33,7 @@ from datetime import datetime, timezone
 from enum import Enum
 
 from protocol_tests.http_helpers import (
+    is_inconclusive,
     INCONCLUSIVE_PREFIX,
     run_summary,
     silence_detail,
@@ -132,8 +133,15 @@ class ProvenanceTestResult:
     response_received: dict | None = None
     elapsed_s: float = 0.0
     timestamp: str = ""
+    #: INCONCLUSIVE as a field, not only as a prefix on `details`.
+    #: `asdict()` carries this; it does not carry the meaning of English.
+    not_evaluated: bool = False
 
     def __post_init__(self):
+        # A prefix written into `details` is the state too, not only a
+        # guard's decision. Derived here so both paths are structural.
+        if is_inconclusive(self.details):
+            self.not_evaluated = True
         if not self.timestamp:
             self.timestamp = datetime.now(timezone.utc).isoformat()
 
@@ -204,6 +212,7 @@ class ProvenanceTests:
             result.response_received = silence_evidence(seen, _rr)
         if _d is not None:
             result.passed = False
+            result.not_evaluated = True
             result.details = _d
         elif result.passed and isinstance(_rr, dict) and not (
                 _rr.get("_error") or _rr.get("error")):

--- a/protocol_tests/ptc_harness.py
+++ b/protocol_tests/ptc_harness.py
@@ -50,6 +50,7 @@ from datetime import datetime, timedelta, timezone
 
 from protocol_tests._utils import Severity, http_post_json, jsonrpc_request, wilson_ci
 from protocol_tests.http_helpers import (
+    is_inconclusive,
     INCONCLUSIVE_PREFIX,
     silence_detail,
     silence_evidence,
@@ -91,8 +92,15 @@ class PTCResult:
     response_received: dict | None = None
     elapsed_s: float = 0.0
     timestamp: str = ""
+    #: INCONCLUSIVE as a field, not only as a prefix on `details`.
+    #: `asdict()` carries this; it does not carry the meaning of English.
+    not_evaluated: bool = False
 
     def __post_init__(self):
+        # A prefix written into `details` is the state too, not only a
+        # guard's decision. Derived here so both paths are structural.
+        if is_inconclusive(self.details):
+            self.not_evaluated = True
         if not self.timestamp:
             self.timestamp = datetime.now(timezone.utc).isoformat()
 
@@ -162,6 +170,7 @@ class PTCTests:
         detail = silence_detail(seen, result.details)
         if detail is not None:
             result.passed = False
+            result.not_evaluated = True
             result.details = detail
             result.response_received = silence_evidence(
                 seen, getattr(result, "response_received", None))

--- a/protocol_tests/return_channel_harness.py
+++ b/protocol_tests/return_channel_harness.py
@@ -35,6 +35,7 @@ from datetime import datetime, timezone
 from enum import Enum
 
 from protocol_tests.http_helpers import (
+    is_inconclusive,
     INCONCLUSIVE_PREFIX,
     inconclusive_detail,
     looks_like_refusal,
@@ -139,6 +140,10 @@ class ReturnChannelTestResult:
     timestamp: str = ""
 
     def __post_init__(self):
+        # A prefix written into `details` is the state too, not only a
+        # guard's decision. Derived here so both paths are structural.
+        if is_inconclusive(self.details):
+            self.not_evaluated = True
         if not self.timestamp:
             self.timestamp = datetime.now(timezone.utc).isoformat()
 

--- a/protocol_tests/tool_search_harness.py
+++ b/protocol_tests/tool_search_harness.py
@@ -121,8 +121,15 @@ class ToolSearchResult:
     response_received: dict | None = None
     elapsed_s: float = 0.0
     timestamp: str = ""
+    #: INCONCLUSIVE as a field, not only as a prefix on `details`.
+    #: `asdict()` carries this; it does not carry the meaning of English.
+    not_evaluated: bool = False
 
     def __post_init__(self):
+        # A prefix written into `details` is the state too, not only a
+        # guard's decision. Derived here so both paths are structural.
+        if is_inconclusive(self.details):
+            self.not_evaluated = True
         if not self.timestamp:
             self.timestamp = datetime.now(timezone.utc).isoformat()
 
@@ -168,6 +175,7 @@ class ToolSearchTests:
         _d = inconclusive_detail(getattr(result, "response_received", None), result.details)
         if _d is not None:
             result.passed = False
+            result.not_evaluated = True
             result.details = _d
         elif is_inconclusive(result):
             # A site that abstained by wording must not also report a pass.

--- a/protocol_tests/watermark_harness.py
+++ b/protocol_tests/watermark_harness.py
@@ -32,6 +32,7 @@ from datetime import datetime, timezone
 from enum import Enum
 
 from protocol_tests.http_helpers import (
+    is_inconclusive,
     INCONCLUSIVE_PREFIX,
     inconclusive_detail,
     run_summary,
@@ -79,6 +80,15 @@ class WatermarkTestResult:
     request_sent: dict | None = None
     response_received: dict | None = None
     elapsed_s: float = 0.0
+    #: INCONCLUSIVE as a field, not only as a prefix on `details`.
+    #: `asdict()` carries this; it does not carry the meaning of English.
+    not_evaluated: bool = False
+
+    def __post_init__(self):
+        # Both INCONCLUSIVE sites here build the prefix into `details` at
+        # construction, so there is no guard later to set the field.
+        if is_inconclusive(self.details):
+            self.not_evaluated = True
 
 
 def jsonrpc_request(method: str, params: dict | None = None, id: str | None = None) -> dict:
@@ -131,6 +141,7 @@ class WatermarkTests:
         _d = inconclusive_detail(getattr(result, "response_received", None), result.details)
         if _d is not None:
             result.passed = False
+            result.not_evaluated = True
             result.details = _d
         status = "PASS ✅" if result.passed else "FAIL ❌"
         print(f"  {status}  {result.test_id}: {result.name}")

--- a/protocol_tests/x402_harness.py
+++ b/protocol_tests/x402_harness.py
@@ -85,6 +85,7 @@ from datetime import datetime, timezone
 from enum import Enum
 
 from protocol_tests.http_helpers import (
+    is_inconclusive,
     looks_like_refusal,
     INCONCLUSIVE_PREFIX,
     instrument_transport,
@@ -333,6 +334,10 @@ class X402TestResult:
     not_evaluated: bool = False
 
     def __post_init__(self):
+        # A prefix written into `details` is the state too, not only a
+        # guard's decision. Derived here so both paths are structural.
+        if is_inconclusive(self.details):
+            self.not_evaluated = True
         if not self.timestamp:
             self.timestamp = datetime.now(timezone.utc).isoformat()
 

--- a/testing/test_inconclusive_is_structural.py
+++ b/testing/test_inconclusive_is_structural.py
@@ -48,31 +48,12 @@ PROTOCOL_TESTS = pathlib.Path(__file__).resolve().parents[1] / "protocol_tests"
 #: Modules whose result dataclasses still carry INCONCLUSIVE only as a prefix on
 #: `details`. **This list may shrink as modules migrate, and must never grow.**
 #:
-#: Adding a module here is not a way to pass this test. A new result class that
-#: can be INCONCLUSIVE gets the field; the list is for the ones that predate it.
-PREFIX_ONLY = {
-    "a2a_harness",
-    "capability_profile_harness",
-    "cloud_agent_harness",
-    "enterprise_adapters",
-    "extended_enterprise_adapters",
-    "extended_thinking_harness",
-    "framework_adapters",
-    "governance_modification_harness",
-    "gtg1002_simulation",
-    "incident_response_harness",
-    "intent_contract_harness",
-    "jailbreak_harness",
-    "kill_switch_harness",
-    "mcp_harness",
-    "memory_harness",
-    "multi_agent_harness",
-    "over_refusal_harness",
-    "provenance_harness",
-    "ptc_harness",
-    "tool_search_harness",
-    "watermark_harness",
-}
+#: It is now empty: all 21 migrated. The list stays because an empty ratchet is
+#: still a ratchet -- a new module that can report INCONCLUSIVE without carrying
+#: the field fails this test rather than quietly reopening the debt. Adding a
+#: module here is not a way to pass. A result class that can be INCONCLUSIVE gets
+#: the field.
+PREFIX_ONLY: set[str] = set()
 
 
 def _modules_that_can_be_inconclusive() -> dict[str, bool]:
@@ -234,3 +215,55 @@ def test_the_state_survives_serialisation():
         "an unexercised control is not a pass; the field distinguishes it from a "
         "failure without changing that"
     )
+
+
+def test_a_prefix_in_details_implies_the_field_on_every_module():
+    """The invariant the migration exists to establish.
+
+    A reader of a serialised result must not have to parse English. So on every
+    inconclusive-capable module, constructing a result whose `details` carries the
+    prefix must also set the field -- whether the module writes the prefix at
+    construction (mcp_harness does, 27 times) or a guard applies it later.
+
+    `identity_harness` is why this covers the modules that were structural first
+    rather than only the 21 that migrated: it carries `informational` for a
+    different concept and used the prose prefix for this one, so a prefixed result
+    there had neither field set.
+    """
+    import dataclasses
+    import importlib
+
+    surveyed = _modules_that_can_be_inconclusive()
+    assert surveyed, "no modules surveyed -- the derivation is broken, not the repo"
+
+    failures = []
+    for name in sorted(surveyed):
+        module = importlib.import_module(f"protocol_tests.{name}")
+        source = (PROTOCOL_TESTS / f"{name}.py").read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        cls = next(n for n in ast.walk(tree)
+                   if isinstance(n, ast.ClassDef)
+                   and any(isinstance(b, ast.AnnAssign)
+                           and getattr(b.target, "id", "") == "passed" for b in n.body))
+        result_cls = getattr(module, cls.name)
+
+        required = {}
+        for f in dataclasses.fields(result_cls):
+            if (f.default is dataclasses.MISSING
+                    and f.default_factory is dataclasses.MISSING):
+                required[f.name] = (
+                    False if f.type in ("bool", bool)
+                    else {} if "dict" in str(f.type)
+                    else 0.0 if "float" in str(f.type)
+                    else "x")
+        required["details"] = INCONCLUSIVE_PREFIX + "the control was never exercised"
+
+        record = result_cls(**required)
+        if not getattr(record, INCONCLUSIVE_FIELDS[0], False):
+            failures.append(f"{name}: prefix in details but the field is False")
+        elif not is_inconclusive(record):
+            failures.append(f"{name}: field set but the predicate disagrees")
+
+    assert not failures, (
+        "the prefix must imply the field everywhere, or a serialised record is "
+        "still only readable as English:\n  " + "\n  ".join(failures))


### PR DESCRIPTION
`#464` gave INCONCLUSIVE a structural home and left 21 modules on a shrink-only ratchet, carrying the state as English on `details`. **This empties that list.**

## The invariant it establishes

```text
a prefix in `details`   =>   not_evaluated is True
```

Asserted on every inconclusive-capable module rather than assumed. A reader of a serialised result no longer has to parse a sentence to tell an unexercised control from a failed one — before this, both were `passed: false` and the difference lived only in prose.

## Two paths write the state, so both set the field

| Path | Modules | How |
|---|---|---|
| Shared post-construction guard | 18 | sets the field where it already sets `passed = False` and swaps in the inconclusive detail |
| `__post_init__` derivation | 25 | covers prefixes built into `details` at construction — `mcp_harness` does this **27 times** and has no guard for them |

`governance_modification_harness` and `kill_switch_harness` gained a `__post_init__` for it. `watermark_harness` needed one because *both* of its INCONCLUSIVE sites are construction-time and it had no guard at all — it would have been the one module that silently kept the old behaviour.

## Why the four already-structural modules are included

`identity_harness` is the reason. It carries `informational` for a genuinely different concept — the check ran and there is nothing to assert — and used the **prose prefix** for this one. So a prefixed result there had *neither* field set, and it would have been the quietest hole in the invariant. `l402`, `x402` and `return_channel` take the derivation as a near no-op; uniformity is worth three lines.

## The ratchet stays

`PREFIX_ONLY` is now empty and remains in place. **An empty ratchet is still a ratchet** — a new module that can report INCONCLUSIVE without carrying the field fails the test rather than quietly reopening the debt.

It also earned its keep on the way in: the migration made every entry stale at once, and the stale-entry assertion failed the build until the list was emptied. A debt register that still lists paid entries overstates the debt, and this one refuses to.

## Nothing about any verdict changed

Three-pole sweeps are identical to the pre-change baseline across all 25 modified modules:

| Pole | Verdicts | Passes | Errors |
|---|---:|---:|---:|
| dead host | 500 | 3 | 0 |
| permissive | 532 | 68 | 0 |
| refusing | 500 | 250 | 0 |

63 suites, unchanged.

`testing/` + `tests/`: **790 passed, 473 subtests.** `ruff F821`, OWASP mapping validator, `count_tests` (608), `verify_release_claims` (6/6) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
