### PR TITLE
chore: 4.18.0rc1 — exercise the release path before trusting it

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you cite this work in research, please use this metadata."
 title: "Agent Security Harness"
-version: "4.17.0"
+version: "4.18.0rc1"
 abstract: "Multi-protocol agent security testing framework. 608 executable security tests across 43 test-bearing modules covering MCP, A2A, L402, and x402 wire protocols. Decision-layer attack scenarios, AIUC-1 pre-certification mapping, NIST AI 800-2 aligned."
 type: software
 authors:

--- a/docs/OWASP-AGENTIC-T1-T15-SUBMISSION-COVERAGE.md
+++ b/docs/OWASP-AGENTIC-T1-T15-SUBMISSION-COVERAGE.md
@@ -11,7 +11,7 @@
 | Report view | Submission (T1–T15) |
 | Report version | 1.0 |
 | Project | Agent Security Harness |
-| Harness version | `4.17.0` |
+| Harness version | `4.18.0rc1` |
 | Assessed commit | [`8d8bc08933637381a32fc32041f139d34eb6271f`](https://github.com/msaleme/red-team-blue-team-agent-fabric/commit/8d8bc08933637381a32fc32041f139d34eb6271f) |
 | Assessed at | 2026-08-02T18:30:00Z |
 | Repository tests | 608 (`python scripts/count_tests.py`) |

--- a/docs/OWASP-AGENTIC-V1.1-COVERAGE.md
+++ b/docs/OWASP-AGENTIC-V1.1-COVERAGE.md
@@ -9,7 +9,7 @@
 | Report view | Complete (T1–T17) |
 | Report version | 1.0 |
 | Project | Agent Security Harness |
-| Harness version | `4.17.0` |
+| Harness version | `4.18.0rc1` |
 | Assessed commit | [`8d8bc08933637381a32fc32041f139d34eb6271f`](https://github.com/msaleme/red-team-blue-team-agent-fabric/commit/8d8bc08933637381a32fc32041f139d34eb6271f) |
 | Assessed at | 2026-08-02T18:30:00Z |
 | Repository tests | 608 (`python scripts/count_tests.py`) |

--- a/docs/coverage/owasp-agentic-v1.1.json
+++ b/docs/coverage/owasp-agentic-v1.1.json
@@ -34,7 +34,7 @@
   "assessment": {
     "project": "Agent Security Harness",
     "repository": "https://github.com/msaleme/red-team-blue-team-agent-fabric",
-    "harness_version": "4.17.0",
+    "harness_version": "4.18.0rc1",
     "git_commit": "8d8bc08933637381a32fc32041f139d34eb6271f",
     "assessed_at": "2026-08-02T18:30:00Z",
     "reverified_at": "2026-08-03T01:05:00Z",

--- a/docs/coverage/owasp-agentic-v1.1.yaml
+++ b/docs/coverage/owasp-agentic-v1.1.yaml
@@ -52,7 +52,7 @@ framework:
 assessment:
   project: Agent Security Harness
   repository: https://github.com/msaleme/red-team-blue-team-agent-fabric
-  harness_version: "4.17.0"
+  harness_version: "4.18.0rc1"
   git_commit: "8d8bc08933637381a32fc32041f139d34eb6271f"
   assessed_at: '2026-08-02T18:30:00Z'
   reverified_at: '2026-08-03T01:05:00Z'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-security-harness"
-version = "4.17.0"
+version = "4.18.0rc1"
 description = "608 security tests for AI agent systems - MCP, A2A, L402, x402, UCP/ACP merchant-journey, AP2 mandate + Fireblocks x402 hardening + Visa TAP / Mastercard Agentic Tokens + denial-of-settlement finality, decision governance, AIUC-1 compliance, NIST AI 800-2 aligned"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
A release candidate cut for one reason: **the provenance path added in #467 has never executed.**

Its logic is unit-tested and its wiring is checked statically, but `publish-pypi.yml` still fires only on `release: published` — the condition that let v4.16.0 be tagged clean and never reach PyPI. The first tag to use the new steps is the first real exercise of them, and it should not be a release anyone is expected to install.

## What this rc establishes, none of which is currently known

- [ ] the Sigstore attestation step succeeds with the granted permissions
- [ ] `build_provenance.py` runs in the workflow with the paths it is given
- [ ] the pre-publish `--offline` verification passes on a real statement
- [ ] PyPI accepts the upload under trusted publishing
- [ ] `gh release upload` attaches four assets with `contents: write`
- [ ] the post-publish digest comparison agrees with what PyPI actually served

If any of those fail, it fails on a prerelease.

## The version bump

Four independent surfaces declare the version, and **each one failed until updated** — `CITATION.cff` and the OWASP mapping both assert against `pyproject.toml`, and the coverage reports are generated from the mapping. Four checks agreeing on one number is the property worth having.

## What is deliberately not touched

`public-metadata.yml` selects the latest tag matching `^v[0-9]+\.[0-9]+\.[0-9]+$`, so it keeps comparing the repository description against v4.17.0 and is undisturbed by this tag. Correct: the description describes the current release, and an rc is not one.

`docs/release-claims.json` still binds its facts to v4.17.0. The 608 count it asserts reproduces at that tag and at HEAD; nothing here contradicts it, and re-pointing a claims manifest at a prerelease would make it describe something nobody should cite.

## Verification

`testing/` + `tests/`: **811 passed, 492 subtests.** `count_tests` 608, `verify_release_claims` 6/6, catalog `--check`, OWASP validator, `ruff F821` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)