### PR TITLE
fix: a dirty tree means modified source, not build output

### DIFF
--- a/scripts/build_provenance.py
+++ b/scripts/build_provenance.py
@@ -117,7 +117,19 @@ def build(dist: Path, source_date: str | None = None) -> dict:
         "source": {
             "commit": os.environ.get("GITHUB_SHA") or git("rev-parse", "HEAD"),
             "ref_name": os.environ.get("GITHUB_REF_NAME") or git("describe", "--tags", "--exact-match"),
-            "tree_is_dirty": bool(git("status", "--porcelain")),
+            # `--untracked-files=no` is load-bearing, and v4.18.0rc1 is why.
+            #
+            # This asked `git status --porcelain`, which reports untracked files.
+            # By the time this script runs, `python -m build` has already created
+            # `dist/`, `*.egg-info/` and `build/`, and the workflow has written
+            # `build-environment.txt`. So every CI build looked dirty, and the
+            # verifier correctly refused a statement that was correctly produced.
+            # The rehearsal failed at the step it was cut to exercise.
+            #
+            # The question this field exists to answer is whether the SOURCE
+            # differs from the commit being claimed. Build output is not source,
+            # and a release build always has some.
+            "tree_is_dirty": bool(git("status", "--porcelain", "--untracked-files=no")),
         },
         "build_environment": {
             "python": sys.version.split()[0],

--- a/testing/test_release_provenance.py
+++ b/testing/test_release_provenance.py
@@ -73,6 +73,52 @@ class TestTheStatement(unittest.TestCase):
         self.assertIsNone(tools["definitely-not-installed"])
 
 
+class TestTheDirtyTreeQuestion(unittest.TestCase):
+    """`tree_is_dirty` must mean modified SOURCE, not build output.
+
+    v4.18.0rc1 failed on this and nothing in the unit tests could have caught it,
+    because they build synthetic dists in a temp directory and never run
+    `python -m build` in the repository. In CI the real build had already created
+    `dist/`, `*.egg-info/` and `build-environment.txt` before this script ran, so
+    `git status --porcelain` reported untracked files, every CI build looked
+    dirty, and the verifier correctly refused a statement that was correctly
+    produced.
+
+    Tested against a throwaway repository rather than this one, so the assertion
+    does not depend on whether the working tree happens to be clean right now.
+    """
+
+    def setUp(self):
+        import subprocess as sp
+        import tempfile
+        self.repo = Path(tempfile.mkdtemp())
+        run = lambda *a: sp.run(a, cwd=self.repo, capture_output=True, check=True)
+        run("git", "init", "-q", ".")
+        (self.repo / "tracked.txt").write_text("source\n")
+        run("git", "add", "tracked.txt")
+        run("git", "-c", "user.email=t@t", "-c", "user.name=t",
+            "commit", "-qm", "init")
+
+    def _dirty(self) -> bool:
+        return bool(build_provenance.git(
+            "status", "--porcelain", "--untracked-files=no", cwd=self.repo))
+
+    def test_untracked_build_output_does_not_make_the_tree_dirty(self):
+        (self.repo / "build-environment.txt").write_text("x\n")
+        (self.repo / "dist").mkdir()
+        (self.repo / "dist" / "pkg.whl").write_text("x\n")
+        self.assertFalse(self._dirty(),
+                         "build output was counted as a modified source tree; "
+                         "this is the defect that failed v4.18.0rc1")
+
+    def test_a_modified_tracked_file_does_make_the_tree_dirty(self):
+        """The positive control. A check that never fires is not a check."""
+        (self.repo / "tracked.txt").write_text("source, edited\n")
+        self.assertTrue(self._dirty(),
+                        "a modified tracked file was not reported; the dirty-tree "
+                        "check cannot detect the thing it exists for")
+
+
 class TestTheVerifier(unittest.TestCase):
     """The verifier has to be able to fail. A checker that always passes is not one."""
 
@@ -201,10 +247,18 @@ class TestTheScriptsRunAsCommands(unittest.TestCase):
         """The positive control. A verifier that refuses everything is not one."""
         import tempfile
         tmp = Path(tempfile.mkdtemp())
+        # GITHUB_REF_NAME is pinned to a tag that cannot exist. Left unset,
+        # `build_provenance.py` falls back to `git describe --exact-match` and
+        # picks up whatever tag this working copy happens to sit on -- which it
+        # did, the moment v4.18.0rc1 was cut on this commit. The verifier then
+        # correctly reported that the real tag disagrees with the fake SHA below.
+        # A fixture that reads the surrounding repository is testing the
+        # repository.
         ci = {"GITHUB_RUN_ID": "424242", "GITHUB_RUN_ATTEMPT": "1",
               "GITHUB_REPOSITORY": "msaleme/red-team-blue-team-agent-fabric",
               "GITHUB_WORKFLOW": "Publish to PyPI",
               "GITHUB_SERVER_URL": "https://github.com",
+              "GITHUB_REF_NAME": "v0.0.0-not-a-real-tag",
               "GITHUB_SHA": "d" * 40, "GITHUB_EVENT_NAME": "release"}
         out = self._build(tmp, ci)
         statement = json.loads(out.read_text())


### PR DESCRIPTION
**v4.18.0rc1 failed at exactly the step it was cut to exercise**, which is the outcome a rehearsal is for.

The build succeeded. Sigstore attested the artifacts. The statement was written. Then the pre-publish verification refused it:

```text
[PASS] schema agent-security-harness/release-provenance/v1
[FAIL] built from a dirty tree at 2a8abab7cf08; not a release build
[PASS] CI run msaleme/red-team-blue-team-agent-fabric #33407869300 attempt 1
[PASS] tag v4.18.0rc1 resolves to the stated commit
```

## The statement was correct and the check was wrong

`git status --porcelain` reports **untracked** files. By the time this script runs, `python -m build` has created `dist/`, `*.egg-info/` and `build/`, and the workflow has written `build-environment.txt`.

So **every CI build looked dirty.** A release build always has build output — that is what makes it a build.

The question the field exists to answer is whether the *source* differs from the commit being claimed, so it now asks `--untracked-files=no`.

## Why no test caught it

The unit tests build synthetic distributions in a temp directory and never run `python -m build` in a repository, so the condition never arose. My fixtures could not falsify my assumption.

`TestTheDirtyTreeQuestion` creates a throwaway git repository and asserts **both** directions:

- untracked build output → **not** dirty
- a modified tracked file → dirty (the positive control; a check that never fires is not a check)

It uses a throwaway repo rather than this one, so the assertion does not depend on whether the working tree happens to be clean when it runs.

## A second fixture defect surfaced with it

`test_a_statement_built_inside_ci_is_accepted` left `GITHUB_REF_NAME` unset, so `build_provenance.py` fell back to `git describe --exact-match` and picked up whatever tag the working copy sat on. The moment `v4.18.0rc1` existed on this commit, the verifier correctly reported that the real tag disagreed with the fixture's fake SHA.

The ref is now pinned to a tag that cannot exist. **That is the second time today a test here was reading its surroundings instead of its subject** — the first was asserting "no CI identity" and passing on a laptop for that reason alone.

## Rehearsed locally before re-cutting

Built the real distributions, ran `build_provenance.py` with build output present on a clean tree, and ran the exact step that failed:

```text
[PASS] commit 86302b9a20df, clean tree
[PASS] CI run msaleme/red-team-blue-team-agent-fabric #999 attempt 1
all checks passed
```

`testing/` + `tests/`: **813 passed, 492 subtests.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)