### PR TITLE
fix: a tag must name the version it ships

### DIFF
--- a/scripts/verify_release_provenance.py
+++ b/scripts/verify_release_provenance.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
 import sys
 import urllib.request
@@ -74,6 +75,26 @@ def check(statement: dict, offline: bool) -> list[str]:
         ok(f"CI run {ci.get('repository')} #{ci['run_id']} attempt {ci.get('run_attempt')}")
 
     ref = src.get("ref_name")
+
+    # v4.18.0rc2 is why this exists. The tag was cut, pyproject.toml was never
+    # bumped from 4.18.0rc1, and the whole pipeline -- build, attestation,
+    # offline verification, PyPI upload, release assets, post-publish digest
+    # comparison -- passed while publishing a version whose name did not match
+    # its tag. Every check agreed, because none of them compared those two
+    # things.
+    #
+    # A tag is the name a release is referred to by. If it names a version the
+    # artifact does not carry, every later citation of that tag points at
+    # something else.
+    if ref and re.fullmatch(r"v\d+.*", ref or ""):
+        tagged = ref[1:]
+        if tagged != version:
+            bad(f"tag {ref} does not match the packaged version {version}; "
+                f"the artifact would be published as {version} under a tag "
+                f"naming {tagged}")
+        else:
+            ok(f"tag {ref} matches the packaged version")
+
     if ref:
         try:
             resolved = subprocess.run(("git", "rev-list", "-n", "1", ref),

--- a/testing/test_release_provenance.py
+++ b/testing/test_release_provenance.py
@@ -151,6 +151,35 @@ class TestTheVerifier(unittest.TestCase):
         failures = verify_release_provenance.check(self.st, offline=True)
         self.assertTrue(any("unknown schema" in f for f in failures), failures)
 
+    def test_a_tag_naming_a_different_version_fails(self):
+        """v4.18.0rc2 shipped 4.18.0rc1 and every check passed.
+
+        The tag was cut, pyproject.toml was never bumped, and build, attestation,
+        offline verification, PyPI upload, release assets and the post-publish
+        digest comparison all agreed -- because none of them compared the tag to
+        the version. A tag is the name a release is cited by; if it names a
+        version the artifact does not carry, every later citation points at
+        something else.
+        """
+        self.st["source"]["ref_name"] = "v9.9.10"      # artifacts are 9.9.9
+        failures = verify_release_provenance.check(self.st, offline=True)
+        self.assertTrue(any("does not match the packaged version" in f
+                            for f in failures), failures)
+
+    def test_a_tag_naming_the_shipped_version_passes(self):
+        """The positive control. This must not reject a correct release."""
+        self.st["source"]["ref_name"] = "v9.9.9"
+        failures = [f for f in verify_release_provenance.check(self.st, offline=True)
+                    if "packaged version" in f]
+        self.assertEqual(failures, [])
+
+    def test_a_non_version_ref_is_not_checked_against_the_version(self):
+        """A branch name is not a claim about the version, so it is not one to break."""
+        self.st["source"]["ref_name"] = "main"
+        failures = [f for f in verify_release_provenance.check(self.st, offline=True)
+                    if "packaged version" in f]
+        self.assertEqual(failures, [])
+
     def test_a_statement_with_no_commit_fails(self):
         self.st["source"]["commit"] = None
         failures = verify_release_provenance.check(self.st, offline=True)
@@ -247,18 +276,24 @@ class TestTheScriptsRunAsCommands(unittest.TestCase):
         """The positive control. A verifier that refuses everything is not one."""
         import tempfile
         tmp = Path(tempfile.mkdtemp())
-        # GITHUB_REF_NAME is pinned to a tag that cannot exist. Left unset,
-        # `build_provenance.py` falls back to `git describe --exact-match` and
-        # picks up whatever tag this working copy happens to sit on -- which it
-        # did, the moment v4.18.0rc1 was cut on this commit. The verifier then
-        # correctly reported that the real tag disagrees with the fake SHA below.
-        # A fixture that reads the surrounding repository is testing the
+        # GITHUB_REF_NAME is pinned, and pinned to the version the synthetic
+        # dist actually carries. Two reasons, both learned the hard way:
+        #
+        # Left unset, `build_provenance.py` falls back to
+        # `git describe --exact-match` and picks up whatever tag this working
+        # copy sits on -- which it did, the moment v4.18.0rc1 was cut on this
+        # commit. A fixture that reads the surrounding repository is testing the
         # repository.
+        #
+        # Pinned to a placeholder like `v0.0.0-not-a-real-tag`, it then failed
+        # the tag-matches-version check added after v4.18.0rc2 shipped 4.18.0rc1.
+        # The check was right; a positive control has to be positive in every
+        # respect, not only the one under test.
         ci = {"GITHUB_RUN_ID": "424242", "GITHUB_RUN_ATTEMPT": "1",
               "GITHUB_REPOSITORY": "msaleme/red-team-blue-team-agent-fabric",
               "GITHUB_WORKFLOW": "Publish to PyPI",
               "GITHUB_SERVER_URL": "https://github.com",
-              "GITHUB_REF_NAME": "v0.0.0-not-a-real-tag",
+              "GITHUB_REF_NAME": "v9.9.9",   # matches _dist()
               "GITHUB_SHA": "d" * 40, "GITHUB_EVENT_NAME": "release"}
         out = self._build(tmp, ci)
         statement = json.loads(out.read_text())


### PR DESCRIPTION
The second thing the v4.18.0rc2 rehearsal found, and the more interesting one.

## What happened

rc2 was cut without bumping `pyproject.toml` from `4.18.0rc1`. **The whole pipeline passed** — build, Sigstore attestation, the pre-publish offline verification, PyPI trusted publishing, four release assets, and the post-publish digest comparison against what PyPI actually served.

Every check agreed. And the release tagged `v4.18.0rc2` shipped an artifact called **`4.18.0rc1`**.

None of them compared those two things. `verify_release_claims.py` already binds a tag to a **commit** — that is how the v4.17.0 manifest defect was caught. Nothing bound a tag to a **version**.

## Why it matters more than it looks

A tag is the name a release is cited by. If it names a version the artifact does not carry, every later citation of that tag points at something else.

**The attestation makes this worse, not better.** It faithfully binds a correctly-built `4.18.0rc1` to `refs/tags/v4.18.0rc2` — verified, signed, and wrong about which release it is. A strong identity claim over a mislabelled subject is harder to catch than a weak one, not easier.

## The check

The verifier now compares them when the ref looks like a version tag, and leaves a branch name alone — a branch is not a claim about the version, so it is not one to break.

Three tests, because the check has to be able to be **right** as well as wrong:

- a mismatched tag fails
- a matching tag passes
- a non-version ref is not compared

The real rehearsal statement is replayed through it and does fail.

## Aligning the fixture was itself instructive

The end-to-end fixture had been pinned to `v0.0.0-not-a-real-tag` to stop it reading the surrounding repository — and that placeholder now fails the new check, correctly. **A positive control has to be positive in every respect, not only in the one under test.**

That is the third fixture defect in this file today, all the same shape: a test asserting something about its environment rather than its subject.

`testing/` + `tests/`: **816 passed, 492 subtests.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)