### PR TITLE
release: v4.18.0 — INCONCLUSIVE became a field, and the read-list emptied

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you cite this work in research, please use this metadata."
 title: "Agent Security Harness"
-version: "4.18.0rc1"
+version: "4.18.0"
 abstract: "Multi-protocol agent security testing framework. 608 executable security tests across 43 test-bearing modules covering MCP, A2A, L402, and x402 wire protocols. Decision-layer attack scenarios, AIUC-1 pre-certification mapping, NIST AI 800-2 aligned."
 type: software
 authors:

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Results: 8/10 passed (80% pass rate) - see report.json
 > servicing the request, reports **INCONCLUSIVE** — never PASS. See
 > [v4.13.1](CHANGELOG.md) for why that distinction is enforced rather than assumed.
 
-608 executable security tests across 43 test-bearing modules on `main` (verified 2026-08-30 via `scripts/count_tests.py`; the v4.17.0 release carries 608). MCP + A2A + L402 + x402 wire-protocol testing, plus UCP/ACP merchant-journey, AP2 mandate-chain, Fireblocks x402 hardening, Visa TAP / Mastercard Agentic Token funding-instrument, and denial-of-settlement finality conformance across the full agentic-payments stack. Decision-layer attack scenarios. One `pip install` away.
+608 executable security tests across 43 test-bearing modules on `main` (verified 2026-08-30 via `scripts/count_tests.py`; the v4.18.0 release carries 608). MCP + A2A + L402 + x402 wire-protocol testing, plus UCP/ACP merchant-journey, AP2 mandate-chain, Fireblocks x402 hardening, Visa TAP / Mastercard Agentic Token funding-instrument, and denial-of-settlement finality conformance across the full agentic-payments stack. Decision-layer attack scenarios. One `pip install` away.
 
 If this evidence discipline is useful in your agent-security work, **star this
 repository to follow releases**.
@@ -307,10 +307,10 @@ modification · v4.6–v4.9 payment-stack depth (AP2 mandate chain, UCP/ACP merc
 agentic tokens, settlement finality, Fireblocks x402) · v4.10 benchmark integrity · v4.11–v4.12
 decision-governance corpus currency and provenance repair · **v4.13 OWASP Agentic v1.1 T1–T17 coverage
 mapping and the human-in-the-loop harness** · v4.13.1 a correctness fix to that harness · v4.14.0
-endpoint provenance · v4.16.0 three target shapes: a verdict must be able to be wrong AND to be right · **v4.17.0 eight modules could not tell a refusal from a compliance** · v4.15.0 unserviced requests are no longer recorded as passes (see
+endpoint provenance · v4.16.0 three target shapes: a verdict must be able to be wrong AND to be right · v4.17.0 eight modules could not tell a refusal from a compliance · **v4.18.0 INCONCLUSIVE became a field, and the read-list emptied** · v4.15.0 unserviced requests are no longer recorded as passes (see
 [CHANGELOG.md](CHANGELOG.md)).
 
-The release carries **608** tests; `main` is at **608**. They agree at v4.17.0 because the tag was cut
+The release carries **608** tests; `main` is at **608**. They agree at v4.18.0 because the tag was cut
 from `main` with no test added or removed since. They do not always agree: at v4.15.0 the release carried
 603 while `main` was at 608, the difference being MAG-019, MEM-011, MEM-012, X4-056 and X4-057, all
 landing after the tag. Both numbers were correct for their own ref, which is why

--- a/docs/OWASP-AGENTIC-T1-T15-SUBMISSION-COVERAGE.md
+++ b/docs/OWASP-AGENTIC-T1-T15-SUBMISSION-COVERAGE.md
@@ -11,7 +11,7 @@
 | Report view | Submission (T1–T15) |
 | Report version | 1.0 |
 | Project | Agent Security Harness |
-| Harness version | `4.18.0rc1` |
+| Harness version | `4.18.0` |
 | Assessed commit | [`8d8bc08933637381a32fc32041f139d34eb6271f`](https://github.com/msaleme/red-team-blue-team-agent-fabric/commit/8d8bc08933637381a32fc32041f139d34eb6271f) |
 | Assessed at | 2026-08-02T18:30:00Z |
 | Repository tests | 608 (`python scripts/count_tests.py`) |

--- a/docs/OWASP-AGENTIC-V1.1-COVERAGE.md
+++ b/docs/OWASP-AGENTIC-V1.1-COVERAGE.md
@@ -9,7 +9,7 @@
 | Report view | Complete (T1–T17) |
 | Report version | 1.0 |
 | Project | Agent Security Harness |
-| Harness version | `4.18.0rc1` |
+| Harness version | `4.18.0` |
 | Assessed commit | [`8d8bc08933637381a32fc32041f139d34eb6271f`](https://github.com/msaleme/red-team-blue-team-agent-fabric/commit/8d8bc08933637381a32fc32041f139d34eb6271f) |
 | Assessed at | 2026-08-02T18:30:00Z |
 | Repository tests | 608 (`python scripts/count_tests.py`) |

--- a/docs/coverage/owasp-agentic-v1.1.json
+++ b/docs/coverage/owasp-agentic-v1.1.json
@@ -34,7 +34,7 @@
   "assessment": {
     "project": "Agent Security Harness",
     "repository": "https://github.com/msaleme/red-team-blue-team-agent-fabric",
-    "harness_version": "4.18.0rc1",
+    "harness_version": "4.18.0",
     "git_commit": "8d8bc08933637381a32fc32041f139d34eb6271f",
     "assessed_at": "2026-08-02T18:30:00Z",
     "reverified_at": "2026-08-03T01:05:00Z",

--- a/docs/coverage/owasp-agentic-v1.1.yaml
+++ b/docs/coverage/owasp-agentic-v1.1.yaml
@@ -52,7 +52,7 @@ framework:
 assessment:
   project: Agent Security Harness
   repository: https://github.com/msaleme/red-team-blue-team-agent-fabric
-  harness_version: "4.18.0rc1"
+  harness_version: "4.18.0"
   git_commit: "8d8bc08933637381a32fc32041f139d34eb6271f"
   assessed_at: '2026-08-02T18:30:00Z'
   reverified_at: '2026-08-03T01:05:00Z'

--- a/docs/release-claims.json
+++ b/docs/release-claims.json
@@ -5,12 +5,12 @@
   "claims": [
     {
       "id": "release-test-count",
-      "fact": "The v4.17.0 release carries 608 unique test IDs.",
+      "fact": "The v4.18.0 release carries 608 unique test IDs.",
       "value": "608",
-      "release_tag": "v4.17.0",
+      "release_tag": "v4.18.0",
       "command": "python3 scripts/count_tests.py",
       "value_extraction": "Definitive count:\\s*(\\d+)",
-      "generated_on": "2026-08-30",
+      "generated_on": "2026-08-31",
       "coverage_report_revision": null,
       "evidence_class": "E1",
       "independence_level": "I0",
@@ -18,7 +18,7 @@
       "surfaces": [
         {
           "path": "README.md",
-          "pattern": "the v4\\.17\\.0 release carries (\\d+)"
+          "pattern": "the v4\\.18\\.0 release carries (\\d+)"
         },
         {
           "path": "README.md",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-security-harness"
-version = "4.18.0rc1"
+version = "4.18.0"
 description = "608 security tests for AI agent systems - MCP, A2A, L402, x402, UCP/ACP merchant-journey, AP2 mandate + Fireblocks x402 hardening + Visa TAP / Mastercard Agentic Tokens + denial-of-settlement finality, decision governance, AIUC-1 compliance, NIST AI 800-2 aligned"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {text = "Apache-2.0"}

--- a/scripts/verify_release_claims.py
+++ b/scripts/verify_release_claims.py
@@ -141,9 +141,33 @@ def check_tag_binds_commit(claim: dict) -> tuple[str, str, str] | None:
 
 def regenerate(claim: dict) -> tuple[str, str, str]:
     """Re-run the declared command at the declared revision and compare."""
-    rev = claim.get("commit") or (claim.get("release_tag") and
-                                  tag_commit(claim["release_tag"])) or "HEAD"
-    label = f"{claim['id']} regenerate @ {claim.get('release_tag') or rev[:12]}"
+    # A declared tag that cannot be resolved must NOT fall through to HEAD.
+    #
+    # It did. `claim.get("commit") or (tag and tag_commit(tag)) or "HEAD"` makes
+    # the middle term None when the tag is absent, so the command ran against
+    # HEAD while the label still read `regenerate @ v4.18.0`, and the run
+    # reported "reproduced 608 @ v4.18.0" for a tag that did not exist.
+    #
+    # That is the same defect this function's own docstring describes one level
+    # up: the number is right and the provenance is false. Found 2026-08-31
+    # while pointing this manifest at v4.18.0 before the tag was cut, where it
+    # was harmless because HEAD was about to become that tag. A typo'd tag name,
+    # or one that was deleted, would have been silently mislabelled instead.
+    tag = claim.get("release_tag")
+    declared_commit = claim.get("commit")
+    label = f"{claim['id']} regenerate @ {tag or (declared_commit or 'HEAD')[:12]}"
+
+    if declared_commit:
+        rev = declared_commit
+    elif tag:
+        rev = tag_commit(tag)
+        if rev is None:
+            return (SKIP, label, (
+                f"tag {tag} is not present in this clone, so nothing was "
+                f"regenerated at it. The value was NOT reproduced; this is not a "
+                f"claim about {tag}."))
+    else:
+        rev = "HEAD"
 
     if not _revision_available(rev):
         return (SKIP, label, (

--- a/testing/test_release_claims.py
+++ b/testing/test_release_claims.py
@@ -37,6 +37,8 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
+import verify_release_claims  # noqa: E402
+
 MANIFEST_PATH = REPO_ROOT / "docs" / "release-claims.json"
 
 REQUIRED_FIELDS = {
@@ -116,3 +118,34 @@ class TestReleaseClaimsManifest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+class TestAnUnresolvableTagIsNotSilentlyHead(unittest.TestCase):
+    """A declared tag that does not exist must SKIP, never regenerate at HEAD.
+
+    `regenerate()` resolved `commit or (tag and tag_commit(tag)) or "HEAD"`, so
+    an absent tag made the middle term falsy and the command ran against HEAD --
+    while the label still read `regenerate @ <tag>`. The run then reported
+    "reproduced 608 @ v4.18.0" for a tag that did not exist.
+
+    Same defect as the one this manifest was built to catch, one level up: the
+    number is right and the provenance is false.
+    """
+
+    def test_a_missing_tag_skips_and_says_it_reproduced_nothing(self):
+        claim = {"id": "synthetic", "release_tag": "v0.0.0-no-such-tag",
+                 "command": "python3 scripts/count_tests.py",
+                 "value": "608", "value_extraction": r"Definitive count:\s*(\d+)"}
+        status, label, detail = verify_release_claims.regenerate(claim)
+        self.assertEqual(status, verify_release_claims.SKIP, f"{label}: {detail}")
+        self.assertIn("NOT reproduced", detail)
+        self.assertIn("v0.0.0-no-such-tag", label)
+
+    def test_a_claim_with_no_tag_still_regenerates_at_head(self):
+        """The positive control. Main-branch claims must keep working."""
+        claim = {"id": "synthetic-head",
+                 "command": "python3 scripts/count_tests.py",
+                 "value": None, "value_extraction": r"Definitive count:\s*(\d+)"}
+        status, label, _ = verify_release_claims.regenerate(claim)
+        self.assertIn("HEAD", label)
+        self.assertNotEqual(status, verify_release_claims.SKIP)
+


### PR DESCRIPTION
Version bumped across the four surfaces that declare it, coverage reports regenerated from the mapping, release claims repointed at v4.18.0.

## A third defect, found while pointing the manifest at the new tag

`verify_release_claims.regenerate()` resolved:

```python
claim["commit"] or (tag and tag_commit(tag)) or "HEAD"
```

An unresolvable tag makes the middle term falsy, so the command ran **against HEAD** while the label still read `regenerate @ v4.18.0`. The run reported *"reproduced 608 @ v4.18.0"* for a tag that did not exist.

That is the same defect this function's own docstring describes one level up, and the same one the independent review found in the v4.17.0 manifest: **the number is right and the provenance is false.** It was harmless here only because HEAD was about to become that tag — a typo'd or deleted tag would have been mislabelled in silence.

An unresolvable tag now SKIPs and says plainly that nothing was regenerated at it. Two tests: a missing tag skips and reports NOT reproduced, and a claim with no tag still regenerates at HEAD — the positive control, because a check that skips everything is not a check.

## Release contents since v4.17.0

- **INCONCLUSIVE is a machine-readable field** on every result class. An unexercised control and a failed one were both `passed: false`, separable only by parsing English. `PREFIX_ONLY` 21 → 0.
- **The UNREAD read-list emptied.** `cbrn_harness`, `harmful_output_harness`, `advanced_attacks` read and repaired — eleven verdicts had passed against an agent that simply complied, and three passed identically against agents that complied *and* refused. Permissive passes 68 → 54.
- **The external implementer is named**, with consent granted in #304.
- **The catalog check compares the whole catalog**, not its ID column, which had let 69% of rows drift while CI reported PASS.
- **Release provenance**: a statement binding digests to commit/tag/run/toolchain, a Sigstore attestation over those digests, four assets on the Release, and verification before and after publishing.

## Rehearsed twice before this tag

rc1 and rc2 exercised a path that had never run.

| | Found |
|---|---|
| **rc1** | the dirty-tree check counted build output as modified source, so every CI build looked dirty |
| **rc2** | published `4.18.0rc1` under a tag named `v4.18.0rc2` — nothing compared a tag to the version it ships |

Both fixed, both with regression tests. The second check is what will confirm this tag before it publishes.

## Verification

`testing/` + `tests/`: **818 passed, 492 subtests.** `count_tests` 608, catalog `--check`, OWASP validator, `ruff F821` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)