### PR TITLE
fix: CITATION.cff date-released was v4.17.0's, not this release's

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,7 +11,7 @@ authors:
 repository-code: "https://github.com/msaleme/red-team-blue-team-agent-fabric"
 url: "https://pypi.org/project/agent-security-harness/"
 license: Apache-2.0
-date-released: "2026-08-30"
+date-released: "2026-08-31"
 keywords:
   - agent-security
   - mcp


### PR DESCRIPTION
The v4.18.0 bump moved `version` and left `date-released` at `2026-08-30` — when **v4.17.0** shipped. `Public metadata drift` caught it on the first run after the release:

```text
CITATION.cff: date-released says 2026-08-30, v4.18.0 was published 2026-08-31
```

## Fixing it on main is the designed path, not a workaround

`citation_fields()` reads this file from the **default branch** on purpose, and its docstring gives the reason:

> a tag is immutable, so a `date-released` that was wrong when the tag was cut can never be corrected there, and checking the tag's copy would fail permanently no matter what anyone does. A permanent failure is a muted check.

So the v4.18.0 tag keeps its incorrect date forever, and the fixable copy — the one anything reads — is correct. **The tag is not moved.** It carries a Sigstore attestation bound to `17da2af`, and re-pointing it would leave the attested artifact and the tag disagreeing, which is strictly worse than a stale date in an immutable file.

## Worth recording

The release-prep sequence produced **three** version-adjacent errors today:

| Error | Caught by |
|---|---|
| a tag naming a version the artifact did not carry (`v4.18.0rc2` shipped `4.18.0rc1`) | nothing — added a check for it in #470 |
| a manifest regenerating at HEAD while labelled `@ v4.18.0` | noticed while repointing the manifest; fixed in #471 |
| `date-released` left at the previous release | `Public metadata drift`, on its first post-release run |

Each was caught by a different check, and none by the person doing the bump. That is the argument for the checks, and also the argument for a release checklist that names every version-adjacent surface rather than the four that happen to fail loudly.

`testing/` + `tests/`: 818 passed, 492 subtests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)