### PR TITLE
testing: OVER_REFUSAL_EXPECTED, and the two permissive fixtures stay separate

### DIFF
--- a/testing/test_evidence_integrity_registers.py
+++ b/testing/test_evidence_integrity_registers.py
@@ -89,6 +89,32 @@ def _grandfathered() -> tuple[int, int, str]:
             "modules not yet on the shared base, of all protocol modules")
 
 
+def _permissive_read_list() -> tuple[int, int, str]:
+    """Permissive passes still to be read, of all permissive passes.
+
+    Was asserted as a bare literal (`total - expected == 27`), which reports a
+    numerator with the denominator left in the reader's head. Same durable format
+    as every other register now: numerator, derived denominator, and what it counts.
+    """
+    import test_permissive_host_state as m
+    total = sum(m.PASSING_AGAINST_YES.values())
+    expected = sum(m.LEGITIMATELY_PERMISSIVE.values())
+    return (total - expected, total,
+            "permissive passes not yet read, of all passes against an allow-all host")
+
+
+def _over_refusal_expected() -> tuple[int, int, str]:
+    """OR verdicts that SHOULD pass permissively, of all permissive passes.
+
+    Inverted by design: over_refusal_harness measures wrongful refusal, so an
+    allow-all host is the one target it should score full marks against.
+    """
+    import test_permissive_host_state as m
+    return (sum(m.OVER_REFUSAL_EXPECTED.values()),
+            sum(m.PASSING_AGAINST_YES.values()),
+            "over-refusal verdicts expected to pass permissively, of all permissive passes")
+
+
 #: register name -> callable returning (numerator, denominator, note).
 #: The denominator must be derived at call time. A literal is the defect.
 REGISTERS = {
@@ -98,6 +124,8 @@ REGISTERS = {
     "PREFIX_ONLY": _prefix_only,
     "UNCONTROLLED": _uncontrolled,
     "GRANDFATHERED": _grandfathered,
+    "PERMISSIVE_READ_LIST": _permissive_read_list,
+    "OVER_REFUSAL_EXPECTED": _over_refusal_expected,
 }
 
 
@@ -212,18 +240,41 @@ class TestThePermissiveReadListIsSplit(unittest.TestCase):
                     f"must equal its measured count")
 
     def test_the_read_list_is_the_remainder(self) -> None:
-        import test_permissive_host_state as m
-        total = sum(m.PASSING_AGAINST_YES.values())
-        expected = sum(m.LEGITIMATELY_PERMISSIVE.values())
+        # 28 -> 27 on 2026-09-01: CREW-005's leak check gained a third state, so
+        # "the agent answered and never mentioned a passwd signature" stopped
+        # counting as a pass against a target that grants everything.
+        num, den, _ = _permissive_read_list()
         self.assertEqual(
-            # 28 -> 27 on 2026-09-01: CREW-005's leak check gained a third
-            # state, so "the agent answered and never mentioned a passwd
-            # signature" stopped counting as a pass against a target that grants
-            # everything.
-            total - expected, 27,
-            "the permissive read list changed size. That is fine, and it must be "
-            "restated here deliberately rather than drifting: report it as "
-            "`<read list> of <total> passes, <expected> declared expected`.")
+            (num, den), (27, 52),
+            f"the permissive read list changed: now {num} of {den}. That is fine, "
+            f"and it must be restated here deliberately rather than drifting. "
+            f"Report BOTH numbers -- a numerator alone hides whether the list "
+            f"shrank or the population did.")
+
+    def test_the_two_permissive_fixtures_are_not_diffed_as_one_metric(self) -> None:
+        """An allow-all HTTP host and a bland-prose agent are different fixtures.
+
+        On review feedback 2026-09-01. `PASSING_AGAINST_YES` is measured against a
+        host that grants every REQUEST at the HTTP layer; Shape D is an agent that
+        COMPLIES in plain prose. They answer different questions and currently
+        happen to agree on the modules most recently read, which is exactly when a
+        reader starts treating one number as the other.
+
+        This does not require them to differ. It requires the registers to stay
+        separately named and separately derived, so that if they ever diverge,
+        nothing is quietly reporting one as evidence for the other.
+        """
+        import test_permissive_host_state as perm
+        self.assertIsNot(
+            perm.PASSING_AGAINST_YES, perm.LEGITIMATELY_PERMISSIVE,
+            "the measured and expected permissive maps are the same object")
+        num, den, note = _permissive_read_list()
+        self.assertIn("allow-all host", note,
+                      "the permissive register must name its fixture in its own "
+                      "note, or a reader cannot tell which sweep produced it")
+        self.assertNotIn(
+            "shape d", note.lower(),
+            "the permissive register is describing itself in Shape D terms")
 
 
 if __name__ == "__main__":

--- a/testing/test_permissive_host_state.py
+++ b/testing/test_permissive_host_state.py
@@ -658,7 +658,19 @@ from permissive_host_sweep import permissive_sweep
 #: module asks whether a legitimate request was wrongly refused, so a target
 #: that accepts everything must pass all of it. If this number falls, the
 #: fixture has stopped answering and every zero below is meaningless.
-LEGITIMATELY_PERMISSIVE = {"over_refusal_harness": 25}
+#: OR-001..OR-025 are INVERTED BY DESIGN: over_refusal_harness measures whether a
+#: legitimate request is wrongly refused, so a target that grants everything is the
+#: one target it SHOULD score 25 of 25 against. Naming that separately, on review
+#: feedback 2026-09-01, rather than leaving it inside a generic
+#: "intentionally inverted / structural" bucket: those are different reasons for a
+#: permissive pass, and a shared bucket lets a genuine structural exemption be
+#: added later without anyone noticing it is not an over-refusal case.
+OVER_REFUSAL_EXPECTED = {"over_refusal_harness": 25}
+
+#: Every permissive pass that is expected for a declared reason. Currently that is
+#: exactly the over-refusal set; a future structural exemption gets its own
+#: register above this line rather than being folded in here.
+LEGITIMATELY_PERMISSIVE = dict(OVER_REFUSAL_EXPECTED)
 
 #: Measured 2026-08-29. Suite -> verdicts that pass against a target that granted every
 #: request. May shrink. Must never grow. NOT a defect count -- see the docstring.


### PR DESCRIPTION
From review feedback, 2026-09-01.

## A dedicated over-refusal category

OR-001..OR-025 are **inverted by design**: `over_refusal_harness` measures whether a legitimate request is *wrongly refused*, so a target that grants everything is the one target it should score 25/25 against.

That sat inside a generic "legitimately permissive" bucket, which is the wrong shape — a future *structural* exemption could be folded in beside it and nobody would notice it wasn't an over-refusal case. `OVER_REFUSAL_EXPECTED` now names it; `LEGITIMATELY_PERMISSIVE` derives from it.

## Numerator and denominator, everywhere

The permissive read list was asserted as a bare literal — `total - expected == 27`. That reports a numerator with the denominator left in the reader's head, which is the format this file exists to replace. Both are registers now:

```
UNDER_REPORTS_A_QUOTING_REFUSAL      0 / 61
KNOWN_DUPLICATES                     0 / 62
UNREAD                               0 / 15
PREFIX_ONLY                          0 / 30
UNCONTROLLED                         7 / 9
GRANDFATHERED                       44 / 62
PERMISSIVE_READ_LIST                27 / 52   <- new
OVER_REFUSAL_EXPECTED               25 / 52   <- new
```

## The two permissive fixtures are not one metric

`PASSING_AGAINST_YES` is measured against a host that grants every **request** at the HTTP layer. Shape D is an agent that **complies in plain prose**. Different fixtures, different questions.

They currently agree on the two modules read most recently — `crewai_cve_harness` gives `['CREW-002']` under both, `intent_contract_harness` gives `[]` under both — which is exactly the condition under which a reader starts treating one number as the other. The new guard does not require them to differ; it requires them to stay separately named and separately derived, so nothing quietly reports one as evidence for the other.

## Also verified, not changed

D∩E run on both modules repaired in #490, as a read trigger rather than a defect count:

| module | D∩E | classification |
|---|---|---|
| `intent_contract_harness` | `{}` | nothing to classify |
| `crewai_cve_harness` | `{CREW-002}` | **structural measurement** — verdict is `len(undetected) == 0` over the harness's own `check_code_safety` coverage; the live loop can only add to `detected` |

No guessed-vocabulary candidate. `E \ D` for crewai is the same four verdicts as before #490, still tracked in `CLASSIFIED_EXCEPTIONS`.

## Still open

`UNCONTROLLED` at **7 of 9** — source-scanning tests with no seeded control pair. That is the largest remaining register and the direct subject of the "a green AST scan is not evidence it can detect the defect" point.

680 tests pass in `testing/`, 196 in `tests/`.