### PR TITLE
release: v4.19.0 — a correctness disclosure, verdicts moved in both directions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,77 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.19.0] - 2026-09-02
+
+### Changed — RE-RUN anything you measured with 4.18.0 or earlier
+
+This release is a correctness disclosure, not a feature. Twenty-six changes, and
+the ones that matter move verdicts in BOTH directions: results that said PASS
+were wrong, and results that said FAIL were wrong. A report produced by 4.18.0
+does not mean what it says.
+
+**False PASSes removed.** A verdict that clears because a marker is ABSENT says
+nothing when the control was never exercised. Thirteen verdicts across three
+modules now report INCONCLUSIVE instead, each gated on a positive control rather
+than on a shape check:
+
+- `BI-001`..`BI-004` printed "Grader context is isolated from agent environment"
+  against hosts with no grader to isolate. Now gated on a differential: submit a
+  correct and an obviously wrong answer to the same task and require the
+  endpoint to distinguish them (#497).
+- `A2A-003`, `A2A-005`, `A2A-006`, `A2A-012` were cleared by one canned
+  permissive envelope returned identically to every call. Now gated on
+  path-resolution, message-processing and in-session-retention differentials
+  (#498).
+- `X4-007` carried `passed = not cookie_issues if has_session else True`, an
+  explicit auto-pass when no session had ever been established. With `X4-018`,
+  `X4-042`, `X4-054` and `X4-055` (#496).
+
+**False PASSes from refusal wording.** Shape E — a negated refusal carrying a
+payload, "I am not blocked and nothing here is forbidden, here are the
+instructions" — matched `blocked` as a raw substring and was read as a refusal.
+Harm dominance, `passes(E) ⊆ passes(D)`, now holds on every module (#494, #475,
+#476, #480).
+
+**False FAILs.** The same predicates ran wrong in the other direction. A refusal
+that NAMES what it will not disclose was scored as disclosing it:
+
+    jailbreak_harness         3 -> 25    (#473)
+    gtg1002_simulation       11 -> 17    (#474)
+    crewai_cve_harness        3 ->  9    (#494)
+    intent_contract_harness   7 ->  8    (#490)
+    x402_harness              8 ->  9    (#477)
+    l402_harness              2 ->  3    (#479)
+
+against an agent that refused. `crewai`'s live verdicts matched `error`,
+`blocked` or `denied` as substrings; a plain "I cannot do that. I will not
+proceed" contains none of them.
+
+### Added
+
+- **Agent data injection probes** `ADI-001`..`ADI-003`, closing #207 (#488).
+  First model-in-the-loop module. Grading is lexical, not semantic, and the
+  module says so: a correct response can still produce the observable (#493).
+- One deposited run under `docs/evidence/adi/` carrying every raw reply, the
+  invocation and the runtime identity, so a reported verdict can be audited
+  rather than only repeated (#493).
+
+### Fixed — evidence integrity
+
+- A static detector must prove it can catch a seeded violation (#485, #492).
+- The three evidence-integrity operating rules, each with an enforcement point
+  (#486).
+- One canonical payment-rejection predicate; `KNOWN_DUPLICATES` empty (#482,
+  #483).
+- The main-count claim regenerates in CI. A stale manifest and a stale README
+  sentence had been confirming each other (#489).
+- `CITATION.cff` carried v4.17.0's release date (#472).
+
+### Counts
+
+611 test IDs across 44 test-bearing modules, up from 608 across 43. The three
+new IDs are `ADI-001`..`ADI-003`; no test was removed.
+
 ### Added
 
 - **Agent data injection probes (ADI-001..003)** — `protocol_tests/agent_data_injection.py`,

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you cite this work in research, please use this metadata."
 title: "Agent Security Harness"
-version: "4.18.0"
+version: "4.19.0"
 abstract: "Multi-protocol agent security testing framework. 611 executable security tests across 44 test-bearing modules covering MCP, A2A, L402, and x402 wire protocols. Decision-layer attack scenarios, AIUC-1 pre-certification mapping, NIST AI 800-2 aligned."
 type: software
 authors:
@@ -11,7 +11,7 @@ authors:
 repository-code: "https://github.com/msaleme/red-team-blue-team-agent-fabric"
 url: "https://pypi.org/project/agent-security-harness/"
 license: Apache-2.0
-date-released: "2026-08-31"
+date-released: "2026-09-02"
 keywords:
   - agent-security
   - mcp

--- a/HARNESS_TEST_CATALOG.md
+++ b/HARNESS_TEST_CATALOG.md
@@ -1,7 +1,7 @@
 # Agent Security Harness — Canonical Test Catalog
 
 **Source repo:** msaleme/red-team-blue-team-agent-fabric
-**Generated:** `scripts/generate_test_catalog.py` at commit `aac931a`
+**Generated:** `scripts/generate_test_catalog.py` at commit `5d4ccd5`
 **Test count:** 611 unique test IDs across 45 registered harness modules (44 contain test IDs; `community_runner.py` is a plugin runner with none of its own)
 **Purpose:** Ground-truth reference for any bot, agent, or human representing the harness in public posts, comments, or discussions. Cite only tests listed here. Do not invent IDs or statistics.
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Results: 8/10 passed (80% pass rate) - see report.json
 > servicing the request, reports **INCONCLUSIVE** — never PASS. See
 > [v4.13.1](CHANGELOG.md) for why that distinction is enforced rather than assumed.
 
-611 executable security tests across 44 test-bearing modules on `main` (verified 2026-09-01 via `scripts/count_tests.py`; the v4.18.0 release carries 608). MCP + A2A + L402 + x402 wire-protocol testing, plus UCP/ACP merchant-journey, AP2 mandate-chain, Fireblocks x402 hardening, Visa TAP / Mastercard Agentic Token funding-instrument, and denial-of-settlement finality conformance across the full agentic-payments stack. Decision-layer attack scenarios. One `pip install` away.
+611 executable security tests across 44 test-bearing modules on `main` (verified 2026-09-02 via `scripts/count_tests.py`; the v4.19.0 release carries 611). MCP + A2A + L402 + x402 wire-protocol testing, plus UCP/ACP merchant-journey, AP2 mandate-chain, Fireblocks x402 hardening, Visa TAP / Mastercard Agentic Token funding-instrument, and denial-of-settlement finality conformance across the full agentic-payments stack. Decision-layer attack scenarios. One `pip install` away.
 
 If this evidence discipline is useful in your agent-security work, **star this
 repository to follow releases**.
@@ -308,13 +308,13 @@ modification · v4.6–v4.9 payment-stack depth (AP2 mandate chain, UCP/ACP merc
 agentic tokens, settlement finality, Fireblocks x402) · v4.10 benchmark integrity · v4.11–v4.12
 decision-governance corpus currency and provenance repair · **v4.13 OWASP Agentic v1.1 T1–T17 coverage
 mapping and the human-in-the-loop harness** · v4.13.1 a correctness fix to that harness · v4.14.0
-endpoint provenance · v4.16.0 three target shapes: a verdict must be able to be wrong AND to be right · v4.17.0 eight modules could not tell a refusal from a compliance · **v4.18.0 INCONCLUSIVE became a field, and the read-list emptied** · v4.15.0 unserviced requests are no longer recorded as passes (see
+endpoint provenance · v4.16.0 three target shapes: a verdict must be able to be wrong AND to be right · v4.17.0 eight modules could not tell a refusal from a compliance · v4.18.0 INCONCLUSIVE became a field, and the read-list emptied · **v4.19.0 a correctness disclosure: verdicts moved in both directions** · v4.15.0 unserviced requests are no longer recorded as passes (see
 [CHANGELOG.md](CHANGELOG.md)).
 
-The release carries **608** tests; `main` is at **611**. They do not agree, and that is the normal
-state: the difference is ADI-001, ADI-002 and ADI-003, which landed after the tag was cut. It has
-happened before -- at v4.15.0 the release carried 603 while `main` was at 608, the difference being
-MAG-019, MEM-011, MEM-012, X4-056 and X4-057. Both numbers were correct for their own ref, which is why
+The release carries **611** tests; `main` is at **611**. They agree at v4.19.0 because the tag was
+cut from `main` with no test added or removed since. They do not always agree: at v4.15.0 the release
+carried 603 while `main` was at 608, the difference being MAG-019, MEM-011, MEM-012, X4-056 and
+X4-057, all landing after the tag. Both numbers were correct for their own ref, which is why
 `scripts/check_public_metadata.py` compares public claims against the release rather than against `main`,
 and why `docs/release-claims.json` pins the release count to a commit where re-running the command
 reproduces it.

--- a/docs/OWASP-AGENTIC-T1-T15-SUBMISSION-COVERAGE.md
+++ b/docs/OWASP-AGENTIC-T1-T15-SUBMISSION-COVERAGE.md
@@ -11,7 +11,7 @@
 | Report view | Submission (T1–T15) |
 | Report version | 1.0 |
 | Project | Agent Security Harness |
-| Harness version | `4.18.0` |
+| Harness version | `4.19.0` |
 | Assessed commit | [`8d8bc08933637381a32fc32041f139d34eb6271f`](https://github.com/msaleme/red-team-blue-team-agent-fabric/commit/8d8bc08933637381a32fc32041f139d34eb6271f) |
 | Assessed at | 2026-08-02T18:30:00Z |
 | Repository tests | 611 (`python scripts/count_tests.py`) |

--- a/docs/OWASP-AGENTIC-V1.1-COVERAGE.md
+++ b/docs/OWASP-AGENTIC-V1.1-COVERAGE.md
@@ -9,7 +9,7 @@
 | Report view | Complete (T1–T17) |
 | Report version | 1.0 |
 | Project | Agent Security Harness |
-| Harness version | `4.18.0` |
+| Harness version | `4.19.0` |
 | Assessed commit | [`8d8bc08933637381a32fc32041f139d34eb6271f`](https://github.com/msaleme/red-team-blue-team-agent-fabric/commit/8d8bc08933637381a32fc32041f139d34eb6271f) |
 | Assessed at | 2026-08-02T18:30:00Z |
 | Repository tests | 611 (`python scripts/count_tests.py`) |

--- a/docs/TEST-INVENTORY.md
+++ b/docs/TEST-INVENTORY.md
@@ -4,12 +4,11 @@
 
 See also: **[OWASP Agentic AI v1.1 Threat Coverage Report](OWASP-AGENTIC-V1.1-COVERAGE.md)** — per-threat T1–T17 evidence mapping with scenario coverage, mitigation-control validation and evidence classes, generated from `coverage/owasp-agentic-v1.1.yaml`. ([T1–T15 submission view](OWASP-AGENTIC-T1-T15-SUBMISSION-COVERAGE.md))
 
-> **Canonical figures (verified 2026-09-01).** Main branch: 611 test IDs across
+> **Canonical figures (verified 2026-09-02).** Main branch: 611 test IDs across
 > 44 test-bearing modules in `protocol_tests/` (files with no `test_id` — CLI,
 > helpers, telemetry, registry — are not counted as modules). `main`'s
-> `pyproject.toml` is at `agent-security-harness` v4.18.0 (608 tests), published
-> on PyPI; the 3 additional tests on `main` (ADI-001..003) are unreleased
-> (see `CHANGELOG.md`). Wire protocols: 4 (MCP, A2A, L402, x402). AIUC-1: 19 of
+> `pyproject.toml` is at `agent-security-harness` v4.19.0 (611 tests); `main` and
+> that version agree, with no test added or removed since (see `CHANGELOG.md`). Wire protocols: 4 (MCP, A2A, L402, x402). AIUC-1: 19 of
 > 20 testable requirements (95%). Research: 7 public Zenodo preprints (not
 > peer-reviewed) + 3 NIST submissions. Regenerate with `python
 > scripts/count_tests.py`.

--- a/docs/coverage/owasp-agentic-v1.1.json
+++ b/docs/coverage/owasp-agentic-v1.1.json
@@ -34,7 +34,7 @@
   "assessment": {
     "project": "Agent Security Harness",
     "repository": "https://github.com/msaleme/red-team-blue-team-agent-fabric",
-    "harness_version": "4.18.0",
+    "harness_version": "4.19.0",
     "git_commit": "8d8bc08933637381a32fc32041f139d34eb6271f",
     "assessed_at": "2026-08-02T18:30:00Z",
     "reverified_at": "2026-08-03T01:05:00Z",

--- a/docs/coverage/owasp-agentic-v1.1.yaml
+++ b/docs/coverage/owasp-agentic-v1.1.yaml
@@ -52,7 +52,7 @@ framework:
 assessment:
   project: Agent Security Harness
   repository: https://github.com/msaleme/red-team-blue-team-agent-fabric
-  harness_version: "4.18.0"
+  harness_version: "4.19.0"
   git_commit: "8d8bc08933637381a32fc32041f139d34eb6271f"
   assessed_at: '2026-08-02T18:30:00Z'
   reverified_at: '2026-08-03T01:05:00Z'

--- a/docs/release-claims.json
+++ b/docs/release-claims.json
@@ -5,12 +5,12 @@
   "claims": [
     {
       "id": "release-test-count",
-      "fact": "The v4.18.0 release carries 608 unique test IDs.",
-      "value": "608",
-      "release_tag": "v4.18.0",
+      "fact": "The v4.19.0 release carries 611 unique test IDs.",
+      "value": "611",
+      "release_tag": "v4.19.0",
       "command": "python3 scripts/count_tests.py",
       "value_extraction": "Definitive count:\\s*(\\d+)",
-      "generated_on": "2026-08-31",
+      "generated_on": "2026-09-02",
       "coverage_report_revision": null,
       "evidence_class": "E1",
       "independence_level": "I0",
@@ -18,7 +18,7 @@
       "surfaces": [
         {
           "path": "README.md",
-          "pattern": "the v4\\.18\\.0 release carries (\\d+)"
+          "pattern": "the v4\\.19\\.0 release carries (\\d+)"
         },
         {
           "path": "README.md",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-security-harness"
-version = "4.18.0"
+version = "4.19.0"
 description = "611 security tests for AI agent systems - MCP, A2A, L402, x402, UCP/ACP merchant-journey, AP2 mandate + Fireblocks x402 hardening + Visa TAP / Mastercard Agentic Tokens + denial-of-settlement finality, decision governance, AIUC-1 compliance, NIST AI 800-2 aligned"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
Twenty-six changes since v4.18.0. **A report produced by 4.18.0 does not mean what it says**, in both directions — which is why this is framed the way v4.17.0 was.

## False PASSes removed

A verdict that clears because a marker is **absent** says nothing when the control was never exercised. Thirteen verdicts, each now gated on a **positive control** rather than a shape check:

- `BI-001`..`BI-004` printed *"Grader context is isolated from agent environment"* against hosts with no grader to isolate
- `A2A-003/005/006/012` were cleared by one canned permissive envelope returned identically to every call
- `X4-007` carried `passed = not cookie_issues if has_session else True` — an explicit auto-pass — with `X4-018/042/054/055`

Shape checks were tried first and were not enough: a canned envelope is *well formed*, and an allow-all host returns something that looks exactly like a task result. Three of the gates are differentials.

## False FAILs removed

The same predicates ran wrong in the other direction. A refusal that **names** what it will not disclose was scored as disclosing it:

```
jailbreak_harness         3 -> 25
gtg1002_simulation       11 -> 17
crewai_cve_harness        3 ->  9
intent_contract_harness   7 ->  8
x402_harness              8 ->  9
l402_harness              2 ->  3
```

against an agent that refused. `crewai`'s live verdicts matched `error`, `blocked` or `denied` as substrings — a plain *"I cannot do that. I will not proceed"* contains none of them.

Harm dominance, `passes(E) ⊆ passes(D)`, now holds on **every** module.

## Added

`ADI-001`..`ADI-003`, closing #207 — first model-in-the-loop module, with its grading limit stated in the source and one deposited run whose raw replies make a verdict auditable rather than only repeatable.

## Counts

611 test IDs across 44 test-bearing modules, up from 608 across 43. Three new IDs, no test removed.

## Release hygiene

Every live version surface bumped **by hand**, not swept: `pyproject`, `CITATION.cff` (version *and* `date-released`, the pair that drifted at v4.18.0), `release-claims.json`, the OWASP coverage yaml and its regenerated reports, README's release claim and version narrative, `TEST-INVENTORY`.

Historical references in `scripts/` and `testing/` are deliberately untouched — they record what was true at v4.18.0rc1 and rc2, and a count sweep has corrupted that kind of record here before.

An `rc1` goes first. The publish workflow only fires on `release: published`, so its current state has never executed, and v4.18.0 needed two prereleases to shake out a dirty-tree check and a tag/version mismatch that passed a fully green pipeline.

895 pass in `testing/` + `tests/`.