### PR TITLE
feat: check_public_metadata.py --apply, so the release-event drift run can pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — `check_public_metadata.py --apply`, so the release run can pass
+
+`Public metadata drift` runs on `release: published` and compares the
+description against the tree at the new tag. It failed on four consecutive
+releases (v4.18.0, v4.19.0rc1, v4.19.0, v4.20.0), correctly each time, because
+the description was edited a few minutes *after* the release was created and
+still named the previous version when the event fired. The Actions token cannot
+edit the description, so the edit moves to the releasing side and before the
+release exists:
+
+```bash
+python3 scripts/check_public_metadata.py --apply   # then gh release create ...
+```
+
+`rewrite_description` is pure and tested offline. `--apply` refuses to write a
+description the checker would still reject, and always runs the normal
+comparison afterwards, so its last line is OK or DRIFT, never "applied".
+
 ## [4.20.0] - 2026-09-02
 
 Second release today. v4.19.0 shipped the correctness disclosure; this finishes

--- a/scripts/check_public_metadata.py
+++ b/scripts/check_public_metadata.py
@@ -39,6 +39,28 @@ test_code_quality.py already records it as a file that went stale on counts
 while CI passed. It was fixed for counts and went stale on the release date
 instead, which is why the date is checked and not only the numbers.
 
+## Release sequencing, and --apply
+
+The workflow also runs on `release: published`. That run compares the description
+against the tree at the tag that was just published, and it fails whenever the
+description is edited AFTER the release is created, because at that instant the
+description still names the previous version. It failed that way on four
+consecutive releases (v4.18.0, v4.19.0rc1, v4.19.0, v4.20.0), each time correctly,
+and each time the description was fixed by hand a few minutes later. A red run
+that is always right and always stale is a process defect, not a checker defect.
+
+The Actions token cannot edit the description (that needs repository
+administration), so the edit has to happen on the releasing side, BEFORE
+`gh release create`:
+
+    python3 scripts/check_public_metadata.py --apply
+
+`--apply` reads the live description, rewrites every release-facing figure to
+what the tree at HEAD implies (`rewrite_description`, pure and tested offline),
+PATCHes it with the caller's token, then runs the normal comparison so the
+output ends in OK or DRIFT rather than in "applied". It refuses to write a
+description the checker itself would still reject.
+
 ## What it compares
 
 The description is a claim about a *published release*, not about `main`, because
@@ -181,6 +203,22 @@ def fetch_description(repo: str) -> str:
     return json.loads(_api(f"https://api.github.com/repos/{repo}")).get("description") or ""
 
 
+def _patch_description(repo: str, description: str) -> None:
+    """PATCH the repository description. Needs a token with admin rights."""
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if not token:
+        raise PermissionError("GITHUB_TOKEN or GH_TOKEN is required to edit the description")
+    body = json.dumps({"description": description}).encode("utf-8")
+    req = urllib.request.Request(
+        f"https://api.github.com/repos/{repo}", data=body, method="PATCH",
+        headers={"Accept": "application/vnd.github+json",
+                 "Content-Type": "application/json",
+                 "Authorization": f"Bearer {token}",
+                 "User-Agent": "agent-security-harness-metadata-check"})
+    with urllib.request.urlopen(req, timeout=30) as r:
+        r.read()
+
+
 # Strings that identify a line as being about THIS project. Used to scope the
 # version check, because every package has a version and these pages legitimately
 # mention other packages' versions.
@@ -286,12 +324,79 @@ def extract(description: str) -> tuple[str | None, str | None]:
     return (c.group(1) if c else None, v.group(1) if v else None)
 
 
+def _swap_group1(m: re.Match[str], value: str) -> str:
+    """The whole match with group 1 replaced, everything else untouched."""
+    start, end = m.start(1) - m.start(0), m.end(1) - m.start(0)
+    whole = m.group(0)
+    return whole[:start] + value + whole[end:]
+
+
+def rewrite_description(description: str, want: dict[str, str]) -> str:
+    """Return the description with every release-facing figure set to the tree's.
+
+    Pure: no network, no side effects, safe to unit-test. Three rewrites:
+
+      1. the release phrase, "<N> [executable tests] in the vX.Y.Z release",
+         gets the tree's count AND version;
+      2. any bare "<N> executable tests" gets the tree's count. This runs at
+         release time, when main and the tag are the same tree, so a main
+         figure and a release figure are legitimately equal;
+      3. every "vX.Y.Z" token becomes the tree's version. extract() reads the
+         FIRST version token, so leaving any stale one is leaving the check
+         red. Historical "measured at vA.B.C" pins belong on the READMEs
+         (see check_surface), not in the one-line description.
+    """
+    count, version = want["count"], want["version"]
+    text = RELEASE_COUNT_RE.sub(lambda m: _swap_group1(m, count), description)
+    text = BARE_COUNT_RE.sub(lambda m: _swap_group1(m, count), text)
+    text = re.sub(r"\bv\d+\.\d+\.\d+\b", f"v{version}", text)
+    return text
+
+
+def apply_description(repo: str, want: dict[str, str]) -> int:
+    """Rewrite the live description to match the tree, or explain why not.
+
+    Exit codes follow main(): 0 written (or already matching), 1 the rewrite
+    would still fail the check so nothing was written, 2 unreachable or no
+    token. A write that the checker would reject is not applied; that is the
+    positive control on the rewrite itself.
+    """
+    try:
+        current = fetch_description(repo)
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError) as e:
+        print(f"UNREACHABLE: could not read the description for {repo}: "
+              f"{type(e).__name__}: {e}")
+        return 2
+    proposed = rewrite_description(current, want)
+    if extract(proposed) != (want["count"], want["version"]):
+        print("REFUSED: the rewritten description would still fail this check, "
+              "so it was not written.")
+        print(f"\ncurrent  : {current}\nproposed : {proposed}")
+        return 1
+    if proposed == current:
+        print("description already matches the tree; nothing written")
+        return 0
+    try:
+        _patch_description(repo, proposed)
+    except PermissionError as e:
+        print(f"UNREACHABLE: {e}")
+        return 2
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError) as e:
+        print(f"UNREACHABLE: could not write the description for {repo}: "
+              f"{type(e).__name__}: {e}")
+        return 2
+    print(f"applied  : {repo} description updated\nbefore   : {current}\nafter    : {proposed}\n")
+    return 0
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--repo", default=os.environ.get("METADATA_REPO", DEFAULT_REPO))
     ap.add_argument("--print-expected", action="store_true",
                     help="print the description fields the tree implies, then exit 0")
+    ap.add_argument("--apply", action="store_true",
+                    help="rewrite the live description to the tree's figures, then check")
     args = ap.parse_args()
 
     want = {"count": canonical_count(),
@@ -303,6 +408,11 @@ def main() -> int:
         return 0
 
     want_count, want_version = want["count"], want["version"]
+
+    if args.apply:
+        rc = apply_description(args.repo, want)
+        if rc:
+            return rc
 
     try:
         description = fetch_description(args.repo)

--- a/testing/test_public_metadata_check.py
+++ b/testing/test_public_metadata_check.py
@@ -87,6 +87,113 @@ class TestExtract(unittest.TestCase):
         self.assertEqual(cpm.extract(dual)[0], STALE_COUNT)
 
 
+class TestRewrite(unittest.TestCase):
+    """rewrite_description is the --apply path with the network removed.
+
+    The release-event run of the workflow failed on four consecutive releases
+    because the description was edited AFTER the release was published. The
+    fix is to edit it BEFORE, from the releasing side, and this is the pure
+    function that decides what that edit says.
+    """
+
+    WANT = {"count": FRESH_COUNT, "modules": "44", "version": "4.15.0"}
+
+    def _ok(self, text: str) -> None:
+        """Whatever the rewrite produces must satisfy the checker's own reader."""
+        self.assertEqual(cpm.extract(text), (FRESH_COUNT, "4.15.0"))
+
+    def test_release_phrase_gets_count_and_version(self) -> None:
+        stale = f"harness: {STALE_COUNT} {_TESTS} in the v4.13.1 release, across MCP."
+        out = cpm.rewrite_description(stale, self.WANT)
+        self.assertEqual(out, f"harness: {FRESH_COUNT} {_TESTS} in the v4.15.0 release, across MCP.")
+        self._ok(out)
+
+    def test_dual_count_shape_sets_both_counts(self) -> None:
+        """At release time main and the tag are one tree, so both figures agree."""
+        stale = (f"{STALE_COUNT} {_TESTS} on main, {STALE_COUNT} in the "
+                 f"v4.13.1 release. v4.13.1")
+        out = cpm.rewrite_description(stale, self.WANT)
+        self.assertEqual(out, f"{FRESH_COUNT} {_TESTS} on main, {FRESH_COUNT} in the "
+                              f"v4.15.0 release. v4.15.0")
+        self._ok(out)
+
+    def test_the_real_2026_08_08_description(self) -> None:
+        out = cpm.rewrite_description(REAL, self.WANT)
+        self.assertIn(f"{FRESH_COUNT} {_TESTS}", out)
+        self.assertTrue(out.endswith("v4.15.0"))
+        self.assertNotIn(STALE_COUNT, out)
+        self.assertNotIn("4.13.1", out)
+        self._ok(out)
+
+    def test_everything_else_is_untouched(self) -> None:
+        """Only the figures move. The prose around them is the maintainer's."""
+        stale = f"A, B, C: {STALE_COUNT} {_TESTS} in the v4.13.1 release; T1-T17 (13 direct). v4.13.1"
+        out = cpm.rewrite_description(stale, self.WANT)
+        self.assertTrue(out.startswith("A, B, C: "))
+        self.assertIn("T1-T17 (13 direct)", out)
+
+    def test_idempotent(self) -> None:
+        once = cpm.rewrite_description(REAL, self.WANT)
+        self.assertEqual(cpm.rewrite_description(once, self.WANT), once)
+
+    def test_a_description_with_no_figures_is_returned_unchanged(self) -> None:
+        """Nothing to rewrite means nothing rewritten; --apply then REFUSES,
+        because extract() on the result still finds no count."""
+        self.assertEqual(cpm.rewrite_description("A harness.", self.WANT), "A harness.")
+
+
+class TestApply(unittest.TestCase):
+    WANT = {"count": FRESH_COUNT, "modules": "44", "version": "4.15.0"}
+
+    def _apply(self, current, patch=None, token="t"):
+        patch = patch or mock.Mock()
+        env = {"GITHUB_TOKEN": token} if token else {}
+        with mock.patch.object(cpm, "fetch_description", lambda repo: current), \
+             mock.patch.object(cpm, "_patch_description", patch), \
+             mock.patch.dict(cpm.os.environ, env, clear=True):
+            return cpm.apply_description("o/r", self.WANT), patch
+
+    def test_writes_the_rewritten_description(self) -> None:
+        rc, patch = self._apply(f"{STALE_COUNT} {_TESTS} in the v4.13.1 release. v4.13.1")
+        self.assertEqual(rc, 0)
+        patch.assert_called_once_with("o/r", f"{FRESH_COUNT} {_TESTS} in the v4.15.0 release. v4.15.0")
+
+    def test_already_matching_writes_nothing(self) -> None:
+        rc, patch = self._apply(f"{FRESH_COUNT} {_TESTS} in the v4.15.0 release. v4.15.0")
+        self.assertEqual(rc, 0)
+        patch.assert_not_called()
+
+    def test_refuses_a_rewrite_the_checker_would_still_fail(self) -> None:
+        """A description with no figures cannot be repaired by substitution.
+        Writing it back unchanged and reporting success would be the muted
+        check this file exists to prevent."""
+        rc, patch = self._apply("A security harness with no figures at all.")
+        self.assertEqual(rc, 1)
+        patch.assert_not_called()
+
+    def test_no_token_is_unreachable_not_success(self) -> None:
+        def _raise(repo, text):
+            raise PermissionError("GITHUB_TOKEN or GH_TOKEN is required")
+        rc, _ = self._apply(f"{STALE_COUNT} {_TESTS} in the v4.13.1 release. v4.13.1",
+                            patch=mock.Mock(side_effect=_raise), token=None)
+        self.assertEqual(rc, 2)
+
+    def test_apply_flag_runs_the_check_afterwards(self) -> None:
+        """--apply is not its own verdict. main() still compares and reports."""
+        argv = ["check_public_metadata.py", "--repo", "o/r", "--apply"]
+        with mock.patch.object(sys, "argv", argv), \
+             mock.patch.object(cpm, "apply_description", lambda repo, want: 0) as _, \
+             mock.patch.object(cpm, "fetch_description",
+                               lambda repo: f"{STALE_COUNT} {_TESTS} in the v4.15.0 release. v4.15.0"), \
+             mock.patch.object(cpm, "canonical_count", lambda: FRESH_COUNT), \
+             mock.patch.object(cpm, "canonical_version", lambda: "4.15.0"), \
+             mock.patch.object(cpm, "canonical_modules", lambda: "44"), \
+             mock.patch.object(cpm, "citation_fields", lambda repo=None: ("4.15.0", "2026-08-07")), \
+             mock.patch.object(cpm, "fetch_release_date", lambda r, tag: "2026-08-07"), \
+             mock.patch.object(cpm, "REMOTE_READMES", ()):
+            self.assertEqual(cpm.main(), 1, "a stale description after apply must still read as DRIFT")
+
+
 class TestExitCodes(unittest.TestCase):
     def _run(self, description=None, exc=None, count=None, version="4.15.0"):
         """Run main() with every outside call stubbed.


### PR DESCRIPTION
`Public metadata drift` is red on **every release since v4.18.0** (v4.18.0, v4.19.0rc1, v4.19.0, v4.20.0), and right each time.

## Why it fails

The workflow runs on `release: published` and compares the description against the tree at the tag that was just published. The description is edited by hand a few minutes **after** `gh release create`, so at the instant the event fires it still names the previous version. Rerunning the checker against v4.20.0 today returns OK. A check that is always right and always stale is a sequencing defect, not a checker defect.

The Actions token cannot fix this from inside the workflow: editing the description needs repository administration, which `GITHUB_TOKEN` does not carry. So the edit has to happen on the releasing side, **before** the release exists.

## What this adds

```bash
python3 scripts/check_public_metadata.py --apply   # then gh release create ...
```

- `rewrite_description(description, want)` — pure, no network. Sets the release phrase's count and version, any bare `<N> executable tests`, and every `vX.Y.Z` token to what the tree at HEAD implies. Prose around the figures is untouched.
- `apply_description(repo, want)` — reads the live description, rewrites it, PATCHes with the caller's token. Exit codes follow `main()`: 0 written or already matching, 1 the rewrite would **still fail the check so nothing was written**, 2 unreachable or no token.
- `--apply` always falls through to the normal comparison afterwards, so the output ends in `OK` or `DRIFT`, never in "applied". The check is the positive control on the write.

## Controls

- 43 offline tests in `testing/test_public_metadata_check.py` (11 new): the release-phrase shape, the dual-count shape, the real 2026-08-08 description, idempotence, prose preserved, a figure-less description **refused** rather than written back, no-token is exit 2, and `--apply` followed by a stale read still exits 1.
- Live dry run of the pure function against the current description: unchanged, and `extract()` on the result reads (611, 4.20.0). The rewrite is a no-op today and would have been the edit at each of the four failed releases.
- Full suite green locally; `test_no_stale_test_count_anywhere` passes (no literal count anywhere in the new text).

## What this does not do

It does not change the workflow, and it does not make the four red runs green retroactively. The next release is the test: run `--apply`, then create the release, and the release-event run should be the first green one on a tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
