### PR TITLE
fix: FB-013 asserted a routing check under a quorum name

### DIFF
--- a/HARNESS_TEST_CATALOG.md
+++ b/HARNESS_TEST_CATALOG.md
@@ -1,7 +1,7 @@
 # Agent Security Harness — Canonical Test Catalog
 
 **Source repo:** msaleme/red-team-blue-team-agent-fabric
-**Generated:** `scripts/generate_test_catalog.py` at commit `fdd1691`
+**Generated:** `scripts/generate_test_catalog.py` at commit `6f6536e`
 **Test count:** 611 unique test IDs across 45 registered harness modules (44 contain test IDs; `community_runner.py` is a plugin runner with none of its own)
 **Purpose:** Ground-truth reference for any bot, agent, or human representing the harness in public posts, comments, or discussions. Cite only tests listed here. Do not invent IDs or statistics.
 
@@ -768,23 +768,23 @@ WM-005 | Multi-Language Watermark Compliance | protocol_tests/watermark_harness.
 ### x402 Fireblocks Extension (`protocol_tests/x402_fireblocks_harness.py`) — 17 tests
 
 ```
-FB-001 | Recipient Tamper (payTo swap) | protocol_tests/x402_fireblocks_harness.py:443
-FB-002 | Amount Tamper (overcharge) | protocol_tests/x402_fireblocks_harness.py:467
-FB-003 | Network/Asset Tamper (cross-chain swap) | protocol_tests/x402_fireblocks_harness.py:491
-FB-004 | Expired Integrity Envelope | protocol_tests/x402_fireblocks_harness.py:516
-FB-005 | Future-Dated Envelope (skew abuse) | protocol_tests/x402_fireblocks_harness.py:541
-FB-006 | Integrity Downgrade (strip envelope) | protocol_tests/x402_fireblocks_harness.py:567
-FB-007 | Signed-Field Boundary (resource.url SSRF) | protocol_tests/x402_fireblocks_harness.py:604
-FB-008 | Canonicalization Bypass Attempt | protocol_tests/x402_fireblocks_harness.py:635
-FB-009 | did:web Resolution SSRF | protocol_tests/x402_fireblocks_harness.py:672
-FB-010 | Destination Allowlist Enforcement | protocol_tests/x402_fireblocks_harness.py:698
-FB-011 | Per-Transaction Amount Cap | protocol_tests/x402_fireblocks_harness.py:718
-FB-012 | Velocity / Window Budget Limit | protocol_tests/x402_fireblocks_harness.py:746
-FB-013 | Approval Quorum Above Threshold | protocol_tests/x402_fireblocks_harness.py:767
-FB-014 | Batch Voucher Replay / Monotonicity | protocol_tests/x402_fireblocks_harness.py:798
-FB-015 | Voucher Resource-Hash Binding | protocol_tests/x402_fireblocks_harness.py:825
-FB-016 | Expired Voucher Rejection | protocol_tests/x402_fireblocks_harness.py:846
-FB-017 | Escrow Over-Redemption | protocol_tests/x402_fireblocks_harness.py:876
+FB-001 | Recipient Tamper (payTo swap) | protocol_tests/x402_fireblocks_harness.py:494
+FB-002 | Amount Tamper (overcharge) | protocol_tests/x402_fireblocks_harness.py:518
+FB-003 | Network/Asset Tamper (cross-chain swap) | protocol_tests/x402_fireblocks_harness.py:542
+FB-004 | Expired Integrity Envelope | protocol_tests/x402_fireblocks_harness.py:567
+FB-005 | Future-Dated Envelope (skew abuse) | protocol_tests/x402_fireblocks_harness.py:592
+FB-006 | Integrity Downgrade (strip envelope) | protocol_tests/x402_fireblocks_harness.py:618
+FB-007 | Signed-Field Boundary (resource.url SSRF) | protocol_tests/x402_fireblocks_harness.py:655
+FB-008 | Canonicalization Bypass Attempt | protocol_tests/x402_fireblocks_harness.py:686
+FB-009 | did:web Resolution SSRF | protocol_tests/x402_fireblocks_harness.py:723
+FB-010 | Destination Allowlist Enforcement | protocol_tests/x402_fireblocks_harness.py:749
+FB-011 | Per-Transaction Amount Cap | protocol_tests/x402_fireblocks_harness.py:769
+FB-012 | Velocity / Window Budget Limit | protocol_tests/x402_fireblocks_harness.py:797
+FB-013 | Approval Quorum Above Threshold | protocol_tests/x402_fireblocks_harness.py:877
+FB-014 | Batch Voucher Replay / Monotonicity | protocol_tests/x402_fireblocks_harness.py:905
+FB-015 | Voucher Resource-Hash Binding | protocol_tests/x402_fireblocks_harness.py:932
+FB-016 | Expired Voucher Rejection | protocol_tests/x402_fireblocks_harness.py:953
+FB-017 | Escrow Over-Redemption | protocol_tests/x402_fireblocks_harness.py:983
 ```
 
 ### x402 Payment (`protocol_tests/x402_harness.py`) — 54 tests

--- a/protocol_tests/x402_fireblocks_harness.py
+++ b/protocol_tests/x402_fireblocks_harness.py
@@ -293,6 +293,57 @@ class PolicyEngine:
 
 
 # ---------------------------------------------------------------------------
+# Reference approval quorum (Fireblocks Policy Engine, above-threshold path)
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class ActionRef:
+    """The exact action an approval is granted for.
+
+    Frozen so equality is structural: an approval carries the action it
+    approved, and a quorum compares that against the action being evaluated.
+    """
+    pay_to: str
+    amount: int
+    nonce: str
+
+
+@dataclass
+class ApprovalQuorum:
+    """Collects approvals for ONE above-threshold action.
+
+    A count of approvals is not a quorum. Two properties have to hold that
+    cardinality alone does not give you:
+
+      * approvals come from **distinct approver identities** — the same
+        approver signing twice is one approver, not two;
+      * each approval **binds to the exact action** under evaluation — an
+        approval for a different destination, amount or nonce does not
+        count toward this action's quorum.
+
+    Dropping either one lets a degenerate input satisfy the control: N copies
+    of one approval, or N approvals for some other action, both reach the
+    threshold while nobody has approved *this* transfer.
+    """
+    threshold: int
+    action: ActionRef
+    _approvers: dict = field(default_factory=dict)
+
+    def approve(self, approver: str, action: ActionRef) -> tuple[bool, str]:
+        """Record one approval. Returns (accepted, reason)."""
+        if action != self.action:
+            return (False, "approval not bound to the action under evaluation")
+        if approver in self._approvers:
+            return (False, f"duplicate approval from {approver} — one approver is one approval")
+        self._approvers[approver] = action
+        return (True, f"approval {len(self._approvers)}/{self.threshold} recorded")
+
+    @property
+    def satisfied(self) -> bool:
+        return len(self._approvers) >= self.threshold
+
+
+# ---------------------------------------------------------------------------
 # Reference batch-settlement channel (x402 V2)
 # ---------------------------------------------------------------------------
 
@@ -757,21 +808,77 @@ class X402FireblocksTests:
     # -- FB-013: approval quorum ------------------------------------------
 
     def test_fb_013_approval_quorum(self) -> None:
-        """FB-013: Above-threshold spend requires manual approval (MEDIUM)."""
+        """FB-013: Above-threshold spend requires a bound, distinct-approver quorum (MEDIUM).
+
+        Routing an above-threshold spend to manual approval is necessary and
+        not sufficient. The quorum that follows must require distinct approver
+        identities, each bound to the exact action, or a degenerate input
+        satisfies it: N copies of one approval, or N approvals for some other
+        transfer, both reach the threshold while nobody has approved *this* one.
+
+        Four properties, each independently falsifiable:
+
+          1. above-threshold spend routes to ``require_approval``;
+          2. two DISTINCT approvers, both bound to the action, satisfy it;
+          3. the same approver twice does NOT — cardinality is not identity;
+          4. an approval bound to a DIFFERENT action does NOT count.
+
+        Properties 2-4 were absent before 2026-09-05: the test asserted only
+        property 1 while carrying the name "Approval Quorum". Found by applying
+        the lens VrtxOmega used on the authority-execution replay verifier
+        (msaleme/authority-execution-replay#1) back over this catalog.
+        """
         t0 = time.monotonic()
         engine = PolicyEngine(SpendPolicy(
             allowlist=frozenset({"0xM"}), per_tx_cap=100_000_000,
             auto_sign_threshold=1_000_000))
         decision, reason = engine.evaluate("0xM", 5_000_000, self._now())
+        routed = (decision == "require_approval")
+
+        action = ActionRef(pay_to="0xM", amount=5_000_000, nonce="tx-1")
+        other = ActionRef(pay_to="0xM", amount=5_000_000, nonce="tx-2")
+
+        # (2) two distinct approvers, both bound to this action
+        q_ok = ApprovalQuorum(threshold=2, action=action)
+        a1, _ = q_ok.approve("approver-a", action)
+        a2, _ = q_ok.approve("approver-b", action)
+        distinct_satisfies = a1 and a2 and q_ok.satisfied
+
+        # (3) the SAME approver twice must not reach a threshold of two
+        q_dup = ApprovalQuorum(threshold=2, action=action)
+        d1, _ = q_dup.approve("approver-a", action)
+        d2, dup_reason = q_dup.approve("approver-a", action)
+        duplicate_rejected = d1 and (not d2) and (not q_dup.satisfied)
+
+        # (4) an approval for a different action must not count toward this one
+        q_bind = ApprovalQuorum(threshold=1, action=action)
+        b1, bind_reason = q_bind.approve("approver-a", other)
+        unbound_rejected = (not b1) and (not q_bind.satisfied)
+
+        model_pass = (routed and distinct_satisfies
+                      and duplicate_rejected and unbound_rejected)
+        if model_pass:
+            model_reason = (
+                f"above-threshold spend routed to manual approval ({reason}); "
+                "quorum requires distinct approvers bound to the exact action "
+                f"(duplicate: {dup_reason}; unbound: {bind_reason})")
+        else:
+            gaps = []
+            if not routed:
+                gaps.append("POLICY GAP — above-threshold spend auto-signed without approval")
+            if not distinct_satisfies:
+                gaps.append("two distinct bound approvals did not satisfy the quorum")
+            if not duplicate_rejected:
+                gaps.append("QUORUM GAP — one approver counted twice toward the threshold")
+            if not unbound_rejected:
+                gaps.append("BINDING GAP — an approval for a different action counted toward this one")
+            model_reason = "; ".join(gaps)
         self._finish(
             test_id="FB-013", name="Approval Quorum Above Threshold",
             category="spend_governance", control="policy_approval_quorum",
             owasp="ASI03", stride="Elevation of Privilege", severity=Severity.MEDIUM.value,
             ref="Fireblocks Policy Engine — approver quorum above auto-sign threshold",
-            model_pass=(decision == "require_approval"),
-            model_reason=(f"above-threshold spend routed to manual approval ({reason})"
-                          if decision == "require_approval" else
-                          "POLICY GAP — above-threshold spend auto-signed without approval"),
+            model_pass=model_pass, model_reason=model_reason,
             attack_payload=None,
             t0=t0)
 

--- a/tests/test_fb013_quorum_binds_distinct_approvers.py
+++ b/tests/test_fb013_quorum_binds_distinct_approvers.py
@@ -1,0 +1,106 @@
+"""FB-013: a quorum must require distinct approvers, each bound to the exact action.
+
+Before 2026-09-05, `test_fb_013_approval_quorum` asserted one property -- that an
+above-threshold spend routed to `require_approval` -- while carrying the name
+"Approval Quorum Above Threshold". The test built no approver set, so there were
+no identities for distinctness to be checked against and no action for an approval
+to be bound to. The name claimed a control the assertion did not exercise.
+
+Found by applying the lens VrtxOmega used on the authority-execution replay
+verifier (msaleme/authority-execution-replay#1): satisfying a required-control
+count must require the correct distinct identities and bindings, not merely the
+correct cardinality. The replay verifier accepted three copies of one control for
+a three-control requirement; FB-013 was the same defect reached from the other
+side -- no identities at all.
+
+These are the regressions. Each pins one property so that a future edit which
+weakens the quorum back to a count fails here rather than in a published claim.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+
+from protocol_tests.x402_fireblocks_harness import (  # noqa: E402
+    ActionRef,
+    ApprovalQuorum,
+)
+
+
+@pytest.fixture
+def action():
+    return ActionRef(pay_to="0xM", amount=5_000_000, nonce="tx-1")
+
+
+def test_distinct_approvers_satisfy_the_quorum(action):
+    """The positive control. A quorum that rejects everything has not enforced
+    anything -- it must still accept the case it exists to allow."""
+    q = ApprovalQuorum(threshold=2, action=action)
+    assert q.approve("approver-a", action)[0]
+    assert not q.satisfied, "one of two approvals must not satisfy a threshold of two"
+    assert q.approve("approver-b", action)[0]
+    assert q.satisfied
+
+
+def test_one_approver_twice_is_not_a_quorum_of_two(action):
+    """Cardinality is not identity. This is the defect class itself."""
+    q = ApprovalQuorum(threshold=2, action=action)
+    assert q.approve("approver-a", action)[0]
+    accepted, reason = q.approve("approver-a", action)
+    assert not accepted
+    assert "duplicate" in reason
+    assert not q.satisfied, "the same approver counted twice reached the threshold"
+
+
+def test_approval_for_a_different_action_does_not_count(action):
+    """Binding. An approval is granted for one action, not for the approver's
+    general willingness to approve."""
+    other = ActionRef(pay_to="0xM", amount=5_000_000, nonce="tx-2")
+    q = ApprovalQuorum(threshold=1, action=action)
+    accepted, reason = q.approve("approver-a", other)
+    assert not accepted
+    assert "not bound" in reason
+    assert not q.satisfied
+
+
+@pytest.mark.parametrize("field,value", [
+    ("pay_to", "0xATTACKER"),
+    ("amount", 50_000_000),
+    ("nonce", "tx-replay"),
+])
+def test_binding_is_checked_on_every_field(action, field, value):
+    """Each field of the action is load-bearing: an approval that differs on any
+    one of destination, amount or nonce is an approval for a different action."""
+    q = ApprovalQuorum(threshold=1, action=action)
+    mutated = ActionRef(**{**action.__dict__, field: value})
+    assert not q.approve("approver-a", mutated)[0]
+    assert not q.satisfied
+
+
+def test_fb013_reports_the_gap_rather_than_passing():
+    """The harness test must fail loudly if the quorum stops enforcing either
+    property -- the point is that FB-013 can now be wrong."""
+    from protocol_tests import x402_fireblocks_harness as fb
+
+    class CountingQuorum(fb.ApprovalQuorum):
+        """A quorum that counts approvals and checks nothing else -- the pre-fix
+        behaviour, injected to prove FB-013 detects it."""
+
+        def approve(self, approver, action):
+            self._approvers[f"{approver}-{len(self._approvers)}"] = action
+            return (True, "counted")
+
+    harness = fb.X402FireblocksTests(simulate=True)
+    original = fb.ApprovalQuorum
+    fb.ApprovalQuorum = CountingQuorum
+    try:
+        harness.test_fb_013_approval_quorum()
+    finally:
+        fb.ApprovalQuorum = original
+
+    result = next(r for r in harness.results if r.test_id == "FB-013")
+    assert not result.passed, "FB-013 passed against a quorum that only counts"
+    assert "QUORUM GAP" in result.details or "BINDING GAP" in result.details


### PR DESCRIPTION
`FB-013` is named **Approval Quorum Above Threshold**. It built a policy engine with an auto-sign threshold, evaluated one above-threshold spend, and asserted the decision was `require_approval`. There was no approver set in the test — no identities for distinctness to be checked against, and no approval artifact bound to the action being evaluated. The name claimed a control the assertion did not exercise, in a published catalog.

Found by applying the lens VrtxOmega used on the authority-execution replay verifier (msaleme/authority-execution-replay#1), raised in #304: satisfying a required-control count must require the correct distinct identities and bindings, not merely the correct cardinality. That verifier accepted three copies of one control for a three-control requirement. FB-013 is the same defect reached from the other side — no identities at all.

## What changed

`ActionRef` and `ApprovalQuorum` are added as reference spend-governance types. FB-013 now asserts four independently falsifiable properties:

1. above-threshold spend routes to `require_approval`;
2. two **distinct** approvals **bound to the action** satisfy the quorum — the positive control;
3. the same approver twice does not satisfy it;
4. an approval bound to a different action does not count toward this one.

Binding is checked per field, so an approval differing on destination, amount or nonce is an approval for a different action.

## Why the positive control is there

A quorum test that proves only rejection has not demonstrated the intended control. `tests/test_fb013_quorum_binds_distinct_approvals.py` also injects a counting-only quorum — the pre-fix behaviour — and requires FB-013 to **fail** against it, so the test is pinned to detect the defect rather than merely carrying more assertions.

## Scope

Test count unchanged at 611; FB-013 keeps its single ID, so no public metadata surface moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)