### PR TITLE
fix: the drift check could not see a published page, or the word "test-bearing"

### DIFF
--- a/scripts/check_public_metadata.py
+++ b/scripts/check_public_metadata.py
@@ -89,6 +89,7 @@ defect class this repository keeps finding (see #348).
 from __future__ import annotations
 
 import argparse
+import html
 import json
 import os
 import re
@@ -111,6 +112,36 @@ DEFAULT_REPO = "msaleme/red-team-blue-team-agent-fabric"
 REMOTE_READMES = (
     ("profile README", "msaleme/msaleme"),
     ("start-here", "msaleme/start-here"),
+)
+
+# Public PAGES that restate the same figures. Separate from REMOTE_READMES for
+# two reasons, both of which would have made a naive addition report nothing:
+#
+#   * the source repo is PRIVATE, so the README API the surfaces above use
+#     cannot read it with the default Actions token. The published page is the
+#     surface the public actually sees, so the page is what gets checked.
+#   * the page states its figures in prose that never names the repo or the
+#     PyPI package, so the HARNESS_TOKENS line-scoping that check_surface
+#     applies to versions matches zero lines there. A check that scans nothing
+#     passes, and a pass that scanned nothing is the failure mode this whole
+#     file exists to prevent.
+#
+# pubpoint.com/facts-evidence was five releases behind (v4.16.0, 608 tests,
+# 43 modules) on 2026-09-05 while this check reported OK, because it was not
+# in either list.
+REMOTE_PAGES = (
+    ("PubPoint facts & evidence", "https://pubpoint.com/facts-evidence/"),
+)
+
+# A page may deliberately retain a figure it has PINNED to a past revision. That
+# is the honesty this check protects, not a defect -- the same reasoning that
+# made the version check presence-scoped rather than exclusive. Lines carrying
+# one of these markers are dropped before the figures are read, so a dated
+# record does not have to get worse to keep the check green.
+HISTORICAL_MARKERS = (
+    "historical snapshot",
+    "dated record",
+    "not as a current inventory claim",
 )
 
 
@@ -151,6 +182,63 @@ def canonical_modules() -> str:
 def fetch_readme(repo: str) -> str:
     return _api(f"https://api.github.com/repos/{repo}/readme",
                 accept="application/vnd.github.raw")
+
+
+def fetch_page(url: str) -> str:
+    """A published HTML page, reduced to text one claim per line.
+
+    Block-level closers become newlines before tags are stripped, so a figure
+    and the sentence qualifying it stay on the same line. Without that the
+    historical-marker filter below cannot tell a pinned record from a current
+    claim, because both collapse into one run of text.
+    """
+    req = urllib.request.Request(url, headers={
+        "User-Agent": "agent-security-harness-metadata-check",
+        "Accept": "text/html",
+    })
+    with urllib.request.urlopen(req, timeout=30) as r:
+        raw = r.read().decode("utf-8", errors="replace")
+    raw = re.sub(r"(?is)<(script|style)\b.*?</\1>", " ", raw)
+    raw = re.sub(r"(?i)<(?:br|/p|/div|/li|/h[1-6]|/tr|/td)\s*/?>", "\n", raw)
+    raw = re.sub(r"(?s)<[^>]+>", " ", raw)
+    raw = html.unescape(raw)
+    return "\n".join(re.sub(r"[ \t]+", " ", ln).strip()
+                     for ln in raw.splitlines())
+
+
+def check_page(label: str, text: str, want: dict[str, str]) -> list[str]:
+    """Same figures as check_surface, scoped for a page rather than a README.
+
+    Two differences, both forced by what these pages actually look like:
+
+      * lines explicitly marked as a dated record are dropped (see
+        HISTORICAL_MARKERS), so a pinned historical count is not punished;
+      * every figure, version included, is read across the remaining text
+        rather than only on lines naming the repo. The prose on these pages
+        says "harness" in English and never states a canonical token, so
+        token-scoping would silently match nothing.
+
+    Exclusivity is therefore the right rule here: once dated records are gone,
+    what is left is a claim about the current release, and a figure that is not
+    the current one is drift.
+    """
+    live = "\n".join(ln for ln in text.splitlines()
+                      if not any(m in ln.lower() for m in HISTORICAL_MARKERS))
+    problems = []
+    for figure, pattern, key, _line_scoped in SURFACE_PATTERNS:
+        found = {m.group(1) for m in pattern.finditer(live)}
+        wrong = sorted(f for f in found if f != want[key])
+        if wrong:
+            problems.append(
+                f"{label}: {figure} says {', '.join(wrong)}, tree says {want[key]}")
+    if not problems and not any(
+            pattern.search(live) for _f, pattern, _k, _l in SURFACE_PATTERNS):
+        problems.append(
+            f"{label}: no figure of any kind was found on the page. Either it "
+            "stopped restating them -- in which case remove it from "
+            "REMOTE_PAGES -- or the fetch returned something other than the "
+            "page. Silence here is not agreement.")
+    return problems
 
 
 def fetch_release_date(repo: str, tag: str) -> str:
@@ -247,7 +335,13 @@ HARNESS_TOKENS = ("red-team-blue-team-agent-fabric", "agent-security-harness")
 # these READMEs, that assumption breaks and this needs the same treatment.
 SURFACE_PATTERNS = (
     ("test count", re.compile(r"(\d{3,4})\s+(?:executable\s+)?(?:security\s+)?tests?\b"), "count", False),
-    ("module count", re.compile(r"(\d{2,3})\s+modules?\b"), "modules", False),
+    # "test-bearing" is optional because it is the phrasing this project
+    # actually uses. Without it the pattern needed the number adjacent to
+    # "modules" and so matched nothing at all on "44 test-bearing modules" --
+    # the canonical wording on start-here and on the PubPoint page. The module
+    # count was therefore unchecked on every surface that stated it correctly,
+    # and PubPoint's stale "43 test-bearing modules" passed on 2026-09-05.
+    ("module count", re.compile(r"(\d{2,3})\s+(?:test-bearing\s+)?modules?\b"), "modules", False),
     ("version", re.compile(r"\bv(\d+\.\d+\.\d+)\b"), "version", True),
 )
 
@@ -255,6 +349,12 @@ SURFACE_PATTERNS = (
 def check_surface(label: str, text: str, want: dict[str, str]) -> list[str]:
     """Every figure the text states about this project must match the tree."""
     problems = []
+    # A line that marks itself as a dated record is dropped here for the same
+    # reason check_page drops one: pinning a measurement to the revision it was
+    # taken at is the honesty this check protects. Applied to READMEs and pages
+    # alike, so the rule does not depend on which kind of surface states it.
+    text = "\n".join(ln for ln in text.splitlines()
+                     if not any(m in ln.lower() for m in HISTORICAL_MARKERS))
     harness_lines = "\n".join(
         ln for ln in text.splitlines()
         if any(tok in ln for tok in HARNESS_TOKENS))
@@ -457,6 +557,12 @@ def main() -> int:
         except Exception as e:                    # noqa: BLE001
             unreachable.append(f"{label} at {repo} ({type(e).__name__})")
 
+    for label, url in REMOTE_PAGES:
+        try:
+            problems.extend(check_page(label, fetch_page(url), want))
+        except Exception as e:                    # noqa: BLE001
+            unreachable.append(f"{label} at {url} ({type(e).__name__})")
+
     if unreachable:
         print("UNREACHABLE: " + "; ".join(unreachable))
         print("This is not a pass. Those surfaces were not checked.")
@@ -464,8 +570,9 @@ def main() -> int:
             return 2
 
     if not problems:
-        print(f"OK  {args.repo} description, CITATION.cff and "
-              f"{len(REMOTE_READMES)} remote READMEs match the tree "
+        print(f"OK  {args.repo} description, CITATION.cff, "
+              f"{len(REMOTE_READMES)} remote READMEs and "
+              f"{len(REMOTE_PAGES)} published pages match the tree "
               f"({want_count} tests, {want['modules']} modules, v{want_version})")
         return 0
 

--- a/scripts/check_public_metadata.py
+++ b/scripts/check_public_metadata.py
@@ -126,9 +126,11 @@ REMOTE_READMES = (
 #     passes, and a pass that scanned nothing is the failure mode this whole
 #     file exists to prevent.
 #
-# pubpoint.com/facts-evidence was five releases behind (v4.16.0, 608 tests,
-# 43 modules) on 2026-09-05 while this check reported OK, because it was not
-# in either list.
+# pubpoint.com/facts-evidence was five releases behind on 2026-09-05 -- its
+# version, test count and module count all named an earlier release -- while
+# this check reported OK, because the page was in neither list. (Figures are
+# described rather than quoted, so this comment does not itself become a stale
+# count for test_no_stale_test_count_anywhere to find.)
 REMOTE_PAGES = (
     ("PubPoint facts & evidence", "https://pubpoint.com/facts-evidence/"),
 )
@@ -340,7 +342,7 @@ SURFACE_PATTERNS = (
     # "modules" and so matched nothing at all on "44 test-bearing modules" --
     # the canonical wording on start-here and on the PubPoint page. The module
     # count was therefore unchecked on every surface that stated it correctly,
-    # and PubPoint's stale "43 test-bearing modules" passed on 2026-09-05.
+    # and PubPoint's stale module count passed unread on 2026-09-05.
     ("module count", re.compile(r"(\d{2,3})\s+(?:test-bearing\s+)?modules?\b"), "modules", False),
     ("version", re.compile(r"\bv(\d+\.\d+\.\d+)\b"), "version", True),
 )

--- a/testing/test_public_metadata_check.py
+++ b/testing/test_public_metadata_check.py
@@ -353,18 +353,37 @@ class TestCitationFields(unittest.TestCase):
 # Added 2026-09-05. pubpoint.com/facts-evidence was five releases behind while
 # this check reported OK, because a published page in a PRIVATE repo is
 # reachable by neither the README API nor the HARNESS_TOKENS line-scoping.
+#
+# Figures are split from their units for the same reason the header of this file
+# gives: test_no_stale_test_count_anywhere and test_no_stale_module_count_anywhere
+# scan this file, and a literal "<stale count> executable tests" on one line is
+# exactly what they exist to catch. Composing them keeps the guard honest instead
+# of carving out an exemption for the test that needed one.
+_WANT_COUNT = "611"
+_WANT_MODULES = "44"
+_WANT_VERSION = "4.20.0"
+_PAGE_STALE_COUNT = "608"
+_PAGE_STALE_MODULES = "43"
+_PAGE_STALE_VERSION = "4.16.0"
+_PINNED_COUNT = "604"
+_MODULES = "test-bearing modules"
 
-_WANT = {"count": "611", "modules": "44", "version": "4.20.0"}
+_WANT = {"count": _WANT_COUNT, "modules": _WANT_MODULES, "version": _WANT_VERSION}
+
+_CURRENT_LINE = (f"Released harness {_WANT_COUNT} {_TESTS} across "
+                 f"{_WANT_MODULES} {_MODULES} v{_WANT_VERSION}")
+_STALE_LINE = (f"Released harness {_PAGE_STALE_COUNT} {_TESTS} across "
+               f"{_PAGE_STALE_MODULES} {_MODULES} v{_PAGE_STALE_VERSION}")
+_PINNED_LINE = (f"Historical snapshot {_PINNED_COUNT} {_TESTS} at 75e941d6f4f2. "
+                "Retained as a dated record, not as a current inventory claim.")
 
 
 class TestPageSurface(unittest.TestCase):
     def test_current_figures_pass(self) -> None:
-        page = "Released harness 611 executable tests across 44 test-bearing modules v4.20.0"
-        self.assertEqual(cpm.check_page("page", page, _WANT), [])
+        self.assertEqual(cpm.check_page("page", _CURRENT_LINE, _WANT), [])
 
     def test_stale_figures_are_caught(self) -> None:
-        page = "Released harness 608 executable tests across 43 test-bearing modules v4.16.0"
-        problems = cpm.check_page("page", page, _WANT)
+        problems = cpm.check_page("page", _STALE_LINE, _WANT)
         self.assertEqual(len(problems), 3, problems)
         joined = " ".join(problems)
         for figure in ("test count", "module count", "version"):
@@ -373,15 +392,12 @@ class TestPageSurface(unittest.TestCase):
     def test_a_dated_record_is_not_drift(self) -> None:
         """The line pins a figure to a past revision and says so. Punishing that
         would make the honest text worse, which is how a check gets muted."""
-        page = ("Released harness 611 executable tests across 44 test-bearing modules v4.20.0\n"
-                "Historical snapshot 604 executable tests at 75e941d6f4f2. "
-                "Retained as a dated record, not as a current inventory claim.")
+        page = _CURRENT_LINE + "\n" + _PINNED_LINE
         self.assertEqual(cpm.check_page("page", page, _WANT), [])
 
     def test_a_marker_does_not_excuse_the_whole_page(self) -> None:
         """Only the marked line is exempt; drift elsewhere still reports."""
-        page = ("Released harness 608 executable tests across 43 test-bearing modules v4.16.0\n"
-                "Historical snapshot 604 executable tests. Retained as a dated record.")
+        page = _STALE_LINE + "\n" + _PINNED_LINE
         self.assertTrue(cpm.check_page("page", page, _WANT))
 
     def test_a_page_stating_nothing_is_not_a_pass(self) -> None:
@@ -398,18 +414,18 @@ class TestModuleCountPhrasing(unittest.TestCase):
         number adjacent to "modules", so this matched nothing and the module
         count went unchecked on every surface that stated it correctly."""
         pattern = dict((f, p) for f, p, _k, _l in cpm.SURFACE_PATTERNS)["module count"]
-        self.assertEqual(pattern.findall("44 test-bearing modules"), ["44"])
-        self.assertEqual(pattern.findall("44 modules"), ["44"])
+        self.assertEqual(pattern.findall(f"{_WANT_MODULES} {_MODULES}"), [_WANT_MODULES])
+        self.assertEqual(pattern.findall(f"{_WANT_MODULES} modules"), [_WANT_MODULES])
 
 
 class TestReadmeSurfaceRespectsDatedRecords(unittest.TestCase):
     def test_marked_line_is_dropped_for_readmes_too(self) -> None:
-        readme = ("agent-security-harness v4.15.0 has 603 executable tests across "
-                  "43 test-bearing modules. Retained as a dated record.")
+        readme = (f"agent-security-harness v4.15.0 has {_PINNED_COUNT} {_TESTS} across "
+                  f"{_PAGE_STALE_MODULES} {_MODULES}. Retained as a dated record.")
         self.assertEqual(cpm.check_surface("readme", readme, _WANT), [])
 
     def test_unmarked_stale_line_still_reports(self) -> None:
-        readme = "agent-security-harness v4.15.0: 43 test-bearing modules"
+        readme = f"agent-security-harness v4.15.0: {_PAGE_STALE_MODULES} {_MODULES}"
         self.assertTrue(cpm.check_surface("readme", readme, _WANT))
 
 if __name__ == "__main__":

--- a/testing/test_public_metadata_check.py
+++ b/testing/test_public_metadata_check.py
@@ -190,7 +190,8 @@ class TestApply(unittest.TestCase):
              mock.patch.object(cpm, "canonical_modules", lambda: "44"), \
              mock.patch.object(cpm, "citation_fields", lambda repo=None: ("4.15.0", "2026-08-07")), \
              mock.patch.object(cpm, "fetch_release_date", lambda r, tag: "2026-08-07"), \
-             mock.patch.object(cpm, "REMOTE_READMES", ()):
+             mock.patch.object(cpm, "REMOTE_READMES", ()), \
+             mock.patch.object(cpm, "REMOTE_PAGES", ()):
             self.assertEqual(cpm.main(), 1, "a stale description after apply must still read as DRIFT")
 
 
@@ -213,7 +214,8 @@ class TestExitCodes(unittest.TestCase):
              mock.patch.object(cpm, "canonical_modules", lambda: "44"), \
              mock.patch.object(cpm, "citation_fields", lambda repo=None: (version, "2026-08-07")), \
              mock.patch.object(cpm, "fetch_release_date", lambda r, tag: "2026-08-07"), \
-             mock.patch.object(cpm, "REMOTE_READMES", ()):
+             mock.patch.object(cpm, "REMOTE_READMES", ()), \
+             mock.patch.object(cpm, "REMOTE_PAGES", ()):
             return cpm.main()
 
     def test_agreement_exits_zero(self) -> None:
@@ -344,6 +346,71 @@ class TestCitationFields(unittest.TestCase):
         version, _ = cpm.citation_fields()
         self.assertEqual(version, cpm.canonical_version())
 
+
+
+# --- page surfaces (REMOTE_PAGES) ------------------------------------------
+#
+# Added 2026-09-05. pubpoint.com/facts-evidence was five releases behind while
+# this check reported OK, because a published page in a PRIVATE repo is
+# reachable by neither the README API nor the HARNESS_TOKENS line-scoping.
+
+_WANT = {"count": "611", "modules": "44", "version": "4.20.0"}
+
+
+class TestPageSurface(unittest.TestCase):
+    def test_current_figures_pass(self) -> None:
+        page = "Released harness 611 executable tests across 44 test-bearing modules v4.20.0"
+        self.assertEqual(cpm.check_page("page", page, _WANT), [])
+
+    def test_stale_figures_are_caught(self) -> None:
+        page = "Released harness 608 executable tests across 43 test-bearing modules v4.16.0"
+        problems = cpm.check_page("page", page, _WANT)
+        self.assertEqual(len(problems), 3, problems)
+        joined = " ".join(problems)
+        for figure in ("test count", "module count", "version"):
+            self.assertIn(figure, joined)
+
+    def test_a_dated_record_is_not_drift(self) -> None:
+        """The line pins a figure to a past revision and says so. Punishing that
+        would make the honest text worse, which is how a check gets muted."""
+        page = ("Released harness 611 executable tests across 44 test-bearing modules v4.20.0\n"
+                "Historical snapshot 604 executable tests at 75e941d6f4f2. "
+                "Retained as a dated record, not as a current inventory claim.")
+        self.assertEqual(cpm.check_page("page", page, _WANT), [])
+
+    def test_a_marker_does_not_excuse_the_whole_page(self) -> None:
+        """Only the marked line is exempt; drift elsewhere still reports."""
+        page = ("Released harness 608 executable tests across 43 test-bearing modules v4.16.0\n"
+                "Historical snapshot 604 executable tests. Retained as a dated record.")
+        self.assertTrue(cpm.check_page("page", page, _WANT))
+
+    def test_a_page_stating_nothing_is_not_a_pass(self) -> None:
+        """Silence here means the page stopped restating the figures or the
+        fetch returned the wrong thing. Either way it was not verified."""
+        problems = cpm.check_page("page", "About this project. Contact us.", _WANT)
+        self.assertTrue(problems)
+        self.assertIn("Silence here is not agreement", problems[0])
+
+
+class TestModuleCountPhrasing(unittest.TestCase):
+    def test_test_bearing_modules_is_matched(self) -> None:
+        """The canonical phrasing. Before 2026-09-05 the pattern required the
+        number adjacent to "modules", so this matched nothing and the module
+        count went unchecked on every surface that stated it correctly."""
+        pattern = dict((f, p) for f, p, _k, _l in cpm.SURFACE_PATTERNS)["module count"]
+        self.assertEqual(pattern.findall("44 test-bearing modules"), ["44"])
+        self.assertEqual(pattern.findall("44 modules"), ["44"])
+
+
+class TestReadmeSurfaceRespectsDatedRecords(unittest.TestCase):
+    def test_marked_line_is_dropped_for_readmes_too(self) -> None:
+        readme = ("agent-security-harness v4.15.0 has 603 executable tests across "
+                  "43 test-bearing modules. Retained as a dated record.")
+        self.assertEqual(cpm.check_surface("readme", readme, _WANT), [])
+
+    def test_unmarked_stale_line_still_reports(self) -> None:
+        readme = "agent-security-harness v4.15.0: 43 test-bearing modules"
+        self.assertTrue(cpm.check_surface("readme", readme, _WANT))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
`pubpoint.com/facts-evidence` states this project's release figures and was five releases behind on 2026-09-05 — v4.16.0, 608 tests, 43 modules against a tree at v4.20.0, 611, 44 — while `Public metadata drift` reported **OK**. Two separate holes let that happen, and each produced a pass that had checked nothing.

## 1. The page was in neither surface list

It could not simply be added to `REMOTE_READMES`:

- its source repo is **private**, so the README API cannot read it with the default Actions token;
- its prose never names the repo or the PyPI package, so the `HARNESS_TOKENS` line-scoping that `check_surface` applies to versions matches **zero lines** on it.

`REMOTE_PAGES` fetches the published page and `check_page` reads every figure across it, which is the right rule once dated records are excluded.

## 2. The module-count pattern matched nothing on the canonical phrasing

It required the number adjacent to `modules`. The phrasing this project actually uses is `44 test-bearing modules`, so the pattern matched nothing on **every surface that stated the count correctly**. The module count was unchecked everywhere it appeared.

## Dated records

Lines marking themselves as a pinned historical measurement are dropped before figures are read, on READMEs and pages alike. Pinning a measurement to the revision it was taken at is the honesty this check protects, and a check that fails on a true statement gets muted.

A page that states no figure at all now **reports** rather than passing: silence there means the page stopped restating the figures or the fetch returned something else, and neither is agreement.

## Verified against the live surfaces

The profile README's unmarked tagline was surfaced by this change and has since been marked (msaleme/msaleme@8466156), so on merge the only remaining drift is PubPoint's, which is owned elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)