### PR TITLE
docs: pin the AIUC-1 19/20 claim to the requirement set it was measured against

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -80,7 +80,7 @@ export PATH="$HOME/.local/bin:$PATH"
 | Jailbreak / Over-Refusal | 25 jailbreak + 25 false-positive rate tests | 50 |
 | GTG-1002 APT Simulation | 17 nation-state pattern reproductions | 17 |
 | Enterprise Platforms | 25 cloud + 20 enterprise platform tests | 45+ |
-| AIUC-1 Compliance | Maps to 19 of 20 testable AIUC-1 requirements | 12 |
+| AIUC-1 Compliance | Maps to 19 of 20 testable AIUC-1 requirements (2026-Q1/Q2 set; see the [crosswalk](docs/AIUC1-CROSSWALK.md) for the Q3-2026 delta) | 12 |
 
 Full inventory: [docs/TEST-INVENTORY.md](docs/TEST-INVENTORY.md)
 

--- a/docs/AIUC1-CROSSWALK.md
+++ b/docs/AIUC1-CROSSWALK.md
@@ -14,7 +14,7 @@ material no matter how many requirements it covers. Executed evidence requires a
 stated target and a pinned revision; independent review requires a qualified
 outside party.
 
-> **Standard currency:** this mapping was built against **v2026-Q1** (reviewed March 2026). AIUC-1 now revises quarterly — **Q2 (April 2026)** added MCP/A2A protocol-security and agent-identity controls; **Q3 (released 2026-07-15)** modified 8 requirements / 41 controls. Requirement-level rows below remain valid (renumbering happened at sub-control level), but see the **Q3-2026 Currency Note** near the end of this document before citing this crosswalk against the current standard. Last currency review: 2026-07-16.
+> **Standard currency:** this mapping was built against **v2026-Q1** (reviewed March 2026). AIUC-1 now revises quarterly — **Q2 (April 2026)** added MCP/A2A protocol-security and agent-identity controls; **Q3 (released 2026-07-15)** modified 8 requirements / 41 controls. Requirement-level rows below remain valid (renumbering happened at sub-control level), but see the **Q3-2026 Currency Note** near the end of this document before citing this crosswalk against the current standard. Last currency review: 2026-07-16. **Next review due on the Q4-2026 release, 2026-10-15**; AIUC-1 ships on a fixed quarterly cadence (Jan/Apr/Jul/Oct 15), so the review date is knowable in advance rather than event-driven.
 
 ---
 


### PR DESCRIPTION
AIUC-1 revises quarterly on a fixed calendar (Jan/Apr/Jul/Oct 15), so **"19 of 20 testable requirements" is only meaningful with the set it is denominated against.**

`docs/AIUC1-CROSSWALK.md` and `README.md` already carried that qualifier and the Q3-2026 delta — the crosswalk is careful. Two leaf surfaces were not:

- `SKILL.md` stated the figure bare;
- the **GitHub repository description** states `AIUC-1 19/20` with no set — and per `check_public_metadata.py`, the description is the text repository search matches, so it is the highest-traffic surface of the three.

Both now name the **2026-Q1/Q2 set** and point at the Q3 currency note. No coverage claim changes: the same 19 requirements, stated with the denominator that makes the number checkable.

The crosswalk additionally records **when its next currency review is due (Q4-2026, 2026-10-15)** rather than leaving it event-driven. The cadence is published, so the date is knowable in advance.

## Why now

KPMG's aIQ Capture was certified against AIUC-1 on 2026-08-27, joining Cursor and a consortium of 250+ Fortune 1000 security leaders, with Schellman as the accredited auditor. The standard now has readers who will check a denominator. A bare `19/20` against a set two quarters old is the same defect class as a stale test count — a true statement that stops being checkable once you drop the thing it was measured against.

`extract()` still parses the amended description correctly (`('611', '4.20.0')`), verified before the change was applied. 927 tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)