### PR TITLE
docs: quote AIUC-1 requirement titles verbatim; A003 said collection, standard says access

### DIFF
--- a/docs/AIUC1-CROSSWALK.md
+++ b/docs/AIUC1-CROSSWALK.md
@@ -14,7 +14,7 @@ material no matter how many requirements it covers. Executed evidence requires a
 stated target and a pinned revision; independent review requires a qualified
 outside party.
 
-> **Standard currency:** this mapping was built against **v2026-Q1** (reviewed March 2026). AIUC-1 now revises quarterly — **Q2 (April 2026)** added MCP/A2A protocol-security and agent-identity controls; **Q3 (released 2026-07-15)** modified 8 requirements / 41 controls. Requirement-level rows below remain valid (renumbering happened at sub-control level), but see the **Q3-2026 Currency Note** near the end of this document before citing this crosswalk against the current standard. Last currency review: 2026-07-16. **Next review due on the Q4-2026 release, 2026-10-15**; AIUC-1 ships on a fixed quarterly cadence (Jan/Apr/Jul/Oct 15), so the review date is knowable in advance rather than event-driven.
+> **Standard currency:** this mapping was built against **v2026-Q1** (reviewed March 2026). AIUC-1 now revises quarterly — **Q2 (April 2026)** added MCP/A2A protocol-security and agent-identity controls; **Q3 (released 2026-07-15)** modified 8 requirements / 41 controls. Requirement-level rows below remain valid (renumbering happened at sub-control level), but see the **Q3-2026 Currency Note** near the end of this document before citing this crosswalk against the current standard. Last currency review: 2026-07-16. **Requirement titles verified verbatim against the published pillar pages on 2026-09-05** (`/security`, `/safety`, `/reliability`, `/data-and-privacy`, `/accountability`, `/society`); four had drifted from the standard's wording and were corrected, most consequentially A003, which this document called *data collection* where the standard says *data access*. **Next review due on the Q4-2026 release, 2026-10-15**; AIUC-1 ships on a fixed quarterly cadence (Jan/Apr/Jul/Oct 15), so the review date is knowable in advance rather than event-driven.
 
 ---
 
@@ -24,9 +24,9 @@ outside party.
 
 | AIUC-1 Req | Requirement | Our Coverage |
 |---|---|---|
-| **B001** | Third-party adversarial robustness testing | Harness test vectors may support evidence collection for prompt injection, jailbreaks, polymorphic attacks, multi-step chains, and CVE reproduction. See the [test inventory](TEST-INVENTORY.md) and run the count script for the current test-ID total. |
+| **B001** | Third-party testing of adversarial robustness | Harness test vectors may support evidence collection for prompt injection, jailbreaks, polymorphic attacks, multi-step chains, and CVE reproduction. See the [test inventory](TEST-INVENTORY.md) and run the count script for the current test-ID total. |
 | **B002** | Detect adversarial input | MCP tool injection (MCP-001-010), A2A message spoofing (A2A-001-012), prompt injection via operational data (APP-001-030) |
-| **B005** | Real-time input filtering | Filter bypass via encoding tricks, nested injection, polymorphic payloads, context displacement (ADV-001-010) |
+| **B005** | Implement real-time input filtering | Filter bypass via encoding tricks, nested injection, polymorphic payloads, context displacement (ADV-001-010) |
 | **B009** | Limit output over-exposure | Information leakage detection, output exfiltration tests, API key regex scanning |
 
 ### D. Reliability (all listed requirements mapped)
@@ -49,7 +49,7 @@ outside party.
 
 | AIUC-1 Req | Requirement | Our Coverage |
 |---|---|---|
-| **A003** | Limit AI agent data collection | MCP capability escalation, A2A cross-session leakage, enterprise platform data access boundary tests |
+| **A003** | Limit AI agent data access | MCP capability escalation, A2A cross-session leakage, enterprise platform data access boundary tests |
 | **A004** | Protect IP & trade secrets | Tool discovery poisoning (exfiltration), context displacement DoS, API key leak detection |
 
 ### E. Accountability (complementary)
@@ -58,7 +58,7 @@ outside party.
 |---|---|---|
 | **E004** | Assign accountability | [CSG paper](https://doi.org/10.5281/zenodo.19162104) defines 3-tier governance with explicit accountability. 12 mechanisms, 77 days production evidence. |
 | **E006** | Conduct vendor due diligence | A bounded, authorized harness run may contribute technical evidence to a vendor-due-diligence review. It does not replace the review or establish a vendor conclusion on its own. |
-| **E015** | Log model activity | JSON reports with full request/response transcripts serve as audit evidence |
+| **E015** | Log AI system activity | JSON reports with full request/response transcripts serve as audit evidence |
 
 ### F. Society (mapped subset)
 


### PR DESCRIPTION
All sixteen mapped requirement titles were checked against the published pillar pages on 2026-09-05 (`/security`, `/safety`, `/reliability`, `/data-and-privacy`, `/accountability`, `/society`). Four had drifted from the standard's own wording.

| ID | This document said | The standard says |
|---|---|---|
| B001 | Third-party adversarial robustness testing | **Third-party testing of adversarial robustness** |
| B005 | Real-time input filtering | **Implement real-time input filtering** |
| E015 | Log model activity | **Log AI system activity** |
| A003 | Limit AI agent data **collection** | **Limit AI agent data access** |

The first three are wording. **A003 is not.** Collection and access are different properties, and a crosswalk that renames a requirement is asserting a mapping to something the standard does not say.

The coverage cell for A003 already described access-boundary tests — MCP capability escalation, A2A cross-session leakage, enterprise platform data access boundaries. So the row was right and its title was wrong, which is the harder direction to notice: nothing downstream disagreed with it, and every reader who checked the coverage against the title would have found them consistent with each other and inconsistent with AIUC-1.

**No coverage claim changes.** The twelve other titles were already verbatim, and the 19-of-20 denominator is untouched.

The currency note now records that titles were verified verbatim and against which pages, so the Q4-2026 review (due 2026-10-15) can diff rather than re-read.

## Verification

Requirement IDs and titles were read from the live pillar pages, not from the changelog — the changelog lists what changed, and absence from it is not confirmation that a requirement still exists under the same name. 927 tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)