### PR TITLE
fix: the quorum fix checked identity without checking authority

### DIFF
--- a/HARNESS_TEST_CATALOG.md
+++ b/HARNESS_TEST_CATALOG.md
@@ -1,7 +1,7 @@
 # Agent Security Harness — Canonical Test Catalog
 
 **Source repo:** msaleme/red-team-blue-team-agent-fabric
-**Generated:** `scripts/generate_test_catalog.py` at commit `6f6536e`
+**Generated:** `scripts/generate_test_catalog.py` at commit `733aaef`
 **Test count:** 611 unique test IDs across 45 registered harness modules (44 contain test IDs; `community_runner.py` is a plugin runner with none of its own)
 **Purpose:** Ground-truth reference for any bot, agent, or human representing the harness in public posts, comments, or discussions. Cite only tests listed here. Do not invent IDs or statistics.
 
@@ -768,23 +768,23 @@ WM-005 | Multi-Language Watermark Compliance | protocol_tests/watermark_harness.
 ### x402 Fireblocks Extension (`protocol_tests/x402_fireblocks_harness.py`) — 17 tests
 
 ```
-FB-001 | Recipient Tamper (payTo swap) | protocol_tests/x402_fireblocks_harness.py:494
-FB-002 | Amount Tamper (overcharge) | protocol_tests/x402_fireblocks_harness.py:518
-FB-003 | Network/Asset Tamper (cross-chain swap) | protocol_tests/x402_fireblocks_harness.py:542
-FB-004 | Expired Integrity Envelope | protocol_tests/x402_fireblocks_harness.py:567
-FB-005 | Future-Dated Envelope (skew abuse) | protocol_tests/x402_fireblocks_harness.py:592
-FB-006 | Integrity Downgrade (strip envelope) | protocol_tests/x402_fireblocks_harness.py:618
-FB-007 | Signed-Field Boundary (resource.url SSRF) | protocol_tests/x402_fireblocks_harness.py:655
-FB-008 | Canonicalization Bypass Attempt | protocol_tests/x402_fireblocks_harness.py:686
-FB-009 | did:web Resolution SSRF | protocol_tests/x402_fireblocks_harness.py:723
-FB-010 | Destination Allowlist Enforcement | protocol_tests/x402_fireblocks_harness.py:749
-FB-011 | Per-Transaction Amount Cap | protocol_tests/x402_fireblocks_harness.py:769
-FB-012 | Velocity / Window Budget Limit | protocol_tests/x402_fireblocks_harness.py:797
-FB-013 | Approval Quorum Above Threshold | protocol_tests/x402_fireblocks_harness.py:877
-FB-014 | Batch Voucher Replay / Monotonicity | protocol_tests/x402_fireblocks_harness.py:905
-FB-015 | Voucher Resource-Hash Binding | protocol_tests/x402_fireblocks_harness.py:932
-FB-016 | Expired Voucher Rejection | protocol_tests/x402_fireblocks_harness.py:953
-FB-017 | Escrow Over-Redemption | protocol_tests/x402_fireblocks_harness.py:983
+FB-001 | Recipient Tamper (payTo swap) | protocol_tests/x402_fireblocks_harness.py:506
+FB-002 | Amount Tamper (overcharge) | protocol_tests/x402_fireblocks_harness.py:530
+FB-003 | Network/Asset Tamper (cross-chain swap) | protocol_tests/x402_fireblocks_harness.py:554
+FB-004 | Expired Integrity Envelope | protocol_tests/x402_fireblocks_harness.py:579
+FB-005 | Future-Dated Envelope (skew abuse) | protocol_tests/x402_fireblocks_harness.py:604
+FB-006 | Integrity Downgrade (strip envelope) | protocol_tests/x402_fireblocks_harness.py:630
+FB-007 | Signed-Field Boundary (resource.url SSRF) | protocol_tests/x402_fireblocks_harness.py:667
+FB-008 | Canonicalization Bypass Attempt | protocol_tests/x402_fireblocks_harness.py:698
+FB-009 | did:web Resolution SSRF | protocol_tests/x402_fireblocks_harness.py:735
+FB-010 | Destination Allowlist Enforcement | protocol_tests/x402_fireblocks_harness.py:761
+FB-011 | Per-Transaction Amount Cap | protocol_tests/x402_fireblocks_harness.py:781
+FB-012 | Velocity / Window Budget Limit | protocol_tests/x402_fireblocks_harness.py:809
+FB-013 | Approval Quorum Above Threshold | protocol_tests/x402_fireblocks_harness.py:898
+FB-014 | Batch Voucher Replay / Monotonicity | protocol_tests/x402_fireblocks_harness.py:926
+FB-015 | Voucher Resource-Hash Binding | protocol_tests/x402_fireblocks_harness.py:953
+FB-016 | Expired Voucher Rejection | protocol_tests/x402_fireblocks_harness.py:974
+FB-017 | Escrow Over-Redemption | protocol_tests/x402_fireblocks_harness.py:1004
 ```
 
 ### x402 Payment (`protocol_tests/x402_harness.py`) — 54 tests

--- a/protocol_tests/x402_fireblocks_harness.py
+++ b/protocol_tests/x402_fireblocks_harness.py
@@ -312,25 +312,37 @@ class ActionRef:
 class ApprovalQuorum:
     """Collects approvals for ONE above-threshold action.
 
-    A count of approvals is not a quorum. Two properties have to hold that
+    A count of approvals is not a quorum. Three properties have to hold that
     cardinality alone does not give you:
 
-      * approvals come from **distinct approver identities** — the same
-        approver signing twice is one approver, not two;
+      * each approver is **eligible** — a signature from someone outside the
+        authorized approver set is not an approval, however well-formed;
+      * approvals come from **distinct identities** — the same approver
+        signing twice is one approver, not two;
       * each approval **binds to the exact action** under evaluation — an
-        approval for a different destination, amount or nonce does not
-        count toward this action's quorum.
+        approval for a different destination, amount or nonce does not count
+        toward this action's quorum.
 
-    Dropping either one lets a degenerate input satisfy the control: N copies
-    of one approval, or N approvals for some other action, both reach the
-    threshold while nobody has approved *this* transfer.
+    Dropping any one lets a degenerate input satisfy the control: N approvals
+    from parties with no authority, N copies of one approval, or N approvals
+    for some other action. Each reaches the threshold while nobody entitled to
+    approve *this* transfer has done so.
+
+    Eligibility was missing from the first version of this class (2026-09-05)
+    and added the same day. The class had been written to fix a test that
+    counted without checking identity, and it checked identity without
+    checking authority -- the same defect one level in. A quorum of two
+    arbitrary strings satisfied it.
     """
     threshold: int
     action: ActionRef
+    eligible_approvers: frozenset
     _approvers: dict = field(default_factory=dict)
 
     def approve(self, approver: str, action: ActionRef) -> tuple[bool, str]:
         """Record one approval. Returns (accepted, reason)."""
+        if approver not in self.eligible_approvers:
+            return (False, f"{approver} is not in the authorized approver set")
         if action != self.action:
             return (False, "approval not bound to the action under evaluation")
         if approver in self._approvers:
@@ -837,31 +849,38 @@ class X402FireblocksTests:
 
         action = ActionRef(pay_to="0xM", amount=5_000_000, nonce="tx-1")
         other = ActionRef(pay_to="0xM", amount=5_000_000, nonce="tx-2")
+        eligible = frozenset({"approver-a", "approver-b"})
 
-        # (2) two distinct approvers, both bound to this action
-        q_ok = ApprovalQuorum(threshold=2, action=action)
+        # (2) two distinct eligible approvers, both bound to this action
+        q_ok = ApprovalQuorum(threshold=2, action=action, eligible_approvers=eligible)
         a1, _ = q_ok.approve("approver-a", action)
         a2, _ = q_ok.approve("approver-b", action)
         distinct_satisfies = a1 and a2 and q_ok.satisfied
 
         # (3) the SAME approver twice must not reach a threshold of two
-        q_dup = ApprovalQuorum(threshold=2, action=action)
+        q_dup = ApprovalQuorum(threshold=2, action=action, eligible_approvers=eligible)
         d1, _ = q_dup.approve("approver-a", action)
         d2, dup_reason = q_dup.approve("approver-a", action)
         duplicate_rejected = d1 and (not d2) and (not q_dup.satisfied)
 
         # (4) an approval for a different action must not count toward this one
-        q_bind = ApprovalQuorum(threshold=1, action=action)
+        q_bind = ApprovalQuorum(threshold=1, action=action, eligible_approvers=eligible)
         b1, bind_reason = q_bind.approve("approver-a", other)
         unbound_rejected = (not b1) and (not q_bind.satisfied)
 
-        model_pass = (routed and distinct_satisfies
-                      and duplicate_rejected and unbound_rejected)
+        # (5) a well-formed approval from outside the authorized set is not an approval
+        q_elig = ApprovalQuorum(threshold=1, action=action, eligible_approvers=eligible)
+        e1, elig_reason = q_elig.approve("approver-z", action)
+        ineligible_rejected = (not e1) and (not q_elig.satisfied)
+
+        model_pass = (routed and distinct_satisfies and duplicate_rejected
+                      and unbound_rejected and ineligible_rejected)
         if model_pass:
             model_reason = (
                 f"above-threshold spend routed to manual approval ({reason}); "
-                "quorum requires distinct approvers bound to the exact action "
-                f"(duplicate: {dup_reason}; unbound: {bind_reason})")
+                "quorum requires eligible, distinct approvers bound to the exact action "
+                f"(duplicate: {dup_reason}; unbound: {bind_reason}; "
+                f"ineligible: {elig_reason})")
         else:
             gaps = []
             if not routed:
@@ -872,6 +891,8 @@ class X402FireblocksTests:
                 gaps.append("QUORUM GAP — one approver counted twice toward the threshold")
             if not unbound_rejected:
                 gaps.append("BINDING GAP — an approval for a different action counted toward this one")
+            if not ineligible_rejected:
+                gaps.append("ELIGIBILITY GAP — a party outside the authorized set counted toward the quorum")
             model_reason = "; ".join(gaps)
         self._finish(
             test_id="FB-013", name="Approval Quorum Above Threshold",

--- a/tests/test_fb013_quorum_binds_distinct_approvers.py
+++ b/tests/test_fb013_quorum_binds_distinct_approvers.py
@@ -35,19 +35,24 @@ def action():
     return ActionRef(pay_to="0xM", amount=5_000_000, nonce="tx-1")
 
 
-def test_distinct_approvers_satisfy_the_quorum(action):
+@pytest.fixture
+def eligible():
+    return frozenset({"approver-a", "approver-b"})
+
+
+def test_distinct_approvers_satisfy_the_quorum(action, eligible):
     """The positive control. A quorum that rejects everything has not enforced
     anything -- it must still accept the case it exists to allow."""
-    q = ApprovalQuorum(threshold=2, action=action)
+    q = ApprovalQuorum(threshold=2, action=action, eligible_approvers=eligible)
     assert q.approve("approver-a", action)[0]
     assert not q.satisfied, "one of two approvals must not satisfy a threshold of two"
     assert q.approve("approver-b", action)[0]
     assert q.satisfied
 
 
-def test_one_approver_twice_is_not_a_quorum_of_two(action):
+def test_one_approver_twice_is_not_a_quorum_of_two(action, eligible):
     """Cardinality is not identity. This is the defect class itself."""
-    q = ApprovalQuorum(threshold=2, action=action)
+    q = ApprovalQuorum(threshold=2, action=action, eligible_approvers=eligible)
     assert q.approve("approver-a", action)[0]
     accepted, reason = q.approve("approver-a", action)
     assert not accepted
@@ -55,15 +60,31 @@ def test_one_approver_twice_is_not_a_quorum_of_two(action):
     assert not q.satisfied, "the same approver counted twice reached the threshold"
 
 
-def test_approval_for_a_different_action_does_not_count(action):
+def test_approval_for_a_different_action_does_not_count(action, eligible):
     """Binding. An approval is granted for one action, not for the approver's
     general willingness to approve."""
     other = ActionRef(pay_to="0xM", amount=5_000_000, nonce="tx-2")
-    q = ApprovalQuorum(threshold=1, action=action)
+    q = ApprovalQuorum(threshold=1, action=action, eligible_approvers=eligible)
     accepted, reason = q.approve("approver-a", other)
     assert not accepted
     assert "not bound" in reason
     assert not q.satisfied
+
+
+def test_an_ineligible_principal_does_not_count(action, eligible):
+    """Identity is not authority. A well-formed approval from outside the
+    authorized set is not an approval, and distinctness does not rescue it:
+    two ineligible strangers are still two strangers."""
+    q = ApprovalQuorum(threshold=1, action=action, eligible_approvers=eligible)
+    accepted, reason = q.approve("approver-z", action)
+    assert not accepted
+    assert "not in the authorized approver set" in reason
+    assert not q.satisfied
+
+    q2 = ApprovalQuorum(threshold=2, action=action, eligible_approvers=eligible)
+    assert not q2.approve("stranger-1", action)[0]
+    assert not q2.approve("stranger-2", action)[0]
+    assert not q2.satisfied, "two distinct ineligible parties formed a quorum"
 
 
 @pytest.mark.parametrize("field,value", [
@@ -71,10 +92,10 @@ def test_approval_for_a_different_action_does_not_count(action):
     ("amount", 50_000_000),
     ("nonce", "tx-replay"),
 ])
-def test_binding_is_checked_on_every_field(action, field, value):
+def test_binding_is_checked_on_every_field(action, eligible, field, value):
     """Each field of the action is load-bearing: an approval that differs on any
     one of destination, amount or nonce is an approval for a different action."""
-    q = ApprovalQuorum(threshold=1, action=action)
+    q = ApprovalQuorum(threshold=1, action=action, eligible_approvers=eligible)
     mutated = ActionRef(**{**action.__dict__, field: value})
     assert not q.approve("approver-a", mutated)[0]
     assert not q.satisfied


### PR DESCRIPTION
`ApprovalQuorum` — added yesterday in #508 to fix a test that counted approvals without checking who gave them — checked that approvers were **distinct** and never that they were **authorized**. Two arbitrary strings formed a quorum.

That is the same defect one level in.

- #508 exists because `FB-013` asserted *routing* under the name "quorum".
- This exists because the class written to fix it asserted *distinctness* under the same name.

Identity is not authority, and a remedy inherits the pull that produced the original.

## What changed

`ApprovalQuorum` takes an `eligible_approvers` set and refuses any approval from outside it before considering binding or distinctness. `FB-013` now asserts five properties:

1. above-threshold spend routes to `require_approval`;
2. two distinct **eligible** approvals bound to the action satisfy the quorum;
3. the same approver twice does not;
4. an approval bound to a different action does not count;
5. **an approval from outside the authorized set does not count.**

The regression adds the case that would have caught this: **two distinct ineligible parties must not form a quorum**, since distinctness alone would have accepted them.

## How it was found

In review of the write-up of #508, before publication. The article described a fix that had this hole, so the code was corrected rather than the prose. Worth recording plainly: the defect was found, named, written about, and then reproduced inside its own remedy.

Test count unchanged at 611; catalog regenerated for the line shift. 928 tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)