### PR TITLE
chore: name what ApprovalQuorum.approve returns at every call site

### DIFF
--- a/tests/test_fb013_quorum_binds_distinct_approvers.py
+++ b/tests/test_fb013_quorum_binds_distinct_approvers.py
@@ -44,18 +44,21 @@ def test_distinct_approvers_satisfy_the_quorum(action, eligible):
     """The positive control. A quorum that rejects everything has not enforced
     anything -- it must still accept the case it exists to allow."""
     q = ApprovalQuorum(threshold=2, action=action, eligible_approvers=eligible)
-    assert q.approve("approver-a", action)[0]
+    recorded, _ = q.approve("approver-a", action)
+    assert recorded, "an eligible, bound approval must be recorded"
     assert not q.satisfied, "one of two approvals must not satisfy a threshold of two"
-    assert q.approve("approver-b", action)[0]
+    recorded, _ = q.approve("approver-b", action)
+    assert recorded
     assert q.satisfied
 
 
 def test_one_approver_twice_is_not_a_quorum_of_two(action, eligible):
     """Cardinality is not identity. This is the defect class itself."""
     q = ApprovalQuorum(threshold=2, action=action, eligible_approvers=eligible)
-    assert q.approve("approver-a", action)[0]
-    accepted, reason = q.approve("approver-a", action)
-    assert not accepted
+    recorded, _ = q.approve("approver-a", action)
+    assert recorded
+    recorded, reason = q.approve("approver-a", action)
+    assert not recorded
     assert "duplicate" in reason
     assert not q.satisfied, "the same approver counted twice reached the threshold"
 
@@ -65,8 +68,8 @@ def test_approval_for_a_different_action_does_not_count(action, eligible):
     general willingness to approve."""
     other = ActionRef(pay_to="0xM", amount=5_000_000, nonce="tx-2")
     q = ApprovalQuorum(threshold=1, action=action, eligible_approvers=eligible)
-    accepted, reason = q.approve("approver-a", other)
-    assert not accepted
+    recorded, reason = q.approve("approver-a", other)
+    assert not recorded
     assert "not bound" in reason
     assert not q.satisfied
 
@@ -76,8 +79,8 @@ def test_an_ineligible_principal_does_not_count(action, eligible):
     authorized set is not an approval, and distinctness does not rescue it:
     two ineligible strangers are still two strangers."""
     q = ApprovalQuorum(threshold=1, action=action, eligible_approvers=eligible)
-    accepted, reason = q.approve("approver-z", action)
-    assert not accepted
+    recorded, reason = q.approve("approver-z", action)
+    assert not recorded
     assert "not in the authorized approver set" in reason
     assert not q.satisfied
 
@@ -97,7 +100,8 @@ def test_binding_is_checked_on_every_field(action, eligible, field, value):
     one of destination, amount or nonce is an approval for a different action."""
     q = ApprovalQuorum(threshold=1, action=action, eligible_approvers=eligible)
     mutated = ActionRef(**{**action.__dict__, field: value})
-    assert not q.approve("approver-a", mutated)[0]
+    recorded, _ = q.approve("approver-a", mutated)
+    assert not recorded
     assert not q.satisfied
 
 


### PR DESCRIPTION
The regression mixed `assert q.approve(...)[0]` with `accepted, reason = q.approve(...)`, so a reader had to decide from context whether a true return meant *this approval was recorded* or *the quorum is now satisfied*. Those are different claims, and one approval cannot satisfy a threshold of two.

Every call site now unpacks to `recorded`, with the satisfied/not-satisfied assertion standing separately beside it. Tests only, no behaviour change; 928 pass locally.

Raised in review of the write-up of #508, where the same snippet needed a sentence of prose to disambiguate its return value. If a code sample needs that sentence, the code is what should change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)