### PR TITLE
fix: the community trust manifest had gone stale and nothing verified it

### DIFF
--- a/community_modules/MANIFEST.yaml
+++ b/community_modules/MANIFEST.yaml
@@ -8,7 +8,7 @@ patterns:
   reviewed_at: '2026-03-30'
 - file: examples/mcp_description_exfil.yaml
   id: CP-0002
-  sha256: 8807b8c74f228661c892acddae0de50bd6597a534accf3f36329cf6a0d07b4bf
+  sha256: 3c2c404732d4ebcc904fdce6dd0b7105a53fed7a4fb854c8ff24a18175673d0a
   trust: verified
   reviewed_by: msaleme
-  reviewed_at: '2026-03-30'
+  reviewed_at: '2026-09-05'

--- a/tests/test_community_manifest_integrity.py
+++ b/tests/test_community_manifest_integrity.py
@@ -1,0 +1,66 @@
+"""The community trust manifest must actually verify.
+
+`community_modules/MANIFEST.yaml` records a sha256, a trust tier and a reviewer
+per pattern, and `community_runner.py` refuses in strict mode to load a pattern
+whose hash does not match. That is a real control, and nothing ran it.
+
+`examples/mcp_description_exfil.yaml` was legitimately edited on 2026-07-10 by
+#235 (a CVE misattribution fix). The manifest had not been touched since
+2026-03-30, when integrity verification was added. So from July onward CP-0002
+failed its integrity check and silently did not load: `--list` reported one
+community pattern where the repository ships two, and the runner's own message
+called it possible tampering. Nobody saw it, because no test invoked the runner.
+
+A manifest that is never verified is a claim about integrity, not evidence of it.
+These tests make the manifest falsifiable in CI: a content change that does not
+update the hash now fails here rather than silently unloading a pattern.
+"""
+import hashlib
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+COMMUNITY = REPO / "community_modules"
+
+yaml = pytest.importorskip("yaml")
+
+
+def _manifest():
+    return yaml.safe_load((COMMUNITY / "MANIFEST.yaml").read_text())
+
+
+def test_every_manifest_entry_points_at_a_file_that_exists():
+    missing = [e["file"] for e in _manifest()["patterns"]
+               if not (COMMUNITY / e["file"]).is_file()]
+    assert missing == [], f"manifest references files that do not exist: {missing}"
+
+
+def test_every_registered_hash_matches_the_file_on_disk():
+    """The regression. A content edit that leaves the hash stale fails here."""
+    bad = []
+    for entry in _manifest()["patterns"]:
+        path = COMMUNITY / entry["file"]
+        if not path.is_file():
+            continue
+        recorded = entry.get("sha256")
+        if not recorded or recorded == "null":
+            continue
+        actual = hashlib.sha256(path.read_bytes()).hexdigest()
+        if actual != recorded:
+            bad.append(f"{entry['file']}: manifest {recorded[:16]}… vs file {actual[:16]}…")
+    assert bad == [], (
+        "stale manifest hashes — the pattern will fail integrity and silently not load:\n  "
+        + "\n  ".join(bad))
+
+
+def test_strict_mode_loads_every_registered_pattern():
+    """The positive control: verifying nothing would also produce no mismatches."""
+    from protocol_tests.community_runner import load_manifest  # noqa: E402
+    registered = {e["file"] for e in _manifest()["patterns"]}
+    assert registered, "manifest is empty; this test would pass vacuously"
+    loaded = load_manifest(str(COMMUNITY))
+    assert len(loaded) == len(registered), (
+        f"runner loaded {len(loaded)} manifest entries for {len(registered)} registered patterns")


### PR DESCRIPTION
`community_modules/MANIFEST.yaml` records a `sha256`, a `trust` tier and a `reviewed_by` per pattern, and `community_runner.py` refuses in strict mode to load a pattern whose hash does not match. That is a real control. **No test ever ran it.**

## What happened

`examples/mcp_description_exfil.yaml` was legitimately edited on **2026-07-10** by #235, a CVE misattribution fix. `MANIFEST.yaml` had not been touched since **2026-03-30**, when integrity verification was added.

From July onward, CP-0002 failed its integrity check and **silently did not load**:

```
Discovered 2 community pattern(s)
Manifest loaded: 2 registered pattern(s)
Validation errors (1):
  ... Hash mismatch for examples/mcp_description_exfil.yaml:
      expected 8807b8c74f228661..., got 3c2c404732d4ebcc...
      File may have been tampered with.
Community patterns (1):
  CP-0001 ...
```

One pattern listed where the repository ships two, and the runner's own message called it possible tampering. Nobody saw it, because nothing invoked the runner.

## What this changes

Refreshes the CP-0002 hash to the file that has been shipping since July, and re-dates that entry's review.

**The hash refresh alone would only restart the clock**, so this also makes the manifest falsifiable in CI:

1. every manifest entry points at a file that exists;
2. **every registered hash matches the file on disk** — the regression;
3. strict mode loads every registered pattern — the positive control, since a verifier that checks nothing also reports no mismatches.

Verified by injecting a corrupted hash: test 2 fails, and passes again when restored. Adding assertions proves more predicates ran; failing against a deliberately broken manifest shows the guard can recognize the defect it exists to catch.

## Provenance

Found while reviewing #516. **The defect predates that PR and is unrelated to it** — #516 contributes fixtures under a new `contrib/` directory, which surfaced the runner output where this was visible.

Full suite: **931 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)