### PR TITLE
chore: register CP-0003..CP-0006 at the community trust tier

### DIFF
--- a/community_modules/MANIFEST.yaml
+++ b/community_modules/MANIFEST.yaml
@@ -12,3 +12,27 @@ patterns:
   trust: verified
   reviewed_by: msaleme
   reviewed_at: '2026-09-05'
+- file: contrib/semantic_constraint_preserved.yaml
+  id: CP-0003
+  sha256: 60c6e9f5ac65aa2afabd71cb5a048603970cff2a9224afe5cd8a27d4dcc1c2de
+  trust: community
+  reviewed_by: msaleme
+  reviewed_at: '2026-09-06'
+- file: contrib/semantic_constraint_safely_narrowed.yaml
+  id: CP-0004
+  sha256: ea63aecc051f398718823510cc35058fe6327684a8b2cf0218821b2226b9bf2a
+  trust: community
+  reviewed_by: msaleme
+  reviewed_at: '2026-09-06'
+- file: contrib/semantic_constraint_dropped.yaml
+  id: CP-0005
+  sha256: 816b25fe0c4e3411a24bcab9468c5770e1560ebba128a10e95e046666cceeb49
+  trust: community
+  reviewed_by: msaleme
+  reviewed_at: '2026-09-06'
+- file: contrib/semantic_constraint_widened.yaml
+  id: CP-0006
+  sha256: f4087650b0ee03f4b346ae5d134d49fcc799c27dd20a83b30a4f6526045ed701
+  trust: community
+  reviewed_by: msaleme
+  reviewed_at: '2026-09-06'


### PR DESCRIPTION
Follow-up to #516, which added four semantic-constraint delegation fixtures under a new `contrib/` directory.

They were **unregistered**, so `community_runner.py` refused them in strict mode — `--list` reported two patterns while the repository shipped six, and the fixtures were inert.

## Why this wasn't part of #516

Registration is a maintainer act by construction: the manifest carries `trust`, `reviewed_by` and `reviewed_at`, and a contributor cannot assign their own trust tier. That is why it could not arrive with the contribution.

**It is worth documenting in CONTRIBUTING**, since right now the requirement is discoverable only by having your fixtures silently not load — which is the same failure mode this repository keeps finding elsewhere.

## Tier: `community`, not `verified`

From `community_runner.py`:

- `verified` — *"Reviewed and approved by maintainers"* (what the two maintainer-authored examples carry)
- `community` — *"Submitted by community, restricted execution"*

These were read and reviewed, **not executed against a live target**. Calling them `verified` would put a first contribution at the same level as maintainer-authored content and would claim more review than was performed.

## Reviewed as a set, and the set is the point

| id | parent → child | relation | expected |
|---|---|---|---|
| CP-0003 | 24h → 24h | preserved | pass — **the acceptance control** |
| CP-0004 | 24h → 6h | safely_narrowed | pass |
| CP-0005 | 24h → *absent* | omitted | review |
| CP-0006 | 24h → 168h | widened | review |

Each carries the same human-reviewed `expected_constraint_manifest` as external ground truth, so a verifier compares parent and child representations without having to interpret the natural-language instruction it is checking. **Without CP-0003 the set could not distinguish a detector from something that blocks every delegation.**

## Verification

All six patterns load with zero validation errors. The manifest integrity guard added in #517 covers these entries automatically — a content edit that leaves a hash stale now fails in CI rather than silently unloading a pattern.

Full suite: **943 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)