### PR TITLE
fix: the attestation record could not say a control was never exercised

### DIFF
--- a/protocol_tests/attestation.py
+++ b/protocol_tests/attestation.py
@@ -128,6 +128,11 @@ class AttestationEntry:
             "name", "remediation", "elapsed_s", "agent_identity",
             "protocol_version", "owasp_asi", "statistical", "details",
             "request_sent", "response_received",
+            # #520: an entry may state what it does not establish, and why a
+            # control went unexercised. Without these the schema could only say
+            # pass or fail, so an unexercised control left the harness as a
+            # failure -- an assertion the run never made.
+            "not_established", "inconclusive_reason",
         ):
             if key in kwargs:
                 self.data[key] = kwargs[key]
@@ -185,6 +190,7 @@ def generate_attestation_report(
         )
     passed = sum(1 for e in entries if e.get("result") == "pass")
     failed = sum(1 for e in entries if e.get("result") == "fail")
+    inconclusive = sum(1 for e in entries if e.get("result") == "inconclusive")
     errored = sum(1 for e in entries if e.get("result") == "error")
     skipped = sum(1 for e in entries if e.get("result") == "skip")
 
@@ -201,6 +207,11 @@ def generate_attestation_report(
             "total": len(entries),
             "passed": passed,
             "failed": failed,
+            # Always present, including at zero. `run_summary()` in http_helpers
+            # already treats this as a first-class bucket; omitting it here when
+            # it is empty would let a reader infer pass+fail == total, which is
+            # the inference this field exists to prevent.
+            "inconclusive": inconclusive,
         },
         "entries": entries,
     }
@@ -224,6 +235,31 @@ def generate_attestation_report(
 # Legacy migration (v3.7 -> v3.8)
 # ---------------------------------------------------------------------------
 
+def _legacy_result(record: dict[str, Any]) -> str:
+    """Map one legacy result to a schema `result`, preserving inconclusive.
+
+    A legacy record carries `passed: bool`, so an unexercised control and a
+    failed control are the same value. The third state survives only in the
+    INCONCLUSIVE_PREFIX on `details` and in the `not_evaluated` / `informational`
+    flags. Reading `passed` alone therefore reports "the control did not hold"
+    about a run that never tested it -- an assertion the harness never made.
+
+    The same predicate and the same field list as the in-process summary, so a
+    report and a summary over the same results cannot disagree. Note the shape
+    difference: `is_inconclusive` reads a result OBJECT via getattr, and a legacy
+    record is a dict, so handing it the record whole silently returns False for
+    every entry. The structural fields are read as keys and the prose form is
+    delegated, which is the one place that mismatch has to be known.
+    """
+    from .http_helpers import INCONCLUSIVE_FIELDS, is_inconclusive
+
+    if any(record.get(field) for field in INCONCLUSIVE_FIELDS):
+        return "inconclusive"
+    if is_inconclusive(record.get("details")):
+        return "inconclusive"
+    return "pass" if record.get("passed") else "fail"
+
+
 def migrate_legacy_report(legacy: dict[str, Any], harness_version: str = "3.8.0") -> dict[str, Any]:
     """Convert a v3.7-style report to the v3.8 attestation format.
 
@@ -236,7 +272,7 @@ def migrate_legacy_report(legacy: dict[str, Any], harness_version: str = "3.8.0"
     entries: list[dict[str, Any]] = []
 
     for r in legacy.get("results", []):
-        result_str = "pass" if r.get("passed") else "fail"
+        result_str = _legacy_result(r)
         entry = AttestationEntry(
             test_id=r.get("test_id", "UNKNOWN"),
             category=r.get("category", ""),
@@ -244,7 +280,8 @@ def migrate_legacy_report(legacy: dict[str, Any], harness_version: str = "3.8.0"
             severity=r.get("severity", "P4-Info"),
             timestamp=r.get("timestamp", legacy.get("timestamp")),
             **{k: r[k] for k in ("name", "owasp_asi", "details", "elapsed_s",
-                                  "request_sent", "response_received")
+                                  "request_sent", "response_received",
+                                  "not_established", "inconclusive_reason")
                if r.get(k) is not None},
         )
 

--- a/schemas/attestation-report.json
+++ b/schemas/attestation-report.json
@@ -87,6 +87,11 @@
           "minimum": 0,
           "description": "Number of entries with result 'fail'."
         },
+        "inconclusive": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Entries whose control was not exercised. NOT required, so records published before this field existed remain valid -- their hashes are the evidence and invalidating them would add no information. Every report this harness generates emits it, including at zero: a reader who can infer passed + failed == total will, and that inference is what this bucket exists to prevent. tests/test_attestation_can_say_inconclusive.py pins the always-emit property."
+        },
         "errored": {
           "type": "integer",
           "minimum": 0,
@@ -176,10 +181,11 @@
           "enum": [
             "pass",
             "fail",
+            "inconclusive",
             "error",
             "skip"
           ],
-          "description": "Test outcome."
+          "description": "Test outcome. `inconclusive` means the control was not exercised -- the target did not service the request, the probe could not run, or the result cannot distinguish a held control from an absent one. It is NOT a fail: a fail asserts the control did not hold, which inconclusive does not establish."
         },
         "severity": {
           "type": "string",
@@ -252,6 +258,14 @@
         "response_received": {
           "type": "object",
           "description": "The response payload received (for evidence)."
+        },
+        "not_established": {
+          "type": "string",
+          "description": "What this entry does NOT establish, stated plainly. Required reading for any party citing the entry as evidence. A passing result bounds a claim; this field says where that bound falls (docs/EVIDENCE-CLASS-TAXONOMY.md, whose every row carries a 'Does not establish' column)."
+        },
+        "inconclusive_reason": {
+          "type": "string",
+          "description": "Why the control was not exercised. Only meaningful when result is `inconclusive`; carrying it elsewhere is a schema smell, not an error."
         }
       },
       "additionalProperties": false

--- a/tests/test_attestation_can_say_inconclusive.py
+++ b/tests/test_attestation_can_say_inconclusive.py
@@ -1,0 +1,126 @@
+"""An attestation record must be able to say a control was never exercised.
+
+The harness has carried three states for a long time: `run_summary()` reports
+PASS / FAIL / INCONCLUSIVE, uses `serviced` as the denominator, and returns
+`pass_rate = None` rather than 0.0 when nothing was serviced, because "a rate of
+zero is a claim, and absence is not."
+
+The attestation report threw the third state away. Its `result` enum was
+`pass | fail | error | skip` with `additionalProperties: false`, and the legacy
+migration read `"pass" if r.get("passed") else "fail"`. So a verdict the harness
+knew was unexercised left the building as a **fail** -- an assertion that the
+control did not hold, which the run never made -- with the distinction surviving
+only as a prefix inside a prose string an auditor is not required to read.
+
+That is the defect this repository keeps finding, in the artifact that goes to
+third parties: a claim stronger than the evidence, produced by the serialization
+boundary rather than by any test.
+
+These tests pin the third state at that boundary, and pin the two fields that let
+an entry state its own limits.
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+
+from protocol_tests.attestation import (  # noqa: E402
+    AttestationEntry,
+    _legacy_result,
+    generate_attestation_report,
+    migrate_legacy_report,
+)
+
+SCHEMA = json.loads((REPO / "schemas" / "attestation-report.json").read_text())
+ENTRY = SCHEMA["$defs"]["attestation_entry"]
+
+
+class TestSchemaAdmitsTheThirdState:
+    def test_result_enum_contains_inconclusive(self):
+        assert "inconclusive" in ENTRY["properties"]["result"]["enum"]
+
+    def test_entry_may_state_what_it_does_not_establish(self):
+        """EVIDENCE-CLASS-TAXONOMY.md gives every level a 'Does not establish'
+        column. Until now no entry could carry one."""
+        assert "not_established" in ENTRY["properties"]
+
+    def test_entry_may_state_why_a_control_went_unexercised(self):
+        assert "inconclusive_reason" in ENTRY["properties"]
+
+    def test_entries_still_reject_unknown_fields(self):
+        """The schema stays closed; this change widens it deliberately, not by
+        loosening additionalProperties."""
+        assert ENTRY["additionalProperties"] is False
+
+
+class TestLegacyMigrationPreservesIt:
+    @pytest.mark.parametrize("record,expected", [
+        ({"passed": True, "details": "control held"}, "pass"),
+        ({"passed": False, "details": "control did not hold"}, "fail"),
+        ({"passed": False, "details": "INCONCLUSIVE - target did not service the request"},
+         "inconclusive"),
+        ({"passed": False, "not_evaluated": True, "details": "x"}, "inconclusive"),
+        ({"passed": False, "informational": True, "details": "x"}, "inconclusive"),
+    ])
+    def test_each_state_survives(self, record, expected):
+        assert _legacy_result(record) == expected
+
+    def test_an_unexercised_control_is_not_reported_as_a_failure(self):
+        """The regression. Before this change every row below became `fail`."""
+        legacy = {"suite": "s", "timestamp": "2026-09-07T00:00:00Z", "results": [
+            {"test_id": "T-1", "category": "c", "severity": "P4-Info", "passed": True,
+             "details": "held"},
+            {"test_id": "T-2", "category": "c", "severity": "P4-Info", "passed": False,
+             "details": "did not hold"},
+            {"test_id": "T-3", "category": "c", "severity": "P4-Info", "passed": False,
+             "details": "INCONCLUSIVE - target did not service the request"},
+        ]}
+        report = migrate_legacy_report(legacy)
+        got = {e["test_id"]: e["result"] for e in report["entries"]}
+        assert got == {"T-1": "pass", "T-2": "fail", "T-3": "inconclusive"}, got
+
+    def test_the_migration_would_fail_against_the_old_collapsing_rule(self):
+        """Fault injection: the pre-fix rule, run against the same input.
+
+        A guard that cannot be shown to fail against the defect it closes is
+        decoration."""
+        record = {"passed": False,
+                  "details": "INCONCLUSIVE - target did not service the request"}
+        collapsing_rule = "pass" if record.get("passed") else "fail"
+        assert collapsing_rule == "fail"
+        assert _legacy_result(record) == "inconclusive"
+        assert _legacy_result(record) != collapsing_rule
+
+
+class TestReportSummary:
+    def _entry(self, test_id, result, **kw):
+        return AttestationEntry(test_id=test_id, category="c", result=result,
+                                severity="P4-Info", **kw).to_dict()
+
+    def test_summary_counts_inconclusive(self):
+        entries = [self._entry("A", "pass"), self._entry("B", "fail"),
+                   self._entry("C", "inconclusive"), self._entry("D", "inconclusive")]
+        s = generate_attestation_report(entries, "s", "4.20.0")["summary"]
+        assert (s["total"], s["passed"], s["failed"], s["inconclusive"]) == (4, 1, 1, 2)
+
+    def test_inconclusive_is_reported_even_at_zero(self):
+        """A reader must never be able to infer passed + failed == total."""
+        s = generate_attestation_report([self._entry("A", "pass")], "s", "4.20.0")["summary"]
+        assert s["inconclusive"] == 0
+        assert "inconclusive" in s
+
+    def test_inconclusive_is_not_counted_as_passed_or_failed(self):
+        s = generate_attestation_report(
+            [self._entry("A", "inconclusive")], "s", "4.20.0")["summary"]
+        assert s["passed"] == 0 and s["failed"] == 0 and s["inconclusive"] == 1
+
+    def test_an_entry_can_carry_its_own_limits(self):
+        e = self._entry("A", "inconclusive",
+                        not_established="that the control holds under load",
+                        inconclusive_reason="target did not service the request")
+        assert e["not_established"] == "that the control holds under load"
+        assert e["inconclusive_reason"] == "target did not service the request"


### PR DESCRIPTION
The harness has carried three states for a long time. `run_summary()` reports PASS / FAIL / INCONCLUSIVE, uses `serviced` as the denominator, and returns `pass_rate = None` rather than `0.0` when nothing was serviced — because *"a rate of zero is a claim, and absence is not."* 152 sites across 34 modules emit an INCONCLUSIVE verdict, and `docs/EVIDENCE-CLASS-TAXONOMY.md` gives every evidence level an explicit **"Does not establish"** column.

**The attestation report threw all of it away at the serialization boundary.**

```
result enum:  pass | fail | error | skip          additionalProperties: false
migration:    "pass" if r.get("passed") else "fail"
```

So a verdict the harness *knew* was unexercised left the building as a **`fail`** — an assertion that the control did not hold, which the run never made — with the distinction surviving only as a prefix inside a prose string no reader is required to parse.

That is this project's own defect class, sitting in the artifact that goes to third parties: a claim stronger than the evidence, produced by serialization rather than by any test.

## What changed

- `result` gains **`inconclusive`**, documented as *not* a fail
- entries gain **`not_established`** (what this entry does not prove) and **`inconclusive_reason`** (why the control went unexercised)
- the summary gains an **`inconclusive`** count, emitted **even at zero**
- `_legacy_result()` preserves the third state through migration

The schema stays **closed** — `additionalProperties: false` is unchanged. This widens it deliberately rather than by loosening it.

## Two things found by testing, not by reading

**`is_inconclusive` is object-shaped; legacy records are dicts.** It reads `getattr(subject, "not_evaluated", False)`, so handing it a record dict returns `False` for every entry. **The first version of this change compiled, ran, and classified nothing.** Structural fields are now read as keys; only the prose form is delegated.

**`inconclusive` is deliberately NOT required in the summary.** Making it required invalidated both published attestation records — whose hashes *are* the evidence. Breaking their verification would add no information. Every report the harness generates emits it, and a test pins that property instead.

## Verification

15 regressions, including **fault injection**: the pre-fix collapsing rule is run against the same input and asserted to disagree with the new one. A guard that cannot be shown to fail against the defect it closes is decoration.

- Full suite: **958 passed**
- A real `inconclusive` entry validates against the schema
- Both historical records (`attestations/self/`, `attestations/external/`) still validate

## Why this one first

Three separate arguments depend on it: the auditor-facing claim that ASH distinguishes *a demonstrated control* from *an unreachable endpoint*; the AIUC-1 submission's point that `B001.1` requires a report but not evidence the instrument could detect a failure; and the four-field evidence chain. All three were true in the code and false in the artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)