### PR TITLE
Evidence pack: an AIUC-1 requirement must declare its denominator

### DIFF
--- a/scripts/evidence_pack.py
+++ b/scripts/evidence_pack.py
@@ -132,6 +132,9 @@ def compute_aiuc1_coverage(
                 "category": req_def["category"],
                 "status": "NO_RESULTS",
                 "test_ids": test_ids,
+                "tests_mapped": len(test_ids),
+                "tests_run": 0,
+                "tests_absent": list(test_ids),
                 "passed": 0,
                 "failed": 0,
                 "total": 0,
@@ -141,7 +144,16 @@ def compute_aiuc1_coverage(
 
         passed = sum(1 for tid in matched if result_by_id[tid].get("passed", False))
         failed = len(matched) - passed
-        status = "PASS" if failed == 0 else "FAIL"
+        # A requirement is only PASS when every test mapped to it actually ran.
+        # Reporting PASS on a strict subset lets "2 of 5 ran, both green" render
+        # identically to "all 5 ran, all green" -- the reader cannot tell a
+        # satisfied requirement from an under-exercised one.
+        if failed > 0:
+            status = "FAIL"
+        elif len(matched) < len(test_ids):
+            status = "PARTIAL"
+        else:
+            status = "PASS"
         covered_count += 1
 
         coverage[req_id] = {
@@ -149,6 +161,9 @@ def compute_aiuc1_coverage(
             "category": req_def["category"],
             "status": status,
             "test_ids": test_ids,
+            "tests_mapped": len(test_ids),
+            "tests_run": len(matched),
+            "tests_absent": [tid for tid in test_ids if tid not in result_by_id],
             "passed": passed,
             "failed": failed,
             "total": len(matched),
@@ -215,7 +230,12 @@ def compute_owasp_coverage(
             "tests_run": len(matched),
             "passed": passed,
             "failed": failed,
-            "status": "PASS" if (matched and failed == 0) else ("FAIL" if failed > 0 else "NOT_TESTED"),
+            "status": (
+                "FAIL" if failed > 0
+                else "NOT_TESTED" if not matched
+                else "PASS" if len(matched) == len(test_ids)
+                else "PARTIAL"
+            ),
         }
 
     return owasp
@@ -297,15 +317,17 @@ def generate_markdown(
         "",
         "## AIUC-1 Requirement Coverage",
         "",
-        "| Requirement | Title | Category | Status | Passed | Failed |",
-        "|-------------|-------|----------|--------|--------|--------|",
+        "| Requirement | Title | Category | Status | Tests Mapped | Tests Run | Passed | Failed |",
+        "|-------------|-------|----------|--------|--------------|-----------|--------|--------|",
     ]
 
     for req_id, req_data in sorted(aiuc1.get("requirements", {}).items()):
         status = req_data["status"]
         lines.append(
             f"| {req_id} | {req_data['title']} | {req_data['category']} "
-            f"| **{status}** | {req_data.get('passed', 0)} | {req_data.get('failed', 0)} |"
+            f"| **{status}** | {req_data.get('tests_mapped', 0)} "
+            f"| {req_data.get('tests_run', 0)} "
+            f"| {req_data.get('passed', 0)} | {req_data.get('failed', 0)} |"
         )
 
     lines.extend([
@@ -334,6 +356,10 @@ def generate_markdown(
         rid: rd for rid, rd in aiuc1.get("requirements", {}).items()
         if rd["status"] == "FAIL"
     }
+    partial_reqs = {
+        rid: rd for rid, rd in aiuc1.get("requirements", {}).items()
+        if rd["status"] == "PARTIAL"
+    }
 
     lines.extend([
         "",
@@ -361,8 +387,26 @@ def generate_markdown(
             )
         lines.append("")
 
-    if not gap_reqs and not fail_reqs:
-        lines.append("No gaps or failures identified.")
+    if partial_reqs:
+        lines.append("### Under-Exercised Requirements")
+        lines.append("")
+        lines.append(
+            "Every test that ran for these requirements passed, but not every test "
+            "mapped to them was present in this report. A passing subset does not "
+            "establish the requirement: the tests that did not run assert nothing."
+        )
+        lines.append("")
+        for req_id, req_data in sorted(partial_reqs.items()):
+            absent = ", ".join(req_data.get("tests_absent", [])) or "unrecorded"
+            lines.append(
+                f"- **{req_id} ({req_data['title']}):** "
+                f"{req_data['tests_run']}/{req_data['tests_mapped']} mapped tests ran; "
+                f"absent from this report: {absent}"
+            )
+        lines.append("")
+
+    if not gap_reqs and not fail_reqs and not partial_reqs:
+        lines.append("No gaps, failures, or under-exercised requirements identified.")
         lines.append("")
 
     lines.extend([

--- a/tests/test_evidence_pack_declares_its_denominator.py
+++ b/tests/test_evidence_pack_declares_its_denominator.py
@@ -1,0 +1,95 @@
+"""An AIUC-1 requirement must not read PASS on a subset of its own mapped tests.
+
+`compute_aiuc1_coverage` derived `total` from the tests it *found in the report*
+rather than the tests *mapped to the requirement*, and set `status = "PASS"`
+whenever none of the found ones failed. A requirement declaring five tests, of
+which two were present and both green, rendered as:
+
+    | A003 | ... | **PASS** | 2 | 0 |
+
+An auditor reading that row cannot distinguish it from a requirement whose five
+mapped tests all ran and all passed. The missing three assert nothing, and the
+artifact did not say they were missing -- the markdown never printed
+`len(test_ids)` at all.
+
+This is the defect class the harness's own AIUC-1 submission argues against: a
+control named, mapped, and passing while the property was never exercised. The
+OWASP path in the same file already emitted `tests_mapped` / `tests_run`; this
+pins the same discipline on the AIUC-1 path and on both status vocabularies.
+"""
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.evidence_pack import compute_aiuc1_coverage, generate_markdown
+
+
+def req_index(mapped):
+    return {
+        "A003": {
+            "title": "Test Requirement",
+            "category": "safety",
+            "status": "MAPPED",
+            "test_ids": list(mapped),
+        }
+    }
+
+
+def results_for(ids, passed=True):
+    return [{"test_id": t, "passed": passed} for t in ids]
+
+
+FIVE = ["T-001", "T-002", "T-003", "T-004", "T-005"]
+
+
+class DenominatorIsDeclared(unittest.TestCase):
+    def test_two_of_five_green_is_not_a_pass(self):
+        cov = compute_aiuc1_coverage(results_for(FIVE[:2]), req_index(FIVE))
+        r = cov["requirements"]["A003"]
+        self.assertEqual(r["status"], "PARTIAL", "a passing subset must not read PASS")
+        self.assertEqual(r["tests_mapped"], 5)
+        self.assertEqual(r["tests_run"], 2)
+        self.assertEqual(r["tests_absent"], ["T-003", "T-004", "T-005"])
+
+    def test_all_five_green_is_a_pass(self):
+        r = compute_aiuc1_coverage(results_for(FIVE), req_index(FIVE))["requirements"]["A003"]
+        self.assertEqual(r["status"], "PASS")
+        self.assertEqual((r["tests_mapped"], r["tests_run"]), (5, 5))
+        self.assertEqual(r["tests_absent"], [])
+
+    def test_a_failure_still_reads_fail_even_when_incomplete(self):
+        """PARTIAL must never mask a real failure."""
+        results = results_for(FIVE[:2], passed=True) + results_for(["T-003"], passed=False)
+        r = compute_aiuc1_coverage(results, req_index(FIVE))["requirements"]["A003"]
+        self.assertEqual(r["status"], "FAIL")
+
+    def test_nothing_present_still_reads_no_results(self):
+        r = compute_aiuc1_coverage([], req_index(FIVE))["requirements"]["A003"]
+        self.assertEqual(r["status"], "NO_RESULTS")
+        self.assertEqual(r["tests_mapped"], 5)
+        self.assertEqual(r["tests_absent"], FIVE)
+
+    def test_the_markdown_an_auditor_reads_shows_the_denominator(self):
+        cov = compute_aiuc1_coverage(results_for(FIVE[:2]), req_index(FIVE))
+        md = generate_markdown(
+            {"total_tests": 2, "passed": 2, "failed": 0, "pass_rate": 1.0},
+            cov,
+            {},
+            "test-target",
+            "2026-09-07T00:00:00Z",
+        )
+        self.assertIn("Tests Mapped", md, "the AIUC-1 table must print the denominator")
+        self.assertIn("PARTIAL", md)
+        self.assertIn("Under-Exercised Requirements", md)
+        self.assertIn("T-003", md, "the absent test IDs must be named, not just counted")
+        self.assertNotIn(
+            "No gaps, failures, or under-exercised requirements identified.",
+            md,
+            "an under-exercised requirement must not render as a clean pack",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The defect

`compute_aiuc1_coverage` derived `total` from the tests it **found in the report**, not the tests **mapped to the requirement**, and set `status = "PASS"` whenever none of the found ones failed.

A requirement declaring five tests, of which two were present and both green, rendered as:

| Requirement | Title | Category | Status | Passed | Failed |
|---|---|---|---|---|---|
| A003 | ... | Security | **PASS** | 2 | 0 |

An auditor cannot distinguish that from a requirement whose five mapped tests all ran and all passed. The three that did not run assert nothing — and the markdown never printed `len(test_ids)` at all, so the omission was not visible anywhere on the page.

This is the defect class this repo's own AIUC-1 submission argues against: *a control named, mapped to a requirement, and passing, while the property that requirement is about was never exercised.*

## The fix

The correct pattern was already in this file — the **OWASP path emits `tests_mapped` / `tests_run` and prints both columns.** The AIUC-1 path just didn't.

- AIUC-1 coverage now emits `tests_mapped`, `tests_run`, and `tests_absent` — the actual missing test IDs, not only a count.
- `status` is `PASS` only at full coverage, `PARTIAL` when everything that ran passed but not everything mapped ran. **`FAIL` still wins**, so `PARTIAL` can never mask a real failure.
- The AIUC-1 table prints Tests Mapped / Tests Run.
- Gaps section grew an **Under-Exercised Requirements** block that names the absent IDs, and the all-clear line accounts for `PARTIAL`.
- OWASP `status` gets the same full-coverage rule — it already printed the columns, only the verdict was wrong.

## Verification

**Fault-injected:** restoring the subset-PASS rule fails `test_two_of_five_green_is_not_a_pass` and the markdown test; both pass on restore.

**Regenerated a real pack** against `reports/mcpstandard-dev-20260327.json`. No requirement changes verdict there — the four covered ones happen to be fully covered. So this was **latent in the published packs, not active**. It would have fired on any run covering part of a requirement; `B005` maps 18 tests and is the obvious candidate.

Full suite: `963 passed, 634 subtests passed, 0 failed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)