### PR TITLE
A multi-trial run reported an unexercised control as failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed — a multi-trial run could report a control it never exercised as failed, and one that gave way as passed (#523)
+
+`trial_runner` is the shared `--trials N` path for 24 harnesses, and it was the
+last summary in the package still computing `failed` as a residual:
+
+```python
+total_tests  = len(stat_results)
+passed_tests = sum(1 for sr in stat_results if sr.pass_rate >= 0.5)
+failed_tests = total_tests - passed_tests
+```
+
+It read only `.passed`, so an INCONCLUSIVE result entered as `passed=False`,
+dragged the rate under the threshold, and was published as a target failure —
+the same substitution `run_summary` was written to stop in #402, in the one
+module that never called it. Against an unresponsive target a ten-trial run
+asserted that controls did not hold, when nothing had been exercised.
+
+The `>= 0.5` threshold was the other half. A test that failed two of five trials
+landed in `summary.passed` and the two failures appeared in no field of the
+written report: `per_trial` was held on the dataclass but `to_dict` never
+serialised it, so "retry until green" was the default and left no trace.
+
+`trial_runner` now delegates counting to `http_helpers.run_summary`, so
+`passed + failed + inconclusive == total`, the denominator is `serviced`, and
+the rate and Wilson interval are `None` rather than `0.0` when nothing was
+serviced. The verdict rule is named in the report rather than implied by a
+threshold: **a test passes only if every serviced trial passed; one serviced
+failure is a failure; no serviced trial is INCONCLUSIVE, never a failure.**
+Unstable tests are listed by id, and every trial's state is serialised.
+
+Three smaller faults in the same function, each of which could shrink a run
+without saying so:
+
+- `"results"` held the **final trial's** list while `summary.total` was computed
+  over the union across trials, with nothing marking the disagreement. If the
+  last trial crashed it silently held the trial before it; if all of them
+  crashed it was `[]`, which reads as "nothing failed" to the exit-code check in
+  every consumer. It is now one representative result per `test_id` — the trial
+  that carries the verdict — and an all-crashed run says so in `error`.
+- `getattr(r, "test_id", None) or r.get("test_id", "unknown")` put every
+  unidentified result in one `"unknown"` bucket: three results, one failing,
+  became a single entry scoring 2/3 and therefore passing. It also raised
+  `AttributeError` on a non-dict result lacking the attribute, dumping the rest
+  of that trial into `trial_errors`.
+- `statistical_summary.trials_per_test` published the **first** test's trial
+  count as if it were uniform. After a partial trial failure it is not; it is
+  now published only when it actually is, with the observed range beside it.
+
+Unchanged on purpose: per-trial error isolation, and matching by `test_id`
+rather than position.
+
 ### Added — `check_public_metadata.py --apply`, so the release run can pass
 
 `Public metadata drift` runs on `release: published` and compares the

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -32,6 +32,25 @@ agent-security test mcp --url http://localhost:8080/mcp --trials 10
 # Pass Rate: 80% (95% CI: 55%-93%)
 ```
 
+The rate and the interval are over **serviced** trials, and are omitted -- not
+reported as zero -- when no trial was serviced.
+
+A test's verdict across N trials follows one named rule, published in the report
+as `aggregation.rule`:
+
+| Trials for one test | Verdict |
+|---------------------|---------|
+| every serviced trial passed | PASS |
+| any serviced trial failed | FAIL — a control that gave way once did not hold |
+| no trial was serviced | INCONCLUSIVE — never FAIL |
+
+Tests that passed some serviced trials and failed others are listed in
+`aggregation.unstable_tests`, and every trial's state is in
+`statistical_summary.per_test[].per_trial_state`.
+
+`results` carries one representative result per `test_id` — the trial that
+carries the verdict — so it always agrees with `summary.total`.
+
 ---
 
 ## Advanced Attack Patterns

--- a/protocol_tests/statistical.py
+++ b/protocol_tests/statistical.py
@@ -93,15 +93,41 @@ def bootstrap_ci(pass_rates: list[float], n_bootstrap: int = 10000,
 
 @dataclass
 class TrialResult:
-    """Result of running a test across multiple trials."""
+    """Result of running a test across multiple trials.
+
+    ``pass_rate`` and ``ci_95`` are ``None`` -- not ``0.0`` and not ``(0.0, 0.0)``
+    -- when no trial was serviced, for the reason ``http_helpers.run_summary``
+    gives: a rate of zero is a claim, and absence is not. The denominator for
+    both is ``n_serviced``, so the rate answers "of what was observed, how much
+    passed" rather than "of everything attempted".
+
+    The three-state fields are appended, with defaults, so the positional
+    constructions in ``l402_harness`` and ``x402_harness`` keep working; those
+    two do not track INCONCLUSIVE per trial and correctly report zero of it.
+    """
     test_id: str
     test_name: str
     n_trials: int
     n_passed: int
-    pass_rate: float
-    ci_95: tuple[float, float]  # Wilson score CI
+    pass_rate: float | None
+    ci_95: tuple[float, float] | None  # Wilson score CI over serviced trials
     per_trial: list[bool]  # Individual trial results
     mean_elapsed_s: float
+    #: Trials that established nothing. Not failures.
+    n_inconclusive: int = 0
+    #: Per-trial "pass"/"fail"/"inconclusive", when the caller tracked it.
+    per_trial_state: list[str] | None = None
+
+    @property
+    def n_serviced(self) -> int:
+        """Trials that actually exercised the control."""
+        return self.n_trials - self.n_inconclusive
+
+    @property
+    def n_failed(self) -> int:
+        """Serviced trials that failed. A residual over `n_trials` would count
+        the inconclusive ones as failures, which is the defect this replaces."""
+        return self.n_serviced - self.n_passed
 
     def to_dict(self) -> dict:
         return {
@@ -109,10 +135,18 @@ class TrialResult:
             "test_name": self.test_name,
             "n_trials": self.n_trials,
             "n_passed": self.n_passed,
+            "n_failed": self.n_failed,
+            "n_inconclusive": self.n_inconclusive,
+            "n_serviced": self.n_serviced,
             "pass_rate": self.pass_rate,
-            "ci_95_lower": self.ci_95[0],
-            "ci_95_upper": self.ci_95[1],
+            "ci_95_lower": self.ci_95[0] if self.ci_95 else None,
+            "ci_95_upper": self.ci_95[1] if self.ci_95 else None,
             "mean_elapsed_s": self.mean_elapsed_s,
+            # `per_trial` was held on the dataclass but never serialised, so the
+            # claim that a flaky test's failures were "recoverable from the JSON"
+            # was not true of any written report. The state sequence is carried
+            # here, and is `None` for callers that do not track it.
+            "per_trial_state": self.per_trial_state,
         }
 
 
@@ -192,14 +226,28 @@ def enhance_report(report: dict, trial_results: list[TrialResult] | None = None)
 
     # Add statistical summary if trial results provided
     if trial_results:
-        pass_rates = [tr.pass_rate for tr in trial_results]
-        aggregate_ci = bootstrap_ci(pass_rates)
+        # Only tests with a serviced trial have a rate. Averaging a `None` in as
+        # 0.0 would drag the aggregate down with observations that were never
+        # made -- the same substitution `run_summary` refuses.
+        pass_rates = [tr.pass_rate for tr in trial_results if tr.pass_rate is not None]
+        trial_counts = [tr.n_trials for tr in trial_results]
+        # `trial_results[0].n_trials` published the FIRST test's trial count as
+        # if it were the whole run's. After a partial trial failure it is not:
+        # a run where T-1 got 3 trials and T-2 got 1 reported "3". So it is
+        # published only when it is actually uniform, and the observed range is
+        # published alongside it either way.
+        uniform = len(set(trial_counts)) == 1
 
         report["statistical_summary"] = {
-            "aggregate_pass_rate": round(sum(pass_rates) / len(pass_rates), 4) if pass_rates else 0,
-            "aggregate_ci_95": list(aggregate_ci),
+            "aggregate_pass_rate": (round(sum(pass_rates) / len(pass_rates), 4)
+                                    if pass_rates else None),
+            "aggregate_ci_95": list(bootstrap_ci(pass_rates)) if pass_rates else None,
             "n_tests": len(trial_results),
-            "trials_per_test": trial_results[0].n_trials if trial_results else 0,
+            "n_tests_with_a_serviced_trial": len(pass_rates),
+            "trials_per_test": trial_counts[0] if uniform else None,
+            "trials_per_test_uniform": uniform,
+            "trials_per_test_min": min(trial_counts),
+            "trials_per_test_max": max(trial_counts),
             "per_test": [tr.to_dict() for tr in trial_results],
         }
 

--- a/protocol_tests/trial_runner.py
+++ b/protocol_tests/trial_runner.py
@@ -3,6 +3,7 @@
 Fixes:
   - #72: matches results by test_id, not positional index
   - #82: per-trial error handling (one failure doesn't abort the rest)
+  - #523: PASS, FAIL and INCONCLUSIVE stay distinct across trials
 
 Usage::
 
@@ -13,16 +14,98 @@ Usage::
         return {"results": suite.run_all()}
 
     report = run_with_trials(single_run, trials=5, report_key="results")
+
+The aggregation rule is named in the report (``aggregation.rule``) rather than
+left implicit in a threshold. See ``AGGREGATION_RULE_TEXT`` for what it says and
+why.
 """
 from __future__ import annotations
 
 import traceback
 from collections import defaultdict
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
+from protocol_tests.http_helpers import (
+    INCONCLUSIVE_FIELDS,
+    INCONCLUSIVE_PREFIX,
+    is_inconclusive,
+    run_summary,
+    summary_lines,
+)
 from protocol_tests.statistical import TrialResult, enhance_report, wilson_ci
+
+#: The three states one trial of one test can be in.
+PASS = "pass"
+FAIL = "fail"
+INCONCLUSIVE = "inconclusive"
+
+#: Machine-readable name of the rule that turns N trial states into one verdict.
+AGGREGATION_RULE = "every-serviced-trial-must-pass"
+
+AGGREGATION_RULE_TEXT = (
+    "A test counts as PASSED only if every serviced trial passed. One serviced "
+    "failure makes the test FAILED: a control that gave way in any trial did not "
+    "hold, and re-running until it holds is not evidence that it does. A test "
+    "with no serviced trial is INCONCLUSIVE, never FAILED -- a fail asserts the "
+    "control did not hold, and an unserviced trial establishes nothing."
+)
+
+
+def _field(result: Any, name: str, default: Any = None) -> Any:
+    """Read *name* off a result that may be an object or a dict.
+
+    The previous form, ``getattr(r, name, None) or r.get(name, default)``, had
+    two faults in one line: it raised ``AttributeError`` on an object that
+    merely lacked the attribute (aborting the rest of that trial's results into
+    ``trial_errors``), and it treated a falsy value as absent.
+    """
+    if isinstance(result, Mapping):
+        return result.get(name, default)
+    value = getattr(result, name, None)
+    return default if value is None else value
+
+
+def _trial_state(result: Any) -> str:
+    """PASS / FAIL / INCONCLUSIVE for a single result.
+
+    The predicate is not reimplemented here. ``is_inconclusive`` reads
+    attributes, so a result that arrives as a dict is handed the same two facts
+    by key; the decision about what those facts mean stays in one place.
+    """
+    if isinstance(result, Mapping):
+        inconclusive = (any(bool(result.get(f)) for f in INCONCLUSIVE_FIELDS)
+                        or is_inconclusive(result.get("details")))
+    else:
+        inconclusive = is_inconclusive(result)
+    if inconclusive:
+        return INCONCLUSIVE
+    return PASS if bool(_field(result, "passed", False)) else FAIL
+
+
+@dataclass
+class _Verdict:
+    """One test's aggregated outcome, in the shape ``run_summary`` already reads.
+
+    Built so the counting can be delegated to ``http_helpers.run_summary``
+    instead of being written a second time here. ``not_evaluated`` is the
+    structural INCONCLUSIVE field that ``is_inconclusive`` looks for.
+    """
+
+    test_id: str
+    test_name: str
+    passed: bool
+    not_evaluated: bool
+    details: str
+
+    def __post_init__(self) -> None:
+        # The package invariant: a prefix in `details` implies the field, so a
+        # serialised record is never readable only as English.
+        # `testing/test_inconclusive_is_structural.py` enforces it here too.
+        if is_inconclusive(self.details):
+            self.not_evaluated = True
 
 
 def run_with_trials(
@@ -42,13 +125,20 @@ def run_with_trials(
 
     Returns:
         Merged report dict with ``statistical_summary`` and per-test stats.
+
+    The summary keeps PASS, FAIL and INCONCLUSIVE distinct and satisfies
+    ``passed + failed + inconclusive == total``. ``results`` holds one
+    representative result per test_id -- the evidence for that test's verdict --
+    so ``len(report["results"]) == report["summary"]["total"]`` by construction.
+    It used to be the final trial's list, which could disagree with the summary,
+    silently fall back to an earlier trial's list, or be empty.
     """
-    # {test_id: [(passed:bool, elapsed:float), ...]}
-    per_test: dict[str, list[tuple[bool, float]]] = defaultdict(list)
+    # {test_id: [(state, result_obj, elapsed), ...]} in trial order
+    per_test: dict[str, list[tuple[str, Any, float]]] = defaultdict(list)
     # Keep first-seen metadata per test_id
     meta: dict[str, dict[str, str]] = {}
-    last_results: list[Any] = []
     trial_errors: list[str] = []
+    unidentified = 0
 
     for trial_idx in range(trials):
         print(f"\n{'#'*60}")
@@ -57,19 +147,23 @@ def run_with_trials(
         try:
             report = run_fn()
             results = report.get(report_key, [])
-            last_results = results
-            for r in results:
-                tid = getattr(r, "test_id", None) or r.get("test_id", "unknown")  # type: ignore[union-attr]
-                passed = getattr(r, "passed", None)
-                if passed is None:
-                    passed = r.get("passed", False)  # type: ignore[union-attr]
-                elapsed = getattr(r, "elapsed_s", 0.0)
-                if elapsed == 0.0 and isinstance(r, dict):
-                    elapsed = r.get("elapsed_s", 0.0)
-                per_test[tid].append((bool(passed), float(elapsed)))
+            for position, r in enumerate(results):
+                tid = _field(r, "test_id", None)
+                if not tid:
+                    # A result with no id cannot be matched to the same test in
+                    # another trial, and pretending otherwise is what the shared
+                    # "unknown" bucket did: three unidentified results, one of
+                    # them failing, collapsed into a single entry that reported
+                    # 2/3 and therefore PASSED. Each gets its own entry, and the
+                    # count is published so the reader knows matching was not
+                    # possible -- rather than the total quietly shrinking.
+                    tid = f"unidentified-t{trial_idx + 1}-{position}"
+                    unidentified += 1
+                elapsed = _field(r, "elapsed_s", 0.0) or 0.0
+                per_test[tid].append((_trial_state(r), r, float(elapsed)))
                 if tid not in meta:
-                    name = getattr(r, "name", None) or (r.get("name") if isinstance(r, dict) else None) or tid
-                    meta[tid] = {"test_name": name}
+                    name = _field(r, "name", None) or tid
+                    meta[tid] = {"test_name": str(name)}
         except Exception:
             msg = traceback.format_exc()
             trial_errors.append(f"Trial {trial_idx + 1}: {msg}")
@@ -77,40 +171,104 @@ def run_with_trials(
 
     # Build statistical results keyed by test_id (fixes #72)
     stat_results: list[TrialResult] = []
+    verdicts: list[_Verdict] = []
+    representative: list[Any] = []
+    unstable: list[str] = []
+
     for tid, outcomes in per_test.items():
-        n = len(outcomes)
-        n_passed = sum(1 for p, _ in outcomes if p)
-        pass_rate = n_passed / n if n else 0.0
-        ci = wilson_ci(n_passed, n)
-        mean_elapsed = sum(e for _, e in outcomes) / n if n else 0.0
+        states = [s for s, _, _ in outcomes]
+        n = len(states)
+        n_passed = states.count(PASS)
+        n_failed = states.count(FAIL)
+        n_inconclusive = states.count(INCONCLUSIVE)
+        serviced = n_passed + n_failed
+        name = meta.get(tid, {}).get("test_name", tid)
+
+        # `None`, not 0.0, when nothing was serviced. Matching http_helpers:
+        # a rate of zero is a claim, and absence is not. The Wilson interval is
+        # over `serviced` for the same reason -- an interval computed over
+        # unserviced observations presents an absence as a measurement.
+        pass_rate = round(n_passed / serviced, 4) if serviced else None
+        ci = wilson_ci(n_passed, serviced) if serviced else None
+        mean_elapsed = sum(e for _, _, e in outcomes) / n if n else 0.0
+
         stat_results.append(TrialResult(
             test_id=tid,
-            test_name=meta.get(tid, {}).get("test_name", tid),
+            test_name=name,
             n_trials=n,
             n_passed=n_passed,
-            pass_rate=round(pass_rate, 4),
+            pass_rate=pass_rate,
             ci_95=ci,
-            per_trial=[p for p, _ in outcomes],
+            per_trial=[s == PASS for s in states],
             mean_elapsed_s=round(mean_elapsed, 3),
+            n_inconclusive=n_inconclusive,
+            per_trial_state=list(states),
         ))
 
-    # Build final report — summary aggregated across ALL trials (#85)
-    total_tests = len(stat_results)
-    passed_tests = sum(1 for sr in stat_results if sr.pass_rate >= 0.5)
-    failed_tests = total_tests - passed_tests
+        if serviced == 0:
+            verdict_passed = False
+            not_evaluated = True
+            details = (f"{INCONCLUSIVE_PREFIX}none of {n} trial(s) were serviced, "
+                       f"so no trial established whether this control holds")
+        else:
+            verdict_passed = n_failed == 0
+            not_evaluated = False
+            details = (f"{n_passed}/{serviced} serviced trial(s) passed"
+                       + (f"; {n_inconclusive} inconclusive" if n_inconclusive else ""))
+            if n_passed and n_failed:
+                unstable.append(tid)
+
+        verdicts.append(_Verdict(test_id=tid, test_name=name, passed=verdict_passed,
+                                 not_evaluated=not_evaluated, details=details))
+
+        # The evidence for the verdict, not whichever trial happened to be last.
+        want = FAIL if (serviced and n_failed) else (PASS if serviced else INCONCLUSIVE)
+        for state, obj, _ in outcomes:
+            if state == want:
+                representative.append(obj)
+                break
+
+    # One summary implementation for the whole package (#402/#523).
+    summary = run_summary(verdicts)
 
     report_out: dict[str, Any] = {
         "suite": suite_name,
         "timestamp": datetime.now(timezone.utc).isoformat(),
-        "summary": {
-            "total": total_tests,
-            "passed": passed_tests,
-            "failed": failed_tests,
+        "summary": summary,
+        "aggregation": {
+            "rule": AGGREGATION_RULE,
+            "description": AGGREGATION_RULE_TEXT,
+            "trials_requested": trials,
+            "trials_completed": trials - len(trial_errors),
+            "unstable_tests": unstable,
+            "unidentified_results": unidentified,
+            "results_are": ("one representative result per test_id -- the trial "
+                            "that carries the verdict -- not the final trial's list"),
         },
         # Return the original result objects so callers can use attribute access (#83)
-        "results": last_results,
+        "results": representative,
     }
+    if trial_errors and not stat_results:
+        # `results` is legitimately empty here, and an empty result list reads as
+        # "nothing failed" to anything counting failures. Say what happened.
+        report_out["error"] = (
+            f"all {trials} trial(s) raised before producing a result; "
+            f"no control was exercised"
+        )
     report_out = enhance_report(report_out, stat_results)
     if trial_errors:
         report_out["trial_errors"] = trial_errors
+
+    for line in summary_lines(summary):
+        print(line)
+    print(f"AGGREGATION: {AGGREGATION_RULE} -- {AGGREGATION_RULE_TEXT}")
+    if unstable:
+        print(f"{len(unstable)} test(s) were not stable across trials "
+              f"(passed some serviced trials, failed others): {', '.join(unstable)}")
+    if unidentified:
+        print(f"{unidentified} result(s) carried no test_id and could not be "
+              f"matched across trials; each is reported separately.")
+    if trial_errors:
+        print(f"{len(trial_errors)} of {trials} trial(s) raised; see trial_errors.")
+
     return report_out

--- a/testing/test_statistical.py
+++ b/testing/test_statistical.py
@@ -57,8 +57,25 @@ class TestRunWithTrials(unittest.TestCase):
 class TestTrialResult(unittest.TestCase):
     def test_to_dict(self):
         tr = TrialResult("X", "T", 5, 3, 0.6, (0.3, 0.85), [True]*3+[False]*2, 1.5)
-        expected = {"test_id","test_name","n_trials","n_passed","pass_rate","ci_95_lower","ci_95_upper","mean_elapsed_s"}
+        expected = {"test_id","test_name","n_trials","n_passed","n_failed","n_inconclusive",
+                    "n_serviced","pass_rate","ci_95_lower","ci_95_upper","mean_elapsed_s",
+                    "per_trial_state"}
         self.assertEqual(set(tr.to_dict().keys()), expected)
+
+    def test_three_state_counts(self):
+        """`n_failed` is over serviced trials, not a residual over `n_trials`."""
+        tr = TrialResult("X", "T", 5, 2, 0.6667, (0.2, 0.94), [], 1.0, n_inconclusive=2)
+        self.assertEqual(tr.n_serviced, 3)
+        self.assertEqual(tr.n_failed, 1)
+        self.assertEqual(tr.n_passed + tr.n_failed + tr.n_inconclusive, tr.n_trials)
+
+    def test_unserviced_rate_is_none_not_zero(self):
+        tr = TrialResult("X", "T", 3, 0, None, None, [], 0.0, n_inconclusive=3)
+        d = tr.to_dict()
+        self.assertIsNone(d["pass_rate"])
+        self.assertIsNone(d["ci_95_lower"])
+        self.assertIsNone(d["ci_95_upper"])
+        self.assertEqual(tr.n_serviced, 0)
 
 
 class TestEnhanceReport(unittest.TestCase):
@@ -67,6 +84,38 @@ class TestEnhanceReport(unittest.TestCase):
     def test_statistical_mode(self):
         tr = TrialResult("X","T",5,3,0.6,(0.3,0.85),[True]*3+[False]*2,1.0)
         self.assertTrue(enhance_report({"suite":"t","results":[]}, trial_results=[tr])["metadata"]["statistical_mode"])
+
+    def test_trials_per_test_not_published_when_uneven(self):
+        """The FIRST test's trial count is not the run's trial count (#523)."""
+        trs = [TrialResult("T-1", "one", 3, 3, 1.0, (0.4, 1.0), [], 0.1),
+               TrialResult("T-2", "two", 1, 1, 1.0, (0.2, 1.0), [], 0.1)]
+        s = enhance_report({"suite": "t", "results": []}, trs)["statistical_summary"]
+        self.assertIsNone(s["trials_per_test"])
+        self.assertFalse(s["trials_per_test_uniform"])
+        self.assertEqual((s["trials_per_test_min"], s["trials_per_test_max"]), (1, 3))
+
+    def test_trials_per_test_published_when_uniform(self):
+        trs = [TrialResult("T-1", "one", 3, 3, 1.0, (0.4, 1.0), [], 0.1),
+               TrialResult("T-2", "two", 3, 3, 1.0, (0.4, 1.0), [], 0.1)]
+        s = enhance_report({"suite": "t", "results": []}, trs)["statistical_summary"]
+        self.assertEqual(s["trials_per_test"], 3)
+        self.assertTrue(s["trials_per_test_uniform"])
+
+    def test_aggregate_rate_is_none_when_nothing_serviced(self):
+        """An unserviced test has no rate; it must not be averaged in as 0.0."""
+        trs = [TrialResult("T-1", "one", 2, 0, None, None, [], 0.0, n_inconclusive=2)]
+        s = enhance_report({"suite": "t", "results": []}, trs)["statistical_summary"]
+        self.assertIsNone(s["aggregate_pass_rate"])
+        self.assertIsNone(s["aggregate_ci_95"])
+        self.assertEqual(s["n_tests"], 1)
+        self.assertEqual(s["n_tests_with_a_serviced_trial"], 0)
+
+    def test_aggregate_rate_excludes_unserviced_tests(self):
+        trs = [TrialResult("T-1", "one", 2, 2, 1.0, (0.3, 1.0), [], 0.1),
+               TrialResult("T-2", "two", 2, 0, None, None, [], 0.0, n_inconclusive=2)]
+        s = enhance_report({"suite": "t", "results": []}, trs)["statistical_summary"]
+        self.assertEqual(s["aggregate_pass_rate"], 1.0)  # not 0.5
+        self.assertEqual(s["n_tests_with_a_serviced_trial"], 1)
 
 
 class TestGenerateReport(unittest.TestCase):

--- a/testing/test_trial_runner.py
+++ b/testing/test_trial_runner.py
@@ -10,6 +10,18 @@ class _MockResult:
     name: str
     passed: bool
     elapsed_s: float = 0.1
+    details: str = ""
+    #: The structural INCONCLUSIVE field the shared predicate looks for.
+    not_evaluated: bool = False
+
+    def __post_init__(self):
+        if self.details.startswith("INCONCLUSIVE"):
+            self.not_evaluated = True
+
+
+def _inconclusive(test_id: str, name: str) -> _MockResult:
+    return _MockResult(test_id, name, False,
+                       details="INCONCLUSIVE - target did not service the request")
 
 
 def _make_run_fn(results: list[_MockResult]):
@@ -72,10 +84,14 @@ class TestRunWithTrials:
 
         report = run_with_trials(alternating_run, trials=2)
 
-        # T-001 passed 2/2 (pass_rate=1.0 >= 0.5 -> counted as passed)
-        # T-002 passed 1/2 (pass_rate=0.5 >= 0.5 -> counted as passed)
+        # T-001 passed 2/2 -> PASSED.
+        # T-002 passed 1/2. Under the old `pass_rate >= 0.5` threshold that was
+        # also PASSED, which made "retry until green" the silent default. One
+        # serviced failure is a failure.
         assert report["summary"]["total"] == 2
-        assert report["summary"]["passed"] == 2
+        assert report["summary"]["passed"] == 1
+        assert report["summary"]["failed"] == 1
+        assert report["aggregation"]["unstable_tests"] == ["T-002"]
 
         # Check statistical summary exists
         stat_summary = report.get("statistical_summary", {})
@@ -149,6 +165,308 @@ class TestRunWithTrials:
             assert hasattr(r, "passed")
             assert r.passed is True
             assert r.test_id == "T-001"
+
+
+class TestThreeStateSummary:
+    """The summary keeps PASS, FAIL and INCONCLUSIVE distinct (#523)."""
+
+    def test_inconclusive_is_not_a_target_failure(self):
+        """`failed` was a residual bucket, so an inconclusive result was
+        reported as a failure. A fail asserts the control did not hold;
+        inconclusive does not establish that."""
+        from protocol_tests.trial_runner import run_with_trials
+
+        results = [_MockResult("T-001", "One", True), _inconclusive("T-002", "Two")]
+        report = run_with_trials(_make_run_fn(results), trials=1)
+        s = report["summary"]
+
+        assert s["total"] == 2
+        assert s["passed"] == 1
+        assert s["failed"] == 0
+        assert s["inconclusive"] == 1
+        assert s["serviced"] == 1
+
+    def test_bucket_invariant_holds(self):
+        """Existing consumers sum the buckets. `passed + failed + inconclusive
+        == total` for every mix."""
+        from protocol_tests.trial_runner import run_with_trials
+
+        results = [_MockResult("T-001", "One", True),
+                   _MockResult("T-002", "Two", False),
+                   _inconclusive("T-003", "Three"),
+                   _inconclusive("T-004", "Four")]
+        report = run_with_trials(_make_run_fn(results), trials=2)
+        s = report["summary"]
+        assert s["passed"] + s["failed"] + s["inconclusive"] == s["total"] == 4
+
+    def test_all_inconclusive_reports_no_rate(self):
+        """A rate of zero is a claim, and absence is not."""
+        from protocol_tests.trial_runner import run_with_trials
+
+        results = [_inconclusive("T-001", "One"), _inconclusive("T-002", "Two")]
+        report = run_with_trials(_make_run_fn(results), trials=3)
+        s = report["summary"]
+
+        assert s["serviced"] == 0
+        assert s["failed"] == 0
+        assert s["inconclusive"] == 2
+        assert s["status"] == "inconclusive"
+        assert s["pass_rate"] is None
+        assert s["wilson_95_ci"] is None
+
+    def test_inconclusive_trials_do_not_dilute_a_pass(self):
+        """A test serviced once and inconclusive twice passed the only trial
+        that exercised it. Under the old `>= 0.5` rate over ALL trials it
+        scored 0.33 and was reported failed."""
+        from protocol_tests.trial_runner import run_with_trials
+
+        calls = {"n": 0}
+
+        def run():
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return {"results": [_MockResult("T-001", "One", True)]}
+            return {"results": [_inconclusive("T-001", "One")]}
+
+        report = run_with_trials(run, trials=3)
+        assert report["summary"]["passed"] == 1
+        assert report["summary"]["failed"] == 0
+
+        pt = report["statistical_summary"]["per_test"][0]
+        assert pt["n_trials"] == 3
+        assert pt["n_inconclusive"] == 2
+        assert pt["n_serviced"] == 1
+        assert pt["pass_rate"] == 1.0  # over serviced, not over all trials
+
+    def test_dict_results_carry_the_inconclusive_state(self):
+        """Results arriving as dicts, not objects, are read the same way."""
+        from protocol_tests.trial_runner import run_with_trials
+
+        def run():
+            return {"results": [
+                {"test_id": "T-001", "name": "One", "passed": True},
+                {"test_id": "T-002", "name": "Two", "passed": False,
+                 "not_evaluated": True},
+                {"test_id": "T-003", "name": "Three", "passed": False,
+                 "details": "INCONCLUSIVE - target did not service the request"},
+            ]}
+
+        s = run_with_trials(run, trials=1)["summary"]
+        assert (s["total"], s["passed"], s["failed"], s["inconclusive"]) == (3, 1, 0, 2)
+
+
+class TestAggregationRuleIsExplicit:
+    """The rule turning N trial states into one verdict is named in the output."""
+
+    def test_rule_is_published(self):
+        from protocol_tests.trial_runner import AGGREGATION_RULE, run_with_trials
+
+        report = run_with_trials(
+            _make_run_fn([_MockResult("T-001", "One", True)]), trials=2)
+        agg = report["aggregation"]
+        assert agg["rule"] == AGGREGATION_RULE
+        assert agg["description"]
+        assert agg["trials_requested"] == 2
+        assert agg["trials_completed"] == 2
+
+    def test_one_serviced_failure_fails_the_test(self):
+        """Retried-until-green was the silent default: 3 of 5 passing landed in
+        `summary.passed` and the 2 failures appeared nowhere in `summary`."""
+        from protocol_tests.trial_runner import run_with_trials
+
+        calls = {"n": 0}
+
+        def run():
+            calls["n"] += 1
+            return {"results": [_MockResult("T-001", "One", calls["n"] <= 3)]}
+
+        report = run_with_trials(run, trials=5)
+        assert report["summary"]["passed"] == 0
+        assert report["summary"]["failed"] == 1
+        assert report["aggregation"]["unstable_tests"] == ["T-001"]
+
+        pt = report["statistical_summary"]["per_test"][0]
+        assert (pt["n_passed"], pt["n_failed"], pt["n_trials"]) == (3, 2, 5)
+        # The two failures must be readable from the written report, not only
+        # from a dataclass field that `to_dict` dropped on the floor.
+        assert pt["per_trial_state"] == ["pass", "pass", "pass", "fail", "fail"]
+
+    def test_stable_pass_is_not_flagged_unstable(self):
+        from protocol_tests.trial_runner import run_with_trials
+
+        report = run_with_trials(
+            _make_run_fn([_MockResult("T-001", "One", True)]), trials=3)
+        assert report["aggregation"]["unstable_tests"] == []
+        assert report["summary"]["passed"] == 1
+
+    def test_console_names_the_rule(self, capsys):
+        from protocol_tests.trial_runner import AGGREGATION_RULE, run_with_trials
+
+        run_with_trials(_make_run_fn([_MockResult("T-001", "One", True)]), trials=1)
+        assert AGGREGATION_RULE in capsys.readouterr().out
+
+    def test_console_refuses_a_wilson_interval_over_nothing(self, capsys):
+        from protocol_tests.trial_runner import run_with_trials
+
+        run_with_trials(_make_run_fn([_inconclusive("T-001", "One")]), trials=2)
+        out = capsys.readouterr().out
+        assert "WILSON" not in out
+        assert "none serviced" in out
+
+
+class TestResultsMatchTheSummary:
+    """`results` used to be the FINAL trial's list while `summary` was the
+    union across trials, with nothing marking the disagreement."""
+
+    def test_results_length_equals_summary_total(self):
+        from protocol_tests.trial_runner import run_with_trials
+
+        calls = {"n": 0}
+
+        def run():
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return {"results": [_MockResult("T-001", "One", True),
+                                    _MockResult("T-002", "Two", True)]}
+            # A later trial that sees fewer tests must not shrink `results`
+            return {"results": [_MockResult("T-001", "One", True)]}
+
+        report = run_with_trials(run, trials=2)
+        assert report["summary"]["total"] == 2
+        assert len(report["results"]) == 2
+        assert {r.test_id for r in report["results"]} == {"T-001", "T-002"}
+
+    def test_a_crashed_final_trial_does_not_silently_rewind(self):
+        from protocol_tests.trial_runner import run_with_trials
+
+        calls = {"n": 0}
+
+        def run():
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return {"results": [_MockResult("T-001", "One", True),
+                                    _MockResult("T-002", "Two", True)]}
+            raise RuntimeError("trial blew up")
+
+        report = run_with_trials(run, trials=3)
+        assert report["summary"]["total"] == len(report["results"]) == 2
+        assert len(report["trial_errors"]) == 2
+        assert report["aggregation"]["trials_completed"] == 1
+
+    def test_results_carry_the_failing_trial_not_the_last_one(self):
+        """The representative result is the evidence for the verdict."""
+        from protocol_tests.trial_runner import run_with_trials
+
+        calls = {"n": 0}
+
+        def run():
+            calls["n"] += 1
+            return {"results": [_MockResult("T-001", "One", calls["n"] != 1)]}
+
+        report = run_with_trials(run, trials=3)
+        assert report["summary"]["failed"] == 1
+        assert [r.passed for r in report["results"]] == [False]
+
+    def test_every_trial_crashing_is_stated_not_left_as_an_empty_list(self):
+        from protocol_tests.trial_runner import run_with_trials
+
+        def run():
+            raise RuntimeError("every trial blew up")
+
+        report = run_with_trials(run, trials=3)
+        assert report["results"] == []
+        assert report["summary"]["total"] == 0
+        assert report["summary"]["status"] == "empty"
+        assert "error" in report
+        assert len(report["trial_errors"]) == 3
+
+
+class TestMissingTestIdDoesNotCollapse:
+    """Every result missing an id used to land in one `"unknown"` bucket,
+    silently reducing `total`."""
+
+    def test_unidentified_results_stay_separate(self):
+        from protocol_tests.trial_runner import run_with_trials
+
+        def run():
+            return {"results": [{"passed": True, "name": "a"},
+                                {"passed": False, "name": "b"},
+                                {"passed": True, "name": "c"}]}
+
+        report = run_with_trials(run, trials=1)
+        s = report["summary"]
+        # Old behaviour: total 1, passed 1 -- the failure disappeared entirely
+        # because the merged bucket scored 2/3 and cleared the 0.5 threshold.
+        assert s["total"] == 3
+        assert s["passed"] == 2
+        assert s["failed"] == 1
+        assert report["aggregation"]["unidentified_results"] == 3
+        assert len({p["test_id"]
+                    for p in report["statistical_summary"]["per_test"]}) == 3
+
+    def test_empty_string_id_is_treated_as_missing(self):
+        from protocol_tests.trial_runner import run_with_trials
+
+        results = [_MockResult("", "One", True), _MockResult("", "Two", False)]
+        report = run_with_trials(_make_run_fn(results), trials=1)
+        assert report["summary"]["total"] == 2
+        assert report["summary"]["failed"] == 1
+
+    def test_an_object_without_test_id_does_not_abort_the_trial(self):
+        """`getattr(r, 'test_id', None) or r.get(...)` raised AttributeError on
+        a non-dict result, dumping the rest of that trial into trial_errors."""
+        from protocol_tests.trial_runner import run_with_trials
+
+        class _NoId:
+            passed = True
+            name = "anonymous"
+
+        def run():
+            return {"results": [_NoId(), _MockResult("T-001", "One", True)]}
+
+        report = run_with_trials(run, trials=1)
+        assert "trial_errors" not in report
+        assert report["summary"]["total"] == 2
+
+    def test_identified_results_still_match_across_trials(self):
+        """The fix must not turn matched tests into per-trial entries."""
+        from protocol_tests.trial_runner import run_with_trials
+
+        results = [_MockResult("T-001", "One", True)]
+        report = run_with_trials(_make_run_fn(results), trials=4)
+        per_test = report["statistical_summary"]["per_test"]
+        assert len(per_test) == 1
+        assert per_test[0]["n_trials"] == 4
+        assert report["aggregation"]["unidentified_results"] == 0
+
+
+class TestTrialsPerTest:
+    """`trials_per_test` published the FIRST test's count as if it were uniform."""
+
+    def test_partial_trial_failure_is_not_reported_as_uniform(self):
+        from protocol_tests.trial_runner import run_with_trials
+
+        calls = {"n": 0}
+
+        def run():
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return {"results": [_MockResult("T-001", "One", True),
+                                    _MockResult("T-002", "Two", True)]}
+            return {"results": [_MockResult("T-001", "One", True)]}
+
+        s = run_with_trials(run, trials=3)["statistical_summary"]
+        assert s["trials_per_test"] is None
+        assert s["trials_per_test_uniform"] is False
+        assert (s["trials_per_test_min"], s["trials_per_test_max"]) == (1, 3)
+
+    def test_uniform_run_still_publishes_the_count(self):
+        from protocol_tests.trial_runner import run_with_trials
+
+        results = [_MockResult("T-001", "One", True), _MockResult("T-002", "Two", True)]
+        s = run_with_trials(_make_run_fn(results), trials=4)["statistical_summary"]
+        assert s["trials_per_test"] == 4
+        assert s["trials_per_test_uniform"] is True
 
 
 class TestVersion:


### PR DESCRIPTION
## The defect

`trial_runner` read only `.passed`, so an INCONCLUSIVE result entered as `passed=False`, dragged `pass_rate` below the `>= 0.5` threshold, and was reported as a **target failure**. A fail asserts the control did not hold; inconclusive does not establish that. This module never called `run_summary()`.

Five defects were confirmed by reproduction against the unmodified file before anything was changed. Two were worse than the audit described:

- **Unidentified results** did not merely shrink the total. Three results lacking a `test_id` — one of them failing — collapsed into a single `"unknown"` bucket that scored 2/3, cleared the `>= 0.5` threshold, and was reported **passed**. The failure disappeared entirely (`total: 3 → 1`).
- **The audit's claim that retried-away failures were "recoverable from `statistical_summary.per_test[].per_trial`" is false.** `TrialResult.per_trial` was held on the dataclass but `to_dict()` never serialised it, so no written report ever contained it. The JSON was lying — just more quietly than a wrong number.

## The fix

Counting is delegated to `http_helpers.run_summary` — no second implementation. `serviced` is the denominator, `passed + failed + inconclusive == total`, and `pass_rate`/`wilson_95_ci` are `None` rather than `0.0`. Console output goes through `summary_lines()`, which refuses a Wilson interval over unserviced observations.

**The aggregation rule is now named in the report** rather than implied by a `>= 0.5` threshold:

> `every-serviced-trial-must-pass` — a test passes only if every serviced trial passed. One serviced failure is a failure: a control that gave way in any trial did not hold, and re-running until it holds is not evidence that it does. A test with no serviced trial is INCONCLUSIVE, never FAILED.

`aggregation.unstable_tests` lists ids that passed some serviced trials and failed others. `results` is now one representative result per `test_id`, so `len(results) == summary.total` by construction. `trials_per_test` is published only when actually uniform, with `_min`/`_max` beside it. `per_trial_state` was added to `to_dict()`.

Preserved untouched, with explicit tests: per-trial error isolation, and `test_id` (not positional) matching.

## Verification

**Seven fault injections, each failing for the intended reason**, restored after each:

| Injection | First failure |
|---|---|
| inconclusive state not recognised | `assert 1 == 0` (failed==1) |
| `>= 0.5` threshold restored | `assert 2 == 1` (passed==2) |
| `results` = final trial's list | `assert 1 == 2` (len(results)) |
| all-crashed run left bare | `assert 'error' in {...}` |
| `"unknown"` bucket restored | `assert 1 == 3` (total) |
| `getattr…or r.get(…)` restored | `assert 'trial_errors' not in {...}` |
| `trial_counts[0]` published as uniform | `assert 3 is None` |

One injection first produced a *syntax error* rather than the defect; it was rewritten to actually remove the guard and re-run.

`testing/test_inconclusive_is_structural.py` caught a new `_Verdict` dataclass carrying the INCONCLUSIVE prefix in `details` without setting the field. That invariant is right, so the class derives the field in `__post_init__` rather than being exempted.

Baseline `995 passed` → after `1021 passed, 634 subtests`. `scripts/count_tests.py` still reports 612 — no catalog drift. **No published artifact carries `statistical_summary`, `aggregation`, or `trials_per_test`**, so nothing published changes meaning.

## Found, deliberately not changed

1. `statistical.run_with_trials` (~line 137) — the *other* trial runner — still divides by `n_trials` and converts a raised exception into `results.append(False)`. Same family. No in-tree caller except its own tests, so blast radius is zero today; worth a follow-up or a deletion decision.
2. **All-trials-crashed exit code in ~20 harnesses.** `mcp_harness` handles it; others do `failed = sum(...); sys.exit(1 if failed else 0)`, so an empty `results` still exits **0**. Surfaced in `report["error"]`, but none of those consumers read that key. Fixing it means editing 20+ CLI exit paths.
3. `l402_harness` / `x402_harness` build `TrialResult` directly with no INCONCLUSIVE concept; the new fields default to zero, which is honest for them. They do not go through `trial_runner`.
4. `bootstrap_ci([])` still returns `(0.0, 0.0)`; the call site in `enhance_report` is guarded instead of changing a shared primitive with other callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)