### PR TITLE
A report could not say which revision, tool, or model produced it

### DIFF
--- a/HARNESS_TEST_CATALOG.md
+++ b/HARNESS_TEST_CATALOG.md
@@ -1,7 +1,7 @@
 # Agent Security Harness — Canonical Test Catalog
 
 **Source repo:** msaleme/red-team-blue-team-agent-fabric
-**Generated:** `scripts/generate_test_catalog.py` at commit `59c0111`
+**Generated:** `scripts/generate_test_catalog.py` at commit `eaef4c9`
 **Test count:** 623 unique test IDs across 46 registered harness modules (45 contain test IDs; `community_runner.py` is a plugin runner with none of its own)
 **Purpose:** Ground-truth reference for any bot, agent, or human representing the harness in public posts, comments, or discussions. Cite only tests listed here. Do not invent IDs or statistics.
 
@@ -215,17 +215,17 @@ CREW-010 | Fallback Sandbox RCE Chain | protocol_tests/crewai_cve_harness.py:121
 ### Delegated-Authority Attenuation (`protocol_tests/delegation_chain_harness.py`) — 11 tests
 
 ```
-DCA-001 | Child Adds a Capability Absent From Its Parent | protocol_tests/delegation_chain_harness.py:828
-DCA-002 | Child Widens Resource Scope (staging -> production) | protocol_tests/delegation_chain_harness.py:898
-DCA-003 | Child Drops or Loosens a Parent Constraint | protocol_tests/delegation_chain_harness.py:989
-DCA-004 | Valid Pass Presented to the Wrong Tool Audience | protocol_tests/delegation_chain_harness.py:1069
-DCA-005 | Replayed Effect Request | protocol_tests/delegation_chain_harness.py:1119
-DCA-006 | Pass Used After Expiry | protocol_tests/delegation_chain_harness.py:1197
-DCA-007 | Pass Used After Revocation Epoch | protocol_tests/delegation_chain_harness.py:1262
-DCA-008 | Tool Acts Under Ambient Credentials | protocol_tests/delegation_chain_harness.py:1329
-DCA-009 | Positive Control: Correctly Attenuated Child | protocol_tests/delegation_chain_harness.py:1378
-DCA-010 | Positive Control: Parent | protocol_tests/delegation_chain_harness.py:1433
-DCA-011 | Three-Hop Chain: Intermediate Re-Widens What Its Parent Narrowed | protocol_tests/delegation_chain_harness.py:1553
+DCA-001 | Child Adds a Capability Absent From Its Parent | protocol_tests/delegation_chain_harness.py:833
+DCA-002 | Child Widens Resource Scope (staging -> production) | protocol_tests/delegation_chain_harness.py:903
+DCA-003 | Child Drops or Loosens a Parent Constraint | protocol_tests/delegation_chain_harness.py:994
+DCA-004 | Valid Pass Presented to the Wrong Tool Audience | protocol_tests/delegation_chain_harness.py:1074
+DCA-005 | Replayed Effect Request | protocol_tests/delegation_chain_harness.py:1124
+DCA-006 | Pass Used After Expiry | protocol_tests/delegation_chain_harness.py:1202
+DCA-007 | Pass Used After Revocation Epoch | protocol_tests/delegation_chain_harness.py:1267
+DCA-008 | Tool Acts Under Ambient Credentials | protocol_tests/delegation_chain_harness.py:1334
+DCA-009 | Positive Control: Correctly Attenuated Child | protocol_tests/delegation_chain_harness.py:1383
+DCA-010 | Positive Control: Parent | protocol_tests/delegation_chain_harness.py:1438
+DCA-011 | Three-Hop Chain: Intermediate Re-Widens What Its Parent Narrowed | protocol_tests/delegation_chain_harness.py:1558
 ```
 
 ### Enterprise Platforms (core) (`protocol_tests/enterprise_adapters.py`) — 31 tests

--- a/HARNESS_TEST_CATALOG.md
+++ b/HARNESS_TEST_CATALOG.md
@@ -1,8 +1,8 @@
 # Agent Security Harness — Canonical Test Catalog
 
 **Source repo:** msaleme/red-team-blue-team-agent-fabric
-**Generated:** `scripts/generate_test_catalog.py` at commit `467c649`
-**Test count:** 612 unique test IDs across 45 registered harness modules (44 contain test IDs; `community_runner.py` is a plugin runner with none of its own)
+**Generated:** `scripts/generate_test_catalog.py` at commit `59c0111`
+**Test count:** 623 unique test IDs across 46 registered harness modules (45 contain test IDs; `community_runner.py` is a plugin runner with none of its own)
 **Purpose:** Ground-truth reference for any bot, agent, or human representing the harness in public posts, comments, or discussions. Cite only tests listed here. Do not invent IDs or statistics.
 
 ## Rules for Citation
@@ -210,6 +210,22 @@ CREW-007 | SSRF Internal Service Detection | protocol_tests/crewai_cve_harness.p
 CREW-008 | SSRF URL Validation Bypass | protocol_tests/crewai_cve_harness.py:1088
 CREW-009 | Docker Availability Check Bypass | protocol_tests/crewai_cve_harness.py:1126
 CREW-010 | Fallback Sandbox RCE Chain | protocol_tests/crewai_cve_harness.py:1214
+```
+
+### Delegated-Authority Attenuation (`protocol_tests/delegation_chain_harness.py`) — 11 tests
+
+```
+DCA-001 | Child Adds a Capability Absent From Its Parent | protocol_tests/delegation_chain_harness.py:828
+DCA-002 | Child Widens Resource Scope (staging -> production) | protocol_tests/delegation_chain_harness.py:898
+DCA-003 | Child Drops or Loosens a Parent Constraint | protocol_tests/delegation_chain_harness.py:989
+DCA-004 | Valid Pass Presented to the Wrong Tool Audience | protocol_tests/delegation_chain_harness.py:1069
+DCA-005 | Replayed Effect Request | protocol_tests/delegation_chain_harness.py:1119
+DCA-006 | Pass Used After Expiry | protocol_tests/delegation_chain_harness.py:1197
+DCA-007 | Pass Used After Revocation Epoch | protocol_tests/delegation_chain_harness.py:1262
+DCA-008 | Tool Acts Under Ambient Credentials | protocol_tests/delegation_chain_harness.py:1329
+DCA-009 | Positive Control: Correctly Attenuated Child | protocol_tests/delegation_chain_harness.py:1378
+DCA-010 | Positive Control: Parent | protocol_tests/delegation_chain_harness.py:1433
+DCA-011 | Three-Hop Chain: Intermediate Re-Widens What Its Parent Narrowed | protocol_tests/delegation_chain_harness.py:1553
 ```
 
 ### Enterprise Platforms (core) (`protocol_tests/enterprise_adapters.py`) — 31 tests

--- a/HARNESS_TEST_CATALOG.md
+++ b/HARNESS_TEST_CATALOG.md
@@ -1,8 +1,8 @@
 # Agent Security Harness — Canonical Test Catalog
 
 **Source repo:** msaleme/red-team-blue-team-agent-fabric
-**Generated:** `scripts/generate_test_catalog.py` at commit `23503a0`
-**Test count:** 623 unique test IDs across 46 registered harness modules (45 contain test IDs; `community_runner.py` is a plugin runner with none of its own)
+**Generated:** `scripts/generate_test_catalog.py` at commit `467c649`
+**Test count:** 612 unique test IDs across 45 registered harness modules (44 contain test IDs; `community_runner.py` is a plugin runner with none of its own)
 **Purpose:** Ground-truth reference for any bot, agent, or human representing the harness in public posts, comments, or discussions. Cite only tests listed here. Do not invent IDs or statistics.
 
 ## Rules for Citation
@@ -51,9 +51,9 @@ STATE-003 | Guardrail Erosion (8-Step Progressive Escalation) | protocol_tests/a
 ### agent_data_injection.py (`protocol_tests/agent_data_injection.py`) — 3 tests
 
 ```
-ADI-001 | a forged provenance field inside an untrusted content body. | protocol_tests/agent_data_injection.py:310
-ADI-002 | a fabricated prior tool call and result inside a response body. | protocol_tests/agent_data_injection.py:326
-ADI-003 | content mimicking the agent's own context boundary. | protocol_tests/agent_data_injection.py:343
+ADI-001 | a forged provenance field inside an untrusted content body. | protocol_tests/agent_data_injection.py:315
+ADI-002 | a fabricated prior tool call and result inside a response body. | protocol_tests/agent_data_injection.py:331
+ADI-003 | content mimicking the agent's own context boundary. | protocol_tests/agent_data_injection.py:348
 ```
 
 ### AIUC-1 Compliance (`protocol_tests/aiuc1_compliance_harness.py`) — 12 tests
@@ -210,22 +210,6 @@ CREW-007 | SSRF Internal Service Detection | protocol_tests/crewai_cve_harness.p
 CREW-008 | SSRF URL Validation Bypass | protocol_tests/crewai_cve_harness.py:1088
 CREW-009 | Docker Availability Check Bypass | protocol_tests/crewai_cve_harness.py:1126
 CREW-010 | Fallback Sandbox RCE Chain | protocol_tests/crewai_cve_harness.py:1214
-```
-
-### Delegated-Authority Attenuation (`protocol_tests/delegation_chain_harness.py`) — 11 tests
-
-```
-DCA-001 | Child Adds a Capability Absent From Its Parent | protocol_tests/delegation_chain_harness.py:828
-DCA-002 | Child Widens Resource Scope (staging -> production) | protocol_tests/delegation_chain_harness.py:898
-DCA-003 | Child Drops or Loosens a Parent Constraint | protocol_tests/delegation_chain_harness.py:989
-DCA-004 | Valid Pass Presented to the Wrong Tool Audience | protocol_tests/delegation_chain_harness.py:1069
-DCA-005 | Replayed Effect Request | protocol_tests/delegation_chain_harness.py:1119
-DCA-006 | Pass Used After Expiry | protocol_tests/delegation_chain_harness.py:1197
-DCA-007 | Pass Used After Revocation Epoch | protocol_tests/delegation_chain_harness.py:1262
-DCA-008 | Tool Acts Under Ambient Credentials | protocol_tests/delegation_chain_harness.py:1329
-DCA-009 | Positive Control: Correctly Attenuated Child | protocol_tests/delegation_chain_harness.py:1378
-DCA-010 | Positive Control: Parent | protocol_tests/delegation_chain_harness.py:1433
-DCA-011 | Three-Hop Chain: Intermediate Re-Widens What Its Parent Narrowed | protocol_tests/delegation_chain_harness.py:1553
 ```
 
 ### Enterprise Platforms (core) (`protocol_tests/enterprise_adapters.py`) — 31 tests

--- a/protocol_tests/agent_data_injection.py
+++ b/protocol_tests/agent_data_injection.py
@@ -78,6 +78,11 @@ from dataclasses import dataclass
 
 from protocol_tests.harness_base import HarnessResult, RecordingHarness
 from protocol_tests.http_helpers import INCONCLUSIVE_PREFIX, is_inconclusive
+from protocol_tests.run_provenance import (
+    run_provenance,
+    subject_model,
+    subject_none,
+)
 
 OLLAMA_URL = os.environ.get("HARNESS_ADI_OLLAMA", "http://127.0.0.1:11434/api/generate")
 
@@ -416,8 +421,26 @@ def main() -> None:
                   f"also not evidence a control held -- read the replies.")
 
     if args.report:
+        # A DOCUMENT, not a bare list. The list had nowhere to put a header, and
+        # docs/evidence/adi/2026-09-02-qwen35-n3-raw.json is what that costs: its
+        # `runtime` block -- server version, model tag, manifest digest, family,
+        # parameter size, quantisation -- was assembled by hand from a shell
+        # session that is not part of the record. A verdict about a model whose
+        # identity was typed in beside it is a verdict about nothing checkable.
+        #
+        # `subject_model()` defaults every detail to `not_queried`, which is the
+        # true state: `ollama_model()` POSTs to /api/generate and nothing here
+        # calls /api/show, so this file can name the tag it ASKED for and not the
+        # weights that answered. Saying so is the point; filling those keys would
+        # require asking.
+        tag = os.environ.get("HARNESS_ADI_MODEL")
+        document = {
+            "provenance": run_provenance(),
+            "subject": subject_model(tag) if tag else subject_none(),
+            "results": [r.__dict__ for r in results],
+        }
         with open(args.report, "w") as fh:
-            json.dump([r.__dict__ for r in results], fh, indent=2, default=str)
+            json.dump(document, fh, indent=2, default=str)
         print(f"Report written to {args.report}", file=sys.stderr)
 
     sys.exit(1 if failed > 0 else 0)

--- a/protocol_tests/attestation.py
+++ b/protocol_tests/attestation.py
@@ -156,6 +156,8 @@ def generate_attestation_report(
     evidence_class: str | None = None,
     independence_level: str | None = None,
     system_under_test: str | None = None,
+    provenance: dict[str, Any] | None = None,
+    subject: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build a complete attestation report dict.
 
@@ -173,6 +175,18 @@ def generate_attestation_report(
     and an operator-invented system under test is the same manufactured claim this
     change removes from the server. A record that makes no claim should be visibly
     silent; verify_attestation_record.py reports the absence explicitly.
+
+    `provenance` and `subject` (from `protocol_tests.run_provenance`) travel
+    TOGETHER or not at all. A subject with no provenance is a statement about
+    what was tested with nothing saying what produced the statement -- the same
+    shape as an I-level with no system under test, rejected for the same reason.
+    So a `subject` without a `provenance` raises, and a `provenance` without a
+    `subject` emits `subject_none()`: "this run reached no subject" is a fact,
+    and an omitted key is not.
+
+    Both stay OPTIONAL at the schema level. Records published before these
+    fields existed are still valid and still hash to what they hashed to;
+    invalidating them would add no information.
     """
     if independence_level is not None and independence_level not in INDEPENDENCE_LEVELS:
         raise ValueError(
@@ -187,6 +201,13 @@ def generate_attestation_report(
             "system_under_test is required whenever independence_level is set. "
             "An I-level with no named system under test is not a claim "
             "(docs/EVIDENCE-CLASS-TAXONOMY.md)."
+        )
+    if subject is not None and provenance is None:
+        raise ValueError(
+            "provenance is required whenever subject is set. A statement about "
+            "what was tested, with nothing saying what produced the statement, "
+            "is the hand-assembled-header shape run_provenance.py exists to "
+            "remove."
         )
     passed = sum(1 for e in entries if e.get("result") == "pass")
     failed = sum(1 for e in entries if e.get("result") == "fail")
@@ -227,6 +248,11 @@ def generate_attestation_report(
         report["system_under_test"] = system_under_test
     if evidence_class is not None:
         report["evidence_class"] = evidence_class
+    if provenance is not None:
+        # Both, always, once either is asked for.
+        from .run_provenance import subject_none
+        report["provenance"] = provenance
+        report["subject"] = subject if subject is not None else subject_none()
 
     return report
 
@@ -370,6 +396,29 @@ def validate_attestation_report(report: dict[str, Any]) -> list[str]:
     ec = report.get("evidence_class")
     if ec is not None and ec not in EVIDENCE_CLASSES:
         errors.append(f"evidence_class: invalid value {ec!r}")
+
+    # Same placement, same reason: a rule that only the jsonschema path enforces
+    # is a rule that stops existing on the machine where jsonschema is missing,
+    # and that machine gets told "NOT SCHEMA-VALIDATED" and nothing else. The
+    # schema ALSO carries this as an if/then, so a document that reaches a
+    # third-party validator is caught there too; the duplication is the same
+    # one `dependentRequired` already has for independence_level.
+    subject = report.get("subject")
+    if isinstance(subject, dict):
+        kind = subject.get("kind")
+        if kind == "model" and subject.get("model") is None:
+            errors.append(
+                "subject.kind is 'model' but subject.model is null. A verdict "
+                "about a model that names no model is not a verdict about a "
+                "model -- state kind 'none' instead."
+            )
+    # Outside the isinstance guard on purpose: a subject of the wrong TYPE with
+    # no provenance is still a subject with no provenance.
+    if "subject" in report and "provenance" not in report:
+        errors.append(
+            "subject is present but provenance is missing. What was tested "
+            "and what produced the statement travel together."
+        )
 
     return errors
 

--- a/protocol_tests/attestation_registry.py
+++ b/protocol_tests/attestation_registry.py
@@ -169,8 +169,23 @@ def strip_sensitive_fields(report: dict) -> dict:
 
     This ensures request/response payloads, URLs, credentials, and other
     infrastructure details are NEVER sent to the registry.
+
+    `provenance` and `subject` are handled separately and NOT by deletion. The
+    substring rule below removes any key containing `url`, which in those two
+    blocks is `subject.url`, `subject.url_absent_reason` and `ci.run_url` --
+    all three required by the schema, so a stripped record stopped validating.
+    The rule is right about what must not travel and wrong about how: deleting
+    a key there destroys the property those blocks exist to have, that a reader
+    can always tell an unknown from an omission. So the value goes, the key
+    stays, and the reason becomes `redacted_for_publication`.
     """
     cleaned = copy.deepcopy(report)
+
+    from .run_provenance import redact_for_publication
+    held = {}
+    for key in ("provenance", "subject"):
+        if isinstance(cleaned.get(key), dict):
+            held[key] = redact_for_publication(cleaned.pop(key))
 
     def _strip(obj: dict | list) -> None:
         if isinstance(obj, dict):
@@ -185,6 +200,7 @@ def strip_sensitive_fields(report: dict) -> dict:
                     _strip(item)
 
     _strip(cleaned)
+    cleaned.update(held)
     return cleaned
 
 

--- a/protocol_tests/delegation_chain_harness.py
+++ b/protocol_tests/delegation_chain_harness.py
@@ -85,6 +85,11 @@ from datetime import datetime, timezone
 
 from protocol_tests._utils import Severity, http_post_json, json_stdout_only
 from protocol_tests.harness_base import HarnessResult, RecordingHarness
+from protocol_tests.run_provenance import (
+    run_provenance,
+    subject_http,
+    subject_none,
+)
 from protocol_tests.http_helpers import (
     INCONCLUSIVE_PREFIX,
     is_inconclusive,
@@ -1643,6 +1648,12 @@ def main() -> None:
         "suite": "Multi-Hop Delegated-Authority Attenuation",
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "mode": "simulate" if simulate else "live",
+        # In simulate mode the verdicts are about the reference model in this
+        # file, so there is no subject to name -- `subject_none()` says that
+        # rather than leaving the field absent, which would be indistinguishable
+        # from a live run whose target went unrecorded.
+        "provenance": run_provenance(),
+        "subject": subject_none() if simulate else subject_http(args.url),
         "status": summary["status"],
         "summary": summary,
         "results": [asdict(r) for r in results],

--- a/protocol_tests/run_provenance.py
+++ b/protocol_tests/run_provenance.py
@@ -1,0 +1,554 @@
+"""What produced this run, and what it was run against -- stated in the artifact.
+
+## The defect this closes
+
+`docs/evidence/adi/2026-09-02-qwen35-n3-raw.json` carries a `runtime` block
+naming an Ollama server version, a model tag, a manifest digest, a parameter
+size and a quantisation. None of it came from the harness. `--report` in
+`agent_data_injection.py` wrote `json.dump([r.__dict__ for r in results], fh)`
+-- a bare LIST, with nowhere to put a header -- so the header was assembled by
+hand from a shell session that is not part of the record. A verdict about a
+model whose identity was typed in beside it is a verdict about nothing
+checkable.
+
+The module DOES talk to the model: `ollama_model()` POSTs to
+`/api/generate`. What it never does is ask `/api/show` who answered. Generation
+and identity are different questions and only one of them was being asked.
+
+## The invariant
+
+**Every key in a provenance or subject block is always present.** Absence of
+knowledge is `null` PAIRED WITH a sibling `<field>_absent_reason` naming why,
+drawn from a closed enum. Formally, for every field `X` that has a sibling
+`X_absent_reason`, exactly one of the two is non-null.
+
+Two things are forbidden and both have bitten this repository:
+
+- **A missing key.** A reader cannot distinguish "the producer does not emit
+  this" from "the producer emitted it and something dropped it". This is the
+  same argument `summary.inconclusive` won in #521: emitted at zero, always,
+  because a reader who can infer a value from the others will.
+- **The string `"unknown"`.** It is indistinguishable from a model literally
+  tagged `unknown`, from a corpus named `unknown`, and from a bug that
+  stringified a `None`. `protocol_tests/version.py::get_harness_version()`
+  returns exactly that string as its last resort, so this module translates it
+  back into `None` plus `version_not_discoverable` rather than letting a
+  sentinel that means "we failed" travel as if it were data.
+
+## What is deliberately NOT recorded
+
+No hostname, no username, no working directory, no absolute paths.
+`docs/PRIVACY.md` lists "Hostnames, paths, or any part of your infrastructure
+topology" under what is never collected, and a report a user is invited to
+publish is held to the same line as telemetry. EVERY absolute path in argv is
+reduced to its basename for that reason -- not only `argv[0]`. On a developer
+machine `--report /home/<username>/evidence/run.json` carries a username and a
+directory tree just as surely as the interpreter path does.
+
+## Argv redaction is the load-bearing part
+
+Documented usage includes `--header "Authorization: Bearer ..."`. Recording raw
+argv into an artifact that is meant to be published and signed would turn a
+provenance feature into a credential-disclosure feature -- the argument is not
+that a leak is likely, it is that this block exists to be handed to third
+parties. `redact_argv()` therefore redacts by flag name, by `--flag=value`,
+and by `key: value` / `key=value` embedded inside a single argument, and sets
+`argv_redacted` when anything was replaced.
+
+Redaction is best-effort and says so: it recognises a list of auth-shaped
+names, and a credential passed under a name not on that list survives. That is
+why the field is `argv_redacted` (something was replaced) and not
+`argv_is_safe` (a claim about what remains).
+"""
+from __future__ import annotations
+
+import copy
+import os
+import platform
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+__all__ = [
+    "ABSENT_REASONS",
+    "PROVENANCE_SCHEMA",
+    "ci_identity",
+    "git",
+    "redact_argv",
+    "redact_for_publication",
+    "run_provenance",
+    "subject_corpus",
+    "subject_http",
+    "subject_model",
+    "subject_none",
+    "tool_versions",
+]
+
+PROVENANCE_SCHEMA = "agent-security-harness/run-provenance/v1"
+
+#: The closed vocabulary a null value may cite. A reason outside this set is a
+#: bug, and `schemas/attestation-report.json` pins the same list, so a document
+#: that invents one fails validation rather than reading as a novel fact.
+ABSENT_REASONS = (
+    # the fact was never sought
+    "not_queried",          # the tool never asked the thing that knows
+    "not_supplied",         # the caller did not pass it
+    # the fact does not apply
+    "not_applicable",       # wrong arm of the subject union
+    "not_running_in_ci",    # no workflow produced this
+    # the fact was sought and could not be had
+    "not_a_git_checkout",
+    "git_unavailable",
+    "no_matching_tag",
+    "version_not_discoverable",
+    "package_not_installed",
+    "not_readable",         # the file is there in name and could not be read
+    "unsupported_by_target",
+    # the fact was known and deliberately withheld from THIS copy
+    "redacted_for_publication",
+)
+
+#: One spelling of the paired-reason suffix, so the invariant cannot drift
+#: between the builder and the redactor.
+_REASON_SUFFIX = "_absent_reason"
+
+REDACTED = "[REDACTED]"
+
+#: Names whose VALUE is a credential. Matched as a substring of a flag name and
+#: of a `key: value` key, case-insensitively, so `--api-key`, `--apiKey`,
+#: `X-Api-Key:` and `--bearer-token=` are all caught by one pattern.
+_AUTH_NAME_RE = re.compile(
+    r"(authorization|authentication|\bauth\b|token|api[-_]?key|apikey|secret|"
+    r"password|passwd|credential|cookie|bearer|private[-_]?key|session[-_]?id)",
+    re.IGNORECASE,
+)
+
+#: Flags whose NEXT argv element is the value. `-H` is here because that is the
+#: short spelling of the header flag; lowercase `-h` is NOT, because it is
+#: `--help` and redacting the argument after it would corrupt the record to
+#: hide a value that was never a credential. Matching is case-sensitive for
+#: exactly that reason.
+_AUTH_FLAGS = {
+    "-H", "--header", "--headers",
+    "--token", "--auth-token", "--bearer",
+    "--api-key", "--apikey", "--key",
+    "--auth", "--authorization",
+    "--secret", "--password", "--passwd", "--credential", "--cookie",
+}
+
+
+# ---------------------------------------------------------------------------
+# Moved here from scripts/build_provenance.py
+#
+# These three answered "what commit is this", "what workflow ran this" and
+# "what built this" for the RELEASE statement. A run statement needs the same
+# three answers. Two implementations of "what commit is this" that can disagree
+# is the defect shape this file exists to avoid, so there is one, here, and
+# scripts/build_provenance.py imports it.
+# ---------------------------------------------------------------------------
+
+def git(*args: str, cwd: Path | None = None) -> str | None:
+    """Run a git command; None if git is absent or the command failed.
+
+    None is deliberately ambiguous between "no git binary" and "not a checkout"
+    at THIS level -- the callers below distinguish them, because only they know
+    which question was being asked.
+    """
+    try:
+        return subprocess.run(("git", *args), cwd=cwd, capture_output=True,
+                              text=True, check=True).stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+
+def tool_versions(names=("setuptools", "wheel", "build", "pip")) -> dict:
+    """Versions of the tools that govern what the artifact contains.
+
+    setuptools is the build backend, so its version is part of what shipped.
+    A tool that is absent is recorded as absent rather than omitted: a missing
+    key and a tool that was not installed are different facts.
+    """
+    from importlib.metadata import PackageNotFoundError, version
+    out = {}
+    for name in names:
+        try:
+            out[name] = version(name)
+        except PackageNotFoundError:
+            out[name] = None
+    return out
+
+
+def ci_identity() -> dict:
+    """The workflow run that produced this, from the environment GitHub sets.
+
+    Every value is None outside CI. That is deliberate: a locally built
+    statement must not look like a CI-built one, and the verifier can tell.
+    """
+    env = os.environ.get
+    run_id, repo = env("GITHUB_RUN_ID"), env("GITHUB_REPOSITORY")
+    return {
+        "repository": repo,
+        "workflow": env("GITHUB_WORKFLOW"),
+        "workflow_ref": env("GITHUB_WORKFLOW_REF"),
+        "run_id": run_id,
+        "run_attempt": env("GITHUB_RUN_ATTEMPT"),
+        "run_url": (f"{env('GITHUB_SERVER_URL', 'https://github.com')}/{repo}"
+                    f"/actions/runs/{run_id}") if (run_id and repo) else None,
+        "runner_os": env("RUNNER_OS"),
+        "runner_arch": env("RUNNER_ARCH"),
+        "event": env("GITHUB_EVENT_NAME"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# The paired-null helper. One function, so the invariant cannot be spelled two
+# ways in two places.
+# ---------------------------------------------------------------------------
+
+def _pair(name: str, value: Any, reason: str) -> dict[str, Any]:
+    """`{name: value, name_absent_reason: None}` or `{name: None, ...: reason}`.
+
+    `value` is normalised: empty string and the literal `"unknown"` are treated
+    as absence, because a producer that failed and a producer that observed the
+    word are otherwise the same document.
+    """
+    if reason not in ABSENT_REASONS:
+        raise ValueError(f"{reason!r} is not one of ABSENT_REASONS")
+    if isinstance(value, str) and value.strip().lower() in ("", "unknown"):
+        value = None
+    return {name: value,
+            f"{name}{_REASON_SUFFIX}": None if value is not None else reason}
+
+
+# ---------------------------------------------------------------------------
+# Argv redaction
+# ---------------------------------------------------------------------------
+
+def _split_flag(arg: str) -> tuple[str, str] | None:
+    """`--api-key=sk-...` -> ('--api-key', 'sk-...'); otherwise None."""
+    if arg.startswith("-") and "=" in arg:
+        flag, _, value = arg.partition("=")
+        return flag, value
+    return None
+
+
+def _redact_inline(arg: str) -> str:
+    """Redact the value half of an embedded `key: value` or `key=value`.
+
+    This is the `--header "Authorization: Bearer ..."` case, where the
+    credential is inside ONE argv element and flag-name matching never sees it.
+    """
+    for sep in (":", "="):
+        if sep in arg:
+            key, _, value = arg.partition(sep)
+            if value.strip() and _AUTH_NAME_RE.search(key):
+                return f"{key}{sep} {REDACTED}" if sep == ":" else f"{key}{sep}{REDACTED}"
+    # A bare token pasted as its own argument, with no key beside it. Matched
+    # on the scheme word rather than on token shape, because a shape heuristic
+    # ("looks high-entropy") eats innocent arguments AND still misses the
+    # shapes nobody thought of -- it buys false positives without buying
+    # completeness.
+    if re.match(r"^(bearer|basic|token)\s+\S", arg, re.IGNORECASE):
+        scheme = arg.split(None, 1)[0]
+        return f"{scheme} {REDACTED}"
+    return arg
+
+
+def _basename_if_absolute(arg: str) -> str:
+    """`/home/alice/runs/out.json` -> `out.json`; everything else unchanged.
+
+    Applied to EVERY element, not only `argv[0]`. `--report
+    /home/<user>/evidence/run.json` puts a username and a directory tree into
+    the record just as surely as the interpreter path does, and the first
+    version of this function only cleaned `argv[0]` -- which read as a rule
+    about paths while enforcing one about position.
+    """
+    if arg.startswith("/") or re.match(r"^[A-Za-z]:[\\/]", arg) or arg.startswith("~/"):
+        return os.path.basename(arg.replace("\\", "/")) or arg
+    return arg
+
+
+def redact_argv(argv: list[str]) -> tuple[list[str], bool]:
+    """Return (argv with credentials removed, whether a credential was replaced).
+
+    Two different reductions happen here and only one of them sets the flag.
+
+    *Credential redaction* replaces a value that is a secret, and sets
+    `argv_redacted`. That flag is the signal an auditor reads.
+
+    *Path reduction* replaces every absolute path with its basename,
+    unconditionally, because `docs/PRIVACY.md` says usernames, directories and
+    topology do not travel. It is not evidence of anything and does not set the
+    flag; it is stated in `not_claimed` on every document instead, so a reader
+    who sees a bare basename knows it was never a full path in this record.
+    """
+    if not argv:
+        return [], False
+
+    out = [_basename_if_absolute(argv[0])]
+    redacted = False
+    expect_value = False
+
+    for arg in argv[1:]:
+        if expect_value:
+            out.append(REDACTED)
+            redacted = True
+            expect_value = False
+            continue
+
+        if arg in _AUTH_FLAGS or (arg.startswith("-") and _AUTH_NAME_RE.search(arg)
+                                  and "=" not in arg):
+            out.append(arg)
+            expect_value = True
+            continue
+
+        split = _split_flag(arg)
+        if split and _AUTH_NAME_RE.search(split[0]) and split[1]:
+            out.append(f"{split[0]}={REDACTED}")
+            redacted = True
+            continue
+
+        cleaned = _redact_inline(arg)
+        if cleaned != arg:
+            redacted = True
+        out.append(_basename_if_absolute(cleaned))
+
+    # A trailing auth flag with no value after it. Nothing to redact, and
+    # dropping the flag would misreport the command that was run.
+    return out, redacted
+
+
+# ---------------------------------------------------------------------------
+# Subjects
+# ---------------------------------------------------------------------------
+
+_SUBJECT_KEYS = ("url", "model", "corpus")
+
+
+def _subject(kind: str, **present: Any) -> dict[str, Any]:
+    """A tagged union with a FIXED key set.
+
+    Every arm carries every key. The arms that do not apply cite
+    `not_applicable`, which is a different fact from `not_supplied`: "this run
+    had no URL because its subject was a model" and "this run had a URL and
+    nobody recorded it" must not be the same document.
+    """
+    block: dict[str, Any] = {"kind": kind}
+    for key in _SUBJECT_KEYS:
+        if key in present:
+            value, reason = present[key]
+            block.update(_pair(key, value, reason))
+        else:
+            block.update(_pair(key, None, "not_applicable"))
+    return block
+
+
+def subject_http(url: str | None = None) -> dict[str, Any]:
+    """The subject is an HTTP target."""
+    return _subject("http", url=(url, "not_supplied"))
+
+
+def subject_model(
+    tag: str | None = None,
+    *,
+    runtime: str | None = None,
+    digest: str | None = None,
+    family: str | None = None,
+    parameter_size: str | None = None,
+    quantization: str | None = None,
+    detail_reason: str = "not_queried",
+) -> dict[str, Any]:
+    """The subject is a model in the loop.
+
+    `detail_reason` defaults to `not_queried` and that default is the point.
+    The ADI module reaches Ollama's `/api/generate` and never its `/api/show`,
+    so the digest, family, parameter size and quantisation are facts the tool
+    could obtain and does not. Recording that as `not_queried` says so; leaving
+    the keys out would let the next hand-assembled header slide in beside them.
+
+    A model subject with no tag is rejected here rather than validated later:
+    `kind: "model"` with `model: null` is a claim about a model that names no
+    model, and the caller passing None knows more about why than the schema
+    does.
+    """
+    if not tag:
+        raise ValueError(
+            "subject_model() requires a tag. A run whose subject is a model "
+            "that cannot be named is not a run about a model -- use "
+            "subject_none() and state that no model was configured.")
+    identity: dict[str, Any] = {"tag": tag}
+    identity.update(_pair("runtime", runtime, detail_reason))
+    identity.update(_pair("digest", digest, detail_reason))
+    identity.update(_pair("family", family, detail_reason))
+    identity.update(_pair("parameter_size", parameter_size, detail_reason))
+    identity.update(_pair("quantization", quantization, detail_reason))
+    return _subject("model", model=(identity, "not_supplied"))
+
+
+def subject_corpus(path: str | os.PathLike[str] | None = None) -> dict[str, Any]:
+    """The subject is a local corpus. Only the basename and size travel.
+
+    The directory a corpus sits in is infrastructure topology; the file itself
+    is the subject. A digest is left to the caller: hashing a large corpus is a
+    cost this function should not impose on every run without being asked.
+    """
+    if path is None:
+        return _subject("corpus", corpus=(None, "not_supplied"))
+    p = Path(path)
+    try:
+        size = p.stat().st_size
+    except OSError:
+        size = None
+    corpus = {"name": p.name}
+    corpus.update(_pair("size_bytes", size, "not_readable"))
+    return _subject("corpus", corpus=(corpus, "not_supplied"))
+
+
+def subject_none() -> dict[str, Any]:
+    """No subject: the run did not reach one. Every arm is `not_applicable`."""
+    return _subject("none")
+
+
+def redact_for_publication(block: dict[str, Any]) -> dict[str, Any]:
+    """Null out the target-identifying fields of a provenance or subject block.
+
+    `attestation_registry.strip_sensitive_fields()` DELETES any key whose name
+    contains `url`, `endpoint`, `host`, `address` or `path`. Applied to these
+    blocks that removes `subject.url`, `subject.url_absent_reason` and
+    `ci.run_url` -- three keys the schema requires -- so a published record no
+    longer validated. The stripper is right about what must not travel and
+    wrong about how: deleting a key here destroys the property the block exists
+    to have, which is that a reader can always tell an unknown from an omission.
+
+    So the value goes and the key stays, with `redacted_for_publication` as the
+    reason. That is a fourth distinct state and it should be: "we did not ask",
+    "it does not apply", "we asked and could not tell" and "we know and are not
+    putting it in this copy" are four different facts about the same null.
+
+    `ci.run_url` is a public github.com actions URL rather than a target, but
+    it is nulled too: the stripper's rule is about what leaves the machine, and
+    narrowing it here would be this function deciding which of the stripper's
+    judgements to honour.
+    """
+    out = copy.deepcopy(block)
+    if "url" in out and f"url{_REASON_SUFFIX}" in out:
+        if out["url"] is not None:
+            out["url"] = None
+            out[f"url{_REASON_SUFFIX}"] = "redacted_for_publication"
+    ci = out.get("ci")
+    if isinstance(ci, dict) and "run_url" in ci:
+        ci["run_url"] = None
+    return out
+
+
+# ---------------------------------------------------------------------------
+# The statement
+# ---------------------------------------------------------------------------
+
+def _source_block(repo: Path) -> dict[str, Any]:
+    """Commit, ref and dirtiness, each with its own reason for being absent.
+
+    They fail for DIFFERENT reasons, which is why there is a reason per field
+    and not one for the block: a checkout with no tag on HEAD knows its commit
+    perfectly well.
+
+    `--untracked-files=no` is carried over from the release statement, where
+    v4.18.0rc1 is the reason it is there: `dist/`, `*.egg-info/` and `build/`
+    exist by the time any report is written, so a status that counts untracked
+    files reports every real run as dirty.
+    """
+    env = os.environ.get
+    commit = env("GITHUB_SHA") or git("rev-parse", "HEAD", cwd=repo)
+    if commit is None:
+        reason = "git_unavailable" if git("--version") is None else "not_a_git_checkout"
+        block = _pair("commit", None, reason)
+        block.update(_pair("ref_name", None, reason))
+        block.update(_pair("tree_is_dirty", None, reason))
+        return block
+
+    block = _pair("commit", commit, "not_a_git_checkout")
+    block.update(_pair(
+        "ref_name",
+        env("GITHUB_REF_NAME") or git("describe", "--tags", "--exact-match", cwd=repo),
+        "no_matching_tag"))
+    status = git("status", "--porcelain", "--untracked-files=no", cwd=repo)
+    block.update(_pair("tree_is_dirty", None if status is None else bool(status),
+                       "not_a_git_checkout"))
+    return block
+
+
+def _harness_version() -> str | None:
+    """None rather than the string this repository already returns for failure.
+
+    `get_harness_version()` ends `return "unknown"`. Five call sites want a
+    string and that is fine for them. A signed artifact is not one of them.
+    """
+    try:
+        from .version import get_harness_version
+        return get_harness_version()
+    except Exception:                                    # noqa: BLE001 - reported
+        return None
+
+
+def run_provenance(**overrides: Any) -> dict[str, Any]:
+    """Build the provenance block for one run.
+
+    Keyword overrides replace top-level keys, for callers that know something
+    this function cannot -- and for tests, which must be able to pin every
+    environment-derived value or they measure the runner rather than the code
+    (the lesson `testing/test_release_provenance.py` records at `CI_VARS`).
+
+    An override is not validated against `ABSENT_REASONS`: a caller replacing a
+    whole sub-block is responsible for its shape, and the schema is what
+    catches a wrong one.
+    """
+    repo = Path(__file__).resolve().parent.parent
+    argv, argv_redacted = redact_argv(list(sys.argv))
+
+    ci = ci_identity()
+    tool: dict[str, Any] = {"name": "agent-security-harness"}
+    tool.update(_pair("version", _harness_version(), "version_not_discoverable"))
+
+    statement: dict[str, Any] = {
+        "schema": PROVENANCE_SCHEMA,
+        "started_at": datetime.now(timezone.utc).isoformat(),
+        "tool": tool,
+        "source": _source_block(repo),
+        "runtime": {
+            "python": platform.python_version(),
+            "platform": platform.platform(),
+            "tools": tool_versions(),
+        },
+        "invocation": {
+            "argv": argv,
+            # Something WAS replaced -- not a claim that what remains is safe.
+            # The name list is best-effort by construction.
+            "argv_redacted": argv_redacted,
+        },
+        # Present at every key even outside CI, where every value is None. A
+        # locally produced statement must not be able to pass for a CI one, and
+        # a reader must be able to see that it was asked.
+        "ci": ci,
+        # The pairing, spelled out rather than via `_pair`: `ci` is a block of
+        # nine values, and it is the WHOLE block that is absent outside CI.
+        "ci_absent_reason": (
+            None if any(v is not None for v in ci.values()) else "not_running_in_ci"),
+        "not_claimed": [
+            "This block states what produced a run. It does not state that the "
+            "run's verdicts are correct, that the target was configured as an "
+            "operator intended, or that anything about the target is secure.",
+            "argv_redacted true means something was replaced. It is not a claim "
+            "that no credential remains: redaction matches a list of auth-shaped "
+            "names and a credential passed under another name survives.",
+            "No hostname, username, working directory or absolute path is "
+            "recorded, by the rule in docs/PRIVACY.md. Every absolute path in "
+            "argv is reduced to its basename, unconditionally and without "
+            "setting argv_redacted, so a bare filename here was never a full "
+            "path in this record. Their absence is a decision, not an omission.",
+        ],
+    }
+    statement.update(overrides)
+    return statement

--- a/schemas/attestation-report.json
+++ b/schemas/attestation-report.json
@@ -136,6 +136,14 @@
       "type": "string",
       "minLength": 1,
       "description": "The system the independence_level is relative to. Required whenever independence_level is present."
+    },
+    "provenance": {
+      "$ref": "#/$defs/provenance",
+      "description": "What produced this run. OPTIONAL, so records published before this field existed stay valid and keep the hashes they were published under."
+    },
+    "subject": {
+      "$ref": "#/$defs/subject",
+      "description": "What this run was run against. OPTIONAL, and requires `provenance`: a statement about what was tested with nothing saying what produced it is the shape this pair exists to remove."
     }
   },
   "additionalProperties": false,
@@ -395,6 +403,682 @@
         }
       },
       "additionalProperties": false
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema",
+        "started_at",
+        "tool",
+        "source",
+        "runtime",
+        "invocation",
+        "ci",
+        "ci_absent_reason",
+        "not_claimed"
+      ],
+      "properties": {
+        "schema": {
+          "type": "string",
+          "const": "agent-security-harness/run-provenance/v1"
+        },
+        "started_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "tool": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "name",
+            "version",
+            "version_absent_reason"
+          ],
+          "properties": {
+            "name": {
+              "type": "string",
+              "minLength": 1
+            },
+            "version": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Version of the producing implementation. Null rather than the string get_harness_version() returns on failure."
+            },
+            "version_absent_reason": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "enum": [
+                null,
+                "not_queried",
+                "not_supplied",
+                "not_applicable",
+                "not_running_in_ci",
+                "not_a_git_checkout",
+                "git_unavailable",
+                "no_matching_tag",
+                "version_not_discoverable",
+                "package_not_installed",
+                "not_readable",
+                "unsupported_by_target",
+                "redacted_for_publication"
+              ],
+              "description": "Why the paired field is null, from a closed vocabulary (protocol_tests/run_provenance.py::ABSENT_REASONS). Exactly one of a field and its `_absent_reason` sibling is non-null. The string \"unknown\" is never a value here: it cannot be told apart from a model literally tagged `unknown` or from a stringified None."
+            }
+          }
+        },
+        "source": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "commit",
+            "commit_absent_reason",
+            "ref_name",
+            "ref_name_absent_reason",
+            "tree_is_dirty",
+            "tree_is_dirty_absent_reason"
+          ],
+          "properties": {
+            "commit": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Commit the run was produced from."
+            },
+            "commit_absent_reason": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "enum": [
+                null,
+                "not_queried",
+                "not_supplied",
+                "not_applicable",
+                "not_running_in_ci",
+                "not_a_git_checkout",
+                "git_unavailable",
+                "no_matching_tag",
+                "version_not_discoverable",
+                "package_not_installed",
+                "not_readable",
+                "unsupported_by_target",
+                "redacted_for_publication"
+              ],
+              "description": "Why the paired field is null, from a closed vocabulary (protocol_tests/run_provenance.py::ABSENT_REASONS). Exactly one of a field and its `_absent_reason` sibling is non-null. The string \"unknown\" is never a value here: it cannot be told apart from a model literally tagged `unknown` or from a stringified None."
+            },
+            "ref_name": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Tag or ref on that commit, if any. A checkout with no tag on HEAD still knows its commit, which is why each field carries its own reason rather than the block."
+            },
+            "ref_name_absent_reason": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "enum": [
+                null,
+                "not_queried",
+                "not_supplied",
+                "not_applicable",
+                "not_running_in_ci",
+                "not_a_git_checkout",
+                "git_unavailable",
+                "no_matching_tag",
+                "version_not_discoverable",
+                "package_not_installed",
+                "not_readable",
+                "unsupported_by_target",
+                "redacted_for_publication"
+              ],
+              "description": "Why the paired field is null, from a closed vocabulary (protocol_tests/run_provenance.py::ABSENT_REASONS). Exactly one of a field and its `_absent_reason` sibling is non-null. The string \"unknown\" is never a value here: it cannot be told apart from a model literally tagged `unknown` or from a stringified None."
+            },
+            "tree_is_dirty": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "description": "Whether tracked SOURCE differs from that commit. Untracked files are excluded: build output is not source and a real run always has some."
+            },
+            "tree_is_dirty_absent_reason": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "enum": [
+                null,
+                "not_queried",
+                "not_supplied",
+                "not_applicable",
+                "not_running_in_ci",
+                "not_a_git_checkout",
+                "git_unavailable",
+                "no_matching_tag",
+                "version_not_discoverable",
+                "package_not_installed",
+                "not_readable",
+                "unsupported_by_target",
+                "redacted_for_publication"
+              ],
+              "description": "Why the paired field is null, from a closed vocabulary (protocol_tests/run_provenance.py::ABSENT_REASONS). Exactly one of a field and its `_absent_reason` sibling is non-null. The string \"unknown\" is never a value here: it cannot be told apart from a model literally tagged `unknown` or from a stringified None."
+            }
+          }
+        },
+        "runtime": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "python",
+            "platform",
+            "tools"
+          ],
+          "properties": {
+            "python": {
+              "type": "string"
+            },
+            "platform": {
+              "type": "string",
+              "description": "platform.platform(). OS, release and architecture. It carries no hostname."
+            },
+            "tools": {
+              "type": "object",
+              "additionalProperties": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "description": "Packaging tool versions; null means the tool was not installed, which is a different fact from an omitted key."
+            }
+          }
+        },
+        "invocation": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "argv",
+            "argv_redacted"
+          ],
+          "properties": {
+            "argv": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "The command, with credential-shaped values replaced by [REDACTED] and every absolute path reduced to its basename. Documented usage includes --header \"Authorization: Bearer ...\" and this block is meant to be published, so a raw argv would make a provenance feature a credential-disclosure feature."
+            },
+            "argv_redacted": {
+              "type": "boolean",
+              "description": "A CREDENTIAL was replaced. Deliberately not named argv_is_safe: redaction matches a list of auth-shaped names, and a credential passed under a name not on that list survives. Path reduction is unconditional and does NOT set this, so the flag stays a signal about secrets rather than about formatting."
+            }
+          }
+        },
+        "ci": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "event",
+            "repository",
+            "run_attempt",
+            "run_id",
+            "run_url",
+            "runner_arch",
+            "runner_os",
+            "workflow",
+            "workflow_ref"
+          ],
+          "properties": {
+            "event": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "repository": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "run_attempt": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "run_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "run_url": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "runner_arch": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "runner_os": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "workflow": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "workflow_ref": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "description": "The workflow that produced this. Every value is null outside CI and the keys are still present: a locally produced statement must not be able to pass for a CI one."
+        },
+        "ci_absent_reason": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            null,
+            "not_queried",
+            "not_supplied",
+            "not_applicable",
+            "not_running_in_ci",
+            "not_a_git_checkout",
+            "git_unavailable",
+            "no_matching_tag",
+            "version_not_discoverable",
+            "package_not_installed",
+            "not_readable",
+            "unsupported_by_target",
+            "redacted_for_publication"
+          ],
+          "description": "Why the paired field is null, from a closed vocabulary (protocol_tests/run_provenance.py::ABSENT_REASONS). Exactly one of a field and its `_absent_reason` sibling is non-null. The string \"unknown\" is never a value here: it cannot be told apart from a model literally tagged `unknown` or from a stringified None."
+        },
+        "not_claimed": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "What this block does not establish, in plain words."
+        }
+      },
+      "description": "What produced this run. Every key is always present; absence of knowledge is null paired with an `_absent_reason`. Deliberately NOT recorded: hostname, username, working directory and absolute paths. docs/PRIVACY.md lists infrastructure topology under what never travels, and a report a user is invited to publish is held to the same line as telemetry. Their absence is a decision, not an omission."
+    },
+    "subject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "url",
+        "url_absent_reason",
+        "model",
+        "model_absent_reason",
+        "corpus",
+        "corpus_absent_reason"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": [
+            "http",
+            "model",
+            "corpus",
+            "none"
+          ],
+          "description": "Which arm of the union applies. `none` means the run reached no subject, which is a fact; an omitted subject is not."
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "HTTP target, when kind is 'http'."
+        },
+        "url_absent_reason": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            null,
+            "not_queried",
+            "not_supplied",
+            "not_applicable",
+            "not_running_in_ci",
+            "not_a_git_checkout",
+            "git_unavailable",
+            "no_matching_tag",
+            "version_not_discoverable",
+            "package_not_installed",
+            "not_readable",
+            "unsupported_by_target",
+            "redacted_for_publication"
+          ],
+          "description": "Why the paired field is null, from a closed vocabulary (protocol_tests/run_provenance.py::ABSENT_REASONS). Exactly one of a field and its `_absent_reason` sibling is non-null. The string \"unknown\" is never a value here: it cannot be told apart from a model literally tagged `unknown` or from a stringified None."
+        },
+        "model": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/model_identity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Model under test, when kind is 'model'."
+        },
+        "model_absent_reason": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            null,
+            "not_queried",
+            "not_supplied",
+            "not_applicable",
+            "not_running_in_ci",
+            "not_a_git_checkout",
+            "git_unavailable",
+            "no_matching_tag",
+            "version_not_discoverable",
+            "package_not_installed",
+            "not_readable",
+            "unsupported_by_target",
+            "redacted_for_publication"
+          ],
+          "description": "Why the paired field is null, from a closed vocabulary (protocol_tests/run_provenance.py::ABSENT_REASONS). Exactly one of a field and its `_absent_reason` sibling is non-null. The string \"unknown\" is never a value here: it cannot be told apart from a model literally tagged `unknown` or from a stringified None."
+        },
+        "corpus": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "name",
+                "size_bytes",
+                "size_bytes_absent_reason"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "Basename only. The directory a corpus sits in is infrastructure topology; the file is the subject."
+                },
+                "size_bytes": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ],
+                  "minimum": 0,
+                  "description": "Size of that file."
+                },
+                "size_bytes_absent_reason": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "enum": [
+                    null,
+                    "not_queried",
+                    "not_supplied",
+                    "not_applicable",
+                    "not_running_in_ci",
+                    "not_a_git_checkout",
+                    "git_unavailable",
+                    "no_matching_tag",
+                    "version_not_discoverable",
+                    "package_not_installed",
+                    "not_readable",
+                    "unsupported_by_target",
+                    "redacted_for_publication"
+                  ],
+                  "description": "Why the paired field is null, from a closed vocabulary (protocol_tests/run_provenance.py::ABSENT_REASONS). Exactly one of a field and its `_absent_reason` sibling is non-null. The string \"unknown\" is never a value here: it cannot be told apart from a model literally tagged `unknown` or from a stringified None."
+                }
+              }
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Local corpus under test, when kind is 'corpus'."
+        },
+        "corpus_absent_reason": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            null,
+            "not_queried",
+            "not_supplied",
+            "not_applicable",
+            "not_running_in_ci",
+            "not_a_git_checkout",
+            "git_unavailable",
+            "no_matching_tag",
+            "version_not_discoverable",
+            "package_not_installed",
+            "not_readable",
+            "unsupported_by_target",
+            "redacted_for_publication"
+          ],
+          "description": "Why the paired field is null, from a closed vocabulary (protocol_tests/run_provenance.py::ABSENT_REASONS). Exactly one of a field and its `_absent_reason` sibling is non-null. The string \"unknown\" is never a value here: it cannot be told apart from a model literally tagged `unknown` or from a stringified None."
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "model"
+              }
+            },
+            "required": [
+              "kind"
+            ]
+          },
+          "then": {
+            "properties": {
+              "model": {
+                "$ref": "#/$defs/model_identity"
+              }
+            }
+          }
+        }
+      ],
+      "description": "What the run was run against, as a tagged union with a FIXED key set: every arm carries every key, and the arms that do not apply cite `not_applicable`. 'This run had no URL because its subject was a model' and 'this run had a URL and nobody recorded it' must not be the same document."
+    },
+    "model_identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "tag",
+        "runtime",
+        "runtime_absent_reason",
+        "digest",
+        "digest_absent_reason",
+        "family",
+        "family_absent_reason",
+        "parameter_size",
+        "parameter_size_absent_reason",
+        "quantization",
+        "quantization_absent_reason"
+      ],
+      "properties": {
+        "tag": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The tag the run asked for, e.g. 'qwen3.5:latest'. Never null: a model subject that names no model is not a model subject."
+        },
+        "runtime": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The server that answered, e.g. 'ollama 0.18.2'."
+        },
+        "runtime_absent_reason": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            null,
+            "not_queried",
+            "not_supplied",
+            "not_applicable",
+            "not_running_in_ci",
+            "not_a_git_checkout",
+            "git_unavailable",
+            "no_matching_tag",
+            "version_not_discoverable",
+            "package_not_installed",
+            "not_readable",
+            "unsupported_by_target",
+            "redacted_for_publication"
+          ],
+          "description": "Why the paired field is null, from a closed vocabulary (protocol_tests/run_provenance.py::ABSENT_REASONS). Exactly one of a field and its `_absent_reason` sibling is non-null. The string \"unknown\" is never a value here: it cannot be told apart from a model literally tagged `unknown` or from a stringified None."
+        },
+        "digest": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Manifest digest of the weights that answered. `not_queried` is the honest default: agent_data_injection.py reaches Ollama's /api/generate and never its /api/show, so it can name the tag it asked for and not the weights it got."
+        },
+        "digest_absent_reason": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            null,
+            "not_queried",
+            "not_supplied",
+            "not_applicable",
+            "not_running_in_ci",
+            "not_a_git_checkout",
+            "git_unavailable",
+            "no_matching_tag",
+            "version_not_discoverable",
+            "package_not_installed",
+            "not_readable",
+            "unsupported_by_target",
+            "redacted_for_publication"
+          ],
+          "description": "Why the paired field is null, from a closed vocabulary (protocol_tests/run_provenance.py::ABSENT_REASONS). Exactly one of a field and its `_absent_reason` sibling is non-null. The string \"unknown\" is never a value here: it cannot be told apart from a model literally tagged `unknown` or from a stringified None."
+        },
+        "family": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Model family as the runtime reports it."
+        },
+        "family_absent_reason": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            null,
+            "not_queried",
+            "not_supplied",
+            "not_applicable",
+            "not_running_in_ci",
+            "not_a_git_checkout",
+            "git_unavailable",
+            "no_matching_tag",
+            "version_not_discoverable",
+            "package_not_installed",
+            "not_readable",
+            "unsupported_by_target",
+            "redacted_for_publication"
+          ],
+          "description": "Why the paired field is null, from a closed vocabulary (protocol_tests/run_provenance.py::ABSENT_REASONS). Exactly one of a field and its `_absent_reason` sibling is non-null. The string \"unknown\" is never a value here: it cannot be told apart from a model literally tagged `unknown` or from a stringified None."
+        },
+        "parameter_size": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Parameter count as the runtime reports it, e.g. '9.7B'."
+        },
+        "parameter_size_absent_reason": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            null,
+            "not_queried",
+            "not_supplied",
+            "not_applicable",
+            "not_running_in_ci",
+            "not_a_git_checkout",
+            "git_unavailable",
+            "no_matching_tag",
+            "version_not_discoverable",
+            "package_not_installed",
+            "not_readable",
+            "unsupported_by_target",
+            "redacted_for_publication"
+          ],
+          "description": "Why the paired field is null, from a closed vocabulary (protocol_tests/run_provenance.py::ABSENT_REASONS). Exactly one of a field and its `_absent_reason` sibling is non-null. The string \"unknown\" is never a value here: it cannot be told apart from a model literally tagged `unknown` or from a stringified None."
+        },
+        "quantization": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Quantisation as the runtime reports it, e.g. 'Q4_K_M'."
+        },
+        "quantization_absent_reason": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            null,
+            "not_queried",
+            "not_supplied",
+            "not_applicable",
+            "not_running_in_ci",
+            "not_a_git_checkout",
+            "git_unavailable",
+            "no_matching_tag",
+            "version_not_discoverable",
+            "package_not_installed",
+            "not_readable",
+            "unsupported_by_target",
+            "redacted_for_publication"
+          ],
+          "description": "Why the paired field is null, from a closed vocabulary (protocol_tests/run_provenance.py::ABSENT_REASONS). Exactly one of a field and its `_absent_reason` sibling is non-null. The string \"unknown\" is never a value here: it cannot be told apart from a model literally tagged `unknown` or from a stringified None."
+        }
+      },
+      "description": "Which model answered, and which parts of that the tool actually asked for. docs/evidence/adi/2026-09-02-qwen35-n3-raw.json carries these five values in a header that was assembled by hand, because the tool had nowhere to put them."
     }
   },
   "anyOf": [
@@ -412,6 +1096,9 @@
   "dependentRequired": {
     "independence_level": [
       "system_under_test"
+    ],
+    "subject": [
+      "provenance"
     ]
   }
 }

--- a/scripts/build_provenance.py
+++ b/scripts/build_provenance.py
@@ -28,11 +28,34 @@ import hashlib
 import json
 import os
 import platform
-import subprocess
 import sys
 from pathlib import Path
 
+# `git()`, `ci_identity()` and `tool_versions()` used to be defined here. They
+# now live in `protocol_tests/run_provenance.py`, which needs the same three
+# answers for a RUN statement. Two implementations of "what commit is this"
+# that can disagree is not a thing a provenance feature may contain, so this
+# script imports the one. They are re-exported by name because
+# `testing/test_release_provenance.py` reaches for `build_provenance.git` and
+# `build_provenance.tool_versions` directly.
+#
+# The path insert is load-bearing: this file is invoked as
+# `python scripts/build_provenance.py` from `publish-pypi.yml`, so sys.path[0]
+# is `scripts/` and the repository root is not on the path at all.
+_REPO_ROOT = str(Path(__file__).resolve().parents[1])
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from protocol_tests.run_provenance import (  # noqa: E402
+    ci_identity,
+    git,
+    tool_versions,
+)
+
 SCHEMA = "agent-security-harness/release-provenance/v1"
+
+__all__ = ["SCHEMA", "build", "ci_identity", "git", "main", "sha256_file",
+           "tool_versions"]
 
 
 def sha256_file(path: Path) -> str:
@@ -41,53 +64,6 @@ def sha256_file(path: Path) -> str:
         for chunk in iter(lambda: fh.read(1 << 20), b""):
             h.update(chunk)
     return h.hexdigest()
-
-
-def tool_versions(names=("setuptools", "wheel", "build", "pip")) -> dict:
-    """Versions of the tools that govern what the artifact contains.
-
-    setuptools is the build backend, so its version is part of what shipped.
-    A tool that is absent is recorded as absent rather than omitted: a missing
-    key and a tool that was not installed are different facts.
-    """
-    from importlib.metadata import PackageNotFoundError, version
-    out = {}
-    for name in names:
-        try:
-            out[name] = version(name)
-        except PackageNotFoundError:
-            out[name] = None
-    return out
-
-
-def git(*args: str, cwd: Path | None = None) -> str | None:
-    try:
-        return subprocess.run(("git", *args), cwd=cwd, capture_output=True,
-                              text=True, check=True).stdout.strip()
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        return None
-
-
-def ci_identity() -> dict:
-    """The workflow run that produced this, from the environment GitHub sets.
-
-    Every value is None outside CI. That is deliberate: a locally built
-    statement must not look like a CI-built one, and the verifier can tell.
-    """
-    env = os.environ.get
-    run_id, repo = env("GITHUB_RUN_ID"), env("GITHUB_REPOSITORY")
-    return {
-        "repository": repo,
-        "workflow": env("GITHUB_WORKFLOW"),
-        "workflow_ref": env("GITHUB_WORKFLOW_REF"),
-        "run_id": run_id,
-        "run_attempt": env("GITHUB_RUN_ATTEMPT"),
-        "run_url": (f"{env('GITHUB_SERVER_URL', 'https://github.com')}/{repo}"
-                    f"/actions/runs/{run_id}") if (run_id and repo) else None,
-        "runner_os": env("RUNNER_OS"),
-        "runner_arch": env("RUNNER_ARCH"),
-        "event": env("GITHUB_EVENT_NAME"),
-    }
 
 
 def build(dist: Path, source_date: str | None = None) -> dict:

--- a/testing/test_evidence_integrity_registers.py
+++ b/testing/test_evidence_integrity_registers.py
@@ -214,7 +214,14 @@ class TestEveryRegisterReportsBothNumbers(unittest.TestCase):
                       "REGISTERS", "REFUSAL_VOCAB", "CALLER_EXTRA", "ALLOWED",
                       "MODULE_TERMS", "HAS_THE_RULE", "DIFFERENT_REMEDY",
                       "LEGITIMATELY_PERMISSIVE", "PASSING_AGAINST_YES",
-                      "RECOGNISES_A_REFUSAL", "RECOGNISES_NO_REFUSAL"}
+                      "RECOGNISES_A_REFUSAL", "RECOGNISES_NO_REFUSAL",
+                      # Scope exclusions in test_report_states_its_provenance:
+                      # files that are not report writers at all (a dispatcher,
+                      # a usage docstring, the shared machinery). Same kind as
+                      # NOT_A_HARNESS in test_inconclusive_summary -- naming
+                      # what is outside the surveyed population, so there is no
+                      # population for it to be a fraction of.
+                      "NOT_A_REPORT_WRITER"}
         expected = declaring - taxonomies
         missing = expected - set(REGISTERS)
         self.assertEqual(

--- a/testing/test_report_states_its_provenance.py
+++ b/testing/test_report_states_its_provenance.py
@@ -49,7 +49,13 @@ WRITES_A_REPORT = re.compile(
     r"^\s*def generate_report|add_argument\(\s*[\"']--report", re.M)
 
 #: The property: the report says what produced the run.
-STATES_ITS_PROVENANCE = re.compile(r"\brun_provenance\b")
+#:
+#: This must match a CALL, not the name. `\brun_provenance\b` also matched the
+#: import line and the module path `protocol_tests.run_provenance`, so a module
+#: that imported the builder and never called it satisfied the ratchet. Caught
+#: by deleting the call from `delegation_chain_harness` while leaving its
+#: import: the suite stayed green.
+STATES_ITS_PROVENANCE = re.compile(r"\brun_provenance\s*\(")
 
 #: Not report writers, for stated reasons rather than because they were
 #: inconvenient.
@@ -97,6 +103,9 @@ GRANDFATHERED: set[str] = {
 #: empty set is not a detector.
 KNOWN_REPORT_WRITERS = 27
 
+# Frozen at the seed. May shrink as modules are migrated; must never grow.
+SEEDED_GRANDFATHER_COUNT = 42
+
 
 def _affected() -> set[str]:
     return {
@@ -127,11 +136,34 @@ class TestTheDetectionStillDetects(unittest.TestCase):
         self.assertIn(MIGRATED, _affected())
 
     def test_the_ratchet_has_something_to_check(self):
-        self.assertEqual(
-            _affected() - GRANDFATHERED, {MIGRATED},
-            "the checked set is not exactly the migrated module; either a "
-            "module was migrated without shrinking GRANDFATHERED, or the "
-            "grandfather list has drifted from the derived set")
+        """The checked set must be non-empty and must contain the migrated one.
+
+        This asserted equality with `{MIGRATED}` when exactly one module
+        complied. That was too strict in the direction that matters: a NEW
+        module which states its provenance correctly is the outcome this
+        ratchet exists to produce, and equality reported it as a failure.
+        `delegation_chain_harness` (#524) was the first such module.
+
+        The property being defended is that the scan is checking something and
+        is checking the module that was migrated -- not that the compliant set
+        never grows. Growth of GRANDFATHERED is what must not happen, and
+        `test_the_grandfather_list_never_grew` pins that separately.
+        """
+        checked = _affected() - GRANDFATHERED
+        self.assertIn(MIGRATED, checked)
+        self.assertTrue(checked, "the ratchet is checking nothing")
+
+    def test_the_grandfather_list_never_grew(self):
+        """Debt may be paid down; it may not be taken on.
+
+        A module that writes a report without provenance must be fixed, not
+        added here. This is the assertion that makes the ratchet a ratchet.
+        """
+        self.assertLessEqual(
+            len(GRANDFATHERED), SEEDED_GRANDFATHER_COUNT,
+            f"GRANDFATHERED grew past its seed of "
+            f"{SEEDED_GRANDFATHER_COUNT}; a new report writer was excused "
+            f"instead of made to state what produced it")
 
     def test_grandfathered_names_all_exist(self):
         """A stale name silently shrinks the checked set to nothing."""

--- a/testing/test_report_states_its_provenance.py
+++ b/testing/test_report_states_its_provenance.py
@@ -1,0 +1,200 @@
+"""A module that writes a report states, in the report, what produced the run.
+
+`docs/evidence/adi/2026-09-02-qwen35-n3-raw.json` is what the alternative looks
+like. Its `runtime` block -- Ollama server version, model tag, manifest digest,
+family, parameter size, quantisation -- was typed in by a person, because
+`agent_data_injection.py --report` wrote a bare LIST and a list has nowhere to
+put a header. The verdicts in that file are about a model whose identity is not
+part of the record.
+
+`agent_data_injection` is the first module migrated. This file is the ratchet
+that keeps the direction one-way.
+
+## The set is derived, not listed
+
+The reference for this shape is `testing/test_inconclusive_summary.py`, whose
+own comment records why: a detector keyed to the literal being REMOVED stops
+detecting exactly when it starts mattering, and a ratchet over an empty set
+passes while every module carries the defect.
+
+So the affected set is computed by scanning `protocol_tests/*.py` for a module
+that writes a report at all -- `def generate_report`, or an argparse `--report`
+flag -- and `GRANDFATHERED` is seeded with every one of them except the migrated
+module. It may shrink. It must never grow.
+
+Two numbers worth keeping straight, because the plan for this change had them
+confused. `def generate_report` matches twenty-seven files and
+`agent_data_injection` is NOT one of them: it writes its report from `main()`
+and defines no such function. Deriving the set from `def generate_report` alone
+would therefore have excluded the one module this change migrated, leaving the
+ratchet asserting nothing about it. The union of the two idioms matches
+forty-three files, `agent_data_injection` among them, and
+`test_the_migrated_module_is_actually_in_the_set` below pins that rather than
+trusting it.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+PROTOCOL_TESTS = REPO_ROOT / "protocol_tests"
+
+#: "This module produces a report document." Both idioms, for the reason in the
+#: module docstring: matching only `def generate_report` misses the module the
+#: change was made for, and matching only `--report` misses the harnesses that
+#: build a report for a caller rather than for a flag.
+WRITES_A_REPORT = re.compile(
+    r"^\s*def generate_report|add_argument\(\s*[\"']--report", re.M)
+
+#: The property: the report says what produced the run.
+STATES_ITS_PROVENANCE = re.compile(r"\brun_provenance\b")
+
+#: Not report writers, for stated reasons rather than because they were
+#: inconvenient.
+#:
+#: `cli` forwards `--report` to the module that writes the report and writes
+#: none itself. It also has a separate latent defect around `runpy.run_module`
+#: and `SystemExit` that deserves its own change, so it is deliberately
+#: untouched here.
+#: `_utils` names `--report` only inside a usage docstring.
+#: `harness_base` and `http_helpers` are the shared machinery, following the
+#: `NOT_A_HARNESS` precedent in `test_inconclusive_summary.py`.
+NOT_A_REPORT_WRITER = {"cli", "_utils", "harness_base", "http_helpers"}
+
+#: The module this change migrated.
+MIGRATED = "agent_data_injection"
+
+#: Report writers that do NOT yet state their provenance. May shrink. Must never
+#: grow -- a new entry means a report writer was added that cannot say what
+#: produced it, which is the shape `run_provenance.py` exists to remove.
+#:
+#: Migrating the rest is deliberately not done here. Each one has its own report
+#: shape and its own callers, and a 43-module mechanical edit is not reviewable.
+GRANDFATHERED: set[str] = {
+    "a2a_harness", "advanced_attacks", "aiuc1_compliance_harness",
+    "ap2_harness", "benchmark_integrity_harness", "capability_profile_harness",
+    "card_token_harness", "cbrn_harness", "cloud_agent_harness",
+    "community_runner", "crewai_cve_harness", "enterprise_adapters",
+    "extended_enterprise_adapters", "extended_thinking_harness",
+    "framework_adapters", "governance_modification_harness",
+    "gtg1002_simulation", "harmful_output_harness", "hitl_harness",
+    "identity_harness", "incident_response_harness", "intent_contract_harness",
+    "jailbreak_harness", "kill_switch_harness", "l402_harness", "mcp_harness",
+    "mcp_supplychain", "mcp_tool_poisoning_harness", "memory_harness",
+    "multi_agent_harness", "over_refusal_harness", "prompt_caching_harness",
+    "provenance_harness", "ptc_harness", "return_channel_harness",
+    "settlement_finality_harness", "skill_security_harness",
+    "tool_search_harness", "ucp_acp_harness", "watermark_harness",
+    "x402_fireblocks_harness", "x402_harness",
+}
+
+#: The count of `def generate_report` modules at the time this was written. Used
+#: as a FLOOR on the derived set: if the scan stops matching -- a renamed
+#: helper, a changed argparse idiom -- the ratchet below would iterate nothing
+#: and pass while nothing was checked. A detector that can silently return the
+#: empty set is not a detector.
+KNOWN_REPORT_WRITERS = 27
+
+
+def _affected() -> set[str]:
+    return {
+        p.stem for p in sorted(PROTOCOL_TESTS.glob("*.py"))
+        if p.stem not in NOT_A_REPORT_WRITER
+        and WRITES_A_REPORT.search(p.read_text(encoding="utf-8"))
+    }
+
+
+class TestTheDetectionStillDetects(unittest.TestCase):
+    """Guards on the scan itself. Without these the ratchet can pass vacuously."""
+
+    def test_the_affected_set_is_not_empty(self):
+        self.assertGreaterEqual(
+            len(_affected()), KNOWN_REPORT_WRITERS,
+            f"fewer report-writing modules found than the "
+            f"{KNOWN_REPORT_WRITERS} known when this was written; the "
+            f"detection is probably broken rather than the repo improved")
+
+    def test_the_migrated_module_is_actually_in_the_set(self):
+        """The specific way this scan could go quiet.
+
+        `agent_data_injection` defines no `generate_report`; it writes its
+        report from `main()`. A scan keyed to `def generate_report` alone would
+        exclude it, and then `_affected() - GRANDFATHERED` is empty and the
+        ratchet asserts nothing about the one module that was changed.
+        """
+        self.assertIn(MIGRATED, _affected())
+
+    def test_the_ratchet_has_something_to_check(self):
+        self.assertEqual(
+            _affected() - GRANDFATHERED, {MIGRATED},
+            "the checked set is not exactly the migrated module; either a "
+            "module was migrated without shrinking GRANDFATHERED, or the "
+            "grandfather list has drifted from the derived set")
+
+    def test_grandfathered_names_all_exist(self):
+        """A stale name silently shrinks the checked set to nothing."""
+        for name in sorted(GRANDFATHERED):
+            with self.subTest(module=name):
+                self.assertTrue((PROTOCOL_TESTS / f"{name}.py").exists())
+
+    def test_the_grandfather_list_is_a_subset_of_the_affected_set(self):
+        self.assertEqual(
+            GRANDFATHERED - _affected(), set(),
+            "a grandfathered module is no longer detected as a report writer; "
+            "either it stopped writing reports (remove it from the list) or "
+            "the detection broke")
+
+
+class TestReportWritersStateTheirProvenance(unittest.TestCase):
+    """The ratchet. Derived, so module forty-four is caught the day it lands."""
+
+    def test_every_non_grandfathered_report_writer_states_its_provenance(self):
+        for name in sorted(_affected() - GRANDFATHERED):
+            with self.subTest(module=name):
+                src = (PROTOCOL_TESTS / f"{name}.py").read_text(encoding="utf-8")
+                self.assertIsNotNone(
+                    STATES_ITS_PROVENANCE.search(src),
+                    f"{name} writes a report and never calls run_provenance(), "
+                    f"so the report cannot say what produced it. That header "
+                    f"then gets assembled by hand, which is how "
+                    f"docs/evidence/adi/2026-09-02-qwen35-n3-raw.json came to "
+                    f"carry a model digest the harness never read.")
+
+    def test_the_migrated_module_writes_a_document_not_a_list(self):
+        """The specific regression: `json.dump([...], fh)` with no header."""
+        src = (PROTOCOL_TESTS / f"{MIGRATED}.py").read_text(encoding="utf-8")
+        self.assertNotIn(
+            "json.dump([r.__dict__ for r in results]", src,
+            "the report is a bare list again; a list has nowhere to put a "
+            "header, which is the whole defect")
+        self.assertIn('"provenance": run_provenance()', src)
+
+    def test_grandfather_list_may_only_shrink(self):
+        """Recorded with its denominator, per docs/EVIDENCE-INTEGRITY rules.
+
+        42 is a numerator and means nothing alone. The denominator is the
+        derived set of report writers, so this reads as "42 of 43 report
+        writers cannot yet say what produced them" -- a fraction that moves
+        correctly whether the numerator shrinks or a new writer lands.
+
+        `testing/test_evidence_integrity_registers.py` covers a register by
+        NAME, and `GRANDFATHERED` is already claimed there by a derivation that
+        reads `test_harness_base_adoption`. So this register's own numbers are
+        stated here rather than assumed covered by that name collision.
+        """
+        affected = _affected()
+        self.assertLessEqual(
+            len(GRANDFATHERED), 42,
+            f"GRANDFATHERED grew to {len(GRANDFATHERED)} of {len(affected)} "
+            f"report writers. A report writer that cannot state what produced "
+            f"it is the pattern this file exists to retire.")
+        self.assertLess(
+            len(GRANDFATHERED), len(affected),
+            "every report writer is grandfathered, so the ratchet checks "
+            "nothing")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/testing/test_static_detectors_can_fire.py
+++ b/testing/test_static_detectors_can_fire.py
@@ -248,6 +248,65 @@ def _run_endpoint_detector(directory: pathlib.Path) -> list[str]:
     return case._scan(sorted(directory.glob("*.py")))
 
 
+# --------------------------------------------------------------------------
+# Detector 5 — a report writer that cannot say what produced the run
+# --------------------------------------------------------------------------
+
+_PROVENANCE_VIOLATION = '''"""A harness that writes a report with no header."""
+import argparse
+import json
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--report")
+    args = ap.parse_args()
+    results = []
+    with open(args.report, "w") as fh:
+        json.dump([r.__dict__ for r in results], fh)
+'''
+
+_PROVENANCE_CONTROL = '''"""The correct form: a document with a header.
+
+Also prose describing the wrong one -- a bare list of results with nowhere to
+put a header -- which the detector must not fire on, because a file that fails
+on an accurate description of what it requires is a file that gets muted.
+"""
+import argparse
+import json
+
+from protocol_tests.run_provenance import run_provenance, subject_none
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--report")
+    args = ap.parse_args()
+    results = []
+    document = {"provenance": run_provenance(), "subject": subject_none(),
+                "results": [r.__dict__ for r in results]}
+    with open(args.report, "w") as fh:
+        json.dump(document, fh)
+'''
+
+
+def _run_provenance_header_detector(directory: pathlib.Path) -> list[str]:
+    # Imported through the package, unlike its neighbours above, because
+    # `tests/` holds a file of the same basename and has no `__init__.py`. A
+    # bare `import test_report_states_its_provenance` therefore resolves to
+    # whichever of the two pytest happened to import first, and that is a
+    # function of collection order.
+    from testing import test_report_states_its_provenance as mod
+    offenders = []
+    for path in sorted(directory.glob("*.py")):
+        src = path.read_text(encoding="utf-8")
+        if not mod.WRITES_A_REPORT.search(src):
+            continue
+        if not mod.STATES_ITS_PROVENANCE.search(src):
+            offenders.append(path.name)
+    return offenders
+
+
 #: detector name -> (runner, seeded violation, legitimate control, guarded file)
 #:
 #: The fourth element is load-bearing. The queue's ratchet used to compare
@@ -268,6 +327,14 @@ DETECTORS = {
     "fabricated default endpoint": (
         _run_endpoint_detector, _ENDPOINT_VIOLATION, _ENDPOINT_CONTROL,
         "test_no_default_endpoints.py"),
+    # A shape that must be PRESENT rather than a construction that must be
+    # absent, which is the direction UNCONTROLLED says a seeded violation is
+    # usually meaningless for. It is not meaningless here: the absence of the
+    # shape IS the violation, so a module that writes a report and never names
+    # run_provenance is a seedable one.
+    "report writer with no provenance header": (
+        _run_provenance_header_detector, _PROVENANCE_VIOLATION,
+        _PROVENANCE_CONTROL, "test_report_states_its_provenance.py"),
 }
 
 #: Derived, never written down: the files that have a seeded control pair.

--- a/tests/test_report_states_its_provenance.py
+++ b/tests/test_report_states_its_provenance.py
@@ -1,0 +1,535 @@
+"""A report must state what produced it and what it ran against, in the file.
+
+`docs/evidence/adi/2026-09-02-qwen35-n3-raw.json` is the exhibit. It carries an
+Ollama server version, a model tag, a manifest digest, a family, a parameter
+size and a quantisation, and the harness produced none of them: `--report`
+wrote `json.dump([r.__dict__ for r in results], fh)` -- a bare LIST, with
+nowhere for a header to go -- so a person typed the header in from a shell
+session that is not part of the record.
+
+That file is not edited by this change. It is a record of a run that happened,
+and editing a dated evidence artifact so it looks machine-generated is
+fabrication. What changes is that the next one cannot be produced that way.
+
+## What is pinned here
+
+1. **Unknown is not omitted, and neither is spelled "unknown".** Every key in
+   both blocks is always present. A null is paired with an `_absent_reason`
+   from a closed enum, and exactly one of the two is non-null. The string
+   `"unknown"` never appears as a value: it cannot be told apart from a model
+   literally tagged `unknown`, a corpus named `unknown`, or a bug that
+   stringified a `None`. `protocol_tests/version.py` returns exactly that
+   string on failure, so this is a live hazard and not a hypothetical one.
+
+2. **Argv redaction.** Documented usage includes
+   `--header "Authorization: Bearer ..."`. This block is meant to be published
+   and signed, so a raw argv would make a provenance feature a
+   credential-disclosure feature. Tested with realistic fake credentials, by
+   asserting the secret does not appear anywhere in the serialised document --
+   not by asserting a particular redacted spelling, which would pass while the
+   secret sat in a neighbouring field.
+
+3. **The published records are untouched.** Both committed attestation records
+   still validate, and their `verification_hash` still recomputes to the value
+   they were published under. New schema fields that silently invalidate signed
+   history are not new schema fields, they are a break.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+
+from protocol_tests.attestation import (  # noqa: E402
+    SCHEMA_PATH,
+    _infer_scope,
+    generate_attestation_report,
+    validate_attestation_report,
+)
+from protocol_tests.run_provenance import (  # noqa: E402
+    ABSENT_REASONS,
+    PROVENANCE_SCHEMA,
+    redact_argv,
+    run_provenance,
+    subject_corpus,
+    subject_http,
+    subject_model,
+    subject_none,
+)
+
+SCHEMA = json.loads(SCHEMA_PATH.read_text())
+
+ENTRY = {
+    "test_id": "ADI-001",
+    "category": "agent_data_injection",
+    "result": "inconclusive",
+    "severity": "P0-Critical",
+    "scope": _infer_scope("ADI-001", "agent_data_injection"),
+    "timestamp": "2026-09-07T00:00:00+00:00",
+}
+
+#: Shaped like the real things and valid nowhere. The point of using realistic
+#: shapes is that a redactor keyed to a toy value ("secret123") passes on the
+#: toy and leaks the real one.
+FAKE_BEARER = "sk-ant-api03-Qx7NOTAREALKEY0000000000000000000000000000000000AA"
+# Not AWS's canonical example access key: that literal trips this repo's own
+# secret scanner (testing/test_code_quality.py), and a fixture that teaches
+# people to add exclusions to a secret scanner costs more than it tests. The
+# name is FAKE_PAT and not FAKE_PAT for the same reason -- that scanner also
+# matches `api_key = "..."`, and it is right to.
+FAKE_PAT = "ghp_NOTAREALTOKEN0000000000000000000000"
+FAKE_PASSWORD = "hunter2-correct-horse-battery-staple"
+
+
+def _report(**kw):
+    return generate_attestation_report([ENTRY], suite="adi",
+                                       harness_version="4.20.0", **kw)
+
+
+def _walk(obj, path="$"):
+    """Yield (path, key, value) for every mapping entry, depth-first."""
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            yield f"{path}.{k}", k, v
+            yield from _walk(v, f"{path}.{k}")
+    elif isinstance(obj, list):
+        for i, v in enumerate(obj):
+            yield from _walk(v, f"{path}[{i}]")
+
+
+# --- 1. unknown vs omitted -------------------------------------------------
+
+BLOCKS = {
+    "provenance": lambda: run_provenance(),
+    "subject_http": lambda: subject_http("http://localhost:8080/mcp"),
+    "subject_http_missing": lambda: subject_http(None),
+    "subject_model": lambda: subject_model("qwen3.5:latest"),
+    "subject_corpus": lambda: subject_corpus(__file__),
+    "subject_none": lambda: subject_none(),
+}
+
+
+def _is_absent(value) -> bool:
+    """Null, or a block whose every value is null.
+
+    The second case is `ci`, which stays a dict of nine keys outside CI so a
+    reader can see WHICH nine were consulted, and so a local statement cannot
+    pass for a CI one. A block in which nothing is known is an absence, and the
+    invariant would be untotal -- with a documented exception -- if it only
+    understood the scalar case.
+    """
+    if value is None:
+        return True
+    return isinstance(value, dict) and bool(value) and all(
+        v is None for v in value.values())
+
+
+@pytest.mark.parametrize("name", sorted(BLOCKS))
+def test_every_null_is_paired_with_a_reason_and_only_a_reason(name):
+    """The invariant, stated as an exclusive or.
+
+    A null with no reason is an absence that explains nothing. A reason beside
+    a present value is a document asserting two incompatible things about the
+    same field.
+    """
+    block = BLOCKS[name]()
+    reasons = [(p, k) for p, k, _ in _walk(block) if k.endswith("_absent_reason")]
+    assert reasons, f"{name} carries no paired reasons at all"
+
+    for path, key in reasons:
+        parent = _resolve(block, path[: -(len(key) + 1)])
+        field = key[: -len("_absent_reason")]
+        assert field in parent, f"{path}: reason with no field beside it"
+        value, reason = parent[field], parent[key]
+        assert _is_absent(value) == (reason is not None), (
+            f"{path}: value={value!r} reason={reason!r}. A reason accompanies "
+            f"an absence and nothing else.")
+        if reason is not None:
+            assert reason in ABSENT_REASONS, f"{path}: {reason!r} is off-enum"
+
+
+def _resolve(root, path):
+    node = root
+    for part in path.split(".")[1:]:
+        node = node[part]
+    return node
+
+
+@pytest.mark.parametrize("name", sorted(BLOCKS))
+def test_no_key_is_ever_omitted(name):
+    """A missing key cannot be told apart from a producer that dropped one."""
+    block = BLOCKS[name]()
+    if name.startswith("subject"):
+        assert set(block) == {
+            "kind", "url", "url_absent_reason", "model", "model_absent_reason",
+            "corpus", "corpus_absent_reason",
+        }, "the subject union must carry every arm's keys in every arm"
+    else:
+        assert set(block) == {
+            "schema", "started_at", "tool", "source", "runtime", "invocation",
+            "ci", "ci_absent_reason", "not_claimed",
+        }
+
+
+@pytest.mark.parametrize("name", sorted(BLOCKS))
+def test_the_string_unknown_never_appears_as_a_value(name):
+    """`"unknown"` is indistinguishable from a model literally tagged that.
+
+    It is also what `protocol_tests/version.py::get_harness_version()` returns
+    when it fails, which is why this is checked rather than assumed.
+    """
+    for path, _, value in _walk(BLOCKS[name]()):
+        if isinstance(value, str):
+            assert value.strip().lower() != "unknown", f"{path} is the string 'unknown'"
+
+
+def test_a_failed_version_lookup_becomes_null_not_the_word_unknown():
+    """The live hazard, exercised: the sentinel must not travel as data."""
+    with mock.patch("protocol_tests.version.get_harness_version", return_value="unknown"):
+        tool = run_provenance()["tool"]
+    assert tool["version"] is None
+    assert tool["version_absent_reason"] == "version_not_discoverable"
+
+
+def test_ci_block_is_present_and_all_null_outside_ci():
+    """A locally produced statement must not be able to pass for a CI one."""
+    scrubbed = {k: v for k, v in os.environ.items()
+                if not k.startswith(("GITHUB_", "RUNNER_"))}
+    with mock.patch.dict(os.environ, scrubbed, clear=True):
+        p = run_provenance()
+    assert p["ci_absent_reason"] == "not_running_in_ci"
+    assert set(p["ci"]) == {"repository", "workflow", "workflow_ref", "run_id",
+                            "run_attempt", "run_url", "runner_os",
+                            "runner_arch", "event"}
+    assert all(v is None for v in p["ci"].values())
+
+
+def test_a_subject_model_with_no_tag_is_refused():
+    """kind 'model' with model null is a claim about a model that names none."""
+    with pytest.raises(ValueError, match="requires a tag"):
+        subject_model("")
+
+
+def test_model_details_default_to_not_queried_rather_than_to_absent():
+    """The ADI case exactly. The tool reaches /api/generate, never /api/show."""
+    model = subject_model("qwen3.5:latest")["model"]
+    assert model["tag"] == "qwen3.5:latest"
+    for field in ("runtime", "digest", "family", "parameter_size", "quantization"):
+        assert model[field] is None
+        assert model[f"{field}_absent_reason"] == "not_queried", (
+            "these are facts the tool could obtain and does not ask for; "
+            "'not_queried' is the difference between that and 'unavailable'")
+
+
+def test_a_subject_arm_that_does_not_apply_says_not_applicable():
+    """Distinct from not_supplied: 'no URL because it is a model' is a fact."""
+    assert subject_model("m")["url_absent_reason"] == "not_applicable"
+    assert subject_http(None)["url_absent_reason"] == "not_supplied"
+
+
+# --- 2. argv redaction -----------------------------------------------------
+
+def test_a_bearer_header_does_not_reach_the_document():
+    """The headline. Asserted as absence from the whole serialised block.
+
+    Checking for the literal `[REDACTED]` instead would pass while the secret
+    sat in a neighbouring field, which is the failure mode worth testing for.
+    """
+    argv = ["/home/someone/.venv/bin/agent-security", "test", "mcp",
+            "--url", "http://localhost:8080/mcp",
+            "--header", f"Authorization: Bearer {FAKE_BEARER}"]
+    with mock.patch.object(sys, "argv", argv):
+        blob = json.dumps(run_provenance())
+    assert FAKE_BEARER not in blob
+    assert "[REDACTED]" in blob
+    assert json.loads(blob)["invocation"]["argv_redacted"] is True
+
+
+@pytest.mark.parametrize("argv,secret", [
+    (["p", "--header", f"Authorization: Bearer {FAKE_BEARER}"], FAKE_BEARER),
+    (["p", "-H", f"X-Api-Key: {FAKE_PAT}"], FAKE_PAT),
+    (["p", f"--api-key={FAKE_PAT}"], FAKE_PAT),
+    (["p", "--api-key", FAKE_PAT], FAKE_PAT),
+    (["p", "--token", FAKE_BEARER], FAKE_BEARER),
+    (["p", "--auth-token", FAKE_BEARER], FAKE_BEARER),
+    (["p", "--password", FAKE_PASSWORD], FAKE_PASSWORD),
+    (["p", f"--authorization=Bearer {FAKE_BEARER}"], FAKE_BEARER),
+    (["p", f"Authorization: Bearer {FAKE_BEARER}"], FAKE_BEARER),
+    (["p", f"Bearer {FAKE_BEARER}"], FAKE_BEARER),
+    (["p", f"--secret={FAKE_PASSWORD}"], FAKE_PASSWORD),
+    (["p", "--cookie", f"session={FAKE_BEARER}"], FAKE_BEARER),
+])
+def test_credential_shapes_are_redacted(argv, secret):
+    out, redacted = redact_argv(argv)
+    assert secret not in " ".join(out), out
+    assert redacted is True, out
+
+
+def test_ordinary_arguments_survive_intact():
+    """Over-redaction that eats the command is its own failure.
+
+    A provenance record that cannot say which model or which target was used
+    has replaced one unverifiable claim with another.
+    """
+    out, redacted = redact_argv(
+        ["p", "test", "agent-data-injection", "--model", "qwen3.5:latest",
+         "--trials", "3", "--url", "http://localhost:8080/mcp"])
+    assert out == ["p", "test", "agent-data-injection", "--model",
+                   "qwen3.5:latest", "--trials", "3", "--url",
+                   "http://localhost:8080/mcp"]
+    assert redacted is False
+
+
+def test_help_is_not_treated_as_a_header_flag():
+    """`-H` is the header short flag; `-h` is --help. Case matters."""
+    out, redacted = redact_argv(["p", "-h", "mcp"])
+    assert out == ["p", "-h", "mcp"]
+    assert redacted is False
+
+
+def test_absolute_paths_are_reduced_but_that_is_not_redaction():
+    """docs/PRIVACY.md: usernames, directories and topology do not travel.
+
+    It must not set argv_redacted, or the flag stops meaning 'a credential was
+    replaced' and starts meaning 'something was reformatted'.
+    """
+    out, redacted = redact_argv(
+        ["/home/alice/.venv/bin/agent-security", "--report",
+         "/home/alice/evidence/run.json"])
+    assert out == ["agent-security", "--report", "run.json"]
+    assert redacted is False
+    assert "alice" not in " ".join(out)
+
+
+def test_no_hostname_username_or_working_directory_is_recorded():
+    """Stated as a decision in the schema; enforced here."""
+    import getpass
+    import socket
+
+    with mock.patch.object(sys, "argv", ["agent-security", "test", "mcp"]):
+        blob = json.dumps(run_provenance())
+    for leak in (socket.gethostname(), getpass.getuser(), os.getcwd(),
+                 str(Path.home())):
+        if leak and len(leak) > 3:
+            assert leak not in blob, f"{leak!r} reached the provenance block"
+
+
+# --- 3. the report carries both blocks -------------------------------------
+
+def test_both_blocks_are_emitted_when_either_is_given():
+    """Half a provenance claim is the hand-assembled-header shape again."""
+    r = _report(provenance=run_provenance())
+    assert r["subject"]["kind"] == "none", "an absent subject is stated, not omitted"
+    assert r["provenance"]["schema"] == PROVENANCE_SCHEMA
+
+
+def test_a_subject_without_a_provenance_is_refused():
+    with pytest.raises(ValueError, match="provenance is required"):
+        _report(subject=subject_model("qwen3.5:latest"))
+
+
+def test_neither_is_emitted_when_neither_is_asked_for():
+    """Backward compatibility is the whole reason these are optional."""
+    r = _report()
+    assert "provenance" not in r
+    assert "subject" not in r
+
+
+def test_a_report_carrying_both_validates_clean():
+    r = _report(provenance=run_provenance(), subject=subject_model("qwen3.5:latest"))
+    errs = [e for e in validate_attestation_report(r) if "NOT SCHEMA-VALIDATED" not in e]
+    assert errs == [], errs
+
+
+def test_validator_rejects_a_model_subject_that_names_no_model():
+    r = _report(provenance=run_provenance(), subject=subject_model("qwen3.5:latest"))
+    r["subject"]["model"] = None
+    assert any("names no model" in e for e in validate_attestation_report(r))
+
+
+def test_the_model_rule_also_fires_without_jsonschema():
+    """The rule must not evaporate on a machine where the validator is absent.
+
+    That machine is told 'NOT SCHEMA-VALIDATED' and, before this, nothing else.
+    """
+    r = _report(provenance=run_provenance(), subject=subject_model("qwen3.5:latest"))
+    r["subject"]["model"] = None
+    with mock.patch.dict(sys.modules, {"jsonschema": None}):
+        errs = validate_attestation_report(r)
+    assert any("NOT SCHEMA-VALIDATED" in e for e in errs), "wrong path exercised"
+    assert any("names no model" in e for e in errs), errs
+
+
+def test_off_enum_absent_reasons_are_rejected():
+    """The vocabulary is closed, so an invented reason is not a novel fact."""
+    r = _report(provenance=run_provenance(), subject=subject_model("qwen3.5:latest"))
+    r["subject"]["model"]["digest_absent_reason"] = "because_reasons"
+    assert validate_attestation_report(r)
+
+
+def test_a_dropped_key_is_rejected():
+    """additionalProperties:false catches additions; `required` catches losses."""
+    r = _report(provenance=run_provenance(), subject=subject_http("http://x/y"))
+    del r["subject"]["url"]
+    assert any("'url' is a required property" in e
+               for e in validate_attestation_report(r))
+
+
+# --- 3b. publishing a report keeps the blocks well-formed ------------------
+
+def test_publishing_redacts_the_target_without_deleting_the_key():
+    """`strip_sensitive_fields` DELETES any key containing 'url'.
+
+    Applied naively to these blocks that removes `subject.url`,
+    `subject.url_absent_reason` and `ci.run_url` -- all three schema-required
+    -- so a published record stopped validating. It was found by trying it,
+    not by reading the stripper.
+
+    The rule is right about what must not travel and wrong about how: a deleted
+    key destroys exactly the property these blocks exist to have.
+    """
+    from protocol_tests.attestation_registry import strip_sensitive_fields
+
+    target = "http://internal.example.invalid:8080/mcp"
+    r = _report(provenance=run_provenance(), subject=subject_http(target))
+    cleaned = strip_sensitive_fields(r)
+
+    errs = [e for e in validate_attestation_report(cleaned)
+            if "NOT SCHEMA-VALIDATED" not in e]
+    assert errs == [], errs
+    assert cleaned["subject"]["url"] is None
+    assert cleaned["subject"]["url_absent_reason"] == "redacted_for_publication"
+    assert cleaned["provenance"]["ci"]["run_url"] is None
+    assert "internal.example.invalid" not in json.dumps(cleaned), (
+        "the target survived publication; the redaction is decorative")
+
+
+def test_redaction_for_publication_is_its_own_reason():
+    """Four different facts about the same null, kept apart.
+
+    'we did not ask', 'it does not apply', 'we asked and could not tell' and
+    'we know and are not putting it in this copy' are not the same, and a
+    reader of a published record has to be able to tell the last from the rest.
+    """
+    from protocol_tests.run_provenance import redact_for_publication
+
+    model = redact_for_publication(subject_model("qwen3.5:latest"))
+    assert model["url_absent_reason"] == "not_applicable", (
+        "a model subject never had a URL; redaction must not overwrite that")
+    assert model["model"]["digest_absent_reason"] == "not_queried"
+
+    http = redact_for_publication(subject_http("http://x.invalid/y"))
+    assert http["url_absent_reason"] == "redacted_for_publication"
+
+    absent = redact_for_publication(subject_http(None))
+    assert absent["url_absent_reason"] == "not_supplied", (
+        "nothing was withheld, so nothing may claim to have been")
+
+
+# --- 4. nothing already published moved ------------------------------------
+
+RECORDS = sorted((REPO / "attestations").rglob("*-record.json"))
+
+
+def test_there_are_records_to_check():
+    """A loop over an empty glob passes and proves nothing."""
+    assert len(RECORDS) >= 2, RECORDS
+
+
+@pytest.mark.parametrize("record", RECORDS, ids=lambda p: p.name)
+def test_a_published_record_still_validates(record):
+    rec = json.loads(record.read_text())
+    errs = [e for e in validate_attestation_report(rec["payload"]["report"])
+            if "NOT SCHEMA-VALIDATED" not in e]
+    assert errs == [], errs
+
+
+@pytest.mark.parametrize("record", RECORDS, ids=lambda p: p.name)
+def test_a_published_record_still_hashes_to_what_it_was_published_as(record):
+    """The canonicalisation is pinned in the server contract, section 4.1.
+
+    If a schema change forced a republish, the signature over the old bytes
+    would be worthless and the old citation would break. Optional fields are
+    how that is avoided; this is the assertion that says so.
+    """
+    rec = json.loads(record.read_text())
+    payload_bytes = json.dumps(rec["payload"], sort_keys=True).encode()
+    assert hashlib.sha256(payload_bytes).hexdigest() == rec["verification_hash"]
+
+
+def test_schema_version_was_not_bumped():
+    """A `const`. Bumping it invalidates every document already in the world."""
+    assert SCHEMA["properties"]["schema_version"]["const"] == "1.0.0"
+
+
+def test_the_new_fields_are_optional():
+    assert "provenance" not in SCHEMA["required"]
+    assert "subject" not in SCHEMA["required"]
+    assert SCHEMA["dependentRequired"]["subject"] == ["provenance"]
+
+
+def test_the_new_defs_are_closed():
+    """additionalProperties:false, or the block accepts anything at all."""
+    for name in ("provenance", "subject", "model_identity"):
+        assert SCHEMA["$defs"][name]["additionalProperties"] is False, name
+
+
+def test_the_schema_enum_matches_the_code_enum():
+    """One vocabulary. Two that can drift is the defect shape, not the fix."""
+    enum = SCHEMA["$defs"]["model_identity"]["properties"]["digest_absent_reason"]["enum"]
+    assert enum == [None, *ABSENT_REASONS]
+
+
+# --- 5. the module this was built for --------------------------------------
+
+def test_adi_report_is_a_document_with_a_header(tmp_path):
+    """End to end, through the module's own `--report`."""
+    out = tmp_path / "adi.json"
+    env = dict(os.environ)
+    env.update({
+        "HARNESS_ADI_MODEL": "qwen3.5:latest",
+        # A closed port, so the probe fails fast and deterministically instead
+        # of depending on whether this machine happens to be running Ollama.
+        "HARNESS_ADI_OLLAMA": "http://127.0.0.1:1/api/generate",
+    })
+    proc = subprocess.run(
+        [sys.executable, "-m", "protocol_tests.agent_data_injection",
+         "--trials", "1", "--report", str(out)],
+        cwd=REPO, env=env, capture_output=True, text=True)
+    assert out.exists(), proc.stdout + proc.stderr
+
+    doc = json.loads(out.read_text())
+    assert not isinstance(doc, list), (
+        "the report is a bare list again; there is nowhere to put a header and "
+        "the next one gets assembled by hand")
+    assert set(doc) == {"provenance", "subject", "results"}
+    assert doc["subject"]["kind"] == "model"
+    assert doc["subject"]["model"]["tag"] == "qwen3.5:latest"
+    assert doc["subject"]["model"]["digest_absent_reason"] == "not_queried"
+    assert doc["provenance"]["schema"] == PROVENANCE_SCHEMA
+    assert FAKE_BEARER not in json.dumps(doc)
+    assert len(doc["results"]) == 3
+
+
+def test_the_hand_assembled_evidence_file_is_left_alone():
+    """It is a record of a run that happened.
+
+    Editing a dated evidence artifact so it looks machine-generated is
+    fabrication, which is worse than the defect. It stays as it is, and this
+    test exists so nobody 'tidies' it into the new shape later.
+    """
+    raw = REPO / "docs" / "evidence" / "adi" / "2026-09-02-qwen35-n3-raw.json"
+    doc = json.loads(raw.read_text())
+    assert doc["runtime"]["model_tag"] == "qwen3.5:latest"
+    assert "provenance" not in doc, (
+        "this file predates run_provenance and must keep saying so; the header "
+        "in it was typed by a person and no later edit can make that untrue")

--- a/tests/test_report_states_its_provenance.py
+++ b/tests/test_report_states_its_provenance.py
@@ -316,11 +316,45 @@ def test_no_hostname_username_or_working_directory_is_recorded():
     import socket
 
     with mock.patch.object(sys, "argv", ["agent-security", "test", "mcp"]):
-        blob = json.dumps(run_provenance())
-    for leak in (socket.gethostname(), getpass.getuser(), os.getcwd(),
-                 str(Path.home())):
-        if leak and len(leak) > 3:
-            assert leak not in blob, f"{leak!r} reached the provenance block"
+        block = run_provenance()
+
+    # Check VALUES, not a substring of the serialised blob. A blob-wide grep
+    # collides with legitimate key names: on GitHub Actions the username is
+    # literally "runner", and the CI block correctly carries the fields
+    # `runner_os` and `runner_arch`. That is a field name, not a leaked
+    # identity, and a substring assertion cannot tell the two apart -- it
+    # failed CI on #525 for exactly that reason.
+    #
+    # The `ci` block is exempt: its contents are GitHub-supplied public
+    # identifiers (repository, workflow ref, run url) that are emitted on
+    # purpose and pinned by their own schema. `not_claimed` is exempt because
+    # it is prose that names these very fields in order to say they are absent.
+    forbidden_keys = {"hostname", "host", "user", "username", "cwd",
+                      "working_directory", "home"}
+
+    def values(node, path="", skip=("ci", "not_claimed")):
+        if isinstance(node, dict):
+            for k, v in node.items():
+                assert k not in forbidden_keys, (
+                    f"provenance emitted a forbidden key {k!r} at {path}"
+                )
+                if k in skip:
+                    continue
+                yield from values(v, f"{path}.{k}", skip)
+        elif isinstance(node, list):
+            for i, v in enumerate(node):
+                yield from values(v, f"{path}[{i}]", skip)
+        elif isinstance(node, str):
+            yield path, node
+
+    leaks = [leak for leak in (socket.gethostname(), getpass.getuser(),
+                               os.getcwd(), str(Path.home()))
+             if leak and len(leak) > 3]
+    for path, value in values(block):
+        for leak in leaks:
+            assert leak not in value, (
+                f"{leak!r} reached the provenance block at {path} = {value!r}"
+            )
 
 
 # --- 3. the report carries both blocks -------------------------------------


### PR DESCRIPTION
## What

Version-pinned run identity, smallest useful version. Two new optional report blocks — `provenance` (who produced this record and from what) and `subject` (what was tested) — plus the emitter that fills them.

**The named defect:** `agent_data_injection.py` wrote `json.dump([r.__dict__ for r in results], fh)` — a bare **list**, with nowhere to put a header. That is why `docs/evidence/adi/2026-09-02-qwen35-n3-raw.json` had to be assembled **by hand**. Its `--report` now writes an object with a real header.

## The invariant

**Every key is always present; a null is paired with a `<field>_absent_reason` from a closed enum, and exactly one of the two is non-null.** `"unknown"` is never a value — `version.py::get_harness_version()` returns that literal on failure, so `run_provenance` translates it to `None` + `version_not_discoverable`. A string `"unknown"` is indistinguishable from a model literally tagged `unknown`, and from a bug that stringified a `None`.

Same argument as `summary.inconclusive` always being emitted at zero.

## Design claims that were wrong, and were corrected

| Claim given to the implementer | Verdict |
|---|---|
| "Nothing in the repo queries Ollama" | **Wrong.** `ollama_model()` POSTs to `/api/generate`; it never calls `/api/show`. Generation and identity are different questions — only one was asked. Encoded as `not_queried`, which is more precise than "the tool has no Ollama access." |
| Seed GRANDFATHERED from `def generate_report`, "all of them minus ADI" | **27 is right; "minus ADI" is wrong.** ADI defines no `generate_report` — it writes from `main()`. Deriving from that regex alone would have left the ratchet checking **nothing** about the one module actually migrated. Detector widened to `def generate_report` OR an argparse `--report` flag (43 files), seeded with 42, plus `test_the_migrated_module_is_actually_in_the_set` to pin it. |

## A real bug found by trying it

`attestation_registry.strip_sensitive_fields()` **deletes** any key containing `url` — which removed `subject.url`, `subject.url_absent_reason`, and `ci.run_url`, all schema-required, so a published record no longer validated. Fixed by nulling the value and keeping the key with a fourth reason, `redacted_for_publication`.

## Redaction — the highest-risk part

Documented usage includes `--header "Authorization: Bearer …"`. Recording raw argv into a signed, publishable artifact would turn a provenance feature into a credential-disclosure feature.

Redaction covers flag names, `--flag=value`, and `key: value` inside a single argument. **Every absolute path is reduced to its basename** — unconditionally, since `--report /home/<user>/…` leaks a username too — and that reduction does *not* set the flag, because it is not a credential event. `argv_redacted` means *a credential was replaced*, deliberately not `argv_is_safe`.

Verified independently on review with a live-shaped fake credential in three positions: credential absent from output, username absent, real machine hostname absent, `argv_redacted: true`. The block's `not_claimed` field states *"a credential passed under another name survives"* — the tool does not overclaim its own redaction.

No hostname, username, or cwd, per `docs/PRIVACY.md`; the omission is stated in the block so it reads as a decision.

## Fault injection — all fired for the intended reason

| Injection | Result |
|---|---|
| `redact_argv` returns argv unchanged | 14 failures, credential present in output |
| Inline `key: value` path disabled only | 2 failures — proves that path is separately load-bearing; the `--header` case survived via the flag path (defence in depth) |
| Ratchet detector regex broken | 4 failures: floor, migrated-module-present, non-empty-checked-set, grandfather-subset |
| ADI reverted to a bare list | 3 failures across both new test files |
| Published record payload tampered | hash-pin test failed on that record only |
| `kind == "model"` check removed | both validation paths failed |
| `"unknown"` normalisation removed | version test failed |
| Publication redaction reverted to plain delete | publish test failed |

## Confirmed but deliberately not fixed

- **`cli.py:698` never catches `SystemExit`** (confirmed by AST; `SystemExit` appears nowhere in the file). Both the telemetry block and the `--html` block are unreachable on the dispatch path. Behavior change; deserves its own PR. Untouched.
- **`schemas/` is not shipped in the wheel** — not in `packages.find`, no `MANIFEST.in`, no `package-data`, so `SCHEMA_PATH` raises `FileNotFoundError` in an installed wheel (the `try` catches only `ImportError`). Pre-existing and orthogonal.

## Not touched, on purpose

`docs/evidence/adi/2026-09-02-qwen35-n3-raw.json` is unedited, and `test_the_hand_assembled_evidence_file_is_left_alone` asserts it stays that way — it is a record of a run that happened. `docs/release-claims.json` untouched; a model verdict is not a reproducible command. `schema_version` stays `1.0.0`.

The secret scanner flagged an AWS-shaped test fixture; the **fixture** was changed, not the scanner. A test fixture that teaches people to add scanner exclusions costs more than it tests.

Suite: `1064 passed, 680 subtests passed` (baseline 995). Verified independently on review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)