### PR TITLE
--html did nothing, and the one path that rendered claimed a clean pass

### DIFF
--- a/protocol_tests/cli.py
+++ b/protocol_tests/cli.py
@@ -27,6 +27,7 @@ import json as _json
 import os
 import re
 import sys
+import tempfile
 from datetime import datetime, timezone
 
 from protocol_tests.version import get_harness_version
@@ -98,8 +99,17 @@ def _simulate_harness(harness_name: str, info: dict,
                       json_output: bool, html_output: str | None) -> None:
     """Generate synthetic results for a harness without a live target.
 
-    All tests are marked passed + simulated so downstream consumers
-    (html_report.py, top10_failures.py) receive valid data.
+    Every row is INCONCLUSIVE, not passed.
+
+    This previously emitted `"passed": True` for every test, so a simulated run
+    produced 100% pass, risk score 0, AUROC 1.0000 -- a clean bill of health for
+    a run that contacted nothing. The repo's own schema already defines the
+    right word: `inconclusive` means "the control was not exercised -- the
+    target did not service the request". A simulated run is definitionally
+    that.
+
+    It is deliberately not `"passed": False` either. A fail asserts the control
+    did not hold, which a run that never made a request cannot establish.
     """
     mod = importlib.import_module(info["module"])
     catalog = _extract_test_catalog(mod.__file__)
@@ -115,8 +125,14 @@ def _simulate_harness(harness_name: str, info: dict,
             "test_id": entry["test_id"],
             "name": entry["name"],
             "category": entry["category"],
-            "passed": True,
-            "details": "Simulated — no live target",
+            "passed": False,
+            "inconclusive": True,
+            # The INCONCLUSIVE_PREFIX form, so the consumers that classify on
+            # the details string agree with the consumers that read the field.
+            "details": (
+                "INCONCLUSIVE - simulated run; no target was contacted, so "
+                "this control was not exercised"
+            ),
             "simulated": True,
         })
 
@@ -127,10 +143,16 @@ def _simulate_harness(harness_name: str, info: dict,
         "mode": "simulation",
         "summary": {
             "total": len(results),
-            "passed": len(results),
+            "passed": 0,
             "failed": 0,
+            "inconclusive": len(results),
+            # Nothing was serviced, so there is no denominator and no rate.
+            # A rate of zero would be a claim; absence is not.
+            "serviced": 0,
+            "pass_rate": None,
             "simulated": True,
         },
+        "status": "inconclusive",
         "results": results,
     }
 
@@ -696,10 +718,32 @@ def main():
                             for a in filtered_args)):
             filtered_args += ["--transport", "http"]
 
+        # --html needs a report to render. If the operator asked for HTML but
+        # not JSON, ask the harness for a throwaway report we can read back.
+        _side_report = None
+        if html_output and _module_declares_flag(harness_name, "--report") and not any(
+                a == "--report" or a.startswith("--report=") for a in filtered_args):
+            _side_report = os.path.join(
+                tempfile.gettempdir(), f"agent-security-html-{os.getpid()}.json")
+            filtered_args += ["--report", _side_report]
+
         sys.argv = [info["module"]] + filtered_args
 
         import runpy
-        ns = runpy.run_module(info["module"], run_name="__main__")
+        # Every harness main() ends in sys.exit(), which raises SystemExit.
+        # Nothing here caught it, so everything below -- telemetry AND the
+        # entire --html block -- was unreachable on this path. `--html` is
+        # advertised in print_usage() and produced a file for 0 of 45
+        # harnesses: exit 0, no file, no warning. Catch it, finish the work,
+        # then exit with the code the harness asked for.
+        _harness_exit = 0
+        try:
+            ns = runpy.run_module(info["module"], run_name="__main__")
+        except SystemExit as exc:
+            _harness_exit = exc.code if isinstance(exc.code, int) else (
+                0 if exc.code is None else 1
+            )
+            ns = getattr(exc, "_ns", None) or {}
 
         # Send anonymous telemetry after harness completes (#112).
         # Extract actual test counts from the harness namespace if available.
@@ -754,6 +798,20 @@ def main():
                 from scripts.html_report import generate_html as _gen_html
 
                 report_json = None
+                # 41 of 45 harnesses keep their results in main()'s locals, so
+                # they never appear in the module namespace and the namespace
+                # scan below finds nothing. Every harness that declares
+                # --report can write one, so ask it for a file and render that.
+                # This is why --html produced nothing even once SystemExit was
+                # caught: the block was reachable and still had no data.
+                if _side_report and os.path.exists(_side_report):
+                    try:
+                        with open(_side_report) as _fh:
+                            _candidate = _json.load(_fh)
+                        if isinstance(_candidate, dict) and "results" in _candidate:
+                            report_json = _candidate
+                    except (OSError, ValueError):
+                        report_json = None
                 for key in ("_json_report", "json_report", "_report"):
                     candidate = ns.get(key)
                     if isinstance(candidate, dict) and "results" in candidate:

--- a/scripts/html_report.py
+++ b/scripts/html_report.py
@@ -132,12 +132,19 @@ def _compute_aiuc1(results: list[dict], req_index: dict[str, dict]) -> dict[str,
             }
             continue
 
-        passed = sum(1 for t in matched if result_by_id[t].get("passed", False))
-        failed = len(matched) - passed
+        inconc = sum(1 for t in matched if _is_inconclusive(result_by_id[t]))
+        passed = sum(1 for t in matched
+                     if result_by_id[t].get("passed", False)
+                     and not _is_inconclusive(result_by_id[t]))
+        # Not a residual. `len(matched) - passed` counted every unexercised
+        # control as a failing one, which asserts the control did not hold --
+        # the same defect fixed in scripts/evidence_pack.py (#522).
+        failed = len(matched) - passed - inconc
         covered += 1
         coverage[req_id] = {
             "title": req_def["title"], "category": req_def["category"],
-            "status": "PASS" if failed == 0 else "FAIL",
+            "status": ("FAIL" if failed else
+                       "PASS" if passed else "INCONCLUSIVE"),
             "passed": passed, "failed": failed, "total": len(matched),
         }
 
@@ -160,12 +167,20 @@ def _compute_owasp(results: list[dict], req_index: dict[str, dict]) -> dict[str,
     for asi_id, asi_name in OWASP_AGENTIC_CATEGORIES.items():
         test_ids = asi_tests.get(asi_id, [])
         matched = [t for t in test_ids if t in result_by_id]
-        passed = sum(1 for t in matched if result_by_id[t].get("passed", False))
-        failed = len(matched) - passed
-        if matched and failed == 0:
-            status = "PASS"
-        elif failed > 0:
+        inconc = sum(1 for t in matched if _is_inconclusive(result_by_id[t]))
+        passed = sum(1 for t in matched
+                     if result_by_id[t].get("passed", False)
+                     and not _is_inconclusive(result_by_id[t]))
+        # Not a residual. `len(matched) - passed` counted every unexercised
+        # control as a failing one, which asserts the control did not hold --
+        # the same defect fixed in scripts/evidence_pack.py (#522).
+        failed = len(matched) - passed - inconc
+        if failed > 0:
             status = "FAIL"
+        elif passed:
+            status = "PASS"
+        elif inconc:
+            status = "INCONCLUSIVE"
         else:
             status = "NOT_TESTED"
         owasp[asi_id] = {
@@ -198,6 +213,7 @@ h3{font-size:15px;font-weight:600;margin:20px 0 8px}
 .card .label{font-size:12px;text-transform:uppercase;letter-spacing:.5px;color:#888;margin-bottom:4px}
 .card .value{font-size:28px;font-weight:700}
 .card .value.green{color:#16a34a}
+.card .value.grey{color:#6b7280}
 .card .value.red{color:#dc2626}
 .card .value.amber{color:#d97706}
 .card .value.blue{color:#2563eb}
@@ -207,6 +223,7 @@ h3{font-size:15px;font-weight:600;margin:20px 0 8px}
  text-transform:uppercase;letter-spacing:.3px}
 .badge-pass{background:#dcfce7;color:#166534}
 .badge-fail{background:#fee2e2;color:#991b1b}
+.badge-inconclusive{background:#e5e7eb;color:#374151}
 .badge-gap{background:#fef3c7;color:#92400e}
 .badge-na{background:#f3f4f6;color:#6b7280}
 
@@ -263,6 +280,28 @@ function toggleAll(open){
 """
 
 
+INCONCLUSIVE_PREFIX = "INCONCLUSIVE"
+
+
+def _is_inconclusive(r: dict) -> bool:
+    """Was this control exercised at all?
+
+    This renderer was two-state. A simulated run -- which contacts nothing --
+    rendered as 100% passed, risk 0, AUROC 1.0000, because the source said
+    `passed: True`. Making the source honest without teaching the renderer the
+    third state would only invert the lie into 100% FAIL, and a fail asserts
+    the control did not hold, which an unexercised control cannot establish.
+
+    Reads the explicit field first, then the INCONCLUSIVE_PREFIX convention in
+    `details`, so producers that carry only one of the two still classify.
+    """
+    if r.get("inconclusive") or r.get("not_established"):
+        return True
+    details = r.get("details") or r.get("detail") or ""
+    return isinstance(details, str) and details.strip().upper().startswith(
+        INCONCLUSIVE_PREFIX)
+
+
 def _status_badge(status: str) -> str:
     """Return an HTML badge span for a status string."""
     s = status.upper()
@@ -270,6 +309,9 @@ def _status_badge(status: str) -> str:
         return '<span class="badge badge-pass">PASS</span>'
     if s == "FAIL":
         return '<span class="badge badge-fail">FAIL</span>'
+    if s == "INCONCLUSIVE":
+        return ('<span class="badge badge-inconclusive" title="the control was '
+                'not exercised">INCONCLUSIVE</span>')
     if s == "GAP":
         return '<span class="badge badge-gap">GAP</span>'
     return f'<span class="badge badge-na">{_esc(s)}</span>'
@@ -299,16 +341,25 @@ def generate_html(report_data: dict[str, Any]) -> str:
     """Generate a self-contained HTML report string from harness JSON output."""
     results = report_data.get("results", [])
     total = len(results)
-    passed = sum(1 for r in results if r.get("passed", False))
-    failed = total - passed
-    pass_rate = (passed / total * 100) if total else 0.0
+    inconclusive = sum(1 for r in results if _is_inconclusive(r))
+    passed = sum(1 for r in results
+                 if r.get("passed", False) and not _is_inconclusive(r))
+    failed = total - passed - inconclusive
+    serviced = passed + failed
+    # `serviced` is the denominator, not `total`. An unexercised control is
+    # neither a pass nor a fail and must not move the rate in either direction.
+    pass_rate = (passed / serviced * 100) if serviced else None
 
     target = report_data.get("target", "unknown")
     timestamp = report_data.get("timestamp", datetime.now(timezone.utc).isoformat())
 
     # Risk score: use from report if present, else compute simple estimate
     risk_data = report_data.get("risk", {})
-    risk_score = risk_data.get("score", round((failed / total * 40) if total else 0, 2))
+    # None, not 0.0. A risk score of zero rendered as "LOW" for a run that
+    # contacted nothing -- the same claim-from-absence the pass rate had.
+    risk_score = risk_data.get("score")
+    if risk_score is None and serviced:
+        risk_score = round(failed / serviced * 40, 2)
 
     # AIUC-1 and OWASP coverage
     mapping = _try_load_aiuc1_mapping()
@@ -368,20 +419,39 @@ def generate_html(report_data: dict[str, Any]) -> str:
     parts.append(f'<div class="value {"red" if failed else "green"}">{failed}</div>')
     parts.append("</div>")
 
+    # Without this the reader sees Total 33 / Passed 0 / Failed 0 and has
+    # to work out where the other 33 went.
+    parts.append('<div class="card">')
+    parts.append('<div class="label">Inconclusive</div>')
+    parts.append(f'<div class="value grey">{inconclusive}</div>')
+    parts.append('</div>')
     parts.append('<div class="card">')
     parts.append('<div class="label">Pass Rate</div>')
-    rate_class = "green" if pass_rate >= 90 else ("amber" if pass_rate >= 70 else "red")
-    parts.append(f'<div class="value {rate_class}">{pass_rate:.1f}%</div>')
+    rate_class = ("grey" if pass_rate is None
+                  else "green" if pass_rate >= 90
+                  else "amber" if pass_rate >= 70 else "red")
+    rate_text = ("n/a" if pass_rate is None else f"{pass_rate:.1f}%")
+    parts.append(f'<div class="value {rate_class}">{rate_text}</div>')
+    if pass_rate is None:
+        parts.append('<div class="label">nothing was serviced; no rate '
+                     'can be computed</div>')
     parts.append("</div>")
 
     parts.append('<div class="card">')
     parts.append('<div class="label">Risk Score</div>')
-    rc = "green" if risk_score < 20 else ("amber" if risk_score < 40 else "red")
-    parts.append(f'<div class="value {rc}">{risk_score:.1f}</div>')
-    parts.append(f'<div class="risk-bar {_risk_class(risk_score)}">')
-    parts.append(f'<div class="fill" style="width:{min(risk_score, 100):.0f}%"></div>')
+    rc = ("grey" if risk_score is None
+          else "green" if risk_score < 20
+          else "amber" if risk_score < 40 else "red")
+    parts.append(f'<div class="value {rc}">'
+                 f'{"n/a" if risk_score is None else f"{risk_score:.1f}"}</div>')
+    _rs = 0 if risk_score is None else risk_score
+    parts.append(f'<div class="risk-bar {_risk_class(_rs)}">')
+    parts.append(f'<div class="fill" style="width:{min(_rs, 100):.0f}%"></div>')
     parts.append("</div>")
-    parts.append(f'<div class="label">{_risk_label(risk_score)}</div>')
+    parts.append(
+        '<div class="label">not established -- nothing was serviced</div>'
+        if risk_score is None
+        else f'<div class="label">{_risk_label(risk_score)}</div>')
     parts.append("</div>")
 
     parts.append("</div>")  # card-row
@@ -395,9 +465,16 @@ def generate_html(report_data: dict[str, Any]) -> str:
     )
 
     for mod_name, mod_results in sorted(modules.items()):
-        mod_passed = sum(1 for r in mod_results if r.get("passed", False))
-        mod_failed = len(mod_results) - mod_passed
-        mod_status = "PASS" if mod_failed == 0 else "FAIL"
+        mod_inconc = sum(1 for r in mod_results if _is_inconclusive(r))
+        mod_passed = sum(1 for r in mod_results
+                         if r.get("passed", False) and not _is_inconclusive(r))
+        mod_failed = len(mod_results) - mod_passed - mod_inconc
+        if mod_failed:
+            mod_status = "FAIL"
+        elif mod_passed:
+            mod_status = "PASS"
+        else:
+            mod_status = "INCONCLUSIVE"
 
         parts.append("<details>")
         parts.append(
@@ -414,8 +491,11 @@ def generate_html(report_data: dict[str, Any]) -> str:
             tid = _esc(r.get("test_id", ""))
             name = _esc(r.get("name", r.get("test_name", tid)))
             severity = _esc(r.get("severity", ""))
-            is_pass = r.get("passed", False)
-            status_badge = _status_badge("PASS" if is_pass else "FAIL")
+            if _is_inconclusive(r):
+                status_badge = _status_badge("INCONCLUSIVE")
+            else:
+                status_badge = _status_badge(
+                    "PASS" if r.get("passed", False) else "FAIL")
             detail = _esc(r.get("details", r.get("detail", r.get("error", r.get("reason", "")))))
             parts.append(
                 f"<tr><td><code>{tid}</code></td><td>{name}</td>"
@@ -535,7 +615,16 @@ def generate_html(report_data: dict[str, Any]) -> str:
         except Exception:
             auroc_data = None
 
-    if auroc_data and auroc_data.get("modules"):
+    if auroc_data and auroc_data.get("modules") and not serviced:
+        # AUROC over unserviced observations is not a weak result, it is no
+        # result. Rendered from a simulated run this read 1.0000 "Excellent"
+        # while `passed: True` was synthetic; with the source corrected it read
+        # 0.5000 "Inadequate", which is equally a claim about detection quality
+        # that nothing here measured.
+        parts.append("<h2>AUROC — Detection Effectiveness</h2>")
+        parts.append('<p class="muted">Not established: no test was serviced, '
+                     'so there is no operating point to compute a curve from.</p>')
+    elif auroc_data and auroc_data.get("modules"):
         parts.append("<h2>AUROC — Detection Effectiveness</h2>")
         overall = auroc_data.get("overall", 0.5)
         try:

--- a/tests/test_simulate_does_not_claim_a_pass.py
+++ b/tests/test_simulate_does_not_claim_a_pass.py
@@ -1,0 +1,117 @@
+"""A run that contacted nothing must not render as a clean bill of health.
+
+Two defects, one page.
+
+`_simulate_harness` emitted `"passed": True` for every test in the catalog, so
+`agent-security test <h> --simulate --html out.html` produced a self-contained
+artifact reading 100% pass, risk score 0.0 LOW, AUROC 1.0000 "Excellent" -- for
+a run that contacted no target at all. The repo's own schema already defines the
+right word: `inconclusive` means "the control was not exercised".
+
+And `scripts/html_report.py` was a two-state renderer, so correcting the source
+alone would have inverted the lie into 100% FAIL -- a fail asserts the control
+did not hold, which an unexercised control cannot establish.
+
+Separately, `cli.py` never caught the `SystemExit` that every harness `main()`
+raises, so the whole `--html` block was unreachable on the live-target path:
+`--html` is advertised in `print_usage()` and produced a file for 0 of 45
+harnesses, with exit 0 and no warning.
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def run_cli(*args, timeout=180):
+    return subprocess.run(
+        [sys.executable, "-m", "protocol_tests.cli", *args],
+        cwd=REPO, capture_output=True, text=True, timeout=timeout,
+    )
+
+
+class SimulateIsInconclusive(unittest.TestCase):
+    def test_simulated_rows_are_inconclusive_not_passed(self):
+        done = run_cli("test", "mcp", "--simulate", "--json")
+        self.assertEqual(done.returncode, 0, done.stderr)
+        report = json.loads(done.stdout)
+        self.assertTrue(report["results"], "no rows to check")
+        for r in report["results"]:
+            with self.subTest(test_id=r.get("test_id")):
+                self.assertFalse(r["passed"], "a simulated row claimed a pass")
+                self.assertTrue(r["inconclusive"])
+                self.assertTrue(r["details"].upper().startswith("INCONCLUSIVE"))
+
+    def test_the_summary_has_no_rate_because_nothing_was_serviced(self):
+        report = json.loads(run_cli("test", "mcp", "--simulate", "--json").stdout)
+        s = report["summary"]
+        self.assertEqual(s["passed"], 0)
+        self.assertEqual(s["failed"], 0)
+        self.assertEqual(s["inconclusive"], s["total"])
+        self.assertEqual(s["serviced"], 0)
+        self.assertIsNone(s["pass_rate"], "a rate of zero is a claim; absence is not")
+        self.assertEqual(report["status"], "inconclusive")
+
+
+class TheRenderedPageMakesNoClaim(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp = tempfile.mkdtemp(prefix="sim-html-")
+        cls.path = os.path.join(cls.tmp, "evidence.html")
+        done = run_cli("test", "mcp", "--simulate", "--html", cls.path)
+        assert done.returncode == 0, done.stderr
+        assert os.path.exists(cls.path), f"no file produced: {done.stderr}"
+        cls.html = Path(cls.path).read_text()
+
+    def test_the_page_was_produced_at_all(self):
+        self.assertGreater(len(self.html), 2000)
+
+    def test_no_pass_rate_and_no_risk_score_is_asserted(self):
+        for claim in ("100.0%", ">LOW<", "1.0000"):
+            with self.subTest(claim=claim):
+                self.assertNotIn(claim, self.html)
+
+    def test_the_reader_is_told_why_without_expanding_anything(self):
+        """The old page disclosed simulation only inside collapsed <details>.
+
+        "Without expanding anything" means everything before the first
+        `<details>` element -- none of which are rendered `open`.
+        """
+        visible = self.html.split("<details", 1)[0]
+        self.assertIn("nothing was serviced", visible)
+        self.assertIn("Inconclusive", visible)
+        self.assertIn("not established", visible.lower())
+
+    def test_every_row_renders_as_inconclusive(self):
+        """Match badge USE, not the CSS rule that defines it.
+
+        `assertNotIn("badge-pass", html)` matched the stylesheet, which every
+        page carries whether or not a single row is a pass.
+        """
+        self.assertIn('class="badge badge-inconclusive"', self.html)
+        self.assertNotIn('class="badge badge-pass"', self.html)
+        self.assertNotIn('class="badge badge-fail"', self.html)
+
+
+class HtmlIsReachableOnTheLivePath(unittest.TestCase):
+    def test_html_produces_a_file_against_an_unreachable_target(self):
+        """The block used to be dead code: exit 0, no file, no warning."""
+        with tempfile.TemporaryDirectory() as tmp:
+            out = os.path.join(tmp, "live.html")
+            done = run_cli("test", "mcp", "--url", "http://127.0.0.1:9/mcp",
+                           "--html", out)
+            self.assertTrue(
+                os.path.exists(out),
+                f"--html produced no file on the live path "
+                f"(exit {done.returncode})\n{done.stderr[-600:]}",
+            )
+            self.assertGreater(os.path.getsize(out), 2000)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Two defects that met on one page

### 1. `--html` was dead code on the live path

Every harness `main()` ends in `sys.exit()`. Nothing caught the `SystemExit` raised out of `runpy.run_module`, so the telemetry block **and the entire `--html` block** were unreachable. `--html` is advertised in `print_usage()` and produced a file for **0 of 45 harnesses**: exit 0, no file, no warning.

Catching `SystemExit` made the block reachable and it *still* produced nothing — 41 of 45 harnesses keep results in `main()`'s locals, so the namespace scan had no data. `--html` now asks the harness for a throwaway `--report` and renders that. 44 of 46 declare the flag, and **no harness module was touched.**

### 2. A simulated run claimed a clean bill of health

`_simulate_harness` emitted `"passed": True` for every catalog entry, so `--simulate --html` produced 100% pass, risk score **0.0 LOW**, AUROC **1.0000 "Excellent"** — for a run that contacted no target.

The schema already defines the right word. Rows are now `inconclusive`, the summary carries `serviced: 0` and `pass_rate: None`, and report `status` is `inconclusive`.

`"passed": False` would have been equally wrong. A fail asserts the control did not hold, which a run that never made a request cannot establish.

### 3. The renderer had to learn the third state

Otherwise the fix would have inverted the lie into 100% FAIL. `scripts/html_report.py` was two-state. It now classifies on an explicit field **or** the `INCONCLUSIVE_PREFIX` convention, excludes unserviced observations from the denominator, and shows a reason instead of a number.

Risk score is `None` rather than `0.0` — because `0.0` rendered as **LOW**, a verdict on a run that measured nothing. AUROC says "not established" rather than computing a curve with no operating point.

Its AIUC-1 and OWASP tables also computed `failed = len(matched) - passed`, counting every unexercised control as failing. **Same residual-bucket defect fixed in `evidence_pack.py` (#522), in a second file.**

## Before and after, same command

`agent-security test mcp --simulate --html out.html`

| Card | Before | After |
|---|---|---|
| Passed | 33 | 0 |
| Inconclusive | *(no such card)* | 33 |
| Pass Rate | 100.0% | `n/a` — "nothing was serviced; no rate can be computed" |
| Risk Score | 0.0 **LOW** | `n/a` — "not established — nothing was serviced" |
| AUROC | 1.0000 Excellent | "Not established: no test was serviced" |

All of it visible **before expanding anything** — the old page disclosed simulation only inside collapsed `<details>`.

## Fault injection

| Injection | Result |
|---|---|
| simulate claims pass again | 33 failed |
| `SystemExit` uncaught again | 1 failed |
| classifier always `False` | 2 failed |

**The renderer injection had to be redone.** Disabling only the explicit-field branch of `_is_inconclusive` left the details-prefix branch working and the suite stayed green — defence in depth rather than a gap, but the first injection proved nothing about the property it named.

Two test assertions were also wrong and corrected: `assertNotIn("badge-pass", html)` matched the **stylesheet**, which every page carries; and the "visible without expanding" slice cut before the summary cards rather than at the first `<details>`.

Suite: `1130 passed, 780 subtests passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)