### PR TITLE
Release v4.21.0 — the instrument was the thing under test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.21.0] - 2026-09-07
+
+**The instrument was the thing under test.** Nine defects landed this release and
+seven of them were in the measurement apparatus rather than in anything it
+measures: a validator that rejected the correct answer, a requirement that could
+pass on a subset of its own tests, a trial runner that called an unexercised
+control a failure, a ratchet satisfied by an import statement, a renderer with no
+word for "not established", a residual bucket in three separate files, a wheel
+that shipped without the schema it reads, and every OWASP category title wrong in
+the three artifacts an auditor actually opens.
+
+Two of these were only reachable from outside the source tree. `pip install`
+users got an uncaught `FileNotFoundError` from a documented function, and
+`--html` produced a file for zero of forty-five harnesses -- both invisible to a
+suite that runs in a checkout, because in a checkout the wrong path happens to be
+right and the dead code path is never taken.
+
+The practice that found them is fault injection with one added step: **verify the
+injection changed the artifact under test before believing the result.** Three
+injections this release initially proved nothing -- a stale build cache served a
+cached wheel, a two-branch classifier kept working when one branch was disabled,
+and two assertions matched a CSS rule and a slice boundary instead of the thing
+they named. Every one of those false passes was indistinguishable from a real one.
+
+Test count 612 -> 623. New: DCA-001..DCA-011, multi-hop delegated-authority
+attenuation, checked at every hop rather than at the ends of the chain.
+
+
 ### Added — delegated authority, checked at every hop instead of at the ends
 
 `protocol_tests/delegation_chain_harness.py`, DCA-001..DCA-011. When an agent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,160 +9,68 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.21.0] - 2026-09-07
 
-**The instrument was the thing under test.** Nine defects landed this release and
-seven of them were in the measurement apparatus rather than in anything it
-measures: a validator that rejected the correct answer, a requirement that could
-pass on a subset of its own tests, a trial runner that called an unexercised
-control a failure, a ratchet satisfied by an import statement, a renderer with no
-word for "not established", a residual bucket in three separate files, a wheel
-that shipped without the schema it reads, and every OWASP category title wrong in
-the three artifacts an auditor actually opens.
+**The instrument was the thing under test.** This release is what happened when
+the harness's own outputs were asked whether they could distinguish *did not
+pass* from *did not run* -- first by the maintainer, then twice by an external
+reviewer working from a public brief. Twenty-one defects landed. Sixteen were in
+the measurement apparatus rather than in anything it measures, and six of those
+were introduced by the fixes for the others and caught by the second pass.
 
-Two of these were only reachable from outside the source tree. `pip install`
-users got an uncaught `FileNotFoundError` from a documented function, and
-`--html` produced a file for zero of forty-five harnesses -- both invisible to a
-suite that runs in a checkout, because in a checkout the wrong path happens to be
-right and the dead code path is never taken.
+### Found by the maintainer (#520–#529)
 
-The practice that found them is fault injection with one added step: **verify the
-injection changed the artifact under test before believing the result.** Three
-injections this release initially proved nothing -- a stale build cache served a
-cached wheel, a two-branch classifier kept working when one branch was disabled,
-and two assertions matched a CSS rule and a slice boundary instead of the thing
-they named. Every one of those false passes was indistinguishable from a real one.
+A validator that rejected the correct answer (`inconclusive`); an AIUC-1
+requirement that could read PASS on two of its five mapped tests; a trial
+runner that called an unexercised control a failure and serialised none of the
+per-trial states it claimed to; a provenance ratchet satisfied by an import
+statement; a renderer with no word for "not established"; a residual bucket
+(`failed = total - passed`) in three separate files; a wheel that shipped
+without the schema it reads (`FileNotFoundError` for every pip user); `--html`
+producing a file for zero of forty-five harnesses; and every OWASP category
+title wrong in the three artifacts an auditor actually opens.
 
-Test count 612 -> 623. New: DCA-001..DCA-011, multi-hop delegated-authority
-attenuation, checked at every hop rather than at the ends of the chain.
+### Found by the first external review (#530)
 
+Three recognized-flag credential shapes leaking into the publication copy; the
+HTML classifier reading `not_established` -- a claim-bound string -- as an
+unevaluated marker, so a legitimate FAIL could leave the denominator by adding
+an honest caveat; the live delegation parser reading `_body`, which exists only
+on HTTP errors, so every live allow was undecided; DCA-005 grading a correctly
+allowing target as "control absent"; three report consumers resolving a
+checkout-only path; and a build that succeeded while shipping no data when
+symlinks materialise as files.
 
-### Added — delegated authority, checked at every hop instead of at the ends
+### Found by the second external review (#532)
 
-`protocol_tests/delegation_chain_harness.py`, DCA-001..DCA-011. When an agent
-hands work to a sub-agent and that sub-agent hands it on again, each hop carries
-a pass. The property under test is that a child's authority is provably no
-broader than its parent's, and that this is decided at the tool boundary — the
-thing that performs the effect — rather than in the calling agent's reasoning
-about what it ought to ask for. An agent's reasoning is not an enforcement
-point; it is an input the attacker may control.
+Three defects in the first review's fixes. `--url=` userinfo survived the
+strip that caught the bare form. DCA-005 read every non-True as a refusal, so
+`{}` and a JSON-RPC error graded PASS. And `python -m build` with no flags --
+the route the publish workflow runs -- failed building the wheel from the sdist.
+The release would have failed at publish time; every wheel test had used
+`--wheel`.
 
-This generalises FB-013. That defect was an approval quorum that checked
-approvers were *distinct* and never that they were *authorized*, so two
-arbitrary strings formed a quorum: a structural property checked in place of an
-authority property. Delegation chains fail the same way and more often, because
-the structural version is so much more convincing — validating that a child pass
-is well-formed rather than narrower, or validating the leaf against the **root**
-rather than against **every hop**.
+### The taxonomy (#531)
 
-The last of those is DCA-011 and is why the module exists rather than a pair of
-extra rows in an existing one. Given
+Eighty-one tests carried an OWASP ASI primary written in April against category
+titles that were themselves wrong. Three independent assignment paths existed;
+the coverage tables read the one that was not the tags. Four HITL rows changed
+category with the *outcome*. Remapped per the review's table, collapsed to one
+source (`protocol_tests/asi_inventory.py`, read from source by AST), and the
+ratchet's helper-literal rule then found four more modules with the same
+outcome-dependence the per-row table could not see. `docs/COMPARISON.md` no
+longer says "Complete ASI01-ASI10"; it says what is mapped and what is thin
+(ASI10 Rogue Agents: 13; ASI08 Cascading Failures: 19).
 
-```
-root  caps {read,write,refund}  scope {staging, production}  spend 100000
-mid   caps {read}               scope {staging}              spend 1000
-leaf  caps {read,write}         scope {staging, production}  spend 100000
-```
+### The practice
 
-the leaf is a strict subset of the root. Every field of it is something the root
-really held, held by a delegate the root really authorized, and the audit trail
-looks clean. It is still an escalation, because `mid` gave up `write`,
-production and 99% of the spend cap, and nothing downstream of `mid` can take
-them back. A leaf-versus-root check accepts it.
+Fault injection with one added step: **verify the injection changed the
+artifact under test before believing the result.** Nine injections across this
+release initially proved nothing -- a stale build cache, a two-branch classifier
+with one branch disabled, assertions matching a CSS rule, a `\1` that became an
+octal escape, a `^` without `(?m)`, a dict entry that was never a corpus test.
+Each was indistinguishable from a real pass until the artifact was checked.
 
-**Positive controls are half the suite, not an afterthought.** Every deny row
-pairs its attack with the legitimate variant inside the same test, and DCA-009
-and DCA-010 assert an ALLOW and nothing else. The consequence is measured rather
-than argued: a boundary whose `authorize` returns `Decision(False)`
-unconditionally fails **all eleven** rows, and a boundary that returns
-`Decision(True)` unconditionally fails ten. DCA-009 is the only row a permissive
-boundary passes, which is what makes the deny rows mean anything.
-
-**Every guard is shown to be able to fail.** `testing/test_delegation_chain_
-attenuation.py` neuters each check in turn — the four attenuation predicates
-individually, audience, expiry, revocation, the replay ledger, the effective-
-authority intersection, the ambient-credential refusal, and the whole per-hop
-walk replaced by a leaf-versus-root walk — and asserts that the row that guard
-exists for then fails *naming that defect*, not incidentally. Writing that
-matrix changed the module: DCA-001, DCA-002 and DCA-003 originally passed with
-the per-hop attenuation check deleted, because the intersection check (DAP-10)
-independently bounded the request. They asserted "the request was refused" when
-the property is "the attenuation check refused it", so they now require the
-denial to carry the clause by name. A guard whose removal changes nothing is
-dead code with a reassuring name.
-
-Live mode is deliberately narrow. There is no interoperable wire format for a
-delegation pass across MCP, A2A and the payment stack, so `--url` grades only
-the two unambiguous answers — the target *allowed* an escalation, or the target
-*allowed* the legitimate chain — and reports everything else INCONCLUSIVE rather
-than reading a rejection it cannot attribute as a passing control.
-
-### Changed — a multi-trial run could report a control it never exercised as failed, and one that gave way as passed (#523)
-
-`trial_runner` is the shared `--trials N` path for 24 harnesses, and it was the
-last summary in the package still computing `failed` as a residual:
-
-```python
-total_tests  = len(stat_results)
-passed_tests = sum(1 for sr in stat_results if sr.pass_rate >= 0.5)
-failed_tests = total_tests - passed_tests
-```
-
-It read only `.passed`, so an INCONCLUSIVE result entered as `passed=False`,
-dragged the rate under the threshold, and was published as a target failure —
-the same substitution `run_summary` was written to stop in #402, in the one
-module that never called it. Against an unresponsive target a ten-trial run
-asserted that controls did not hold, when nothing had been exercised.
-
-The `>= 0.5` threshold was the other half. A test that failed two of five trials
-landed in `summary.passed` and the two failures appeared in no field of the
-written report: `per_trial` was held on the dataclass but `to_dict` never
-serialised it, so "retry until green" was the default and left no trace.
-
-`trial_runner` now delegates counting to `http_helpers.run_summary`, so
-`passed + failed + inconclusive == total`, the denominator is `serviced`, and
-the rate and Wilson interval are `None` rather than `0.0` when nothing was
-serviced. The verdict rule is named in the report rather than implied by a
-threshold: **a test passes only if every serviced trial passed; one serviced
-failure is a failure; no serviced trial is INCONCLUSIVE, never a failure.**
-Unstable tests are listed by id, and every trial's state is serialised.
-
-Three smaller faults in the same function, each of which could shrink a run
-without saying so:
-
-- `"results"` held the **final trial's** list while `summary.total` was computed
-  over the union across trials, with nothing marking the disagreement. If the
-  last trial crashed it silently held the trial before it; if all of them
-  crashed it was `[]`, which reads as "nothing failed" to the exit-code check in
-  every consumer. It is now one representative result per `test_id` — the trial
-  that carries the verdict — and an all-crashed run says so in `error`.
-- `getattr(r, "test_id", None) or r.get("test_id", "unknown")` put every
-  unidentified result in one `"unknown"` bucket: three results, one failing,
-  became a single entry scoring 2/3 and therefore passing. It also raised
-  `AttributeError` on a non-dict result lacking the attribute, dumping the rest
-  of that trial into `trial_errors`.
-- `statistical_summary.trials_per_test` published the **first** test's trial
-  count as if it were uniform. After a partial trial failure it is not; it is
-  now published only when it actually is, with the observed range beside it.
-
-Unchanged on purpose: per-trial error isolation, and matching by `test_id`
-rather than position.
-
-### Added — `check_public_metadata.py --apply`, so the release run can pass
-
-`Public metadata drift` runs on `release: published` and compares the
-description against the tree at the new tag. It failed on four consecutive
-releases (v4.18.0, v4.19.0rc1, v4.19.0, v4.20.0), correctly each time, because
-the description was edited a few minutes *after* the release was created and
-still named the previous version when the event fired. The Actions token cannot
-edit the description, so the edit moves to the releasing side and before the
-release exists:
-
-```bash
-python3 scripts/check_public_metadata.py --apply   # then gh release create ...
-```
-
-`rewrite_description` is pure and tested offline. `--apply` refuses to write a
-description the checker would still reject, and always runs the normal
-comparison afterwards, so its last line is OK or DRIFT, never "applied".
+Test count 612 -> 623 (DCA-001..DCA-011, multi-hop delegated-authority
+attenuation). Suite: 1191 passed, 864 subtests.
 
 ## [4.20.0] - 2026-09-02
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you cite this work in research, please use this metadata."
 title: "Agent Security Harness"
-version: "4.20.0"
+version: "4.21.0"
 abstract: "Multi-protocol agent security testing framework. 623 executable security tests across 45 test-bearing modules covering MCP, A2A, L402, and x402 wire protocols. Decision-layer attack scenarios, AIUC-1 pre-certification mapping, NIST AI 800-2 aligned."
 type: software
 authors:

--- a/HARNESS_TEST_CATALOG.md
+++ b/HARNESS_TEST_CATALOG.md
@@ -1,7 +1,7 @@
 # Agent Security Harness — Canonical Test Catalog
 
 **Source repo:** msaleme/red-team-blue-team-agent-fabric
-**Generated:** `scripts/generate_test_catalog.py` at commit `f2926bf`
+**Generated:** `scripts/generate_test_catalog.py` at commit `ace0df3`
 **Test count:** 623 unique test IDs across 46 registered harness modules (45 contain test IDs; `community_runner.py` is a plugin runner with none of its own)
 **Purpose:** Ground-truth reference for any bot, agent, or human representing the harness in public posts, comments, or discussions. Cite only tests listed here. Do not invent IDs or statistics.
 

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ modification · v4.6–v4.9 payment-stack depth (AP2 mandate chain, UCP/ACP merc
 agentic tokens, settlement finality, Fireblocks x402) · v4.10 benchmark integrity · v4.11–v4.12
 decision-governance corpus currency and provenance repair · **v4.13 OWASP Agentic v1.1 T1–T17 coverage
 mapping and the human-in-the-loop harness** · v4.13.1 a correctness fix to that harness · v4.14.0
-endpoint provenance · v4.16.0 three target shapes: a verdict must be able to be wrong AND to be right · v4.17.0 eight modules could not tell a refusal from a compliance · v4.18.0 INCONCLUSIVE became a field, and the read-list emptied · v4.19.0 a correctness disclosure: verdicts moved in both directions · **v4.20.0 the last absence-graded verdicts got a positive control** · v4.15.0 unserviced requests are no longer recorded as passes (see
+endpoint provenance · v4.16.0 three target shapes: a verdict must be able to be wrong AND to be right · v4.17.0 eight modules could not tell a refusal from a compliance · v4.18.0 INCONCLUSIVE became a field, and the read-list emptied · v4.19.0 a correctness disclosure: verdicts moved in both directions · v4.20.0 the last absence-graded verdicts got a positive control · **v4.21.0 the instrument was the thing under test: 7 of 9 defects were in the measurement apparatus** · v4.15.0 unserviced requests are no longer recorded as passes (see
 [CHANGELOG.md](CHANGELOG.md)).
 
 The release carries **611** tests; `main` is at **623**. They diverge by MCP-021, the MCP

--- a/docs/OWASP-AGENTIC-T1-T15-SUBMISSION-COVERAGE.md
+++ b/docs/OWASP-AGENTIC-T1-T15-SUBMISSION-COVERAGE.md
@@ -11,7 +11,7 @@
 | Report view | Submission (T1–T15) |
 | Report version | 1.0 |
 | Project | Agent Security Harness |
-| Harness version | `4.20.0` |
+| Harness version | `4.21.0` |
 | Assessed commit | [`8d8bc08933637381a32fc32041f139d34eb6271f`](https://github.com/msaleme/red-team-blue-team-agent-fabric/commit/8d8bc08933637381a32fc32041f139d34eb6271f) |
 | Assessed at | 2026-08-02T18:30:00Z |
 | Repository tests | 623 (`python scripts/count_tests.py`) |

--- a/docs/OWASP-AGENTIC-V1.1-COVERAGE.md
+++ b/docs/OWASP-AGENTIC-V1.1-COVERAGE.md
@@ -9,7 +9,7 @@
 | Report view | Complete (T1–T17) |
 | Report version | 1.0 |
 | Project | Agent Security Harness |
-| Harness version | `4.20.0` |
+| Harness version | `4.21.0` |
 | Assessed commit | [`8d8bc08933637381a32fc32041f139d34eb6271f`](https://github.com/msaleme/red-team-blue-team-agent-fabric/commit/8d8bc08933637381a32fc32041f139d34eb6271f) |
 | Assessed at | 2026-08-02T18:30:00Z |
 | Repository tests | 623 (`python scripts/count_tests.py`) |

--- a/docs/coverage/owasp-agentic-v1.1.json
+++ b/docs/coverage/owasp-agentic-v1.1.json
@@ -34,7 +34,7 @@
   "assessment": {
     "project": "Agent Security Harness",
     "repository": "https://github.com/msaleme/red-team-blue-team-agent-fabric",
-    "harness_version": "4.20.0",
+    "harness_version": "4.21.0",
     "git_commit": "8d8bc08933637381a32fc32041f139d34eb6271f",
     "assessed_at": "2026-08-02T18:30:00Z",
     "reverified_at": "2026-08-03T01:05:00Z",

--- a/docs/coverage/owasp-agentic-v1.1.yaml
+++ b/docs/coverage/owasp-agentic-v1.1.yaml
@@ -52,7 +52,7 @@ framework:
 assessment:
   project: Agent Security Harness
   repository: https://github.com/msaleme/red-team-blue-team-agent-fabric
-  harness_version: "4.20.0"
+  harness_version: "4.21.0"
   git_commit: "8d8bc08933637381a32fc32041f139d34eb6271f"
   assessed_at: '2026-08-02T18:30:00Z'
   reverified_at: '2026-08-03T01:05:00Z'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-security-harness"
-version = "4.20.0"
+version = "4.21.0"
 description = "623 security tests for AI agent systems - MCP, A2A, L402, x402, UCP/ACP merchant-journey, AP2 mandate + Fireblocks x402 hardening + Visa TAP / Mastercard Agentic Tokens + denial-of-settlement finality, decision governance, AIUC-1 compliance, NIST AI 800-2 aligned"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## What this release is

**Nine defects, seven of them in the measurement apparatus rather than in anything it measures.**

| Defect | Where |
|---|---|
| Validator rejected the correct answer (`inconclusive`) | #521 |
| A requirement could pass on a subset of its own tests | #522 |
| A trial runner called an unexercised control a failure | #523 |
| Delegation tests passed with the guard deleted | #524 |
| A ratchet satisfied by an import statement | #525 |
| The wheel shipped without the schema it reads | #526 |
| `--html` did nothing; simulate claimed a clean pass | #527 |
| Every OWASP category title wrong, in three renderers | #528 |

**Two were only reachable from outside the source tree.** `pip install` users got an uncaught `FileNotFoundError` from a documented function, and `--html` produced a file for **zero of forty-five** harnesses. Both invisible to a suite that runs in a checkout — because in a checkout the wrong path happens to be right, and the dead code path is never taken.

## The practice that found them

Fault injection, with one added step: **verify the injection changed the artifact under test before believing the result.**

Three injections this release initially proved nothing — a stale build cache served a cached wheel, a two-branch classifier kept working when one branch was disabled, and two assertions matched a CSS rule and a slice boundary instead of the thing they named. Every one of those false passes was indistinguishable from a real one.

## New tests

**DCA-001..DCA-011** — multi-hop delegated-authority attenuation, checked at every hop rather than at the ends of the chain. Test count 612 → 623.

## One thing deliberately not changed

The README release-claim line still reads `the v4.20.0 release carries 611`. A claim that a release carries N tests cannot be made before that release exists, and `verify_release_claims.py` regenerates the count **at the tag**. It is updated in the commit after the tag, when the claim becomes checkable.

Suite: `1139 passed, 789 subtests passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)