### PR TITLE
Second external review: url= userinfo, replay grading conflation, sdist build

### DIFF
--- a/HARNESS_TEST_CATALOG.md
+++ b/HARNESS_TEST_CATALOG.md
@@ -1,7 +1,7 @@
 # Agent Security Harness — Canonical Test Catalog
 
 **Source repo:** msaleme/red-team-blue-team-agent-fabric
-**Generated:** `scripts/generate_test_catalog.py` at commit `ee2a159`
+**Generated:** `scripts/generate_test_catalog.py` at commit `f2926bf`
 **Test count:** 623 unique test IDs across 46 registered harness modules (45 contain test IDs; `community_runner.py` is a plugin runner with none of its own)
 **Purpose:** Ground-truth reference for any bot, agent, or human representing the harness in public posts, comments, or discussions. Cite only tests listed here. Do not invent IDs or statistics.
 

--- a/HARNESS_TEST_CATALOG.md
+++ b/HARNESS_TEST_CATALOG.md
@@ -215,17 +215,17 @@ CREW-010 | Fallback Sandbox RCE Chain | protocol_tests/crewai_cve_harness.py:121
 ### Delegated-Authority Attenuation (`protocol_tests/delegation_chain_harness.py`) — 11 tests
 
 ```
-DCA-001 | Child Adds a Capability Absent From Its Parent | protocol_tests/delegation_chain_harness.py:863
-DCA-002 | Child Widens Resource Scope (staging -> production) | protocol_tests/delegation_chain_harness.py:933
-DCA-003 | Child Drops or Loosens a Parent Constraint | protocol_tests/delegation_chain_harness.py:1024
-DCA-004 | Valid Pass Presented to the Wrong Tool Audience | protocol_tests/delegation_chain_harness.py:1104
-DCA-005 | Replayed Effect Request | protocol_tests/delegation_chain_harness.py:1154
-DCA-006 | Pass Used After Expiry | protocol_tests/delegation_chain_harness.py:1270
-DCA-007 | Pass Used After Revocation Epoch | protocol_tests/delegation_chain_harness.py:1335
-DCA-008 | Tool Acts Under Ambient Credentials | protocol_tests/delegation_chain_harness.py:1402
-DCA-009 | Positive Control: Correctly Attenuated Child | protocol_tests/delegation_chain_harness.py:1451
-DCA-010 | Positive Control: Parent | protocol_tests/delegation_chain_harness.py:1506
-DCA-011 | Three-Hop Chain: Intermediate Re-Widens What Its Parent Narrowed | protocol_tests/delegation_chain_harness.py:1626
+DCA-001 | Child Adds a Capability Absent From Its Parent | protocol_tests/delegation_chain_harness.py:885
+DCA-002 | Child Widens Resource Scope (staging -> production) | protocol_tests/delegation_chain_harness.py:955
+DCA-003 | Child Drops or Loosens a Parent Constraint | protocol_tests/delegation_chain_harness.py:1046
+DCA-004 | Valid Pass Presented to the Wrong Tool Audience | protocol_tests/delegation_chain_harness.py:1126
+DCA-005 | Replayed Effect Request | protocol_tests/delegation_chain_harness.py:1176
+DCA-006 | Pass Used After Expiry | protocol_tests/delegation_chain_harness.py:1302
+DCA-007 | Pass Used After Revocation Epoch | protocol_tests/delegation_chain_harness.py:1367
+DCA-008 | Tool Acts Under Ambient Credentials | protocol_tests/delegation_chain_harness.py:1434
+DCA-009 | Positive Control: Correctly Attenuated Child | protocol_tests/delegation_chain_harness.py:1483
+DCA-010 | Positive Control: Parent | protocol_tests/delegation_chain_harness.py:1538
+DCA-011 | Three-Hop Chain: Intermediate Re-Widens What Its Parent Narrowed | protocol_tests/delegation_chain_harness.py:1658
 ```
 
 ### Enterprise Platforms (core) (`protocol_tests/enterprise_adapters.py`) — 31 tests

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,9 @@
+# The build_py hook in setup.py copies runtime data from these canonical
+# roots into the package. An sdist that omits them cannot build a wheel:
+# `python -m build` (no flags) builds the sdist and then the wheel FROM it,
+# which is exactly what .github/workflows/publish-pypi.yml runs. A --wheel
+# build from a checkout passing does not cover that route. Found by an
+# external second review, 2026-09-07, from a clean worktree.
+graft schemas
+graft configs
+graft docs/coverage

--- a/protocol_tests/delegation_chain_harness.py
+++ b/protocol_tests/delegation_chain_harness.py
@@ -695,6 +695,28 @@ class DelegationChainTests(RecordingHarness):
     _DECISION_KEYS = ("allowed", "granted")
 
     @classmethod
+    def _target_decision(cls, resp: dict) -> str:
+        """'allow' | 'deny' | 'undecided'. Three states, because two conflate.
+
+        `_target_allowed` returned False for an explicit `{"allowed": false}`
+        AND for `{}`, `{"allowed": "true"}`, a JSON-RPC error, or a transport
+        error. `_live_replay` read that False as "the replay was refused" and
+        graded PASS. A second response that established NOTHING was counted as
+        the control holding. Found by an external second review, 2026-09-07,
+        with a real HTTP fixture. 'deny' now requires a boolean False under a
+        decision key; anything else that is not a boolean True is undecided.
+        """
+        if not isinstance(resp, dict) or resp.get("_error") or "error" in resp:
+            return "undecided"
+        for k in cls._DECISION_KEYS:
+            v = resp.get(k)
+            if v is True:
+                return "allow"
+            if v is False:
+                return "deny"
+        return "undecided"
+
+    @classmethod
     def _target_allowed(cls, resp: dict) -> bool:
         """Structural read of the decision. Booleans only, on the parsed dict.
 
@@ -1181,29 +1203,39 @@ class DelegationChainTests(RecordingHarness):
         INCONCLUSIVE, stated. The first allow is never a finding: it is the
         legitimate request this row exists to replay.
         """
-        first, first_ok = self._probe_live(chain, req)
-        second, second_ok = self._probe_live(chain, req)
+        first, _ = self._probe_live(chain, req)
+        second, _ = self._probe_live(chain, req)
+        d1, d2 = self._target_decision(first), self._target_decision(second)
         sent = {"delegation_chain": [p.as_json() for p in chain],
                 "request": req.as_json(), "sent_times": 2}
-        # The shared serviced guard reads `_status` off `response_received`
-        # and downgrades to INCONCLUSIVE when it is absent. The verdict here is
-        # about the SECOND presentation, so its status is the composite's.
-        response = {"_status": second.get("_status", 0), "first": first, "second": second}
+        # Both observations must have been serviced for ANY verdict here. The
+        # composite carries the WORSE of the two statuses so the shared guard
+        # sees a failed first request, not only a failed second one.
+        s1, s2 = int(first.get("_status") or 0), int(second.get("_status") or 0)
+        worst = min(s1, s2) if (s1 and s2) else 0
+        response = {"_status": worst, "first": first, "second": second}
         r1, r2 = first.get("receipt"), second.get("receipt")
-        if not first_ok:
+        if d1 != "allow":
             return (False, f"{INCONCLUSIVE_PREFIX}the target did not allow the "
                     "legitimate first request, so there is nothing to replay. "
                     "Replay handling is not exercised by this run.",
                     response, sent)
-        if not second_ok:
+        if d2 == "undecided":
+            return (False, f"{INCONCLUSIVE_PREFIX}the second presentation produced no "
+                    "decision (empty body, non-boolean decision, or an application "
+                    "error). That is not a refusal; nothing about replay handling "
+                    "is established.", response, sent)
+        if d2 == "deny":
             return (True, "replay REFUSED by the live target: the second presentation "
-                    "of one request identifier was not allowed", response, sent)
-        if r1 is not None and r1 == r2:
+                    "of one request identifier was explicitly denied", response, sent)
+        # d2 == "allow": a receipt is evidence only if it is a nonempty string.
+        if isinstance(r1, str) and r1 and r1 == r2:
             return (True, f"replay was IDEMPOTENT: the live target returned the same "
                     f"receipt ({r1}) for both presentations", response, sent)
         return (False, f"{INCONCLUSIVE_PREFIX}the live target allowed both "
                 "presentations" + (f" with different receipts ({r1} vs {r2})"
-                                   if r1 is not None else " and returned no receipt")
+                                   if isinstance(r1, str) and r1 else
+                                   " and returned no usable receipt")
                 + ". Whether a second EFFECT occurred cannot be established over "
                 "this wire -- there is no effect counter -- so this is not graded "
                 "as a replay finding. Run --simulate for the reference-model verdict.",

--- a/protocol_tests/run_provenance.py
+++ b/protocol_tests/run_provenance.py
@@ -362,6 +362,16 @@ def redact_argv(argv: list[str]) -> tuple[list[str], bool]:
             out.append(f"{split[0]}={REDACTED}")
             redacted = True
             continue
+        # A NON-auth flag's equals value can still be a URL with userinfo:
+        # `--url=https://u:p@host/`. The userinfo strip was anchored to the
+        # start of the whole element, so the bare form was scrubbed and this
+        # form was not. Found by an external second review, 2026-09-07.
+        if split and split[1]:
+            value = _strip_url_userinfo(split[1])
+            if value != split[1]:
+                out.append(f"{split[0]}={value}")
+                redacted = True
+                continue
 
         cleaned = _redact_inline(arg)
         cleaned2 = _strip_url_userinfo(cleaned)

--- a/setup.py
+++ b/setup.py
@@ -37,9 +37,17 @@ class build_py(_build_py):
         for local, source, pattern in _DATA:
             files = sorted(source.glob(pattern))
             if not files:
+                # Building from an sdist: the canonical roots are grafted in by
+                # MANIFEST.in, but if an older sdist lacks them the package-
+                # local copies it carries ARE the shipped files. Use those;
+                # refuse only when neither exists.
+                local_src = ROOT / "protocol_tests" / local
+                files = sorted(local_src.glob(pattern)) if local_src.is_dir() else []
+            if not files:
                 raise SystemExit(
-                    f"setup.py: no {pattern} under canonical {source}; refusing to "
-                    f"build a wheel that would ship without runtime data")
+                    f"setup.py: no {pattern} under canonical {source} nor under "
+                    f"protocol_tests/{local}; refusing to build a wheel that would "
+                    f"ship without runtime data")
             dest = pkg_dir / local
             # Whatever the symlink became -- a link, a dir, or a placeholder
             # file -- is replaced by real files from the canonical root.

--- a/testing/test_delegation_live_fixtures.py
+++ b/testing/test_delegation_live_fixtures.py
@@ -236,3 +236,59 @@ class LegitimateChainAllowed(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+# ---------------------------------------------------------------------------
+# Second external review, 2026-09-07: a False decision is not a refusal.
+# ---------------------------------------------------------------------------
+
+def _second_response_policy(second_body):
+    def policy(payload, fx):
+        rid = payload["request"]["request_id"]
+        seen = [r for r in fx.requests[:-1] if r["request"]["request_id"] == rid]
+        return second_body if seen else {"allowed": True, "receipt": "r-first"}
+    return policy
+
+
+class AFalseDecisionIsNotARefusal(unittest.TestCase):
+    """The old grader read every non-True as refused. These second responses
+    establish nothing about replay and must be INCONCLUSIVE, never PASS."""
+
+    def _replay(self, second_body):
+        fx = _Fixture(_second_response_policy(second_body))
+        try:
+            return _run(fx)[REPLAY_ROW]
+        finally:
+            fx.close()
+
+    def test_empty_body_is_undecided(self):
+        r = self._replay({})
+        self.assertTrue(is_inconclusive(r), r.details); self.assertFalse(r.passed)
+
+    def test_string_true_is_undecided(self):
+        r = self._replay({"allowed": "true"})
+        self.assertTrue(is_inconclusive(r), r.details); self.assertFalse(r.passed)
+
+    def test_jsonrpc_error_is_undecided(self):
+        r = self._replay({"error": {"code": -32601, "message": "method not found"}})
+        self.assertTrue(is_inconclusive(r), r.details); self.assertFalse(r.passed)
+
+    def test_explicit_false_is_a_refusal(self):
+        r = self._replay({"allowed": False, "reason": "replay"})
+        self.assertTrue(r.passed, r.details); self.assertIn("explicitly denied", r.details)
+
+    def test_matching_empty_receipts_are_not_idempotence(self):
+        fx = _Fixture(lambda p, f: {"allowed": True, "receipt": ""})
+        try:
+            r = _run(fx)[REPLAY_ROW]
+        finally:
+            fx.close()
+        self.assertTrue(is_inconclusive(r), r.details); self.assertFalse(r.passed)
+
+    def test_matching_non_string_receipts_are_not_idempotence(self):
+        fx = _Fixture(lambda p, f: {"allowed": True, "receipt": {"id": 1}})
+        try:
+            r = _run(fx)[REPLAY_ROW]
+        finally:
+            fx.close()
+        self.assertTrue(is_inconclusive(r), r.details); self.assertFalse(r.passed)

--- a/tests/test_report_states_its_provenance.py
+++ b/tests/test_report_states_its_provenance.py
@@ -602,6 +602,8 @@ def test_the_hand_assembled_evidence_file_is_left_alone():
     (["p", "--header=X-Custom: " + CANARY], CANARY),
     (["p", "-H" + "Authorization: Bearer " + CANARY], CANARY),
     (["p", "--url", "https://alice:" + CANARY + "@host.example/mcp"], CANARY),
+    # equals form of the same thing; the strip was anchored to the element
+    (["p", "--url=https://alice:" + CANARY + "@host.example/mcp"], CANARY),
 ])
 def test_no_recognized_credential_survives_into_the_publication_copy(argv, secret):
     """`run_provenance()` -> `strip_sensitive_fields()` is the path a record

--- a/tests/test_the_wheel_ships_what_it_reads.py
+++ b/tests/test_the_wheel_ships_what_it_reads.py
@@ -206,3 +206,33 @@ class InstalledConsumersCanReadTheirMapping(unittest.TestCase):
                              f"an installed consumer could not read its mapping:\n"
                              f"{done.stdout}\n{done.stderr[-800:]}")
             self.assertIn("OK", done.stdout)
+
+
+class TheDefaultBuildRouteWorks(unittest.TestCase):
+    """`python -m build` with no flags: sdist, then wheel FROM the sdist. This
+    is the route .github/workflows/publish-pypi.yml takes. The --wheel tests
+    above never exercised it, and the build_py hook's canonical-root
+    requirement failed it from a clean worktree (second external review,
+    2026-09-07). The release would have failed at publish time."""
+
+    def test_sdist_then_wheel_from_a_clean_copy(self):
+        try:
+            import build  # noqa: F401
+        except ImportError:
+            raise unittest.SkipTest("the `build` package is not installed")
+        with tempfile.TemporaryDirectory(prefix="default-build-") as tmp:
+            src = Path(tmp) / "src"
+            shutil.copytree(REPO, src, symlinks=True,
+                            ignore=shutil.ignore_patterns(".git", ".venv", "build",
+                                                          "*.egg-info", "__pycache__", "dist"))
+            out = Path(tmp) / "dist"
+            done = subprocess.run([sys.executable, "-m", "build", "-o", str(out)],
+                                  cwd=src, capture_output=True, text=True)
+            self.assertEqual(done.returncode, 0,
+                             f"default build failed:\n{done.stdout[-1500:]}\n{done.stderr[-1500:]}")
+            wheels = list(out.glob("*.whl")); sdists = list(out.glob("*.tar.gz"))
+            self.assertEqual(len(wheels), 1, wheels); self.assertEqual(len(sdists), 1, sdists)
+            names = zipfile.ZipFile(wheels[0]).namelist()
+            for parts in RUNTIME_DATA:
+                with self.subTest(data="/".join(parts)):
+                    self.assertIn("protocol_tests/" + "/".join(parts), names)


### PR DESCRIPTION
Three P1 findings from the second review (2026-09-07), all in #530's code.

1. `--url=https://u:p@host/` survived. The userinfo strip was anchored to the
   start of the argv element, so the bare form was scrubbed and the equals
   form of the same URL was not. A non-auth flag's equals value now gets the
   strip; pinned through the publication path.

2. DCA-005 graded PASS on a second response that established nothing.
   `_target_allowed` returned False for an explicit `{"allowed": false}` AND
   for `{}`, `{"allowed": "true"}`, a JSON-RPC error, or a transport error;
   `_live_replay` read every False as "the replay was refused". Three states
   now: allow, deny (a boolean False under a decision key), undecided. Only
   an explicit deny supports the refusal PASS. Both observations must have
   been serviced -- the composite carries the WORSE of the two statuses so
   the shared guard sees a failed first request. A receipt is evidence only
   as a nonempty string; matching empty strings or objects are not
   idempotence. Six new fixture-backed cases.

3. `python -m build` with no flags failed. It builds the sdist, then the
   wheel FROM the sdist; the build_py hook required canonical roots the
   sdist did not carry. That is the exact route publish-pypi.yml runs. The
   --wheel tests never exercised it; the release would have failed at
   publish time. Two defenses, deliberately redundant: MANIFEST.in grafts
   the canonical roots into the sdist, and build_py falls back to the
   package-local copies when the roots are absent. Either alone passes the
   new default-route test from a clean copy; removing both fails it.

Injections, each verified to have reached the file. Two were redone: the
first 2a replaced the undecided branch and still read INCONCLUSIVE via a
different branch -- it never reproduced the defect; the correct one restores
the old two-state conflation. The first 3 emptied MANIFEST.in alone and
passed because the fallback rescues it -- that is the redundancy, shown
explicitly by 3b.
  equals-form strip removed                          1 failed
  non-True second conflated with deny (old defect)   2 failed
  untyped receipt equality again                     2 failed
  fallback AND graft removed                         1 failed
  fallback removed, graft kept                       passes (redundant by design)

Catalog regenerated: _target_decision shifted DCA line numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)