### PR TITLE
CITATION.cff: date-released is the release date

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,7 +11,7 @@ authors:
 repository-code: "https://github.com/msaleme/red-team-blue-team-agent-fabric"
 url: "https://pypi.org/project/agent-security-harness/"
 license: Apache-2.0
-date-released: "2026-09-02"
+date-released: "2026-09-07"
 keywords:
   - agent-security
   - mcp


### PR DESCRIPTION
The release-event drift check flagged `date-released: 2026-09-02` on v4.21.0. Version was bumped; the date was not.

The checker reads the published file, so it clears only after this merges — verified post-merge, not pre-push. And it would have caught this pre-tag if it ran in the release PR's CI rather than only on the release event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)