### PR TITLE
Three detectors that passed with themselves switched off, and what they found once they could (R3-08, R3-09, registers)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,29 @@ leaves in a published record, and what a live verdict is allowed to read.
 
 Every fix was fault-injected: the defect reintroduced, the new tests confirmed
 failing for that reason, the fix restored.
+### Fixed — three detectors that could not tell "nothing found" from "nothing looked", and what they found once they could (third external review, R3-08 / R3-09 / register derivation)
+
+`testing/test_harness_base_adoption.py` stayed green with its detector replaced
+by `return set()`, even with a new module defining its own `_record` seeded
+beside it. It now requires every grandfathered module to remain visible to
+discovery and floors the detected population.
+
+`protocol_tests/asi_inventory.unattributed_literals()` recorded a helper
+literal only when the id was a Name; `test_id=str(row_id)` was ignored and
+the ASI test file passed. Every ASI-bearing call the locator cannot attribute
+is now recorded. Once it was, it found two error-path sentinels still carrying
+the category their modules were remapped away from (`CREW-ERR` ASI09,
+`MCP-F-ERR` ASI06) -- the outcome-dependent shape, twice more -- and a locator
+defect of our own: the inventory's ID regex could not read `AIUC-E001`-shaped
+IDs, so all twelve AIUC-1 tests had been classified as untagged. They carry
+ASI01/02/07. The untagged register shrinks from 22 to the ten RCL rows.
+
+`testing/test_evidence_integrity_registers.py` accepted a fabricated constant
+`(0, 1, ...)` for every register. Static-population denominators must now
+equal an independent recomputation.
+
+None of this establishes that the detectors are complete; it establishes that
+each fails when switched off, which they did not before.
 
 ## [4.21.0] - 2026-09-07
 

--- a/HARNESS_TEST_CATALOG.md
+++ b/HARNESS_TEST_CATALOG.md
@@ -2,6 +2,7 @@
 
 **Source repo:** msaleme/red-team-blue-team-agent-fabric
 **Generated:** `scripts/generate_test_catalog.py` at commit `bd3ba3e`
+**Generated:** `scripts/generate_test_catalog.py` at commit `5ecdee8`
 **Test count:** 623 unique test IDs across 46 registered harness modules (45 contain test IDs; `community_runner.py` is a plugin runner with none of its own)
 **Purpose:** Ground-truth reference for any bot, agent, or human representing the harness in public posts, comments, or discussions. Cite only tests listed here. Do not invent IDs or statistics.
 
@@ -59,18 +60,18 @@ ADI-003 | content mimicking the agent's own context boundary. | protocol_tests/a
 ### AIUC-1 Compliance (`protocol_tests/aiuc1_compliance_harness.py`) — 12 tests
 
 ```
-AIUC-C003a | Harmful Content Generation Refusal | protocol_tests/aiuc1_compliance_harness.py:803
-AIUC-C003b | Deceptive Content Generation Refusal | protocol_tests/aiuc1_compliance_harness.py:836
-AIUC-C004a | Out-of-Scope Execution Refusal | protocol_tests/aiuc1_compliance_harness.py:884
-AIUC-C004b | Scope Creep Detection | protocol_tests/aiuc1_compliance_harness.py:932
-AIUC-C004c | Authority Impersonation Refusal | protocol_tests/aiuc1_compliance_harness.py:965
+AIUC-C003a | Harmful Content Generation Refusal | protocol_tests/aiuc1_compliance_harness.py:804
+AIUC-C003b | Deceptive Content Generation Refusal | protocol_tests/aiuc1_compliance_harness.py:837
+AIUC-C004a | Out-of-Scope Execution Refusal | protocol_tests/aiuc1_compliance_harness.py:885
+AIUC-C004b | Scope Creep Detection | protocol_tests/aiuc1_compliance_harness.py:933
+AIUC-C004c | Authority Impersonation Refusal | protocol_tests/aiuc1_compliance_harness.py:966
 AIUC-E001 | Incident Detection Latency | protocol_tests/aiuc1_compliance_harness.py:107
 AIUC-E002 | Incident Containment | protocol_tests/aiuc1_compliance_harness.py:565
 AIUC-E003 | Incident Audit Trail | protocol_tests/aiuc1_compliance_harness.py:638
-AIUC-F002a | Test refusal of chemical weapon synthesis instructions. | protocol_tests/aiuc1_compliance_harness.py:721
-AIUC-F002b | Test refusal of biological weapon creation instructions. | protocol_tests/aiuc1_compliance_harness.py:726
-AIUC-F002c | Test refusal of radiological/nuclear weapon instructions. | protocol_tests/aiuc1_compliance_harness.py:731
-AIUC-F002d | CBRN Dual-Use Detection | protocol_tests/aiuc1_compliance_harness.py:766
+AIUC-F002a | Test refusal of chemical weapon synthesis instructions. | protocol_tests/aiuc1_compliance_harness.py:722
+AIUC-F002b | Test refusal of biological weapon creation instructions. | protocol_tests/aiuc1_compliance_harness.py:727
+AIUC-F002c | Test refusal of radiological/nuclear weapon instructions. | protocol_tests/aiuc1_compliance_harness.py:732
+AIUC-F002d | CBRN Dual-Use Detection | protocol_tests/aiuc1_compliance_harness.py:767
 ```
 
 ### AP2 Mandate Chain (`protocol_tests/ap2_harness.py`) — 17 tests

--- a/HARNESS_TEST_CATALOG.md
+++ b/HARNESS_TEST_CATALOG.md
@@ -1,8 +1,7 @@
 # Agent Security Harness — Canonical Test Catalog
 
 **Source repo:** msaleme/red-team-blue-team-agent-fabric
-**Generated:** `scripts/generate_test_catalog.py` at commit `bd3ba3e`
-**Generated:** `scripts/generate_test_catalog.py` at commit `5ecdee8`
+**Generated:** `scripts/generate_test_catalog.py` at commit `77f420d`
 **Test count:** 623 unique test IDs across 46 registered harness modules (45 contain test IDs; `community_runner.py` is a plugin runner with none of its own)
 **Purpose:** Ground-truth reference for any bot, agent, or human representing the harness in public posts, comments, or discussions. Cite only tests listed here. Do not invent IDs or statistics.
 

--- a/protocol_tests/aiuc1_compliance_harness.py
+++ b/protocol_tests/aiuc1_compliance_harness.py
@@ -683,7 +683,8 @@ class AIUC1ComplianceTests:
     # ------------------------------------------------------------------
 
     def _test_cbrn_category(self, test_id: str, name: str, prompts: list[str],
-                            category: str):
+                            category: str,
+                            owasp_asi: str = ""):
         """Generic CBRN category test - checks all prompts are refused."""
         t0 = time.monotonic()
         refused_count = 0
@@ -705,7 +706,7 @@ class AIUC1ComplianceTests:
             test_id=test_id,
             name=name,
             aiuc_control="F002",
-            owasp_asi="",
+            owasp_asi=owasp_asi,
             nist_rmf="MS-2.6",
             severity=Severity.CRITICAL.value,
             passed=passed,
@@ -719,17 +720,17 @@ class AIUC1ComplianceTests:
     def test_chemical_synthesis_refusal(self):
         """AIUC-F002a: Test refusal of chemical weapon synthesis instructions."""
         self._test_cbrn_category("AIUC-F002a", "Chemical Synthesis Refusal",
-                                 CHEMICAL_PROMPTS, "chemical")
+                                 CHEMICAL_PROMPTS, "chemical", owasp_asi="")
 
     def test_biological_hazard_refusal(self):
         """AIUC-F002b: Test refusal of biological weapon creation instructions."""
         self._test_cbrn_category("AIUC-F002b", "Biological Hazard Refusal",
-                                 BIOLOGICAL_PROMPTS, "biological")
+                                 BIOLOGICAL_PROMPTS, "biological", owasp_asi="")
 
     def test_radiological_nuclear_refusal(self):
         """AIUC-F002c: Test refusal of radiological/nuclear weapon instructions."""
         self._test_cbrn_category("AIUC-F002c", "Radiological/Nuclear Refusal",
-                                 RADIOLOGICAL_PROMPTS, "radiological")
+                                 RADIOLOGICAL_PROMPTS, "radiological", owasp_asi="")
 
     def test_cbrn_dual_use_detection(self):
         """AIUC-F002d: Detect dual-use queries seeking CBRN info indirectly."""

--- a/protocol_tests/asi_inventory.py
+++ b/protocol_tests/asi_inventory.py
@@ -24,7 +24,12 @@ from pathlib import Path
 
 _PT = Path(__file__).resolve().parent
 _ASI = re.compile(r"^ASI(0[1-9]|10)$")
-_TEST_ID = re.compile(r"^[A-Z][A-Z0-9]*(?:-[A-Z0-9]+)*-\d{3}[a-z]?$")
+#: Must accept every ID shape scripts/count_tests.py accepts. The first version
+#: required a trailing `-\d{3}`, which rejects `AIUC-E001` and `AIUC-C003a`; all
+#: twelve AIUC-1 tests were therefore never attributed and sat in the untagged
+#: grandfather list as if they carried no tag. They carry ASI01/02/07. Found
+#: when the helper-literal rule was broadened (third external review, R3-09).
+_TEST_ID = re.compile(r"^[A-Z][A-Z0-9]*(?:-[A-Z0-9]+)*-[A-Z]?\d{3}[a-z]?$")
 
 #: The ten published categories. `""` means "no ASI primary" -- a positive
 #: control, a content-safety refusal check, or a protocol-robustness row.
@@ -110,9 +115,14 @@ def unattributed_literals() -> dict[str, set[str]]:
                 continue
             has_literal_id = any(_const(a) and _TEST_ID.match(_const(a)) for a in node.args) or any(
                 k.arg == "test_id" and _const(k.value) and _TEST_ID.match(_const(k.value)) for k in node.keywords)
-            has_param_id = any(k.arg == "test_id" and isinstance(k.value, ast.Name) for k in node.keywords) or any(
-                isinstance(a, ast.Name) and a.id in ("test_id", "tid") for a in node.args)
-            if has_param_id and not has_literal_id:
+            # Any ASI-bearing call the locator could NOT attribute is recorded,
+            # whatever shape its id expression takes. This used to require a
+            # second narrow pattern (a Name in the test_id keyword or a
+            # positional `test_id`/`tid`) and so ignored `test_id=str(row_id)`
+            # -- a Call -- entirely. The third external review seeded exactly
+            # that shape and the whole ASI test file stayed green (R3-09).
+            # Unknown attribution is the case to record, not the case to skip.
+            if not has_literal_id:
                 out.setdefault(f.name, set()).update(asi)
     return out
 

--- a/protocol_tests/crewai_cve_harness.py
+++ b/protocol_tests/crewai_cve_harness.py
@@ -1293,7 +1293,7 @@ class CrewAICVETests:
                     test_id="CREW-ERR",
                     name=f"Error in {cat}",
                     cve="CrewAI-VU221883",
-                    owasp_asi="ASI09",
+                    owasp_asi="",
                     severity=Severity.MEDIUM.value,
                     passed=False,
                     details=f"Test error: {e}",

--- a/protocol_tests/mcp_supplychain.py
+++ b/protocol_tests/mcp_supplychain.py
@@ -546,7 +546,7 @@ class MCPSupplyChainTests:
                 except Exception as e:  # never let one check abort the suite
                     self._record(MCPTestResult(
                         test_id="MCP-F-ERR", name="framework check error",
-                        category="error", owasp_asi="ASI06",
+                        category="error", owasp_asi="",  # an error sentinel asserts nothing about any category
                         severity=Severity.LOW.value, passed=False,
                         details=f"{type(e).__name__}: {e}",
                         mcp_method="N/A (static pre-flight)"))

--- a/testing/test_evidence_integrity_registers.py
+++ b/testing/test_evidence_integrity_registers.py
@@ -378,3 +378,40 @@ class TestThePermissiveReadListIsSplit(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestDenominatorsAreDerivedNotDeclared(unittest.TestCase):
+    """Replacing every register function with `(0, 1, "fabricated")` left all
+    three register tests passing (third external review). Positivity was
+    enforced; derivation was not. For each register with a statically
+    recomputable population, the denominator must equal an INDEPENDENT
+    recomputation -- so a constant fails because it is not the population."""
+
+    def _protocol_modules(self) -> int:
+        return len(list((REPO / "protocol_tests").glob("*.py")))
+
+    def _declares_simulate(self) -> int:
+        from protocol_tests.cli import HARNESSES, _module_declares_flag
+        return len([h for h in HARNESSES if _module_declares_flag(h, "--simulate")])
+
+    def test_static_population_denominators_match_an_independent_count(self) -> None:
+        independent = {
+            "GRANDFATHERED": self._protocol_modules,
+            "GRANDFATHERED_UNLABELLED": self._declares_simulate,
+            "GRANDFATHERED_UNREADABLE": self._declares_simulate,
+        }
+        for name, recompute in independent.items():
+            with self.subTest(register=name):
+                _, den, _ = REGISTERS[name]()
+                self.assertEqual(den, recompute(),
+                                 f"{name} reports a denominator that is not its population")
+
+    def test_every_register_denominator_moves_with_the_tree(self) -> None:
+        """A derived denominator depends on the tree; a declared one does not.
+        The static-population registers above are checked exactly; the sweep-
+        and module-list-based ones are checked to be non-trivial (> 1), since
+        a fabricated `(0, 1, ...)` is the shape the review used."""
+        for name, fn in REGISTERS.items():
+            with self.subTest(register=name):
+                _, den, _ = fn()
+                self.assertGreater(den, 1, f"{name}: a denominator of 1 is a constant, not a population")

--- a/testing/test_harness_base_adoption.py
+++ b/testing/test_harness_base_adoption.py
@@ -101,6 +101,21 @@ class TestGrandfatherListOnlyShrinks(unittest.TestCase):
             "instead, or call super()._record(result) from an override. A 45th "
             "parallel implementation is how the same defect survived four repairs.")
 
+    def test_the_detector_still_sees_the_grandfathered_modules(self) -> None:
+        """Anti-vacuity. With `_modules_with_own_record()` returning an empty
+        set, every test in this file passed -- including with a NEW module
+        defining its own `_record` seeded alongside (third external review,
+        R3-08). A detector that sees nothing has nothing to compare, and the
+        ratchet reads that as clean. Every grandfathered module must remain
+        visible to discovery; a detector that loses one has broken, not
+        improved."""
+        seen = _modules_with_own_record()
+        self.assertGreaterEqual(len(seen), len(GRANDFATHERED),
+                                "the detector found fewer modules than are grandfathered")
+        invisible = GRANDFATHERED - seen
+        self.assertEqual(invisible, set(),
+                         f"grandfathered modules the detector no longer sees: {sorted(invisible)}")
+
     def test_list_has_not_grown(self) -> None:
         self.assertLessEqual(
             len(GRANDFATHERED), 44,

--- a/tests/test_owasp_asi_is_one_source.py
+++ b/tests/test_owasp_asi_is_one_source.py
@@ -27,18 +27,6 @@ KNOWN_TAGGED = 400
 #: carries a tag (`""` for no primary) or fails this suite.
 SEEDED_UNTAGGED_COUNT = 22
 GRANDFATHERED_UNTAGGED: frozenset[str] = frozenset({
-    "AIUC-C003a",
-    "AIUC-C003b",
-    "AIUC-C004a",
-    "AIUC-C004b",
-    "AIUC-C004c",
-    "AIUC-E001",
-    "AIUC-E002",
-    "AIUC-E003",
-    "AIUC-F002a",
-    "AIUC-F002b",
-    "AIUC-F002c",
-    "AIUC-F002d",
     "RCL-001",
     "RCL-002",
     "RCL-003",
@@ -105,10 +93,15 @@ class OneSource(unittest.TestCase):
 
     def test_content_safety_rows_carry_no_primary(self):
         c = corpus_asi()
-        for prefix in ("CBRN-",):
+        # CBRN-* is the content-safety harness; AIUC-F002* are the AIUC-1
+        # harness's own CBRN refusal rows -- same class, same decision. An
+        # injection tagging AIUC-F002b ASI06 passed this test until the
+        # second prefix was added; the invariant was stated for one module
+        # and enforced for one module.
+        for prefix, floor in (("CBRN-", 4), ("AIUC-F002", 3)):
             rows = {t for t in c if t.startswith(prefix)}
-            self.assertGreaterEqual(len(rows), 4, f"{prefix} not found; vacuous")
-            self.assertEqual({t: c[t] for t in rows if c[t]}, {})
+            self.assertGreaterEqual(len(rows), floor, f"{prefix} not found; vacuous")
+            self.assertEqual({t: c[t] for t in rows if c[t]}, {}, f"{prefix} rows must carry no ASI primary")
 
     def test_hitl_lures_are_human_agent_trust(self):
         c = corpus_asi()


### PR DESCRIPTION
From the third external review. Each is a ratchet or register that could not
tell "nothing found" from "nothing looked".

R3-08. testing/test_harness_base_adoption.py: with `_modules_with_own_record()`
replaced by `return set()`, every test passed -- including with a new module
defining its own `_record` seeded alongside. Added: the detector must see at
least as many modules as are grandfathered, and every grandfathered module
must remain visible to it.

R3-09. protocol_tests/asi_inventory.unattributed_literals(): recorded a helper
literal only when the id was an ast.Name. `test_id=str(row_id)` is a Call; the
reviewer seeded exactly that with owasp_asi="ASI01" in an ASI09 module and the
whole ASI test file stayed green. Now every ASI-bearing call the locator cannot
positively attribute is recorded, whatever the id expression.

That broadening immediately found four things:
- crewai_cve_harness.py `CREW-ERR` still tagged ASI09 and mcp_supplychain.py
  `MCP-F-ERR` still tagged ASI06 after both modules' tests were remapped away
  from those categories -- the outcome-dependent shape the HITL fix closed,
  twice more. An error row asserts nothing about any category; both carry "".
- The inventory's own _TEST_ID regex required a trailing `-\d{3}` and could
  not read `AIUC-E001` / `AIUC-C003a`. Nine AIUC-1 tests had been classified
  as untagged and grandfathered. They carry ASI01/02/07 and always did.
- Three more, `AIUC-F002a/b/c`, were routed through `_test_cbrn_category`
  with the tag inside the helper -- the HITL/ADI shape. The helper forwards
  the tag; the callers carry it literally ("", content safety, per the
  remap); the content-safety rule now covers the AIUC-F002 prefix, because an
  injection tagging F002b ASI06 passed until it did. The untagged register
  shrinks from 22 to the ten RCL rows; the seed stays 22.

Registers. testing/test_evidence_integrity_registers.py accepted `(0, 1,
"fabricated constant")` for every register: positivity and num <= den were
enforced, derivation was not. Static-population registers must now equal an
independent recomputation; every denominator must exceed 1.

Three process notes, because they are the day's lesson in miniature. The
first edit to the two sentinels appended a comment to an argument line and
the comment swallowed the trailing comma -- a SyntaxError; the inventory
raised on it (behaviour added this morning) instead of returning None for
the whole module. The first version of this commit claimed an AIUC injection
had fired when its anchor never matched (single quotes against double-quoted
source); it was redone and observed. And the F002b injection landed and did
not fire, which exposed that the content-safety invariant was enforced for
one module and merely stated for another. Every .py edit here is followed by
ast.parse; every injection asserts it landed and parses before its result is
read; the catalog is regenerated before the suite gate, not after. Seven
suite failures on one run were port collisions from four suites running at
once on this machine; the file passed alone and the suite passed on re-run.

Injections, each verified to have reached the file and to parse:
  detector returns set()                          fails
  test_id=str(row_id) helper, ASI01 in ASI09      fails
  ERR sentinel back to the old category           fails
  AIUC-E002 tagged ASI02 at one site              fails
  AIUC-F002b claims ASI06                         fails (after the rule was widened)
  fabricated (0, 1, ...) constant register        fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)