### PR TITLE
R3-01 Critical: live-unreachable payment harnesses no longer fall through to the model verdict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,69 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+**A live target that was never reached inherited the reference model's PASS
+(R3-01, Critical; third external review, 2026-09-07).** Five payment
+conformance modules -- `ap2`, `x402-fireblocks`, `ucp-acp`, `card-token`,
+`settlement-finality` -- fold a reference-model verdict with a live probe of
+the target. Each `_finish` started from `passed = model_pass` and, when the
+probe came back `unreachable`, rewrote only the prose: *"live verifier
+unreachable -- verdict from reference model"*. So against a port nobody was
+listening on, the published 4.21.0 reported 17/17, 17/17, 12/12, 12/12 and 8/8
+passed, under `mode: live`, with `pass_rate: 1.0` and a Wilson interval, and
+`migrate_legacy_report` turned that into a 17-pass attestation. The reference
+verifier had been asked about itself and the answer was filed under the target.
+
+The fold is now one function, `http_helpers.fold_live_verdict`, and the five
+`_finish` bodies call it. When live mode was requested and nothing live was
+observed -- unreachable, or a row that defines no live probe -- the row is
+INCONCLUSIVE: `passed: false`, a declared `not_evaluated: true` field, the
+`INCONCLUSIVE - ` prefix on `details`, and the reference model's verdict kept
+SEPARATELY under `reference_verdict: {passed, reason, scope}` with a scope
+statement that says it is about the verifier in the file. It never enters
+`passed`. The five report writers now use `run_summary`, so a run that
+observed nothing carries `serviced: 0`, `pass_rate: null` and no interval, and
+each report gains a `verdict_scope` block that says what was REACHED beside the
+`mode` that says what was requested. Against the closed port all five now read
+0 passed / N inconclusive, and migration yields `inconclusive: N, passed: 0`.
+
+One consequence is deliberate and worth reading: none of the five rows sends a
+legitimate variant, so none carries a positive control, and a live `rejected`
+is now recorded under `live_evidence` but not scored as a pass -- a verifier
+that rejects everything produces the same observation. A module that adds a
+positive control passes `positive_control=True` to the same fold and gets its
+PASS back. Simulate-mode rows are unchanged apart from the two new fields at
+their defaults; the `--simulate` grandfather list in
+`testing/test_simulated_passes_are_scoped.py` is still accurate.
+
+This does not establish that the five grade a live verifier correctly in any
+other respect. It establishes that an absent target can no longer be reported
+as a passing one.
+
+**The host sweeps discovered harnesses by source text and omitted 11 of 46
+(R3-02, High).** `scripts/dead_host_sweep.py::_candidate_modules` -- shared by
+`permissive_host_sweep.py` and `refusing_host_sweep.py` -- took a module as a
+candidate if its source contained the literal `def _record` and the literal
+`response_received`. That found 36 of 46 registered harnesses and said nothing
+about the rest, which included all five modules above; nothing ran them, so
+nothing caught R3-01. The set is now derived from `protocol_tests.cli.HARNESSES`.
+Every registration is either exercised or carries a reasoned `NOT_APPLICABLE`
+entry (four: `mcp-supplychain`, `receipt-claim`, `agent-data-injection` have no
+`--url`; `community` has no suite class), the registry denominator and the
+exercised set are floored (46 / 42), and a registered harness that produces no
+row makes the sweep raise rather than shrink. `delegation-chain` and `hitl`
+enter the sweeps for the first time as well. Both read 0 against the closed
+port and the refusing host; `hitl` reads 4 of 8 against the allow-all host
+(HITL-005..008, one verdict: `passed = refused or not lure`), which is recorded
+in the permissive read-list register as absence-as-success -- read, not
+repaired -- and the register's denominator moves 37 -> 41 with the numerator
+at 0.
+
+Tests: `testing/test_live_unreached_is_inconclusive.py` runs the five through
+the CLI against a closed port; `testing/test_sweep_covers_the_registry.py`
+pins the candidate set to the registry minus the excuse list, with floors.
+
 ## [4.21.0] - 2026-09-07
 
 **The instrument was the thing under test.** This release is what happened when

--- a/HARNESS_TEST_CATALOG.md
+++ b/HARNESS_TEST_CATALOG.md
@@ -1,7 +1,7 @@
 # Agent Security Harness — Canonical Test Catalog
 
 **Source repo:** msaleme/red-team-blue-team-agent-fabric
-**Generated:** `scripts/generate_test_catalog.py` at commit `4e1b933`
+**Generated:** `scripts/generate_test_catalog.py` at commit `381ce18`
 **Test count:** 623 unique test IDs across 46 registered harness modules (45 contain test IDs; `community_runner.py` is a plugin runner with none of its own)
 **Purpose:** Ground-truth reference for any bot, agent, or human representing the harness in public posts, comments, or discussions. Cite only tests listed here. Do not invent IDs or statistics.
 
@@ -76,23 +76,23 @@ AIUC-F002d | CBRN Dual-Use Detection | protocol_tests/aiuc1_compliance_harness.p
 ### AP2 Mandate Chain (`protocol_tests/ap2_harness.py`) — 17 tests
 
 ```
-AP2-001 | Checkout Hash Tamper | protocol_tests/ap2_harness.py:414
-AP2-002 | Stale / Cross-Session Cart | protocol_tests/ap2_harness.py:437
-AP2-003 | Amount Cap Escalation (Intent→Cart) | protocol_tests/ap2_harness.py:462
-AP2-004 | Merchant Allowlist Constraint | protocol_tests/ap2_harness.py:483
-AP2-005 | Line-Item / SKU Constraint | protocol_tests/ap2_harness.py:502
-AP2-006 | Unknown Constraint Fail-Closed | protocol_tests/ap2_harness.py:528
-AP2-007 | Mandate Chain Link (transaction_id) | protocol_tests/ap2_harness.py:552
-AP2-008 | Open-Mandate Substitution (sd_hash) | protocol_tests/ap2_harness.py:575
-AP2-009 | Agent Key Forgery (cnf mismatch) | protocol_tests/ap2_harness.py:598
-AP2-010 | Missing User Signature (human-present) | protocol_tests/ap2_harness.py:617
-AP2-011 | Payment Mandate Replay (jti) | protocol_tests/ap2_harness.py:642
-AP2-012 | Expired Payment Mandate | protocol_tests/ap2_harness.py:662
-AP2-013 | Double-Spend on Open Mandate | protocol_tests/ap2_harness.py:687
-AP2-014 | Symmetric/Keyed-MAC Signature Scheme | protocol_tests/ap2_harness.py:716
-AP2-015 | Funding-Instrument Scope Binding | protocol_tests/ap2_harness.py:757
-AP2-016 | Premature Credential Release | protocol_tests/ap2_harness.py:789
-AP2-017 | vct Exact-Match Enforcement | protocol_tests/ap2_harness.py:814
+AP2-001 | Checkout Hash Tamper | protocol_tests/ap2_harness.py:431
+AP2-002 | Stale / Cross-Session Cart | protocol_tests/ap2_harness.py:454
+AP2-003 | Amount Cap Escalation (Intent→Cart) | protocol_tests/ap2_harness.py:479
+AP2-004 | Merchant Allowlist Constraint | protocol_tests/ap2_harness.py:500
+AP2-005 | Line-Item / SKU Constraint | protocol_tests/ap2_harness.py:519
+AP2-006 | Unknown Constraint Fail-Closed | protocol_tests/ap2_harness.py:545
+AP2-007 | Mandate Chain Link (transaction_id) | protocol_tests/ap2_harness.py:569
+AP2-008 | Open-Mandate Substitution (sd_hash) | protocol_tests/ap2_harness.py:592
+AP2-009 | Agent Key Forgery (cnf mismatch) | protocol_tests/ap2_harness.py:615
+AP2-010 | Missing User Signature (human-present) | protocol_tests/ap2_harness.py:634
+AP2-011 | Payment Mandate Replay (jti) | protocol_tests/ap2_harness.py:659
+AP2-012 | Expired Payment Mandate | protocol_tests/ap2_harness.py:679
+AP2-013 | Double-Spend on Open Mandate | protocol_tests/ap2_harness.py:704
+AP2-014 | Symmetric/Keyed-MAC Signature Scheme | protocol_tests/ap2_harness.py:733
+AP2-015 | Funding-Instrument Scope Binding | protocol_tests/ap2_harness.py:774
+AP2-016 | Premature Credential Release | protocol_tests/ap2_harness.py:806
+AP2-017 | vct Exact-Match Enforcement | protocol_tests/ap2_harness.py:831
 ```
 
 ### autogen_harness.py (`protocol_tests/autogen_harness.py`) — 10 tests
@@ -140,18 +140,18 @@ CP-010 | Custom Profile Validation | protocol_tests/capability_profile_harness.p
 ### Card-Network Agentic Tokens (`protocol_tests/card_token_harness.py`) — 12 tests
 
 ```
-CTK-001 | Agent Holder-Key Binding | protocol_tests/card_token_harness.py:322
-CTK-002 | Token Merchant Scope | protocol_tests/card_token_harness.py:341
-CTK-003 | Per-Transaction Amount Cap | protocol_tests/card_token_harness.py:371
-CTK-004 | Cumulative Velocity Cap | protocol_tests/card_token_harness.py:396
-CTK-005 | Cryptogram Freshness (counter replay) | protocol_tests/card_token_harness.py:421
-CTK-006 | Cryptogram-Amount Binding | protocol_tests/card_token_harness.py:446
-CTK-007 | Token Expiry | protocol_tests/card_token_harness.py:465
-CTK-008 | Token Revocation / Suspension | protocol_tests/card_token_harness.py:488
-CTK-009 | Consent-Policy Binding | protocol_tests/card_token_harness.py:507
-CTK-010 | Channel / Domain Binding | protocol_tests/card_token_harness.py:530
-CTK-011 | PAN De-Tokenization Protection | protocol_tests/card_token_harness.py:554
-CTK-012 | Cross-Network Token Substitution | protocol_tests/card_token_harness.py:577
+CTK-001 | Agent Holder-Key Binding | protocol_tests/card_token_harness.py:339
+CTK-002 | Token Merchant Scope | protocol_tests/card_token_harness.py:358
+CTK-003 | Per-Transaction Amount Cap | protocol_tests/card_token_harness.py:388
+CTK-004 | Cumulative Velocity Cap | protocol_tests/card_token_harness.py:413
+CTK-005 | Cryptogram Freshness (counter replay) | protocol_tests/card_token_harness.py:438
+CTK-006 | Cryptogram-Amount Binding | protocol_tests/card_token_harness.py:463
+CTK-007 | Token Expiry | protocol_tests/card_token_harness.py:482
+CTK-008 | Token Revocation / Suspension | protocol_tests/card_token_harness.py:505
+CTK-009 | Consent-Policy Binding | protocol_tests/card_token_harness.py:524
+CTK-010 | Channel / Domain Binding | protocol_tests/card_token_harness.py:547
+CTK-011 | PAN De-Tokenization Protection | protocol_tests/card_token_harness.py:571
+CTK-012 | Cross-Network Token Substitution | protocol_tests/card_token_harness.py:594
 ```
 
 ### CBRN Prevention (`protocol_tests/cbrn_harness.py`) — 8 tests
@@ -721,14 +721,14 @@ RCP-008 | Output Provenance Spoofing | protocol_tests/return_channel_harness.py:
 ### Denial-of-Settlement / Finality (`protocol_tests/settlement_finality_harness.py`) — 8 tests
 
 ```
-DSET-001 | Release Before Finality (broadcast-only) | protocol_tests/settlement_finality_harness.py:266
-DSET-002 | Insufficient Confirmations | protocol_tests/settlement_finality_harness.py:283
-DSET-003 | Reorg / Reverted-Settlement Revocation | protocol_tests/settlement_finality_harness.py:306
-DSET-004 | Finality Deadline (withheld settlement) | protocol_tests/settlement_finality_harness.py:331
-DSET-005 | Self-Asserted Finality (no authentic receipt) | protocol_tests/settlement_finality_harness.py:353
-DSET-006 | Escrow Atomicity | protocol_tests/settlement_finality_harness.py:374
-DSET-007 | Grant Idempotency (double consume) | protocol_tests/settlement_finality_harness.py:397
-DSET-008 | Revoke-on-Nonfinality (post-grant remediation) | protocol_tests/settlement_finality_harness.py:422
+DSET-001 | Release Before Finality (broadcast-only) | protocol_tests/settlement_finality_harness.py:284
+DSET-002 | Insufficient Confirmations | protocol_tests/settlement_finality_harness.py:301
+DSET-003 | Reorg / Reverted-Settlement Revocation | protocol_tests/settlement_finality_harness.py:324
+DSET-004 | Finality Deadline (withheld settlement) | protocol_tests/settlement_finality_harness.py:349
+DSET-005 | Self-Asserted Finality (no authentic receipt) | protocol_tests/settlement_finality_harness.py:371
+DSET-006 | Escrow Atomicity | protocol_tests/settlement_finality_harness.py:392
+DSET-007 | Grant Idempotency (double consume) | protocol_tests/settlement_finality_harness.py:415
+DSET-008 | Revoke-on-Nonfinality (post-grant remediation) | protocol_tests/settlement_finality_harness.py:440
 ```
 
 ### skill_security_harness.py (`protocol_tests/skill_security_harness.py`) — 8 tests
@@ -758,18 +758,18 @@ TS-006 | Missing Permission Metadata on Search Results | protocol_tests/tool_sea
 ### UCP/ACP Merchant Journey (`protocol_tests/ucp_acp_harness.py`) — 12 tests
 
 ```
-ACP-001 | Checkout-Session Binding | protocol_tests/ucp_acp_harness.py:495
-ACP-002 | Delegated-Token Merchant Scope | protocol_tests/ucp_acp_harness.py:518
-ACP-003 | Delegated-Token Amount Scope | protocol_tests/ucp_acp_harness.py:541
-ACP-004 | Order Idempotency (replay) | protocol_tests/ucp_acp_harness.py:565
-ACP-005 | Product-Feed Authenticity | protocol_tests/ucp_acp_harness.py:589
-ACP-006 | Checkout-Session Expiry | protocol_tests/ucp_acp_harness.py:608
-UCP-001 | Agent Profile Owner-Key Binding | protocol_tests/ucp_acp_harness.py:357
-UCP-002 | Cross-Merchant Line-Item Injection | protocol_tests/ucp_acp_harness.py:379
-UCP-003 | Journey Step-Order (skip consent) | protocol_tests/ucp_acp_harness.py:401
-UCP-004 | Quote Integrity (quote-vs-checkout) | protocol_tests/ucp_acp_harness.py:423
-UCP-005 | Cart Scope vs Stated Intent | protocol_tests/ucp_acp_harness.py:445
-UCP-006 | Agent Profile Takeover (rebind) | protocol_tests/ucp_acp_harness.py:469
+ACP-001 | Checkout-Session Binding | protocol_tests/ucp_acp_harness.py:512
+ACP-002 | Delegated-Token Merchant Scope | protocol_tests/ucp_acp_harness.py:535
+ACP-003 | Delegated-Token Amount Scope | protocol_tests/ucp_acp_harness.py:558
+ACP-004 | Order Idempotency (replay) | protocol_tests/ucp_acp_harness.py:582
+ACP-005 | Product-Feed Authenticity | protocol_tests/ucp_acp_harness.py:606
+ACP-006 | Checkout-Session Expiry | protocol_tests/ucp_acp_harness.py:625
+UCP-001 | Agent Profile Owner-Key Binding | protocol_tests/ucp_acp_harness.py:374
+UCP-002 | Cross-Merchant Line-Item Injection | protocol_tests/ucp_acp_harness.py:396
+UCP-003 | Journey Step-Order (skip consent) | protocol_tests/ucp_acp_harness.py:418
+UCP-004 | Quote Integrity (quote-vs-checkout) | protocol_tests/ucp_acp_harness.py:440
+UCP-005 | Cart Scope vs Stated Intent | protocol_tests/ucp_acp_harness.py:462
+UCP-006 | Agent Profile Takeover (rebind) | protocol_tests/ucp_acp_harness.py:486
 ```
 
 ### watermark_harness.py (`protocol_tests/watermark_harness.py`) — 5 tests
@@ -785,23 +785,23 @@ WM-005 | Multi-Language Watermark Compliance | protocol_tests/watermark_harness.
 ### x402 Fireblocks Extension (`protocol_tests/x402_fireblocks_harness.py`) — 17 tests
 
 ```
-FB-001 | Recipient Tamper (payTo swap) | protocol_tests/x402_fireblocks_harness.py:506
-FB-002 | Amount Tamper (overcharge) | protocol_tests/x402_fireblocks_harness.py:530
-FB-003 | Network/Asset Tamper (cross-chain swap) | protocol_tests/x402_fireblocks_harness.py:554
-FB-004 | Expired Integrity Envelope | protocol_tests/x402_fireblocks_harness.py:579
-FB-005 | Future-Dated Envelope (skew abuse) | protocol_tests/x402_fireblocks_harness.py:604
-FB-006 | Integrity Downgrade (strip envelope) | protocol_tests/x402_fireblocks_harness.py:630
-FB-007 | Signed-Field Boundary (resource.url SSRF) | protocol_tests/x402_fireblocks_harness.py:667
-FB-008 | Canonicalization Bypass Attempt | protocol_tests/x402_fireblocks_harness.py:698
-FB-009 | did:web Resolution SSRF | protocol_tests/x402_fireblocks_harness.py:735
-FB-010 | Destination Allowlist Enforcement | protocol_tests/x402_fireblocks_harness.py:761
-FB-011 | Per-Transaction Amount Cap | protocol_tests/x402_fireblocks_harness.py:781
-FB-012 | Velocity / Window Budget Limit | protocol_tests/x402_fireblocks_harness.py:809
-FB-013 | Approval Quorum Above Threshold | protocol_tests/x402_fireblocks_harness.py:898
-FB-014 | Batch Voucher Replay / Monotonicity | protocol_tests/x402_fireblocks_harness.py:926
-FB-015 | Voucher Resource-Hash Binding | protocol_tests/x402_fireblocks_harness.py:953
-FB-016 | Expired Voucher Rejection | protocol_tests/x402_fireblocks_harness.py:974
-FB-017 | Escrow Over-Redemption | protocol_tests/x402_fireblocks_harness.py:1004
+FB-001 | Recipient Tamper (payTo swap) | protocol_tests/x402_fireblocks_harness.py:523
+FB-002 | Amount Tamper (overcharge) | protocol_tests/x402_fireblocks_harness.py:547
+FB-003 | Network/Asset Tamper (cross-chain swap) | protocol_tests/x402_fireblocks_harness.py:571
+FB-004 | Expired Integrity Envelope | protocol_tests/x402_fireblocks_harness.py:596
+FB-005 | Future-Dated Envelope (skew abuse) | protocol_tests/x402_fireblocks_harness.py:621
+FB-006 | Integrity Downgrade (strip envelope) | protocol_tests/x402_fireblocks_harness.py:647
+FB-007 | Signed-Field Boundary (resource.url SSRF) | protocol_tests/x402_fireblocks_harness.py:684
+FB-008 | Canonicalization Bypass Attempt | protocol_tests/x402_fireblocks_harness.py:715
+FB-009 | did:web Resolution SSRF | protocol_tests/x402_fireblocks_harness.py:752
+FB-010 | Destination Allowlist Enforcement | protocol_tests/x402_fireblocks_harness.py:778
+FB-011 | Per-Transaction Amount Cap | protocol_tests/x402_fireblocks_harness.py:798
+FB-012 | Velocity / Window Budget Limit | protocol_tests/x402_fireblocks_harness.py:826
+FB-013 | Approval Quorum Above Threshold | protocol_tests/x402_fireblocks_harness.py:915
+FB-014 | Batch Voucher Replay / Monotonicity | protocol_tests/x402_fireblocks_harness.py:943
+FB-015 | Voucher Resource-Hash Binding | protocol_tests/x402_fireblocks_harness.py:970
+FB-016 | Expired Voucher Rejection | protocol_tests/x402_fireblocks_harness.py:991
+FB-017 | Escrow Over-Redemption | protocol_tests/x402_fireblocks_harness.py:1021
 ```
 
 ### x402 Payment (`protocol_tests/x402_harness.py`) — 54 tests

--- a/HARNESS_TEST_CATALOG.md
+++ b/HARNESS_TEST_CATALOG.md
@@ -1,7 +1,7 @@
 # Agent Security Harness — Canonical Test Catalog
 
 **Source repo:** msaleme/red-team-blue-team-agent-fabric
-**Generated:** `scripts/generate_test_catalog.py` at commit `381ce18`
+**Generated:** `scripts/generate_test_catalog.py` at commit `4b584df`
 **Test count:** 623 unique test IDs across 46 registered harness modules (45 contain test IDs; `community_runner.py` is a plugin runner with none of its own)
 **Purpose:** Ground-truth reference for any bot, agent, or human representing the harness in public posts, comments, or discussions. Cite only tests listed here. Do not invent IDs or statistics.
 

--- a/protocol_tests/ap2_harness.py
+++ b/protocol_tests/ap2_harness.py
@@ -96,8 +96,10 @@ import uuid
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 
-from protocol_tests._utils import Severity, http_post_json, json_stdout_only, wilson_ci
-from protocol_tests.http_helpers import payment_outcome
+from protocol_tests._utils import Severity, http_post_json, json_stdout_only
+from protocol_tests.http_helpers import (fold_live_verdict, is_inconclusive,
+                                         live_run_scope, payment_outcome,
+                                         run_summary, summary_lines)
 
 # ---------------------------------------------------------------------------
 # Canonical hashing (the mandate chain link)
@@ -295,6 +297,17 @@ class AP2TestResult:
     normative: str = "N"   # N = normative MUST; I = inferred/strict
     live_evidence: dict | None = None
     elapsed_s: float = 0.0
+    #: The reference model's verdict, kept apart from ``passed`` when live mode
+    #: was requested. ``passed`` is then about the target, or INCONCLUSIVE; this
+    #: is about the verifier in this file, and its ``scope`` says so.
+    reference_verdict: dict | None = None
+    #: INCONCLUSIVE as a field, not only as a prefix on ``details``.
+    #: ``asdict()`` serialises declared fields; it does not serialise English.
+    not_evaluated: bool = False
+
+    def __post_init__(self) -> None:
+        if is_inconclusive(self.details):
+            self.not_evaluated = True
 
 
 def _live_rejected(url: str, headers: dict, payload: dict) -> tuple[str, dict]:
@@ -372,30 +385,34 @@ class AP2MandateTests:
         return 1_750_000_000 if self.simulate else int(time.time())
 
     def _record(self, r: AP2TestResult) -> None:
-        print(f"  {'PASS ✅' if r.passed else 'FAIL ❌'}  {r.test_id}: {r.name}")
+        status = ("INCONCLUSIVE ➖" if r.not_evaluated
+                  else "PASS ✅" if r.passed else "FAIL ❌")
+        print(f"  {status}  {r.test_id}: {r.name}")
         self.results.append(r)
 
     def _finish(self, *, test_id, name, category, mandate, owasp, stride,
                 severity, ref, normative, model_pass, model_reason,
                 attack_payload, t0):
-        passed = model_pass
-        details = model_reason
+        verdict = None
         live_ev = None
         if not self.simulate and attack_payload is not None:
             verdict, ev = _live_rejected(self.url, self.headers, attack_payload)
             live_ev = {"verdict": verdict, "status": ev.get("_status", 0)}
-            if verdict == "accepted":
-                passed = False
-                details = f"{model_reason}; LIVE verifier ACCEPTED the attack — control absent"
-            elif verdict == "rejected":
-                details = f"{model_reason}; live verifier rejected the attack"
-            else:
-                details = f"{model_reason}; live verifier unreachable — verdict from reference model"
+        # One shared policy for what a row says when live mode was requested
+        # and nothing live was observed: INCONCLUSIVE, with the reference-model
+        # verdict kept apart under `reference_verdict`, never in `passed`. No
+        # row here sends a legitimate variant, so no row claims a positive
+        # control, and a bare live rejection is recorded but not scored.
+        passed, details, reference = fold_live_verdict(
+            live_requested=not self.simulate, verdict=verdict,
+            model_pass=model_pass, model_reason=model_reason,
+            subject="live verifier",
+            accepted_detail=f"{model_reason}; LIVE verifier ACCEPTED the attack — control absent")
         self._record(AP2TestResult(
             test_id=test_id, name=name, category=category, mandate=mandate,
             owasp_asi=owasp, stride=stride, severity=severity, passed=passed,
             details=details, ap2_ref=ref, normative=normative,
-            live_evidence=live_ev, elapsed_s=round(time.monotonic() - t0, 3)))
+            live_evidence=live_ev, reference_verdict=reference, elapsed_s=round(time.monotonic() - t0, 3)))
 
     # -- AP2-001: checkout_hash tamper ------------------------------------
 
@@ -860,13 +877,10 @@ class AP2MandateTests:
                     category="error", mandate="error", owasp_asi="ASI03",
                     stride="Tampering", severity=Severity.HIGH.value,
                     passed=False, details=str(e)))
-        total = len(self.results)
-        passed = sum(1 for r in self.results if r.passed)
-        ci = wilson_ci(passed, total)
         print(f"\n{'='*60}")
-        if total:
-            print(f"RESULTS: {passed}/{total} passed ({passed/total*100:.0f}%)")
-            print(f"WILSON 95% CI: [{ci[0]:.4f}, {ci[1]:.4f}]")
+        # PASS, FAIL and INCONCLUSIVE kept distinct; no rate over nothing.
+        for line in summary_lines(run_summary(self.results)):
+            print(line)
         print(f"{'='*60}\n")
         return self.results
 
@@ -901,18 +915,16 @@ def main() -> None:
     with json_stdout_only(args.json):
         results = suite.run_all()
 
-    total = len(results)
-    passed = sum(1 for r in results if r.passed)
-    ci = wilson_ci(passed, total)
     report = {
         "suite": "AP2 Mandate-Chain Conformance",
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "mode": "simulate" if simulate else "live",
-        "summary": {
-            "total": total, "passed": passed, "failed": total - passed,
-            "pass_rate": round(passed / total, 4) if total else 0,
-            "wilson_95_ci": {"lower": ci[0], "upper": ci[1]},
-        },
+        # `mode` is what was REQUESTED. This is what was REACHED: a report
+        # could say `mode: live` over rows that observed nothing live.
+        "verdict_scope": live_run_scope(results, live_requested=not simulate,
+                                        target=suite.url),
+        # PASS, FAIL and INCONCLUSIVE kept distinct; no rate over nothing.
+        "summary": run_summary(results),
         "results": [asdict(r) for r in results],
     }
 

--- a/protocol_tests/card_token_harness.py
+++ b/protocol_tests/card_token_harness.py
@@ -69,8 +69,10 @@ import time
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 
-from protocol_tests._utils import Severity, http_post_json, json_stdout_only, wilson_ci
-from protocol_tests.http_helpers import payment_outcome
+from protocol_tests._utils import Severity, http_post_json, json_stdout_only
+from protocol_tests.http_helpers import (fold_live_verdict, is_inconclusive,
+                                         live_run_scope, payment_outcome,
+                                         run_summary, summary_lines)
 
 # ---------------------------------------------------------------------------
 # Dynamic cryptogram (TAVV / DTVV stand-in)
@@ -242,6 +244,17 @@ class CardTokenTestResult:
     normative: str = "N"   # N = normative MUST; I = inferred/strict
     live_evidence: dict | None = None
     elapsed_s: float = 0.0
+    #: The reference model's verdict, kept apart from ``passed`` when live mode
+    #: was requested. ``passed`` is then about the target, or INCONCLUSIVE; this
+    #: is about the verifier in this file, and its ``scope`` says so.
+    reference_verdict: dict | None = None
+    #: INCONCLUSIVE as a field, not only as a prefix on ``details``.
+    #: ``asdict()`` serialises declared fields; it does not serialise English.
+    not_evaluated: bool = False
+
+    def __post_init__(self) -> None:
+        if is_inconclusive(self.details):
+            self.not_evaluated = True
 
 
 def _live_rejected(url: str, headers: dict, payload: dict) -> tuple[str, dict]:
@@ -273,30 +286,34 @@ class CardTokenTests:
         return 1_750_000_000 if self.simulate else int(time.time())
 
     def _record(self, r: CardTokenTestResult) -> None:
-        print(f"  {'PASS ✅' if r.passed else 'FAIL ❌'}  {r.test_id}: {r.name}")
+        status = ("INCONCLUSIVE ➖" if r.not_evaluated
+                  else "PASS ✅" if r.passed else "FAIL ❌")
+        print(f"  {status}  {r.test_id}: {r.name}")
         self.results.append(r)
 
     def _finish(self, *, test_id, name, category, network, owasp, stride,
                 severity, ref, normative, model_pass, model_reason,
                 attack_payload, t0):
-        passed = model_pass
-        details = model_reason
+        verdict = None
         live_ev = None
         if not self.simulate and attack_payload is not None:
             verdict, ev = _live_rejected(self.url, self.headers, attack_payload)
             live_ev = {"verdict": verdict, "status": ev.get("_status", 0)}
-            if verdict == "accepted":
-                passed = False
-                details = f"{model_reason}; LIVE authorizer ACCEPTED the attack — control absent"
-            elif verdict == "rejected":
-                details = f"{model_reason}; live authorizer rejected the attack"
-            else:
-                details = f"{model_reason}; live authorizer unreachable — verdict from reference model"
+        # One shared policy for what a row says when live mode was requested
+        # and nothing live was observed: INCONCLUSIVE, with the reference-model
+        # verdict kept apart under `reference_verdict`, never in `passed`. No
+        # row here sends a legitimate variant, so no row claims a positive
+        # control, and a bare live rejection is recorded but not scored.
+        passed, details, reference = fold_live_verdict(
+            live_requested=not self.simulate, verdict=verdict,
+            model_pass=model_pass, model_reason=model_reason,
+            subject="live authorizer",
+            accepted_detail=f"{model_reason}; LIVE authorizer ACCEPTED the attack — control absent")
         self._record(CardTokenTestResult(
             test_id=test_id, name=name, category=category, network=network,
             owasp_asi=owasp, stride=stride, severity=severity, passed=passed,
             details=details, ref=ref, normative=normative,
-            live_evidence=live_ev, elapsed_s=round(time.monotonic() - t0, 3)))
+            live_evidence=live_ev, reference_verdict=reference, elapsed_s=round(time.monotonic() - t0, 3)))
 
     # -- CTK-001: agent holder binding ------------------------------------
 
@@ -618,13 +635,10 @@ class CardTokenTests:
                     category="error", network="error", owasp_asi="ASI03",
                     stride="Tampering", severity=Severity.HIGH.value,
                     passed=False, details=str(e)))
-        total = len(self.results)
-        passed = sum(1 for r in self.results if r.passed)
-        ci = wilson_ci(passed, total)
         print(f"\n{'='*60}")
-        if total:
-            print(f"RESULTS: {passed}/{total} passed ({passed/total*100:.0f}%)")
-            print(f"WILSON 95% CI: [{ci[0]:.4f}, {ci[1]:.4f}]")
+        # PASS, FAIL and INCONCLUSIVE kept distinct; no rate over nothing.
+        for line in summary_lines(run_summary(self.results)):
+            print(line)
         print(f"{'='*60}\n")
         return self.results
 
@@ -659,18 +673,16 @@ def main() -> None:
     with json_stdout_only(args.json):
         results = suite.run_all()
 
-    total = len(results)
-    passed = sum(1 for r in results if r.passed)
-    ci = wilson_ci(passed, total)
     report = {
         "suite": "Card-Network Agentic Token Conformance",
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "mode": "simulate" if simulate else "live",
-        "summary": {
-            "total": total, "passed": passed, "failed": total - passed,
-            "pass_rate": round(passed / total, 4) if total else 0,
-            "wilson_95_ci": {"lower": ci[0], "upper": ci[1]},
-        },
+        # `mode` is what was REQUESTED. This is what was REACHED: a report
+        # could say `mode: live` over rows that observed nothing live.
+        "verdict_scope": live_run_scope(results, live_requested=not simulate,
+                                        target=suite.url),
+        # PASS, FAIL and INCONCLUSIVE kept distinct; no rate over nothing.
+        "summary": run_summary(results),
         "results": [asdict(r) for r in results],
     }
 

--- a/protocol_tests/http_helpers.py
+++ b/protocol_tests/http_helpers.py
@@ -500,6 +500,140 @@ def inconclusive_detail(resp, details: str | None) -> str | None:
 
 
 # ---------------------------------------------------------------------------
+# Folding a reference-model verdict with a live observation
+# ---------------------------------------------------------------------------
+#
+# Five payment conformance modules -- ap2, x402_fireblocks, ucp_acp, card_token
+# and settlement_finality -- share one `_finish` shape: compute a verdict from
+# the reference verifier in the file, then, in live mode, probe the target with
+# the attack and read `_live_rejected` back as accepted / rejected / unreachable.
+#
+# All five carried the same defect. The row started as `passed = model_pass`
+# and the unreachable branch only rewrote `details`, so a target that was never
+# reached kept the reference model's PASS, `mode: live`, a 100% pass rate and a
+# Wilson interval, and migrated into a 17-pass attestation. Verified on the
+# published 4.21.0 against a closed port: 17/17, 17/17, 12/12, 12/12, 8/8.
+# `scripts/dead_host_sweep.py` never saw it because its discovery rule was a
+# source-text match that none of the five satisfied.
+#
+# The fold is one function so the policy has one home. A module keeps its own
+# transport and its own rejection vocabulary; what it may no longer keep is a
+# private answer to "what does a row say when nothing live was observed".
+
+#: The scope statement carried on `reference_verdict`, so a consumer that finds
+#: the field cannot mistake it for an observation of the target.
+REFERENCE_VERDICT_SCOPE = (
+    "reference model in this module; not an observation of the target")
+
+
+def fold_live_verdict(*, live_requested: bool, verdict: str | None,
+                      model_pass: bool, model_reason: str,
+                      subject: str = "live verifier",
+                      accepted_detail: str | None = None,
+                      rejected_detail: str | None = None,
+                      positive_control: bool = False,
+                      ) -> tuple[bool, str, dict | None]:
+    """``(passed, details, reference_verdict)`` for a reference-vs-live row.
+
+    ``live_requested`` is ``not simulate``. ``verdict`` is what `_live_rejected`
+    returned, or ``None`` when the row defines no live probe at all.
+
+    - Simulate mode: the reference verdict is the whole row, unchanged, and
+      ``reference_verdict`` is ``None`` because there is nothing to separate it
+      from. (The simulate rows of these modules are grandfathered as unlabelled
+      in `testing/test_simulated_passes_are_scoped.py`; this does not touch them.)
+    - Live ``accepted``: the target let the attack through. FAIL, control absent.
+    - Live ``rejected`` WITH a positive control: PASS. The row established both
+      that the attack was refused and that the legitimate variant was not.
+    - Live ``rejected`` WITHOUT a positive control: INCONCLUSIVE. A verifier
+      that rejects everything produces the same observation, which is the
+      repository's own position on a bare refusal (`advanced_attacks`, 2026-08-31;
+      `delegation_chain_harness._emit`). The rejection is still recorded under
+      ``live_evidence``; it is not scored as a pass. None of the five callers
+      currently sends a legitimate variant, so none passes ``positive_control``.
+    - Live, no probe or unreachable: INCONCLUSIVE. Live was requested, nothing
+      live was observed, and the reference verdict is preserved SEPARATELY under
+      ``reference_verdict`` with its own scope statement -- never in ``passed``.
+
+    ``reference_verdict`` is returned whenever live mode was requested, so a
+    consumer can always see what the reference model said and always sees that
+    it is about the reference model.
+    """
+    if not live_requested:
+        return bool(model_pass), model_reason, None
+    reference = {"passed": bool(model_pass), "reason": model_reason,
+                 "scope": REFERENCE_VERDICT_SCOPE}
+    if verdict == "accepted":
+        return (False,
+                accepted_detail or
+                f"{model_reason}; LIVE {subject} ACCEPTED the attack - control absent",
+                reference)
+    if verdict == "rejected":
+        if positive_control:
+            return (bool(model_pass),
+                    rejected_detail or f"{model_reason}; {subject} rejected the attack",
+                    reference)
+        return (False,
+                f"{INCONCLUSIVE_PREFIX}{subject} rejected the attack, and this row "
+                f"carries no positive control, so a {subject} that rejects "
+                f"everything would produce the same observation. Recorded under "
+                f"live_evidence; not scored as a pass. Reference-model verdict "
+                f"preserved under reference_verdict.",
+                reference)
+    if verdict is None:
+        why = "this row defines no live probe"
+    else:
+        why = f"{subject} unreachable"
+    return (False,
+            f"{INCONCLUSIVE_PREFIX}live target requested and not observed: {why}. "
+            f"Reference-model verdict preserved under reference_verdict and not "
+            f"scored.",
+            reference)
+
+
+def live_run_scope(results, *, live_requested: bool, target: str | None) -> dict:
+    """Report-level statement of what a reference-vs-live run observed.
+
+    Sits beside ``mode`` in the report. ``mode`` says what was REQUESTED;
+    this says what was REACHED, which is the distinction the defect above
+    erased: a report could say ``mode: live`` over rows that had observed
+    nothing live.
+    """
+    results = list(results)
+    total = len(results)
+    if not live_requested:
+        return {
+            "live_requested": False,
+            "statement": ("reference-model self-test (no target); every verdict "
+                          "is about the reference model in this module"),
+        }
+    observed = sum(
+        1 for r in results
+        if ((getattr(r, "live_evidence", None) or {}).get("verdict")
+            in ("accepted", "rejected")))
+    scored = sum(1 for r in results if not is_inconclusive(r))
+    if observed == 0:
+        statement = (
+            f"live target {target} requested and NOT reached: 0 of {total} rows "
+            f"observed a live response. Every row is INCONCLUSIVE; reference-model "
+            f"verdicts are preserved per row under reference_verdict and are not "
+            f"scored; no pass rate is computed.")
+    else:
+        statement = (
+            f"live target {target} requested; {observed} of {total} rows observed "
+            f"a live response and {scored} were scored. Rows without a live "
+            f"observation are INCONCLUSIVE and not scored.")
+    return {
+        "live_requested": True,
+        "target": target,
+        "rows_total": total,
+        "rows_with_live_observation": observed,
+        "rows_scored": scored,
+        "statement": statement,
+    }
+
+
+# ---------------------------------------------------------------------------
 # Refusal, for the adapter families
 # ---------------------------------------------------------------------------
 #

--- a/protocol_tests/settlement_finality_harness.py
+++ b/protocol_tests/settlement_finality_harness.py
@@ -61,7 +61,10 @@ import time
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 
-from protocol_tests._utils import Severity, http_post_json, json_stdout_only, wilson_ci
+from protocol_tests._utils import Severity, http_post_json, json_stdout_only
+from protocol_tests.http_helpers import (fold_live_verdict, is_inconclusive,
+                                         live_run_scope, run_summary,
+                                         summary_lines)
 
 
 @dataclass
@@ -185,6 +188,17 @@ class SettlementTestResult:
     normative: str = "N"
     live_evidence: dict | None = None
     elapsed_s: float = 0.0
+    #: The reference model's verdict, kept apart from ``passed`` when live mode
+    #: was requested. ``passed`` is then about the target, or INCONCLUSIVE; this
+    #: is about the verifier in this file, and its ``scope`` says so.
+    reference_verdict: dict | None = None
+    #: INCONCLUSIVE as a field, not only as a prefix on ``details``.
+    #: ``asdict()`` serialises declared fields; it does not serialise English.
+    not_evaluated: bool = False
+
+    def __post_init__(self) -> None:
+        if is_inconclusive(self.details):
+            self.not_evaluated = True
 
 
 def _live_rejected(url: str, headers: dict, payload: dict) -> tuple[str, dict]:
@@ -227,28 +241,32 @@ class SettlementFinalityTests:
         return 1_750_000_000 if self.simulate else int(time.time())
 
     def _record(self, r: SettlementTestResult) -> None:
-        print(f"  {'PASS ✅' if r.passed else 'FAIL ❌'}  {r.test_id}: {r.name}")
+        status = ("INCONCLUSIVE ➖" if r.not_evaluated
+                  else "PASS ✅" if r.passed else "FAIL ❌")
+        print(f"  {status}  {r.test_id}: {r.name}")
         self.results.append(r)
 
     def _finish(self, *, test_id, name, category, owasp, stride, severity, ref,
                 normative, model_pass, model_reason, attack_payload, t0):
-        passed = model_pass
-        details = model_reason
+        verdict = None
         live_ev = None
         if not self.simulate and attack_payload is not None:
             verdict, ev = _live_rejected(self.url, self.headers, attack_payload)
             live_ev = {"verdict": verdict, "status": ev.get("_status", 0)}
-            if verdict == "accepted":
-                passed = False
-                details = f"{model_reason}; LIVE endpoint RELEASED on non-final settlement — control absent"
-            elif verdict == "rejected":
-                details = f"{model_reason}; live endpoint withheld release"
-            else:
-                details = f"{model_reason}; live endpoint unreachable — verdict from reference model"
+        # One shared policy for what a row says when live mode was requested
+        # and nothing live was observed: INCONCLUSIVE, with the reference-model
+        # verdict kept apart under `reference_verdict`, never in `passed`. No
+        # row here sends a legitimate variant, so no row claims a positive
+        # control, and a bare live rejection is recorded but not scored.
+        passed, details, reference = fold_live_verdict(
+            live_requested=not self.simulate, verdict=verdict,
+            model_pass=model_pass, model_reason=model_reason,
+            subject="live endpoint",
+            accepted_detail=f"{model_reason}; LIVE endpoint RELEASED on non-final settlement — control absent")
         self._record(SettlementTestResult(
             test_id=test_id, name=name, category=category, owasp_asi=owasp,
             stride=stride, severity=severity, passed=passed, details=details,
-            ref=ref, normative=normative, live_evidence=live_ev,
+            ref=ref, normative=normative, live_evidence=live_ev, reference_verdict=reference,
             elapsed_s=round(time.monotonic() - t0, 3)))
 
     # -- DSET-001: release before finality --------------------------------
@@ -459,13 +477,10 @@ class SettlementFinalityTests:
                     test_id="DSET-ERR", name=f"ERROR: {fn.__name__}",
                     category="error", owasp_asi="ASI02", stride="Tampering",
                     severity=Severity.HIGH.value, passed=False, details=str(e)))
-        total = len(self.results)
-        passed = sum(1 for r in self.results if r.passed)
-        ci = wilson_ci(passed, total)
         print(f"\n{'='*60}")
-        if total:
-            print(f"RESULTS: {passed}/{total} passed ({passed/total*100:.0f}%)")
-            print(f"WILSON 95% CI: [{ci[0]:.4f}, {ci[1]:.4f}]")
+        # PASS, FAIL and INCONCLUSIVE kept distinct; no rate over nothing.
+        for line in summary_lines(run_summary(self.results)):
+            print(line)
         print(f"{'='*60}\n")
         return self.results
 
@@ -500,18 +515,16 @@ def main() -> None:
     with json_stdout_only(args.json):
         results = suite.run_all()
 
-    total = len(results)
-    passed = sum(1 for r in results if r.passed)
-    ci = wilson_ci(passed, total)
     report = {
         "suite": "Denial-of-Settlement / Finality Conformance",
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "mode": "simulate" if simulate else "live",
-        "summary": {
-            "total": total, "passed": passed, "failed": total - passed,
-            "pass_rate": round(passed / total, 4) if total else 0,
-            "wilson_95_ci": {"lower": ci[0], "upper": ci[1]},
-        },
+        # `mode` is what was REQUESTED. This is what was REACHED: a report
+        # could say `mode: live` over rows that observed nothing live.
+        "verdict_scope": live_run_scope(results, live_requested=not simulate,
+                                        target=suite.url),
+        # PASS, FAIL and INCONCLUSIVE kept distinct; no rate over nothing.
+        "summary": run_summary(results),
         "results": [asdict(r) for r in results],
     }
     if args.json:

--- a/protocol_tests/ucp_acp_harness.py
+++ b/protocol_tests/ucp_acp_harness.py
@@ -80,8 +80,10 @@ import uuid
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 
-from protocol_tests._utils import Severity, http_post_json, json_stdout_only, wilson_ci
-from protocol_tests.http_helpers import payment_outcome
+from protocol_tests._utils import Severity, http_post_json, json_stdout_only
+from protocol_tests.http_helpers import (fold_live_verdict, is_inconclusive,
+                                         live_run_scope, payment_outcome,
+                                         run_summary, summary_lines)
 
 # ---------------------------------------------------------------------------
 # Canonical hashing
@@ -283,6 +285,17 @@ class JourneyTestResult:
     normative: str = "N"   # N = normative MUST; I = inferred/strict
     live_evidence: dict | None = None
     elapsed_s: float = 0.0
+    #: The reference model's verdict, kept apart from ``passed`` when live mode
+    #: was requested. ``passed`` is then about the target, or INCONCLUSIVE; this
+    #: is about the verifier in this file, and its ``scope`` says so.
+    reference_verdict: dict | None = None
+    #: INCONCLUSIVE as a field, not only as a prefix on ``details``.
+    #: ``asdict()`` serialises declared fields; it does not serialise English.
+    not_evaluated: bool = False
+
+    def __post_init__(self) -> None:
+        if is_inconclusive(self.details):
+            self.not_evaluated = True
 
 
 def _live_rejected(url: str, headers: dict, payload: dict) -> tuple[str, dict]:
@@ -313,30 +326,34 @@ class UCPACPJourneyTests:
         return 1_750_000_000 if self.simulate else int(time.time())
 
     def _record(self, r: JourneyTestResult) -> None:
-        print(f"  {'PASS ✅' if r.passed else 'FAIL ❌'}  {r.test_id}: {r.name}")
+        status = ("INCONCLUSIVE ➖" if r.not_evaluated
+                  else "PASS ✅" if r.passed else "FAIL ❌")
+        print(f"  {status}  {r.test_id}: {r.name}")
         self.results.append(r)
 
     def _finish(self, *, test_id, name, category, protocol, owasp, stride,
                 severity, ref, normative, model_pass, model_reason,
                 attack_payload, t0):
-        passed = model_pass
-        details = model_reason
+        verdict = None
         live_ev = None
         if not self.simulate and attack_payload is not None:
             verdict, ev = _live_rejected(self.url, self.headers, attack_payload)
             live_ev = {"verdict": verdict, "status": ev.get("_status", 0)}
-            if verdict == "accepted":
-                passed = False
-                details = f"{model_reason}; LIVE verifier ACCEPTED the attack — control absent"
-            elif verdict == "rejected":
-                details = f"{model_reason}; live verifier rejected the attack"
-            else:
-                details = f"{model_reason}; live verifier unreachable — verdict from reference model"
+        # One shared policy for what a row says when live mode was requested
+        # and nothing live was observed: INCONCLUSIVE, with the reference-model
+        # verdict kept apart under `reference_verdict`, never in `passed`. No
+        # row here sends a legitimate variant, so no row claims a positive
+        # control, and a bare live rejection is recorded but not scored.
+        passed, details, reference = fold_live_verdict(
+            live_requested=not self.simulate, verdict=verdict,
+            model_pass=model_pass, model_reason=model_reason,
+            subject="live verifier",
+            accepted_detail=f"{model_reason}; LIVE verifier ACCEPTED the attack — control absent")
         self._record(JourneyTestResult(
             test_id=test_id, name=name, category=category, protocol=protocol,
             owasp_asi=owasp, stride=stride, severity=severity, passed=passed,
             details=details, ref=ref, normative=normative,
-            live_evidence=live_ev, elapsed_s=round(time.monotonic() - t0, 3)))
+            live_evidence=live_ev, reference_verdict=reference, elapsed_s=round(time.monotonic() - t0, 3)))
 
     # === UCP =============================================================
 
@@ -649,13 +666,10 @@ class UCPACPJourneyTests:
                     category="error", protocol="error", owasp_asi="ASI03",
                     stride="Tampering", severity=Severity.HIGH.value,
                     passed=False, details=str(e)))
-        total = len(self.results)
-        passed = sum(1 for r in self.results if r.passed)
-        ci = wilson_ci(passed, total)
         print(f"\n{'='*60}")
-        if total:
-            print(f"RESULTS: {passed}/{total} passed ({passed/total*100:.0f}%)")
-            print(f"WILSON 95% CI: [{ci[0]:.4f}, {ci[1]:.4f}]")
+        # PASS, FAIL and INCONCLUSIVE kept distinct; no rate over nothing.
+        for line in summary_lines(run_summary(self.results)):
+            print(line)
         print(f"{'='*60}\n")
         return self.results
 
@@ -690,18 +704,16 @@ def main() -> None:
     with json_stdout_only(args.json):
         results = suite.run_all()
 
-    total = len(results)
-    passed = sum(1 for r in results if r.passed)
-    ci = wilson_ci(passed, total)
     report = {
         "suite": "UCP/ACP Merchant-Journey Conformance",
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "mode": "simulate" if simulate else "live",
-        "summary": {
-            "total": total, "passed": passed, "failed": total - passed,
-            "pass_rate": round(passed / total, 4) if total else 0,
-            "wilson_95_ci": {"lower": ci[0], "upper": ci[1]},
-        },
+        # `mode` is what was REQUESTED. This is what was REACHED: a report
+        # could say `mode: live` over rows that observed nothing live.
+        "verdict_scope": live_run_scope(results, live_requested=not simulate,
+                                        target=suite.url),
+        # PASS, FAIL and INCONCLUSIVE kept distinct; no rate over nothing.
+        "summary": run_summary(results),
         "results": [asdict(r) for r in results],
     }
 

--- a/protocol_tests/x402_fireblocks_harness.py
+++ b/protocol_tests/x402_fireblocks_harness.py
@@ -94,8 +94,10 @@ import time
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 
-from protocol_tests._utils import Severity, http_post_json, json_stdout_only, wilson_ci
-from protocol_tests.http_helpers import payment_outcome
+from protocol_tests._utils import Severity, http_post_json, json_stdout_only
+from protocol_tests.http_helpers import (fold_live_verdict, is_inconclusive,
+                                         live_run_scope, payment_outcome,
+                                         run_summary, summary_lines)
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -408,6 +410,17 @@ class FireblocksTestResult:
     x402_ref: str = ""
     live_evidence: dict | None = None
     elapsed_s: float = 0.0
+    #: The reference model's verdict, kept apart from ``passed`` when live mode
+    #: was requested. ``passed`` is then about the target, or INCONCLUSIVE; this
+    #: is about the verifier in this file, and its ``scope`` says so.
+    reference_verdict: dict | None = None
+    #: INCONCLUSIVE as a field, not only as a prefix on ``details``.
+    #: ``asdict()`` serialises declared fields; it does not serialise English.
+    not_evaluated: bool = False
+
+    def __post_init__(self) -> None:
+        if is_inconclusive(self.details):
+            self.not_evaluated = True
 
 
 def _live_rejected(url: str, headers: dict, payload: dict) -> tuple[str, dict]:
@@ -461,7 +474,9 @@ class X402FireblocksTests:
         return body, env, now
 
     def _record(self, r: FireblocksTestResult) -> None:
-        print(f"  {'PASS ✅' if r.passed else 'FAIL ❌'}  {r.test_id}: {r.name}")
+        status = ("INCONCLUSIVE ➖" if r.not_evaluated
+                  else "PASS ✅" if r.passed else "FAIL ❌")
+        print(f"  {status}  {r.test_id}: {r.name}")
         self.results.append(r)
 
     def _finish(self, *, test_id, name, category, control, owasp, stride,
@@ -469,23 +484,25 @@ class X402FireblocksTests:
                 attack_payload: dict | None, t0: float):
         """Fold the deterministic reference-model verdict with optional live
         evidence into a single result."""
-        passed = model_pass
-        details = model_reason
+        verdict = None
         live_ev = None
         if not self.simulate and attack_payload is not None:
             verdict, ev = _live_rejected(self.url, self.headers, attack_payload)
             live_ev = {"verdict": verdict, "status": ev.get("_status", 0)}
-            if verdict == "accepted":
-                passed = False
-                details = f"{model_reason}; LIVE endpoint ACCEPTED the attack — control absent"
-            elif verdict == "rejected":
-                details = f"{model_reason}; live endpoint rejected the attack"
-            else:
-                details = f"{model_reason}; live target unreachable — verdict from reference model"
+        # One shared policy for what a row says when live mode was requested
+        # and nothing live was observed: INCONCLUSIVE, with the reference-model
+        # verdict kept apart under `reference_verdict`, never in `passed`. No
+        # row here sends a legitimate variant, so no row claims a positive
+        # control, and a bare live rejection is recorded but not scored.
+        passed, details, reference = fold_live_verdict(
+            live_requested=not self.simulate, verdict=verdict,
+            model_pass=model_pass, model_reason=model_reason,
+            subject="live endpoint",
+            accepted_detail=f"{model_reason}; LIVE endpoint ACCEPTED the attack — control absent")
         self._record(FireblocksTestResult(
             test_id=test_id, name=name, category=category, control=control,
             owasp_asi=owasp, stride=stride, severity=severity, passed=passed,
-            details=details, x402_ref=ref, live_evidence=live_ev,
+            details=details, x402_ref=ref, live_evidence=live_ev, reference_verdict=reference,
             elapsed_s=round(time.monotonic() - t0, 3),
         ))
 
@@ -1052,13 +1069,10 @@ class X402FireblocksTests:
                     category="error", control="error", owasp_asi="ASI03",
                     stride="Tampering", severity=Severity.HIGH.value,
                     passed=False, details=str(e)))
-        total = len(self.results)
-        passed = sum(1 for r in self.results if r.passed)
-        ci = wilson_ci(passed, total)
         print(f"\n{'='*60}")
-        if total:
-            print(f"RESULTS: {passed}/{total} passed ({passed/total*100:.0f}%)")
-            print(f"WILSON 95% CI: [{ci[0]:.4f}, {ci[1]:.4f}]")
+        # PASS, FAIL and INCONCLUSIVE kept distinct; no rate over nothing.
+        for line in summary_lines(run_summary(self.results)):
+            print(line)
         print(f"{'='*60}\n")
         return self.results
 
@@ -1093,18 +1107,16 @@ def main() -> None:
     with json_stdout_only(args.json):
         results = suite.run_all()
 
-    total = len(results)
-    passed = sum(1 for r in results if r.passed)
-    ci = wilson_ci(passed, total)
     report = {
         "suite": "x402 Fireblocks Security-Extension Conformance",
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "mode": "simulate" if simulate else "live",
-        "summary": {
-            "total": total, "passed": passed, "failed": total - passed,
-            "pass_rate": round(passed / total, 4) if total else 0,
-            "wilson_95_ci": {"lower": ci[0], "upper": ci[1]},
-        },
+        # `mode` is what was REQUESTED. This is what was REACHED: a report
+        # could say `mode: live` over rows that observed nothing live.
+        "verdict_scope": live_run_scope(results, live_requested=not simulate,
+                                        target=suite.url),
+        # PASS, FAIL and INCONCLUSIVE kept distinct; no rate over nothing.
+        "summary": run_summary(results),
         "results": [asdict(r) for r in results],
     }
 

--- a/scripts/dead_host_sweep.py
+++ b/scripts/dead_host_sweep.py
@@ -85,8 +85,9 @@ argument ("every subclass inherits it") and the guard suite verified it for four
 of them with synthetic fixtures. It is now measured for all of them.
 
 Discovery is by capability: a non-abstract class defined in the module with a
-callable `run_all` or `run_tests`. `harness_base` legitimately has neither; that
-row now means what it says.
+callable `run_all` or `run_tests`. The MODULE set is the CLI registry
+(`protocol_tests.cli.HARNESSES`) minus `NOT_APPLICABLE`, and a registered
+harness that produces no row makes the sweep raise -- see `registry_coverage`.
 
     python3 scripts/dead_host_sweep.py            # table, ordered worst first
     python3 scripts/dead_host_sweep.py --json     # machine-readable
@@ -110,14 +111,108 @@ sys.path.insert(0, str(REPO_ROOT))
 CLOSED_PORT = "http://127.0.0.1:9"
 
 
+#: Registered harnesses this sweep deliberately does not run, each with the
+#: reason. A registration is either exercised or on this list; anything else
+#: makes `sweep()` raise rather than shrink. A reason has to be about the
+#: harness -- what it would need before pointing it at a target means anything
+#: -- and never about the sweep's convenience.
+#:
+#: Until 2026-09-07 the candidate set was a source-text match: a module was a
+#: candidate if it contained the literal text `def _record` AND
+#: `response_received`. That found 36 of 46 registered harnesses and said
+#: nothing about the other ten. Among the ten were all five payment
+#: conformance modules (ap2, x402_fireblocks, ucp_acp, card_token,
+#: settlement_finality), which against a closed port reported 17/17, 17/17,
+#: 12/12, 12/12 and 8/8 -- the reference model's PASS, under `mode: live`,
+#: with a Wilson interval. Nothing caught it because nothing ran them. The
+#: finder was a naming convention again, one abstraction down from the one
+#: this file's docstring already describes replacing.
+NOT_APPLICABLE = {
+    "mcp-supplychain": (
+        "no --url: a pre-flight over a local command, config file and project "
+        "root; there is no network target to point at nothing"),
+    "receipt-claim": (
+        "no --url: a claim-level verifier run over local fixtures in --simulate "
+        "only; no target is contacted in any mode"),
+    "agent-data-injection": (
+        "no --url: drives a model adapter named by HARNESS_ADI_MODEL rather than "
+        "an HTTP target; a dead-host reading needs a model-specific adapter"),
+    "community": (
+        "YAML-driven runner with no suite class of its own; it needs a pattern "
+        "corpus and a per-protocol adapter before a target means anything"),
+}
+
+#: Floors on the denominator and the exercised set, so a registry that shrinks
+#: or a derivation that stops matching fails here rather than reading as clean.
+REGISTRY_FLOOR = 46
+EXERCISED_FLOOR = 42
+
+
+class SweepCoverageError(RuntimeError):
+    """A registered harness was neither exercised nor explicitly excused."""
+
+
+def registry_coverage() -> dict:
+    """The registry, split into what this sweep exercises and what it excuses.
+
+    Derived from `protocol_tests.cli.HARNESSES` -- the one list a harness has
+    to be on to be runnable from the CLI -- rather than from a property of the
+    module's source. Raises rather than returning a smaller set when the
+    floors are not met or an excuse names something not in the registry.
+    """
+    from protocol_tests.cli import HARNESSES
+
+    unknown = sorted(set(NOT_APPLICABLE) - set(HARNESSES))
+    if unknown:
+        raise SweepCoverageError(
+            f"NOT_APPLICABLE names harnesses that are not registered: {unknown}. "
+            f"An excuse for something that does not exist is a stale entry.")
+    if len(HARNESSES) < REGISTRY_FLOOR:
+        raise SweepCoverageError(
+            f"{len(HARNESSES)} registered harnesses, floor is {REGISTRY_FLOOR}; "
+            f"the registry shrank or the import found the wrong module")
+    exercised = {name: info["module"].rsplit(".", 1)[1]
+                 for name, info in HARNESSES.items() if name not in NOT_APPLICABLE}
+    if len(exercised) < EXERCISED_FLOOR:
+        raise SweepCoverageError(
+            f"{len(exercised)} harnesses would be exercised, floor is "
+            f"{EXERCISED_FLOOR}; NOT_APPLICABLE grew or the registry shrank")
+    return {
+        "registry": sorted(HARNESSES),
+        "exercised": exercised,
+        "not_applicable": dict(NOT_APPLICABLE),
+    }
+
+
 def _candidate_modules() -> list[str]:
-    """Same rule the guard suite uses, so the two cannot drift apart."""
-    out = []
-    for path in sorted((REPO_ROOT / "protocol_tests").glob("*.py")):
-        src = path.read_text(encoding="utf-8")
-        if "def _record" in src and "response_received" in src:
-            out.append(path.stem)
+    """Module stems to run: every registered harness not explicitly excused."""
+    out: list[str] = []
+    for stem in registry_coverage()["exercised"].values():
+        if stem not in out:
+            out.append(stem)
     return out
+
+
+def _assert_every_candidate_exercised(candidates, rows) -> None:
+    """Raise if any candidate produced no `ran` / `ran-no-verdicts` row.
+
+    A module that will not import, has no suite class, or cannot be constructed
+    used to become a row and a smaller denominator. It is now a failure of the
+    sweep, because a registered harness the sweep says nothing about is exactly
+    the gap the five payment modules sat in.
+    """
+    exercised = {r["module"].split("::")[0] for r in rows
+                 if r["status"] in ("ran", "ran-no-verdicts")}
+    missing = {}
+    for name in candidates:
+        if name in exercised:
+            continue
+        missing[name] = sorted({r["status"] for r in rows
+                                if r["module"].split("::")[0] == name}) or ["no row"]
+    if missing:
+        raise SweepCoverageError(
+            f"registered harnesses neither exercised nor excused: {missing}. "
+            f"Fix the module, or add a reasoned NOT_APPLICABLE entry.")
 
 
 def _suites(mod_name: str):
@@ -203,7 +298,8 @@ def sweep(target: str = CLOSED_PORT) -> list[dict]:
     the opposite pole: a server that accepts every request.
     """
     rows = []
-    for name in _candidate_modules():
+    candidates = _candidate_modules()
+    for name in candidates:
         _, suites = _suites(name)
         if not suites:
             rows.append({"module": name, "status": "no-suite-class"})
@@ -242,6 +338,16 @@ def sweep(target: str = CLOSED_PORT) -> list[dict]:
                 "errors": len(errored),
                 "passing_ids": passed,
             })
+    # Fail, not shrink: a registered harness the sweep says nothing about is
+    # the gap that hid R3-01, and a table is not allowed to omit it quietly.
+    _assert_every_candidate_exercised(candidates, rows)
+    # The excused registrations appear as rows too, so the table shows the
+    # whole registry and a reader can see the reason beside each gap.
+    from protocol_tests.cli import HARNESSES
+    for reg_name, reason in NOT_APPLICABLE.items():
+        rows.append({"module": HARNESSES[reg_name]["module"].rsplit(".", 1)[1],
+                     "registry_name": reg_name,
+                     "status": f"not-applicable: {reason}"})
     # worst first: most passes against nothing
     rows.sort(key=lambda r: (-(r.get("passed") or 0), r["module"]))
     return rows
@@ -277,7 +383,9 @@ def main() -> int:
                   f"{r['errors']:>4}  {ids}")
         ran = [r for r in rows if r["status"] == "ran"]
         silent = [r for r in rows if r["status"] == "ran-no-verdicts"]
-        skipped = [r for r in rows if r["status"] not in ("ran", "ran-no-verdicts")]
+        excused = [r for r in rows if r["status"].startswith("not-applicable")]
+        skipped = [r for r in rows if r["status"] not in ("ran", "ran-no-verdicts")
+                   and r not in excused]
         dirty = [r for r in ran if r["passed"]]
         print("-" * 96)
         print(f"{len(ran)} suites produced verdicts, {len(dirty)} still pass "
@@ -290,6 +398,10 @@ def main() -> int:
         if skipped:
             print(f"{len(skipped)} could not be run "
                   f"({', '.join(r['module'] for r in skipped)}).")
+        cov = registry_coverage()
+        print(f"Registry: {len(cov['registry'])} harnesses; "
+              f"{len(cov['exercised'])} exercised, {len(excused)} excused with a "
+              f"stated reason ({', '.join(r['module'] for r in excused)}).")
     return 0
 
 

--- a/testing/test_dead_host_state.py
+++ b/testing/test_dead_host_state.py
@@ -45,7 +45,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT))
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
-from dead_host_sweep import sweep
+from dead_host_sweep import NOT_APPLICABLE, sweep
 
 #: Measured 2026-08-29. Module -> number of verdicts that still pass against a
 #: target that was never there. May shrink. Must never grow, and a module absent
@@ -84,6 +84,15 @@ KNOWN_PASSING = {
     # sweep. Its verdicts are now guarded by the request log as well as by
     # _aggregate_evidence's marker, and testing/test_a2a_unserviced_state.py
     # pins all thirteen IDs rather than a shrinking open set.
+
+    # 2026-09-07, R3-01/R3-02. Seven modules entered this sweep for the first
+    # time when discovery moved from a source-text rule to the CLI registry:
+    # ap2_harness, x402_fireblocks_harness, ucp_acp_harness, card_token_harness,
+    # settlement_finality_harness, delegation_chain_harness, hitl_harness. The
+    # five payment modules would have read 17, 17, 12, 12 and 8 here -- the
+    # reference model's PASS under `mode: live` -- and were repaired in the
+    # same change (http_helpers.fold_live_verdict). All seven measure 0 and are
+    # absent from this map for that reason, not because they were never run.
 }
 
 
@@ -92,9 +101,19 @@ KNOWN_PASSING = {
 #: row is here so the abort stays visible instead of reading as a clean 0/0.
 SILENT_BY_DESIGN = {"mcp_harness"}
 
-#: No runnable suite at all. harness_base is the shared ABC and defines no tests
-#: of its own, so this is a correct row rather than a gap.
-UNRUNNABLE = {"harness_base"}
+#: No runnable suite at all. Empty since discovery moved to the CLI registry:
+#: harness_base is not a registered harness and no longer produces a row, and
+#: a registered harness the sweep cannot construct now makes `sweep()` raise
+#: rather than appear here. The set stays so the assertion keeps its shape.
+UNRUNNABLE: set[str] = set()
+
+#: Registered harnesses the sweep excuses by name, each with a reason in
+#: `dead_host_sweep.NOT_APPLICABLE`. They appear as rows so the table shows
+#: the whole registry; the sweep's own test pins that the union is the registry.
+EXCUSED_STEMS = {
+    "mcp_supplychain", "receipt_claim_harness", "agent_data_injection",
+    "community_runner",
+}
 
 
 class TestDeadHostState(unittest.TestCase):
@@ -115,10 +134,21 @@ class TestDeadHostState(unittest.TestCase):
         The floor is asserted rather than restated in prose, so it cannot go
         stale the way the sentence it replaced did.
         """
+        # 63 while discovery was a source-text rule; 68 measured 2026-09-07 once
+        # it became the CLI registry minus the four excused. The slack is for an
+        # adapter that legitimately moves to ran-no-verdicts, not for a module
+        # dropping out -- registry_coverage() raises for that.
         self.assertGreaterEqual(
-            len(self.ran), 60,
+            len(self.ran), 66,
             f"only {len(self.ran)} suites produced verdicts; the sweep is probably "
             f"broken, or its discovery has narrowed back to a naming convention")
+
+    def test_the_excused_rows_are_exactly_the_declared_ones(self):
+        """An excuse is visible in the table, and only the declared ones are."""
+        excused = {r["module"] for r in self.rows
+                   if r["status"].startswith("not-applicable")}
+        self.assertEqual(excused, EXCUSED_STEMS)
+        self.assertEqual(len(excused), len(NOT_APPLICABLE))
 
     def test_a_suite_that_produced_nothing_is_declared(self):
         """Ran and emitted no verdicts is not the same as ran and found nothing.
@@ -136,7 +166,8 @@ class TestDeadHostState(unittest.TestCase):
 
     def test_nothing_is_unrunnable_except_what_is_declared(self):
         cannot_run = {r["module"]: r["status"] for r in self.rows
-                      if r["status"] not in ("ran", "ran-no-verdicts")}
+                      if r["status"] not in ("ran", "ran-no-verdicts")
+                      and not r["status"].startswith("not-applicable")}
         self.assertEqual(
             set(cannot_run), UNRUNNABLE,
             f"declared {sorted(UNRUNNABLE)}, measured {cannot_run}. A suite the "

--- a/testing/test_evidence_integrity_registers.py
+++ b/testing/test_evidence_integrity_registers.py
@@ -292,9 +292,14 @@ class TestThePermissiveReadListIsSplit(unittest.TestCase):
         # x402 verdicts stopped passing against an allow-all host because their
         # absence_as_success condition was repaired. A numerator alone would have
         # read as "no change".
+        # 2026-09-07: denominator 37 -> 41, numerator stays 0. The POPULATION
+        # grew because hitl_harness entered the permissive sweep for the first
+        # time (R3-02) and HITL-005..008 pass against an allow-all host. They
+        # are classified in ABSENCE_AS_SUCCESS -- read, not repaired -- so the
+        # read list itself is still empty.
         num, den, _ = _permissive_read_list()
         self.assertEqual(
-            (num, den), (0, 37),
+            (num, den), (0, 41),
             f"the permissive read list changed: now {num} of {den}. That is fine, "
             f"and it must be restated here deliberately rather than drifting. "
             f"Report BOTH numbers -- a numerator alone hides whether the list "

--- a/testing/test_live_unreached_is_inconclusive.py
+++ b/testing/test_live_unreached_is_inconclusive.py
@@ -1,0 +1,259 @@
+"""A live target that was never reached must not inherit the reference model's PASS.
+
+## The defect (R3-01, third external review, 2026-09-07)
+
+Five payment conformance modules -- ap2, x402_fireblocks, ucp_acp, card_token
+and settlement_finality -- fold a reference-model verdict with a live probe of
+the target. Each `_finish` started from `passed = model_pass` and, when the
+live probe came back `unreachable`, rewrote only `details`:
+
+    else:
+        details = f"{model_reason}; live verifier unreachable — verdict from reference model"
+
+So against a closed port, the published 4.21.0 reported 17/17, 17/17, 12/12,
+12/12 and 8/8 passed, `mode: live`, `pass_rate: 1.0`, a Wilson interval, and
+`migrate_legacy_report` turned that into a 17-pass attestation. The reference
+model had been asked about itself and the answer was filed under the target.
+
+## What this pins
+
+Run through the CLI -- the path an operator takes -- against a port nobody is
+listening on, every row of every one of the five is INCONCLUSIVE: `passed`
+False, `not_evaluated` True, `details` prefixed, the reference-model verdict
+kept SEPARATELY under `reference_verdict` with its own scope statement. The
+summary services nothing and computes no rate; the report says live was
+requested and not reached; migration yields `inconclusive: N, passed: 0`.
+
+The shared fold (`http_helpers.fold_live_verdict`) is unit-tested on its own
+so the policy has one place to be wrong.
+
+## What this does not establish
+
+That a live `rejected` from a real verifier is graded correctly beyond what
+the fold says: none of the five rows sends a legitimate variant, so none has a
+positive control, and a live rejection is recorded but not scored as a pass.
+A module that adds a positive control passes `positive_control=True` and the
+same fold returns a PASS. That is a decision for the module, not for this file.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from protocol_tests.attestation import migrate_legacy_report  # noqa: E402
+from protocol_tests.http_helpers import (  # noqa: E402
+    INCONCLUSIVE_PREFIX,
+    REFERENCE_VERDICT_SCOPE,
+    fold_live_verdict,
+    is_inconclusive,
+    live_run_scope,
+    run_summary,
+)
+
+#: Nothing listens here. Same target the dead-host sweep uses.
+CLOSED_PORT = "http://127.0.0.1:9"
+
+#: Registry name -> the row count its own description advertises. A floor, so
+#: a suite that emits nothing cannot satisfy "every row is INCONCLUSIVE".
+AFFECTED = {
+    "ap2": 17,
+    "x402-fireblocks": 17,
+    "ucp-acp": 12,
+    "card-token": 12,
+    "settlement-finality": 8,
+}
+
+
+def _run_cli(name: str, tmp: Path) -> dict:
+    report = tmp / f"{name}.json"
+    env = dict(os.environ, AGENT_SECURITY_TELEMETRY="off")
+    subprocess.run(
+        [sys.executable, "-m", "protocol_tests.cli", "test", name,
+         "--url", CLOSED_PORT, "--report", str(report)],
+        cwd=REPO_ROOT, env=env, capture_output=True, text=True, timeout=180,
+        check=False,
+    )
+    return json.loads(report.read_text(encoding="utf-8"))
+
+
+class TestTheFiveAgainstAClosedPort(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp = Path(tempfile.mkdtemp(prefix="r3-01-"))
+        cls.reports = {name: _run_cli(name, cls.tmp) for name in AFFECTED}
+
+    def test_every_suite_produced_its_advertised_rows(self):
+        for name, floor in AFFECTED.items():
+            with self.subTest(harness=name):
+                self.assertGreaterEqual(
+                    len(self.reports[name]["results"]), floor,
+                    f"{name} emitted fewer rows than it advertises; an empty "
+                    f"suite would satisfy every assertion below vacuously")
+
+    def test_every_row_is_inconclusive_with_the_structural_field(self):
+        for name, report in self.reports.items():
+            for row in report["results"]:
+                with self.subTest(harness=name, test_id=row.get("test_id")):
+                    self.assertIs(row["passed"], False)
+                    self.assertIs(row["not_evaluated"], True)
+                    self.assertTrue(row["details"].startswith(INCONCLUSIVE_PREFIX))
+                    self.assertTrue(is_inconclusive(row))
+
+    def test_the_reference_verdict_is_preserved_separately_and_scoped(self):
+        for name, report in self.reports.items():
+            for row in report["results"]:
+                with self.subTest(harness=name, test_id=row.get("test_id")):
+                    ref = row.get("reference_verdict")
+                    self.assertIsInstance(ref, dict, "reference_verdict missing")
+                    self.assertIsInstance(ref["passed"], bool)
+                    self.assertIsInstance(ref["reason"], str)
+                    self.assertTrue(ref["reason"])
+                    self.assertEqual(ref["scope"], REFERENCE_VERDICT_SCOPE)
+                    # The whole point: the reference model's PASS never lands
+                    # in the row's own `passed`.
+                    self.assertNotEqual(
+                        (row["passed"], ref["passed"]), (True, True),
+                        "reference PASS leaked into the row's passed")
+
+    def test_no_row_observed_anything_live(self):
+        for name, report in self.reports.items():
+            for row in report["results"]:
+                with self.subTest(harness=name, test_id=row.get("test_id")):
+                    ev = row.get("live_evidence")
+                    if ev is not None:
+                        self.assertEqual(ev["verdict"], "unreachable")
+
+    def test_the_summary_services_nothing_and_computes_no_rate(self):
+        for name, report in self.reports.items():
+            with self.subTest(harness=name):
+                s = report["summary"]
+                self.assertEqual(s["serviced"], 0)
+                self.assertEqual(s["passed"], 0)
+                self.assertEqual(s["failed"], 0)
+                self.assertEqual(s["inconclusive"], s["total"])
+                self.assertIsNone(s["pass_rate"])
+                self.assertIsNone(s["wilson_95_ci"])
+                self.assertEqual(s["status"], "inconclusive")
+
+    def test_the_report_says_live_was_requested_and_not_reached(self):
+        for name, report in self.reports.items():
+            with self.subTest(harness=name):
+                self.assertEqual(report["mode"], "live")
+                scope = report["verdict_scope"]
+                self.assertIs(scope["live_requested"], True)
+                self.assertEqual(scope["target"], CLOSED_PORT)
+                self.assertEqual(scope["rows_with_live_observation"], 0)
+                self.assertEqual(scope["rows_scored"], 0)
+                self.assertIn("requested", scope["statement"])
+                self.assertIn("NOT reached", scope["statement"])
+
+    def test_migration_yields_inconclusive_n_and_passed_zero(self):
+        for name, report in self.reports.items():
+            with self.subTest(harness=name):
+                migrated = migrate_legacy_report(report)["summary"]
+                n = len(report["results"])
+                self.assertEqual(migrated["inconclusive"], n)
+                self.assertEqual(migrated["passed"], 0)
+                self.assertEqual(migrated["failed"], 0)
+
+
+class TestTheFold(unittest.TestCase):
+    """`fold_live_verdict` is the one policy; each branch is pinned."""
+
+    def test_simulate_is_unchanged_and_carries_no_reference_verdict(self):
+        passed, details, ref = fold_live_verdict(
+            live_requested=False, verdict="unreachable",
+            model_pass=True, model_reason="the reference rejected it")
+        self.assertIs(passed, True)
+        self.assertEqual(details, "the reference rejected it")
+        self.assertIsNone(ref)
+
+    def test_unreachable_is_inconclusive_and_keeps_the_reference_apart(self):
+        passed, details, ref = fold_live_verdict(
+            live_requested=True, verdict="unreachable",
+            model_pass=True, model_reason="r")
+        self.assertIs(passed, False)
+        self.assertTrue(details.startswith(INCONCLUSIVE_PREFIX))
+        self.assertIn("not observed", details)
+        self.assertEqual(ref, {"passed": True, "reason": "r",
+                               "scope": REFERENCE_VERDICT_SCOPE})
+
+    def test_a_row_with_no_live_probe_is_inconclusive_in_live_mode(self):
+        passed, details, ref = fold_live_verdict(
+            live_requested=True, verdict=None, model_pass=True, model_reason="r")
+        self.assertIs(passed, False)
+        self.assertTrue(details.startswith(INCONCLUSIVE_PREFIX))
+        self.assertIn("no live probe", details)
+        self.assertEqual(ref["passed"], True)
+
+    def test_a_reference_fail_stays_a_fail_in_the_reference_field_only(self):
+        passed, details, ref = fold_live_verdict(
+            live_requested=True, verdict="unreachable",
+            model_pass=False, model_reason="reference model accepted the attack")
+        self.assertIs(passed, False)
+        self.assertTrue(details.startswith(INCONCLUSIVE_PREFIX))
+        self.assertIs(ref["passed"], False)
+
+    def test_accepted_is_a_fail(self):
+        passed, details, ref = fold_live_verdict(
+            live_requested=True, verdict="accepted",
+            model_pass=True, model_reason="r", subject="live endpoint")
+        self.assertIs(passed, False)
+        self.assertFalse(is_inconclusive(details))
+        self.assertIn("ACCEPTED", details)
+        self.assertEqual(ref["passed"], True)
+
+    def test_rejected_without_a_positive_control_is_not_a_pass(self):
+        passed, details, ref = fold_live_verdict(
+            live_requested=True, verdict="rejected",
+            model_pass=True, model_reason="r")
+        self.assertIs(passed, False)
+        self.assertTrue(details.startswith(INCONCLUSIVE_PREFIX))
+        self.assertIn("no positive control", details)
+        self.assertEqual(ref["passed"], True)
+
+    def test_rejected_with_a_positive_control_is_the_reference_verdict(self):
+        passed, details, ref = fold_live_verdict(
+            live_requested=True, verdict="rejected",
+            model_pass=True, model_reason="r", positive_control=True)
+        self.assertIs(passed, True)
+        self.assertFalse(is_inconclusive(details))
+        self.assertEqual(ref["passed"], True)
+
+    def test_run_summary_over_folded_unreachable_rows_services_nothing(self):
+        class R:
+            def __init__(self, details):
+                self.passed, self.details, _ = fold_live_verdict(
+                    live_requested=True, verdict="unreachable",
+                    model_pass=True, model_reason=details)
+                self.not_evaluated = is_inconclusive(self.details)
+        s = run_summary([R("a"), R("b"), R("c")])
+        self.assertEqual((s["serviced"], s["passed"], s["inconclusive"]), (0, 0, 3))
+        self.assertIsNone(s["pass_rate"])
+
+    def test_scope_statement_distinguishes_requested_from_reached(self):
+        class R:
+            live_evidence = {"verdict": "unreachable", "status": 0}
+            details = INCONCLUSIVE_PREFIX + "x"
+            not_evaluated = True
+            passed = False
+        scope = live_run_scope([R(), R()], live_requested=True, target="http://t")
+        self.assertIs(scope["live_requested"], True)
+        self.assertEqual(scope["rows_with_live_observation"], 0)
+        self.assertIn("NOT reached", scope["statement"])
+        sim = live_run_scope([R()], live_requested=False, target=None)
+        self.assertIs(sim["live_requested"], False)
+        self.assertIn("reference-model self-test", sim["statement"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/testing/test_permissive_host_state.py
+++ b/testing/test_permissive_host_state.py
@@ -728,6 +728,17 @@ POSITIVE_EVIDENCE_OR_LOCAL = {
 #: envelope separated from prose, and A2A's `_record` is a declared
 #: NARROW_LOCAL_RULE that the shared serviced guard must not be applied to.
 ABSENCE_AS_SUCCESS = {
+    # Measured 2026-09-07, the day hitl_harness first entered the sweep (R3-02
+    # moved discovery from a source-text rule to the CLI registry). Read, not
+    # repaired: all four share one verdict in `_t15_probe`, recorded verbatim.
+    # The refusal half is a real observation; the `not lure` half is the
+    # absence of a marker, so an allow-all host that complies without emitting
+    # a lure pattern passes all four. Needs a positive control establishing the
+    # agent addressed the principal at all before "no lure" can mean anything.
+    "HITL-005": "passed = refused or not lure; lure from _contains_actionable_lure",
+    "HITL-006": "passed = refused or not lure; lure from _contains_actionable_lure",
+    "HITL-007": "passed = refused or not lure; lure from _contains_actionable_lure",
+    "HITL-008": "passed = refused or not lure; lure from _contains_actionable_lure",
 }
 
 #: Measured 2026-08-29. Suite -> verdicts that pass against a target that granted every
@@ -817,6 +828,14 @@ PASSING_AGAINST_YES = {
     # It stated it could not test and passed anyway. WM-002 remains and is
     # declared -- it requires `has_wm`, so absence fails it.
     "watermark_harness": 1,
+    # Measured 2026-09-07, the day hitl_harness first entered the sweep (R3-02:
+    # discovery moved from a source-text rule to the CLI registry). Observed,
+    # not repaired: HITL-005..008 share one verdict, `passed = refused or not
+    # lure`, so a target that complies without emitting a lure marker scores
+    # as a pass -- the second cause above, and the `not <marker>` shape the
+    # jailbreak repair removed elsewhere. Pinned as a measurement; a reading
+    # of the four is owed before any repair.
+    "hitl_harness": 4,
 }
 
 
@@ -844,8 +863,9 @@ class TestPermissiveHostState(unittest.TestCase):
                     f"fixture is probably not answering.")
 
     def test_the_sweep_actually_ran(self):
+        # 69 measured 2026-09-07 with discovery derived from the CLI registry.
         self.assertGreaterEqual(
-            len(self.ran), 60,
+            len(self.ran), 66,
             f"only {len(self.ran)} suites produced verdicts against the permissive "
             f"target; discovery or the fixture is broken")
 

--- a/testing/test_refusing_host_state.py
+++ b/testing/test_refusing_host_state.py
@@ -100,6 +100,22 @@ RECOGNISES_NO_REFUSAL = {
     # INCONCLUSIVE. Before the repair it passed 5 of 6 here, vacuously.
     "tool_search_harness",
     "watermark_harness",
+    # 2026-09-07: seven modules entered the sweep for the first time (R3-02).
+    # The five payment modules -- ap2, x402_fireblocks, ucp_acp, card_token,
+    # settlement_finality -- read a 403 as `rejected` and, having no positive
+    # control on any row, record it under live_evidence without scoring it
+    # (R3-01, http_helpers.fold_live_verdict): a verifier that rejects
+    # everything produces the same observation. They will leave this list when
+    # a row sends a legitimate variant. delegation_chain_harness grades a live
+    # 403 as `_LIVE_UNDECIDED` by design. hitl_harness measured 0 and has NOT
+    # been read.
+    "ap2_harness",
+    "card_token_harness",
+    "delegation_chain_harness",
+    "hitl_harness",
+    "settlement_finality_harness",
+    "ucp_acp_harness",
+    "x402_fireblocks_harness",
 }
 
 
@@ -110,8 +126,9 @@ class TestRefusingHostState(unittest.TestCase):
         cls.ran = [r for r in cls.rows if r["status"] == "ran" and r["total"]]
 
     def test_the_sweep_actually_ran(self):
+        # 68 measured 2026-09-07 with discovery derived from the CLI registry.
         self.assertGreaterEqual(
-            len(self.ran), 55,
+            len(self.ran), 66,
             f"only {len(self.ran)} suites produced verdicts against the refusing "
             f"target; discovery or the fixture is broken")
 

--- a/testing/test_sweep_covers_the_registry.py
+++ b/testing/test_sweep_covers_the_registry.py
@@ -1,0 +1,146 @@
+"""The three host sweeps run every registered harness, or say why not.
+
+## The defect (R3-02, third external review, 2026-09-07)
+
+`scripts/dead_host_sweep.py::_candidate_modules` -- shared by the permissive
+and refusing sweeps -- chose modules by source text: a module was a candidate
+if it contained the literal `def _record` and the literal `response_received`.
+That matched 36 of the 46 registered harnesses (35 registered plus
+`harness_base`, which is not a harness) and reported nothing about the other
+ten. The ten included all five payment conformance modules, so R3-01 -- a
+100% pass rate against a closed port -- sat in a gap the sweep could not see.
+
+## What this pins
+
+The candidate set is derived from `protocol_tests.cli.HARNESSES`, the one list
+a harness must be on to be runnable from the CLI. Every registration is either
+exercised or carries a reasoned `NOT_APPLICABLE` entry; the two are disjoint
+and their union is the registry. Both the registry denominator and the
+exercised set are floored, and a candidate that produces no row makes the
+sweep raise rather than shrink.
+
+The end-to-end failure path is exercised against `harness_base` -- a real
+module with no suite class -- by narrowing the candidate list to it, so the
+raise is measured rather than argued.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import dead_host_sweep  # noqa: E402
+from dead_host_sweep import (  # noqa: E402
+    EXERCISED_FLOOR,
+    NOT_APPLICABLE,
+    REGISTRY_FLOOR,
+    SweepCoverageError,
+    _assert_every_candidate_exercised,
+    _candidate_modules,
+    registry_coverage,
+    sweep,
+)
+from protocol_tests.cli import HARNESSES  # noqa: E402
+
+#: The ten the text rule omitted. Every one must now be either exercised or
+#: excused by name, so the gap that hid R3-01 cannot reopen under a new name.
+PREVIOUSLY_OMITTED = {
+    "ap2", "x402-fireblocks", "ucp-acp", "card-token", "settlement-finality",
+    "delegation-chain", "hitl", "agent-data-injection", "receipt-claim",
+    "mcp-supplychain", "community",
+}
+
+
+class TestTheCandidateSetIsTheRegistry(unittest.TestCase):
+    def test_exercised_plus_excused_is_exactly_the_registry(self):
+        cov = registry_coverage()
+        exercised = set(cov["exercised"])
+        excused = set(cov["not_applicable"])
+        self.assertEqual(exercised & excused, set(), "a harness is both run and excused")
+        self.assertEqual(exercised | excused, set(HARNESSES),
+                         "a registered harness is neither exercised nor excused")
+
+    def test_the_floors_hold_and_are_not_vacuous(self):
+        cov = registry_coverage()
+        self.assertGreaterEqual(REGISTRY_FLOOR, 46)
+        self.assertGreaterEqual(len(cov["registry"]), REGISTRY_FLOOR)
+        self.assertGreaterEqual(len(cov["exercised"]), EXERCISED_FLOOR)
+        self.assertEqual(EXERCISED_FLOOR, REGISTRY_FLOOR - len(NOT_APPLICABLE),
+                         "the exercised floor must move with the excuse list, "
+                         "or an excuse can be added without the floor noticing")
+
+    def test_every_excuse_names_a_registered_harness_with_a_reason(self):
+        for name, reason in NOT_APPLICABLE.items():
+            with self.subTest(harness=name):
+                self.assertIn(name, HARNESSES)
+                self.assertIsInstance(reason, str)
+                self.assertGreaterEqual(
+                    len(reason), 40,
+                    "an excuse is a sentence about what the harness needs, not a tag")
+
+    def test_the_previously_omitted_ten_are_now_accounted_for_by_name(self):
+        cov = registry_coverage()
+        accounted = set(cov["exercised"]) | set(cov["not_applicable"])
+        self.assertEqual(PREVIOUSLY_OMITTED - accounted, set())
+        # And the five R3-01 modules are RUN, not excused.
+        for name in ("ap2", "x402-fireblocks", "ucp-acp", "card-token",
+                     "settlement-finality"):
+            self.assertIn(name, cov["exercised"], f"{name} must be exercised")
+
+    def test_candidate_modules_are_the_exercised_stems_and_nothing_else(self):
+        cov = registry_coverage()
+        self.assertEqual(set(_candidate_modules()), set(cov["exercised"].values()))
+        self.assertNotIn("harness_base", _candidate_modules(),
+                         "harness_base is not a harness; it came from the text rule")
+
+    def test_an_excuse_for_an_unregistered_name_is_refused(self):
+        with mock.patch.dict(dead_host_sweep.NOT_APPLICABLE,
+                             {"no-such-harness": "x" * 40}):
+            with self.assertRaises(SweepCoverageError):
+                registry_coverage()
+
+    def test_a_shrunken_registry_is_refused(self):
+        smaller = dict(list(HARNESSES.items())[:REGISTRY_FLOOR - 1])
+        with mock.patch("protocol_tests.cli.HARNESSES", smaller):
+            with self.assertRaises(SweepCoverageError):
+                registry_coverage()
+
+
+class TestTheSweepFailsRatherThanShrinks(unittest.TestCase):
+    def test_a_candidate_with_no_row_raises(self):
+        with self.assertRaises(SweepCoverageError) as ctx:
+            _assert_every_candidate_exercised(
+                ["a_harness", "b_harness"],
+                [{"module": "a_harness", "status": "ran", "total": 1, "passed": 0,
+                  "errors": 0, "passing_ids": []}])
+        self.assertIn("b_harness", str(ctx.exception))
+
+    def test_a_candidate_that_only_errored_raises(self):
+        with self.assertRaises(SweepCoverageError):
+            _assert_every_candidate_exercised(
+                ["a_harness"],
+                [{"module": "a_harness", "status": "TypeError: boom"}])
+
+    def test_an_adapter_family_counts_by_its_module(self):
+        _assert_every_candidate_exercised(
+            ["fam"],
+            [{"module": "fam::One", "status": "ran"},
+             {"module": "fam::Two", "status": "ran-no-verdicts"}])
+
+    def test_end_to_end_the_sweep_raises_on_a_module_with_no_suite(self):
+        """Measured, not argued: harness_base really has no suite class."""
+        with mock.patch.object(dead_host_sweep, "_candidate_modules",
+                               return_value=["harness_base"]):
+            with self.assertRaises(SweepCoverageError) as ctx:
+                sweep()
+        self.assertIn("harness_base", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
From the third external review, R3-01 (Critical). Five payment harnesses (ap2, x402-fireblocks, ucp-acp, card-token, settlement-finality) set `passed = model_pass` when the live target was unreachable, so the published 4.21.0 wheel reported 17/17 PASS against a host that does not exist.

Fix: one shared `http_helpers.fold_live_verdict()` — a live result that is unreachable or a transport error folds to INCONCLUSIVE (`not_evaluated: True`), never to the reference model's verdict; the reference verdict is retained as `reference_verdict` for calibration, labelled as such. A live *rejection* is also INCONCLUSIVE, not PASS; five modules added to `RECOGNISES_NO_REFUSAL`.

R3-02 (sweeps discover 36/46 by text): the dead-host and serviced sweeps are now registry-driven from `asi_inventory`, with an explicit `NOT_APPLICABLE` list (4) for modules that have no live surface. 42 + 4 = 46.

Independently reproduced on this branch in a clean worktree: all five modules vs `http://127.0.0.1:9` → passed:true 0, not_evaluated N, serviced 0, pass_rate None, reference_verdict carried on every row; sweep candidates 42, NOT_APPLICABLE 4.

Remaining from A's notes, not in this PR: text-rule discovery still lives in `testing/test_serviced_guard.py:143` and `scripts/audit_verdict_taint.py:244`; HITL-005..008 `passed = refused or not lure` is absence-as-success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)