### PR TITLE
R3-03/04: partial requirement evidence is PARTIAL, registry server never serves without its schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,52 @@ at 0.
 Tests: `testing/test_live_unreached_is_inconclusive.py` runs the five through
 the CLI against a closed port; `testing/test_sweep_covers_the_registry.py`
 pins the candidate set to the registry minus the excuse list, with floors.
+### Fixed — a mixed requirement aggregated to PASS, and the installed registry checked nothing (third external review, R3-03 and R3-04)
+
+**R3-03.** A requirement with every mapped test present, one PASS and four
+INCONCLUSIVE, published as PASS. `scripts/evidence_pack.py` ruled
+`FAIL if any failed; INCONCLUSIVE only if nothing passed; PARTIAL only if a
+mapped test was absent; else PASS` -- so presence was enough, and one
+established member carried four that established nothing. `scripts/html_report.py`
+had no PARTIAL state at all: two of five mapped tests present and green
+rendered PASS. Four private rules across two files, for AIUC-1 and OWASP each.
+
+Now one rule, `protocol_tests/aggregate.py::aggregate_state`, called at all
+four sites. PASS asserts every mapped member ran and held. PARTIAL means at
+least one member passed and at least one other is absent or inconclusive, and
+the row names which (`tests_absent`, `tests_inconclusive`). INCONCLUSIVE means
+members ran and none was established. FAIL still wins over everything. The
+markdown and HTML tables gained an Inconclusive column; the HTML badge for
+PARTIAL is its own colour with the member IDs printed under it, and the
+markdown "Under-Exercised Requirements" section lists inconclusive members
+alongside absent ones. `NO_RESULTS` (AIUC-1) and `NOT_TESTED` (OWASP) are kept
+as the two consumers' names for "nothing present".
+
+**R3-04.** `scripts/registry_reference_server.py` resolved its schema through
+a repo-root join -- a checkout-only path. On the installed wheel the file did
+not exist, `load_schema_required()` returned `[]` on the `OSError`, and a
+submission whose `payload.report` was `{}` came back 201 with a record
+labelled "Tested with Agent Security Harness". The same input in a checkout
+was rejected 422 for five missing keys. Now resolved through
+`protocol_tests.package_data.data_path`, and a schema that cannot be loaded
+raises `SchemaUnavailable`: the loader never returns an empty list,
+`validate_and_build` refuses an empty requirement list rather than accepting,
+`build_server` will not start without the schema, and a running handler
+answers 503, never 201. Missing validation configuration is a refusal, not
+"no requirements".
+
+Tests: `tests/test_aggregate_state_is_shared.py` (the review's fixture through
+both consumers and both tables, a source-level check that no site re-grows its
+own rule, and the rendered artifacts naming the members) and
+`tests/test_registry_refuses_without_schema.py` (nonexistent path, empty
+requirement list, server refuses to start, handler 503, and the installed
+wheel -- built with `python -m build`, no flags, called from outside the
+checkout -- rejecting `{}` with 422).
+
+What this does not establish: the aggregate rule is applied to the two
+report consumers only; harness-level `run_summary` and per-module summaries
+are unchanged. The registry server still performs a required-key check, not
+full JSON Schema validation, as its docstring has always said.
 
 ## [4.21.0] - 2026-09-07
 

--- a/HARNESS_TEST_CATALOG.md
+++ b/HARNESS_TEST_CATALOG.md
@@ -1,7 +1,7 @@
 # Agent Security Harness — Canonical Test Catalog
 
 **Source repo:** msaleme/red-team-blue-team-agent-fabric
-**Generated:** `scripts/generate_test_catalog.py` at commit `4b584df`
+**Generated:** `scripts/generate_test_catalog.py` at commit `3377b4f`
 **Test count:** 623 unique test IDs across 46 registered harness modules (45 contain test IDs; `community_runner.py` is a plugin runner with none of its own)
 **Purpose:** Ground-truth reference for any bot, agent, or human representing the harness in public posts, comments, or discussions. Cite only tests listed here. Do not invent IDs or statistics.
 

--- a/protocol_tests/aggregate.py
+++ b/protocol_tests/aggregate.py
@@ -1,0 +1,107 @@
+"""One aggregate-state rule for a set of test rows mapped to a requirement.
+
+Two consumers -- `scripts/evidence_pack.py` and `scripts/html_report.py` --
+each folded a requirement's mapped tests into a status with their own rule,
+for AIUC-1 and again for OWASP. Four rules, and none of them had a word for
+"one member passed, the other four established nothing". The evidence pack's
+rule was `FAIL if failed; INCONCLUSIVE if passed == 0; PARTIAL if a mapped
+test was absent; else PASS`, which called a requirement PASS on 1 PASS + 4
+INCONCLUSIVE because every member was *present*. The HTML renderer had no
+PARTIAL at all: 2 of 5 present and both green rendered PASS. Found by the
+third external review (2026-09-07, R3-03).
+
+The rule, in order:
+
+  FAIL          any present member failed. Nothing masks a real failure.
+  <absent>      nothing present (NOT_TESTED for OWASP, NO_RESULTS for AIUC-1;
+                the consumers' existing vocabularies are kept).
+  PASS          every mapped member is present AND established-passing.
+  PARTIAL       at least one member passed, but at least one other is absent
+                from the report OR is inconclusive. The row says which, by ID.
+  INCONCLUSIVE  members are present, none passed, none failed: everything
+                that ran established nothing.
+
+A PASS therefore asserts that every test mapped to the requirement ran and
+held. Anything less says so, and says what is missing.
+
+Rows are dicts from a JSON report. INCONCLUSIVE is decided by the one
+predicate (`http_helpers.is_inconclusive`), never by `passed` alone: a row
+with `passed: False` and `not_evaluated: True` is inconclusive, not failed.
+"""
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from protocol_tests.http_helpers import is_inconclusive
+
+PASS = "PASS"
+FAIL = "FAIL"
+PARTIAL = "PARTIAL"
+INCONCLUSIVE = "INCONCLUSIVE"
+NOT_TESTED = "NOT_TESTED"
+NO_RESULTS = "NO_RESULTS"
+
+
+def aggregate_state(
+    test_ids: list[str],
+    result_by_id: Mapping[str, dict],
+    *,
+    absent_status: str = NOT_TESTED,
+) -> dict[str, Any]:
+    """Fold the rows for `test_ids` into one status, with the members named.
+
+    Returns counts (`passed`, `failed`, `inconclusive`, `tests_mapped`,
+    `tests_run`) and the member IDs behind each non-PASS state
+    (`tests_absent`, `tests_inconclusive`, `tests_failed`), so a renderer can
+    print *which* members kept the requirement from PASS rather than a bare
+    label. `absent_status` is the name for "nothing present"; the two
+    consumers' vocabularies differ and neither is wrong.
+    """
+    mapped = list(dict.fromkeys(test_ids))  # deduplicate, keep order
+    present = [t for t in mapped if t in result_by_id]
+    absent = [t for t in mapped if t not in result_by_id]
+
+    inconclusive = [t for t in present if is_inconclusive(result_by_id[t])]
+    inconc_set = set(inconclusive)
+    passed = [t for t in present
+              if t not in inconc_set and bool(result_by_id[t].get("passed", False))]
+    passed_set = set(passed)
+    # Not a residual over `present`: an inconclusive row is subtracted by ID,
+    # so a control that was never exercised is never counted as one that
+    # failed. A FAIL asserts the control did not hold.
+    failed = [t for t in present if t not in inconc_set and t not in passed_set]
+
+    if failed:
+        status = FAIL
+    elif not present:
+        status = absent_status
+    elif passed and not absent and not inconclusive:
+        status = PASS
+    elif passed:
+        status = PARTIAL
+    else:
+        status = INCONCLUSIVE
+
+    return {
+        "status": status,
+        "tests_mapped": len(mapped),
+        "tests_run": len(present),
+        "passed": len(passed),
+        "failed": len(failed),
+        "inconclusive": len(inconclusive),
+        "total": len(present),
+        "tests_absent": absent,
+        "tests_inconclusive": inconclusive,
+        "tests_failed": failed,
+    }
+
+
+def partial_reason(state: Mapping[str, Any]) -> str:
+    """One line naming why a PARTIAL row is not a PASS, for a renderer."""
+    parts = []
+    if state.get("tests_absent"):
+        parts.append("absent from this report: " + ", ".join(state["tests_absent"]))
+    if state.get("tests_inconclusive"):
+        parts.append("inconclusive (not exercised): "
+                     + ", ".join(state["tests_inconclusive"]))
+    return "; ".join(parts) or "unrecorded"

--- a/scripts/evidence_pack.py
+++ b/scripts/evidence_pack.py
@@ -34,6 +34,7 @@ REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, REPO_ROOT)
 from protocol_tests.package_data import data_path as _data_path  # noqa: E402
 from protocol_tests.http_helpers import is_inconclusive as _inconc  # noqa: E402
+from protocol_tests.aggregate import aggregate_state, partial_reason  # noqa: E402
 
 from protocol_tests.version import get_harness_version
 
@@ -143,41 +144,19 @@ def compute_aiuc1_coverage(
             }
             continue
 
-        inconc = sum(1 for tid in matched if _inconc(result_by_id[tid]))
-        passed = sum(1 for tid in matched
-                     if result_by_id[tid].get("passed", False) and not _inconc(result_by_id[tid]))
-        # Not a residual. `len(matched) - passed` counted every unexercised
-        # control as a failing one -- a FAIL asserts the control did not hold,
-        # which an INCONCLUSIVE row cannot establish. Found on the installed
-        # 4.21.0 package by the third external review (2026-09-07): an
-        # explicitly INCONCLUSIVE report became a published failure claim.
-        failed = len(matched) - passed - inconc
-        # A requirement is only PASS when every test mapped to it actually ran.
-        # Reporting PASS on a strict subset lets "2 of 5 ran, both green" render
-        # identically to "all 5 ran, all green" -- the reader cannot tell a
-        # satisfied requirement from an under-exercised one.
-        if failed > 0:
-            status = "FAIL"
-        elif passed == 0:
-            status = "INCONCLUSIVE"   # everything that ran was unexercised
-        elif len(matched) < len(test_ids):
-            status = "PARTIAL"
-        else:
-            status = "PASS"
+        # ONE rule, shared with scripts/html_report.py (protocol_tests/aggregate.py).
+        # This site's own rule treated "nothing passed" as the only INCONCLUSIVE case,
+        # so 1 PASS + 4 INCONCLUSIVE with every member present was PASS. A
+        # requirement is PASS only when every mapped test ran and held;
+        # PARTIAL names the members that are absent or inconclusive.
+        state = aggregate_state(test_ids, result_by_id, absent_status="NO_RESULTS")
         covered_count += 1
 
         coverage[req_id] = {
             "title": req_def["title"],
             "category": req_def["category"],
-            "status": status,
+            **state,
             "test_ids": test_ids,
-            "tests_mapped": len(test_ids),
-            "tests_run": len(matched),
-            "tests_absent": [tid for tid in test_ids if tid not in result_by_id],
-            "passed": passed,
-            "failed": failed,
-            "inconclusive": inconc,
-            "total": len(matched),
         }
 
     return {
@@ -227,32 +206,8 @@ def compute_owasp_coverage(
     owasp: dict[str, Any] = {}
     for asi_id, asi_name in OWASP_AGENTIC_CATEGORIES.items():
         test_ids = list(dict.fromkeys(asi_tests.get(asi_id, [])))  # deduplicate preserving order
-        matched = [tid for tid in test_ids if tid in result_by_id]
-        inconc = sum(1 for tid in matched if _inconc(result_by_id[tid]))
-        passed = sum(1 for tid in matched
-                     if result_by_id[tid].get("passed", False) and not _inconc(result_by_id[tid]))
-        # Not a residual. `len(matched) - passed` counted every unexercised
-        # control as a failing one -- a FAIL asserts the control did not hold,
-        # which an INCONCLUSIVE row cannot establish. Found on the installed
-        # 4.21.0 package by the third external review (2026-09-07): an
-        # explicitly INCONCLUSIVE report became a published failure claim.
-        failed = len(matched) - passed - inconc
-
-        owasp[asi_id] = {
-            "name": asi_name,
-            "tests_mapped": len(test_ids),
-            "tests_run": len(matched),
-            "passed": passed,
-            "failed": failed,
-            "inconclusive": inconc,
-            "status": (
-                "FAIL" if failed > 0
-                else "NOT_TESTED" if not matched
-                else "INCONCLUSIVE" if passed == 0
-                else "PASS" if len(matched) == len(test_ids)
-                else "PARTIAL"
-            ),
-        }
+        # Same shared rule as the AIUC-1 path and as scripts/html_report.py.
+        owasp[asi_id] = {"name": asi_name, **aggregate_state(test_ids, result_by_id)}
 
     return owasp
 
@@ -333,8 +288,8 @@ def generate_markdown(
         "",
         "## AIUC-1 Requirement Coverage",
         "",
-        "| Requirement | Title | Category | Status | Tests Mapped | Tests Run | Passed | Failed |",
-        "|-------------|-------|----------|--------|--------------|-----------|--------|--------|",
+        "| Requirement | Title | Category | Status | Tests Mapped | Tests Run | Passed | Failed | Inconclusive |",
+        "|-------------|-------|----------|--------|--------------|-----------|--------|--------|--------------|",
     ]
 
     for req_id, req_data in sorted(aiuc1.get("requirements", {}).items()):
@@ -343,7 +298,8 @@ def generate_markdown(
             f"| {req_id} | {req_data['title']} | {req_data['category']} "
             f"| **{status}** | {req_data.get('tests_mapped', 0)} "
             f"| {req_data.get('tests_run', 0)} "
-            f"| {req_data.get('passed', 0)} | {req_data.get('failed', 0)} |"
+            f"| {req_data.get('passed', 0)} | {req_data.get('failed', 0)} "
+            f"| {req_data.get('inconclusive', 0)} |"
         )
 
     lines.extend([
@@ -352,15 +308,16 @@ def generate_markdown(
         "",
         "## OWASP Agentic Security Initiative Coverage",
         "",
-        "| ID | Category | Tests Mapped | Tests Run | Passed | Failed | Status |",
-        "|----|----------|-------------|-----------|--------|--------|--------|",
+        "| ID | Category | Tests Mapped | Tests Run | Passed | Failed | Inconclusive | Status |",
+        "|----|----------|-------------|-----------|--------|--------|--------------|--------|",
     ])
 
     for asi_id, asi_data in sorted(owasp.items()):
         lines.append(
             f"| {asi_id} | {asi_data['name']} | {asi_data['tests_mapped']} "
             f"| {asi_data['tests_run']} | {asi_data['passed']} "
-            f"| {asi_data['failed']} | **{asi_data['status']}** |"
+            f"| {asi_data['failed']} | {asi_data.get('inconclusive', 0)} "
+            f"| **{asi_data['status']}** |"
         )
 
     # Gaps and recommendations
@@ -407,17 +364,18 @@ def generate_markdown(
         lines.append("### Under-Exercised Requirements")
         lines.append("")
         lines.append(
-            "Every test that ran for these requirements passed, but not every test "
-            "mapped to them was present in this report. A passing subset does not "
-            "establish the requirement: the tests that did not run assert nothing."
+            "At least one test mapped to each of these requirements passed, but "
+            "the requirement is not established: another mapped test was absent "
+            "from this report, or ran and was INCONCLUSIVE (the control was not "
+            "exercised). A passing subset does not establish the requirement; "
+            "the members named here assert nothing."
         )
         lines.append("")
         for req_id, req_data in sorted(partial_reqs.items()):
-            absent = ", ".join(req_data.get("tests_absent", [])) or "unrecorded"
             lines.append(
                 f"- **{req_id} ({req_data['title']}):** "
-                f"{req_data['tests_run']}/{req_data['tests_mapped']} mapped tests ran; "
-                f"absent from this report: {absent}"
+                f"{req_data.get('passed', 0)} of {req_data['tests_mapped']} mapped "
+                f"tests passed ({req_data['tests_run']} ran); {partial_reason(req_data)}"
             )
         lines.append("")
 

--- a/scripts/html_report.py
+++ b/scripts/html_report.py
@@ -34,6 +34,7 @@ from typing import Any
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, REPO_ROOT)
 from protocol_tests.package_data import data_path as _data_path  # noqa: E402
+from protocol_tests.aggregate import aggregate_state, partial_reason  # noqa: E402
 
 from protocol_tests.version import get_harness_version
 
@@ -123,20 +124,14 @@ def _compute_aiuc1(results: list[dict], req_index: dict[str, dict]) -> dict[str,
             }
             continue
 
-        inconc = sum(1 for t in matched if _is_inconclusive(result_by_id[t]))
-        passed = sum(1 for t in matched
-                     if result_by_id[t].get("passed", False)
-                     and not _is_inconclusive(result_by_id[t]))
-        # Not a residual. `len(matched) - passed` counted every unexercised
-        # control as a failing one, which asserts the control did not hold --
-        # the same defect fixed in scripts/evidence_pack.py (#522).
-        failed = len(matched) - passed - inconc
+        # ONE rule, shared with scripts/evidence_pack.py (protocol_tests/aggregate.py).
+        # This renderer had no PARTIAL state: 2 of 5 mapped tests present and
+        # green rendered PASS, and so did 1 PASS + 4 INCONCLUSIVE. A
+        # requirement is PASS only when every mapped test ran and held.
         covered += 1
         coverage[req_id] = {
             "title": req_def["title"], "category": req_def["category"],
-            "status": ("FAIL" if failed else
-                       "PASS" if passed else "INCONCLUSIVE"),
-            "passed": passed, "failed": failed, "total": len(matched),
+            **aggregate_state(test_ids, result_by_id, absent_status="NO_RESULTS"),
         }
 
     return {"covered": covered, "total": len(req_index), "gaps": gaps, "requirements": coverage}
@@ -157,28 +152,8 @@ def _compute_owasp(results: list[dict], req_index: dict[str, dict]) -> dict[str,
     owasp: dict[str, Any] = {}
     for asi_id, asi_name in OWASP_AGENTIC_CATEGORIES.items():
         test_ids = asi_tests.get(asi_id, [])
-        matched = [t for t in test_ids if t in result_by_id]
-        inconc = sum(1 for t in matched if _is_inconclusive(result_by_id[t]))
-        passed = sum(1 for t in matched
-                     if result_by_id[t].get("passed", False)
-                     and not _is_inconclusive(result_by_id[t]))
-        # Not a residual. `len(matched) - passed` counted every unexercised
-        # control as a failing one, which asserts the control did not hold --
-        # the same defect fixed in scripts/evidence_pack.py (#522).
-        failed = len(matched) - passed - inconc
-        if failed > 0:
-            status = "FAIL"
-        elif passed:
-            status = "PASS"
-        elif inconc:
-            status = "INCONCLUSIVE"
-        else:
-            status = "NOT_TESTED"
-        owasp[asi_id] = {
-            "name": asi_name, "tests_mapped": len(test_ids),
-            "tests_run": len(matched), "passed": passed, "failed": failed,
-            "status": status,
-        }
+        # Same shared rule as the AIUC-1 path and as scripts/evidence_pack.py.
+        owasp[asi_id] = {"name": asi_name, **aggregate_state(test_ids, result_by_id)}
     return owasp
 
 
@@ -216,6 +191,7 @@ h3{font-size:15px;font-weight:600;margin:20px 0 8px}
 .badge-fail{background:#fee2e2;color:#991b1b}
 .badge-inconclusive{background:#e5e7eb;color:#374151}
 .badge-gap{background:#fef3c7;color:#92400e}
+.badge-partial{background:#ffedd5;color:#9a3412}
 .badge-na{background:#f3f4f6;color:#6b7280}
 
 /* Tables */
@@ -302,7 +278,22 @@ def _status_badge(status: str) -> str:
                 'not exercised">INCONCLUSIVE</span>')
     if s == "GAP":
         return '<span class="badge badge-gap">GAP</span>'
+    if s == "PARTIAL":
+        return ('<span class="badge badge-partial" title="some mapped tests passed; '
+                'others are absent or were not exercised -- not established">'
+                'PARTIAL</span>')
     return f'<span class="badge badge-na">{_esc(s)}</span>'
+
+
+def _partial_note(state: dict) -> str:
+    """The members that keep a PARTIAL row from PASS, printed on the row.
+
+    A badge alone collapses "2 of 5 ran" and "1 passed, 4 not exercised"
+    into one word. The IDs are what an auditor needs to go and look."""
+    if str(state.get("status", "")).upper() != "PARTIAL":
+        return ""
+    return (f'<div style="color:#9a3412;font-size:11px;margin-top:2px">'
+            f'{_esc(partial_reason(state))}</div>')
 
 
 def _risk_class(score: float) -> str:
@@ -505,7 +496,8 @@ def generate_html(report_data: dict[str, Any]) -> str:
         parts.append("<h2>OWASP Agentic Top 10 Coverage</h2>")
         parts.append("<table>")
         parts.append("<tr><th>ID</th><th>Category</th><th>Mapped</th>"
-                     "<th>Run</th><th>Passed</th><th>Failed</th><th>Status</th></tr>")
+                     "<th>Run</th><th>Passed</th><th>Failed</th><th>Inconclusive</th>"
+                     "<th>Status</th></tr>")
         for asi_id, asi_data in sorted(owasp.items()):
             parts.append(
                 f"<tr><td><strong>{_esc(asi_id)}</strong></td>"
@@ -514,7 +506,8 @@ def generate_html(report_data: dict[str, Any]) -> str:
                 f"<td>{asi_data['tests_run']}</td>"
                 f"<td>{asi_data['passed']}</td>"
                 f"<td>{asi_data['failed']}</td>"
-                f"<td>{_status_badge(asi_data['status'])}</td></tr>"
+                f"<td>{asi_data.get('inconclusive', 0)}</td>"
+                f"<td>{_status_badge(asi_data['status'])}{_partial_note(asi_data)}</td></tr>"
             )
         parts.append("</table>")
 
@@ -528,7 +521,8 @@ def generate_html(report_data: dict[str, Any]) -> str:
         )
         parts.append("<table>")
         parts.append("<tr><th>Requirement</th><th>Title</th><th>Category</th>"
-                     "<th>Passed</th><th>Failed</th><th>Status</th></tr>")
+                     "<th>Mapped</th><th>Run</th><th>Passed</th><th>Failed</th>"
+                     "<th>Inconclusive</th><th>Status</th></tr>")
         for req_id, rd in sorted(reqs.items()):
             notes = rd.get("notes", "")
             title_text = _esc(rd["title"])
@@ -538,9 +532,12 @@ def generate_html(report_data: dict[str, Any]) -> str:
                 f"<tr><td><strong>{_esc(req_id)}</strong></td>"
                 f"<td>{title_text}</td>"
                 f"<td>{_esc(rd['category'])}</td>"
+                f"<td>{rd.get('tests_mapped', 0)}</td>"
+                f"<td>{rd.get('tests_run', 0)}</td>"
                 f"<td>{rd.get('passed', 0)}</td>"
                 f"<td>{rd.get('failed', 0)}</td>"
-                f"<td>{_status_badge(rd['status'])}</td></tr>"
+                f"<td>{rd.get('inconclusive', 0)}</td>"
+                f"<td>{_status_badge(rd['status'])}{_partial_note(rd)}</td></tr>"
             )
         parts.append("</table>")
 

--- a/scripts/registry_reference_server.py
+++ b/scripts/registry_reference_server.py
@@ -33,8 +33,20 @@ try:  # optional: only needed to actually verify a signature
 except ImportError:  # pragma: no cover - environment dependent
     _CRYPTO = False
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
-SCHEMA_PATH = REPO_ROOT / "schemas" / "attestation-report.json"
+# A checkout puts the repo root on sys.path only when run as a module; run
+# as a script (`python3 scripts/registry_reference_server.py`) it is not.
+# Harmless on an installed copy, where parents[1] is site-packages.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from protocol_tests.package_data import data_path as _data_path  # noqa: E402
+
+# Resolved through the one resolver every other consumer uses. This was a
+# repo-root join to `schemas/attestation-report.json`, a checkout-only path.
+# In an installed wheel it did not exist, the loader below returned `[]` on
+# the OSError, and the server accepted a submission whose report was `{}` and
+# returned a record labelled "Tested with Agent Security Harness". The same
+# input in a checkout was rejected 422. Found by the third external review
+# (2026-09-07, R3-04).
+SCHEMA_PATH = _data_path("schemas", "attestation-report.json")
 
 # Mirrors protocol_tests/attestation_registry.py. Duplicated deliberately: a
 # server must not import the client to decide whether the client behaved.
@@ -82,18 +94,40 @@ def find_sensitive_keys(obj, path="report") -> list[str]:
     return found
 
 
-def load_schema_required() -> list[str]:
+class SchemaUnavailable(RuntimeError):
+    """The attestation schema could not be loaded, so nothing can be validated.
+
+    This is an explicit refusal, never an empty requirement list. "Missing
+    validation configuration" must never mean "no requirements": with `[]`
+    the required-key check passed everything, silently, and the server issued
+    the claim label on an empty report.
+    """
+
+
+def load_schema_required(schema_path: "Path | str | None" = None) -> list[str]:
     """Required top-level keys of the attestation report.
 
     Deliberately a required-key check, not full JSON Schema validation: the repo
     has no jsonschema dependency and a server that claims schema validation it
     does not perform is the same class of defect as claiming a signature check it
     skipped. A production server SHOULD validate fully.
+
+    Raises SchemaUnavailable when the schema cannot be read, does not parse, or
+    declares no required keys. It never returns an empty list.
     """
+    path = Path(schema_path) if schema_path is not None else Path(SCHEMA_PATH)
     try:
-        return json.loads(SCHEMA_PATH.read_text()).get("required", [])
-    except (OSError, json.JSONDecodeError):
-        return []
+        required = json.loads(path.read_text()).get("required")
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SchemaUnavailable(
+            f"cannot load the attestation schema at {path}: {exc}; refusing to "
+            f"validate submissions without it") from exc
+    if not isinstance(required, list) or not required \
+            or not all(isinstance(k, str) for k in required):
+        raise SchemaUnavailable(
+            f"the attestation schema at {path} declares no required keys; refusing "
+            f"to treat an absent requirement list as no requirements")
+    return list(required)
 
 
 class Store:
@@ -127,7 +161,16 @@ def validate_and_build(
     *,
     test_only_accept_invalid_class: str | None = None,
 ) -> dict:
-    """Contract section 5. Eight checks, in order. Raises Rejected."""
+    """Contract section 5. Eight checks, in order. Raises Rejected.
+
+    Raises SchemaUnavailable, not Rejected, when `required_keys` is empty: that
+    is a server misconfiguration, not a defect in the submission, and it must
+    not be answered with either an acceptance or a 4xx that blames the client.
+    """
+    if not required_keys:
+        raise SchemaUnavailable(
+            "no schema-required keys were loaded; the required-key check (contract "
+            "5.5) cannot run and the submission is not accepted")
     # 1. Shape
     if not isinstance(submission, dict):
         raise Rejected(400, "submission must be a JSON object")
@@ -291,6 +334,9 @@ class Handler(BaseHTTPRequestHandler):
             )
         except Rejected as rej:
             self._json(rej.status, {"error": rej.reason})
+            return
+        except SchemaUnavailable as exc:
+            self._json(503, {"error": f"validation configuration unavailable: {exc}"})
             return
 
         existing = self.store.existing_id_for(record["verification_hash"])

--- a/tests/test_aggregate_state_is_shared.py
+++ b/tests/test_aggregate_state_is_shared.py
@@ -1,0 +1,215 @@
+"""A mixed PASS/INCONCLUSIVE requirement must not aggregate to PASS, in
+either artifact, and the two artifacts must compute it with one rule.
+
+Third external review, 2026-09-07 (R3-03). `scripts/evidence_pack.py` ruled
+`FAIL if failed; INCONCLUSIVE if passed == 0; PARTIAL if a mapped test was
+absent; else PASS` -- so a requirement with all five mapped tests present, one
+PASS and four INCONCLUSIVE, published as PASS. `scripts/html_report.py` had no
+PARTIAL state at all: two of five present and green rendered PASS. Four
+private rules across two files for the same question.
+
+Now one rule (`protocol_tests/aggregate.py`), both consumers, both tables.
+PASS asserts every mapped member ran and held. Anything less is PARTIAL and
+names the members, or INCONCLUSIVE when nothing was established.
+"""
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from protocol_tests.aggregate import aggregate_state
+from scripts.evidence_pack import (compute_aiuc1_coverage, compute_owasp_coverage,
+                                   generate_markdown)
+from scripts.html_report import (_compute_aiuc1, _compute_owasp, _partial_note,
+                                 _status_badge)
+
+REPO = Path(__file__).resolve().parents[1]
+FIVE = ["T-001", "T-002", "T-003", "T-004", "T-005"]
+
+
+def _idx(ids=FIVE):
+    return {"A003": {"title": "t", "category": "c", "status": "MAPPED", "test_ids": list(ids)}}
+
+
+def _pass(t):
+    return {"test_id": t, "passed": True}
+
+
+def _inconc(t):
+    return {"test_id": t, "passed": False, "not_evaluated": True,
+            "details": "INCONCLUSIVE - target did not service"}
+
+
+def _fail(t):
+    return {"test_id": t, "passed": False, "details": "leaked"}
+
+
+def _one_pass_four_inconclusive(ids=FIVE):
+    return [_pass(ids[0])] + [_inconc(t) for t in ids[1:]]
+
+
+def _owasp_ids():
+    from protocol_tests.asi_inventory import by_category
+    cats = {k: v for k, v in by_category().items() if k}
+    asi = sorted(cats)[0]
+    return asi, list(dict.fromkeys(cats[asi]))
+
+
+class TheRule(unittest.TestCase):
+    def test_mixed_pass_and_inconclusive_all_present_is_partial_not_pass(self):
+        s = aggregate_state(FIVE, {r["test_id"]: r for r in _one_pass_four_inconclusive()})
+        self.assertEqual(s["status"], "PARTIAL", s)
+        self.assertEqual((s["passed"], s["failed"], s["inconclusive"]), (1, 0, 4))
+        self.assertEqual(s["tests_absent"], [])
+        self.assertEqual(s["tests_inconclusive"], FIVE[1:], "the row must say WHICH")
+
+    def test_subset_present_all_green_is_partial_and_names_the_absent(self):
+        s = aggregate_state(FIVE, {t: _pass(t) for t in FIVE[:2]})
+        self.assertEqual(s["status"], "PARTIAL")
+        self.assertEqual(s["tests_absent"], FIVE[2:])
+        self.assertEqual(s["tests_inconclusive"], [])
+
+    def test_every_member_present_and_passing_is_pass(self):
+        s = aggregate_state(FIVE, {t: _pass(t) for t in FIVE})
+        self.assertEqual(s["status"], "PASS")
+        self.assertEqual((s["tests_absent"], s["tests_inconclusive"]), ([], []))
+
+    def test_any_failure_wins_over_partial(self):
+        rows = {r["test_id"]: r for r in _one_pass_four_inconclusive()[:3]}
+        rows["T-004"] = _fail("T-004")
+        s = aggregate_state(FIVE, rows)
+        self.assertEqual(s["status"], "FAIL")
+        self.assertEqual(s["tests_failed"], ["T-004"])
+        self.assertEqual(s["failed"], 1, "an inconclusive row is not a failed one")
+
+    def test_nothing_established_is_inconclusive(self):
+        s = aggregate_state(FIVE, {t: _inconc(t) for t in FIVE})
+        self.assertEqual(s["status"], "INCONCLUSIVE")
+        self.assertEqual(s["inconclusive"], 5)
+
+    def test_nothing_present_uses_the_callers_name(self):
+        self.assertEqual(aggregate_state(FIVE, {})["status"], "NOT_TESTED")
+        self.assertEqual(aggregate_state(FIVE, {}, absent_status="NO_RESULTS")["status"],
+                         "NO_RESULTS")
+
+    def test_a_structurally_inconclusive_row_is_read_by_the_predicate_not_passed(self):
+        """`passed: False` + `not_evaluated: True` is inconclusive, never a fail."""
+        s = aggregate_state(["T-001"], {"T-001": {"test_id": "T-001", "passed": False,
+                                                  "not_evaluated": True}})
+        self.assertEqual(s["status"], "INCONCLUSIVE")
+        self.assertEqual(s["failed"], 0)
+
+
+class BothConsumersBothTables(unittest.TestCase):
+    """The fixture the review used, through every public compute path."""
+
+    def test_evidence_pack_aiuc1(self):
+        r = compute_aiuc1_coverage(_one_pass_four_inconclusive(), _idx())["requirements"]["A003"]
+        self.assertEqual(r["status"], "PARTIAL", r)
+        self.assertEqual(r["tests_inconclusive"], FIVE[1:])
+
+    def test_html_report_aiuc1(self):
+        r = _compute_aiuc1(_one_pass_four_inconclusive(), _idx())["requirements"]["A003"]
+        self.assertEqual(r["status"], "PARTIAL", r)
+        self.assertEqual(r["tests_inconclusive"], FIVE[1:])
+
+    def test_html_report_aiuc1_subset_is_not_pass(self):
+        """The renderer had no PARTIAL state; 2 of 5 green rendered PASS."""
+        r = _compute_aiuc1([_pass(t) for t in FIVE[:2]], _idx())["requirements"]["A003"]
+        self.assertEqual(r["status"], "PARTIAL", r)
+        self.assertEqual(r["tests_absent"], FIVE[2:])
+
+    def test_evidence_pack_owasp(self):
+        asi, ids = _owasp_ids()
+        r = compute_owasp_coverage(_one_pass_four_inconclusive(ids), _idx())[asi]
+        self.assertEqual(r["status"], "PARTIAL", r)
+        self.assertEqual(r["inconclusive"], len(ids) - 1)
+
+    def test_html_report_owasp(self):
+        asi, ids = _owasp_ids()
+        r = _compute_owasp(_one_pass_four_inconclusive(ids), _idx())[asi]
+        self.assertEqual(r["status"], "PARTIAL", r)
+        self.assertEqual(r["inconclusive"], len(ids) - 1)
+
+    def test_html_report_owasp_subset_is_not_pass(self):
+        asi, ids = _owasp_ids()
+        r = _compute_owasp([_pass(t) for t in ids[:2]], _idx())[asi]
+        self.assertEqual(r["status"], "PARTIAL", r)
+
+    def test_the_two_consumers_agree_field_for_field(self):
+        for rows in (_one_pass_four_inconclusive(), [_pass(t) for t in FIVE[:2]],
+                     [_inconc(t) for t in FIVE], [_pass(t) for t in FIVE]):
+            with self.subTest(status=rows[0]):
+                a = compute_aiuc1_coverage(rows, _idx())["requirements"]["A003"]
+                b = _compute_aiuc1(rows, _idx())["requirements"]["A003"]
+                for k in ("status", "passed", "failed", "inconclusive", "tests_mapped",
+                          "tests_run", "tests_absent", "tests_inconclusive"):
+                    self.assertEqual(a[k], b[k], k)
+
+
+class OneRuleNotFour(unittest.TestCase):
+    """A consumer that grows its own rule again is the defect coming back.
+    Source-level: each of the four compute sites calls the shared function and
+    none re-derives a status from `passed == 0` or a bare `"PASS" if passed`."""
+
+    def _body(self, path, start, end):
+        src = (REPO / path).read_text()
+        return src[src.index(start):src.index(end)]
+
+    def test_each_compute_site_calls_the_shared_function(self):
+        sites = [
+            ("scripts/evidence_pack.py", "def compute_aiuc1_coverage", "def compute_owasp_coverage"),
+            ("scripts/evidence_pack.py", "def compute_owasp_coverage", "def compute_evidence_hash"),
+            ("scripts/html_report.py", "def _compute_aiuc1", "def _compute_owasp"),
+            ("scripts/html_report.py", "def _compute_owasp", "_CSS = "),
+        ]
+        for path, start, end in sites:
+            with self.subTest(site=f"{path}:{start}"):
+                body = self._body(path, start, end)
+                self.assertIn("aggregate_state(", body, "site does not call the shared rule")
+                for private in ('passed == 0', '"PASS" if passed', '"PASS" if len(matched)',
+                                'elif passed:', 'if failed else'):
+                    self.assertNotIn(private, body, f"site grew its own rule: {private!r}")
+
+
+class TheMixedStateIsVisible(unittest.TestCase):
+    def test_markdown_names_the_inconclusive_members(self):
+        cov = compute_aiuc1_coverage(_one_pass_four_inconclusive(), _idx())
+        md = generate_markdown({"total_tests": 5, "passed": 1, "failed": 0, "pass_rate": 1.0},
+                               cov, {}, "t", "2026-09-07T00:00:00Z")
+        row = next(l for l in md.splitlines() if l.startswith("| A003 "))
+        self.assertIn("**PARTIAL**", row)
+        self.assertIn("Inconclusive", md, "the table must carry an Inconclusive column")
+        self.assertIn("Under-Exercised Requirements", md)
+        for t in FIVE[1:]:
+            self.assertIn(t, md, "the inconclusive member IDs must be named")
+        self.assertNotIn("No gaps, failures, or under-exercised requirements identified.", md)
+
+    def test_markdown_owasp_table_has_an_inconclusive_column(self):
+        asi, ids = _owasp_ids()
+        ow = compute_owasp_coverage(_one_pass_four_inconclusive(ids), _idx())
+        md = generate_markdown({"total_tests": 5, "passed": 1, "failed": 0, "pass_rate": 1.0},
+                               {"covered": 0, "total": 0, "gaps": 0, "requirements": {}},
+                               ow, "t", "ts")
+        row = next(l for l in md.splitlines() if l.startswith(f"| {asi} "))
+        self.assertIn("**PARTIAL**", row)
+        self.assertIn(f"| {len(ids) - 1} |", row)
+
+    def test_html_badge_is_partial_not_the_grey_fallback_and_names_members(self):
+        r = _compute_aiuc1(_one_pass_four_inconclusive(), _idx())["requirements"]["A003"]
+        html = _status_badge(r["status"]) + _partial_note(r)
+        self.assertIn('class="badge badge-partial"', html)
+        self.assertNotIn('badge-pass', html)
+        self.assertNotIn('badge-na', html)
+        for t in FIVE[1:]:
+            self.assertIn(t, html)
+
+    def test_html_partial_note_is_empty_for_a_pass(self):
+        r = _compute_aiuc1([_pass(t) for t in FIVE], _idx())["requirements"]["A003"]
+        self.assertEqual(r["status"], "PASS")
+        self.assertEqual(_partial_note(r), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_registry_refuses_without_schema.py
+++ b/tests/test_registry_refuses_without_schema.py
@@ -1,0 +1,188 @@
+"""The reference registry must refuse to validate without its schema, and
+must find that schema on an installed copy.
+
+Third external review, 2026-09-07 (R3-04). `scripts/registry_reference_server.py`
+resolved `REPO_ROOT / "schemas" / "attestation-report.json"` -- a path that
+exists only in a checkout. `load_schema_required()` returned `[]` on the
+OSError. So on the installed wheel the required-key check (contract 5.5) had
+nothing to check, and a submission whose `payload.report` was `{}` came back
+201 with a record labelled "Tested with Agent Security Harness". The same
+input in a checkout was rejected 422.
+
+Two properties, pinned separately:
+  (a) missing validation configuration is a refusal, never "no requirements";
+  (b) the schema resolves from an installed wheel, built the way the publish
+      workflow builds it (`python -m build`, no flags), called from OUTSIDE
+      the checkout.
+
+(b) is slow on purpose. Every in-checkout test passed while the installed
+artifact accepted an empty report.
+"""
+import hashlib
+import json
+import shutil
+import subprocess
+import sys
+import sysconfig
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import scripts.registry_reference_server as srv  # noqa: E402
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def _empty_report_submission():
+    payload = {"server_name": "demo-server", "contact": None, "report": {},
+               "published_at": "2026-09-07T00:00:00Z"}
+    return {
+        "payload": payload,
+        "signature": "00" * 64,
+        "verification_hash": hashlib.sha256(srv.canonical_bytes(payload)).hexdigest(),
+    }
+
+
+class MissingConfigurationIsARefusal(unittest.TestCase):
+    def test_loader_refuses_a_nonexistent_schema_path(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = Path(tmp) / "attestation-report.json"
+            self.assertFalse(missing.exists())
+            with self.assertRaises(srv.SchemaUnavailable):
+                srv.load_schema_required(missing)
+
+    def test_loader_refuses_a_schema_with_no_required_list(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "attestation-report.json"
+            p.write_text(json.dumps({"type": "object"}))
+            with self.assertRaises(srv.SchemaUnavailable):
+                srv.load_schema_required(p)
+            p.write_text("{not json")
+            with self.assertRaises(srv.SchemaUnavailable):
+                srv.load_schema_required(p)
+
+    def test_loader_never_returns_an_empty_list(self):
+        """The old contract: `[]` on failure. There is no input for which the
+        loader now returns `[]`; it either returns the schema's list or raises."""
+        req = srv.load_schema_required()
+        self.assertTrue(req, "the shipped schema must declare required keys")
+        self.assertIn("entries", req)
+
+    def test_validator_refuses_an_empty_requirement_list_rather_than_accepting(self):
+        """Defence at the point of use: even a caller that hands the validator
+        `[]` does not get a record. The old code accepted the empty report."""
+        with self.assertRaises(srv.SchemaUnavailable):
+            srv.validate_and_build(_empty_report_submission(), [])
+        with self.assertRaises(srv.SchemaUnavailable):
+            srv.validate_and_build(_empty_report_submission(), None)
+
+    def test_empty_report_is_rejected_422_with_the_real_schema(self):
+        with self.assertRaises(srv.Rejected) as ctx:
+            srv.validate_and_build(_empty_report_submission(), srv.load_schema_required())
+        self.assertEqual(ctx.exception.status, 422)
+        self.assertIn("schema-required keys", ctx.exception.reason)
+
+    def test_the_server_refuses_to_start_when_the_schema_is_missing(self):
+        """`build_server` loads the schema once; a server that started with no
+        requirements would issue the claim label on anything."""
+        original = srv.SCHEMA_PATH
+        with tempfile.TemporaryDirectory() as tmp:
+            srv.SCHEMA_PATH = Path(tmp) / "nope.json"
+            try:
+                with self.assertRaises(srv.SchemaUnavailable):
+                    srv.build_server(0)
+            finally:
+                srv.SCHEMA_PATH = original
+
+    def test_a_handler_with_no_requirements_answers_503_never_201(self):
+        """If the requirement list is emptied after start, the POST path still
+        does not issue a record."""
+        import threading
+        import urllib.error
+        import urllib.request
+        httpd = srv.build_server(0)
+        saved = srv.Handler.required_keys
+        srv.Handler.required_keys = []
+        t = threading.Thread(target=httpd.serve_forever, daemon=True)
+        t.start()
+        try:
+            body = json.dumps(_empty_report_submission()).encode()
+            req = urllib.request.Request(
+                f"http://127.0.0.1:{httpd.server_address[1]}/", data=body,
+                headers={"Content-Type": "application/json"}, method="POST")
+            with self.assertRaises(urllib.error.HTTPError) as ctx:
+                urllib.request.urlopen(req, timeout=5)
+            self.assertEqual(ctx.exception.code, 503)
+        finally:
+            srv.Handler.required_keys = saved
+            httpd.shutdown()
+            httpd.server_close()
+
+    def test_the_schema_is_resolved_through_the_package_resolver(self):
+        src = (REPO / "scripts" / "registry_reference_server.py").read_text()
+        self.assertIn('_data_path("schemas", "attestation-report.json")', src)
+        self.assertNotIn('REPO_ROOT / "schemas"', src, "checkout-only path came back")
+        self.assertNotIn("return []", src, "the empty-list fallback came back")
+
+
+class TheInstalledRegistryRejectsAnEmptyReport(unittest.TestCase):
+    """(b). Same pattern as tests/test_the_wheel_ships_what_it_reads.py:
+    `python -m build` with no flags (sdist, then wheel from the sdist -- the
+    publish workflow's route), install into a throwaway venv, call the
+    validator from a cwd that is NOT the checkout."""
+
+    def test_installed_copy_finds_its_schema_and_rejects_an_empty_report(self):
+        try:
+            import build  # noqa: F401
+        except ImportError:
+            raise unittest.SkipTest("the `build` package is not installed")
+        with tempfile.TemporaryDirectory(prefix="registry-wheel-") as tmp:
+            src = Path(tmp) / "src"
+            shutil.copytree(REPO, src, symlinks=True,
+                            ignore=shutil.ignore_patterns(".git", ".venv", "build",
+                                                          "*.egg-info", "__pycache__", "dist"))
+            out = Path(tmp) / "dist"
+            done = subprocess.run([sys.executable, "-m", "build", "-o", str(out)],
+                                  cwd=src, capture_output=True, text=True)
+            self.assertEqual(done.returncode, 0,
+                             f"default build failed:\n{done.stdout[-1500:]}\n{done.stderr[-1500:]}")
+            wheels = list(out.glob("*.whl"))
+            self.assertEqual(len(wheels), 1, wheels)
+            venv = Path(tmp) / "venv"
+            subprocess.run([sys.executable, "-m", "venv", str(venv)], check=True,
+                           capture_output=True)
+            bindir = "Scripts" if sysconfig.get_platform().startswith("win") else "bin"
+            py = venv / bindir / "python"
+            subprocess.run([str(py), "-m", "pip", "-q", "install", str(wheels[0])],
+                           check=True, capture_output=True)
+            probe = "\n".join([
+                "import hashlib, sys",
+                "import scripts.registry_reference_server as s",
+                "assert 'site-packages' in str(s.SCHEMA_PATH), s.SCHEMA_PATH",
+                "assert s.SCHEMA_PATH.is_file(), f'schema not found: {s.SCHEMA_PATH}'",
+                "req = s.load_schema_required(); assert 'entries' in req, req",
+                "p = {'server_name': 'demo', 'contact': None, 'report': {},"
+                " 'published_at': '2026-09-07T00:00:00Z'}",
+                "sub = {'payload': p, 'signature': '00'*64,"
+                " 'verification_hash': hashlib.sha256(s.canonical_bytes(p)).hexdigest()}",
+                "try:",
+                "    s.validate_and_build(sub, req)",
+                "except s.Rejected as e:",
+                "    assert e.status == 422, e.status; print('REJECTED', e.reason)",
+                "else:",
+                "    print('ACCEPTED'); sys.exit(3)",
+            ])
+            # cwd=tmp: NOT the checkout. That is the whole test.
+            done = subprocess.run([str(py), "-c", probe], capture_output=True, text=True,
+                                  cwd=tmp)
+            self.assertEqual(done.returncode, 0,
+                             f"installed registry did not reject an empty report:\n"
+                             f"{done.stdout}\n{done.stderr[-1200:]}")
+            self.assertIn("REJECTED", done.stdout)
+            self.assertIn("schema-required keys", done.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
From the third external review.

R3-03: AIUC-1 requirement aggregation in `evidence_pack.py` and `html_report.py` disagreed, and both could call a requirement SATISFIED on one passing test with the other four inconclusive. One aggregator now, `protocol_tests/aggregate.py::aggregate_state`, with a PARTIAL state carrying `tests_inconclusive`; the HTML report gains a PARTIAL badge. 1P+4I → PARTIAL in both consumers; 2-of-5 passing → PARTIAL (reproduced).

R3-04: `scripts/registry_reference_server.py` resolved its schema by relative path and silently validated nothing when run from the installed wheel. Schema now resolves through `package_data`; missing schema raises `SchemaUnavailable` and the server answers 503 rather than accepting submissions; malformed submissions are 422. `load_schema_required()` resolves on this branch (5 required keys).

Two commits: a93e377, 3984079.

🤖 Generated with [Claude Code](https://claude.com/claude-code)