### PR TITLE
R3-05/06/10/13: provenance redaction of query params and paths, no-precedence decision parsing, --simulate honours --report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,45 @@ What this does not establish: the aggregate rule is applied to the two
 report consumers only; harness-level `run_summary` and per-module summaries
 are unchanged. The registry server still performs a required-key check, not
 full JSON Schema validation, as its docstring has always said.
+### Found by the third external review, second pass (R3-05, R3-06, R3-10, R3-13)
+
+Four defects in the two places this project says it is most careful: what
+leaves in a published record, and what a live verdict is allowed to read.
+
+- **A credential in a URL query survived redaction** (High).
+  `--url=http://host/?api_key=<secret>` reached the publication copy with
+  `argv_redacted=False`: the userinfo strip never looks past the netloc, and
+  the flag's own `=` hid the query's from the inline matcher. URLs are now
+  parsed as URLs, bare or after `--flag=`. Inside a query (and fragment) every
+  value is replaced unless the parameter NAME is on a short allowlist of
+  protocol/format selectors (`transport`, `protocol`, `version`,
+  `api-version`, `api_version`, `v`, `format`, `mode`, `stream`, `model`) --
+  an allowlist rather than a longer name list, because a query name is chosen
+  by the target, and `?sig=`, `?k=`, `?code=` are not on anyone's list.
+  Scheme, host, port and path are kept as sent. The allowlist is stated in the
+  block's `not_claimed`, so a `[REDACTED]` query value reads as "not on the
+  allowlist", not as "a credential was here".
+- **Windows equals-form and UNC paths contradicted the privacy statement.**
+  `--report=C:\Users\<user>\...` and `\\host\share\...` both survived while
+  `not_claimed` promised no absolute path is recorded. Path reduction now
+  applies to the value half of `--flag=value` and recognises `\\host\share`,
+  `X:/`, `X:\` and `~user/` forms, as data, on every host.
+- **Two decision parsers disagreed on a contradictory response.**
+  `_target_decision` (read by DCA-005) stopped at the first key and called
+  `{"allowed": false, "granted": true}` a deny; `_target_allowed` (read by
+  every other live row) accepted any true alias and called it an allow. So
+  DCA-009/010 PASSED on a body DCA-005 called a refusal. One parser now.
+  Precedence, stated: none -- every boolean present must agree, and a
+  contradiction (or a non-boolean under a decision key) is undecided, named
+  on the row as INCONCLUSIVE. Fixtures pin both orderings: every row
+  INCONCLUSIVE, no finding, no pass.
+- **`--simulate --report x.json` exited 0 and wrote nothing.** The dispatcher
+  exits before the module would see `--report`. The simulate path now writes
+  the same document `--json` prints to the requested path, and an unwritable
+  path is a non-zero exit with the reason -- silent success was the defect.
+
+Every fix was fault-injected: the defect reintroduced, the new tests confirmed
+failing for that reason, the fix restored.
 
 ## [4.21.0] - 2026-09-07
 

--- a/HARNESS_TEST_CATALOG.md
+++ b/HARNESS_TEST_CATALOG.md
@@ -2,6 +2,7 @@
 
 **Source repo:** msaleme/red-team-blue-team-agent-fabric
 **Generated:** `scripts/generate_test_catalog.py` at commit `3377b4f`
+**Generated:** `scripts/generate_test_catalog.py` at commit `381ce18`
 **Test count:** 623 unique test IDs across 46 registered harness modules (45 contain test IDs; `community_runner.py` is a plugin runner with none of its own)
 **Purpose:** Ground-truth reference for any bot, agent, or human representing the harness in public posts, comments, or discussions. Cite only tests listed here. Do not invent IDs or statistics.
 
@@ -215,17 +216,17 @@ CREW-010 | Fallback Sandbox RCE Chain | protocol_tests/crewai_cve_harness.py:121
 ### Delegated-Authority Attenuation (`protocol_tests/delegation_chain_harness.py`) — 11 tests
 
 ```
-DCA-001 | Child Adds a Capability Absent From Its Parent | protocol_tests/delegation_chain_harness.py:885
-DCA-002 | Child Widens Resource Scope (staging -> production) | protocol_tests/delegation_chain_harness.py:955
-DCA-003 | Child Drops or Loosens a Parent Constraint | protocol_tests/delegation_chain_harness.py:1046
-DCA-004 | Valid Pass Presented to the Wrong Tool Audience | protocol_tests/delegation_chain_harness.py:1126
-DCA-005 | Replayed Effect Request | protocol_tests/delegation_chain_harness.py:1176
-DCA-006 | Pass Used After Expiry | protocol_tests/delegation_chain_harness.py:1302
-DCA-007 | Pass Used After Revocation Epoch | protocol_tests/delegation_chain_harness.py:1367
-DCA-008 | Tool Acts Under Ambient Credentials | protocol_tests/delegation_chain_harness.py:1434
-DCA-009 | Positive Control: Correctly Attenuated Child | protocol_tests/delegation_chain_harness.py:1483
-DCA-010 | Positive Control: Parent | protocol_tests/delegation_chain_harness.py:1538
-DCA-011 | Three-Hop Chain: Intermediate Re-Widens What Its Parent Narrowed | protocol_tests/delegation_chain_harness.py:1658
+DCA-001 | Child Adds a Capability Absent From Its Parent | protocol_tests/delegation_chain_harness.py:906
+DCA-002 | Child Widens Resource Scope (staging -> production) | protocol_tests/delegation_chain_harness.py:976
+DCA-003 | Child Drops or Loosens a Parent Constraint | protocol_tests/delegation_chain_harness.py:1067
+DCA-004 | Valid Pass Presented to the Wrong Tool Audience | protocol_tests/delegation_chain_harness.py:1147
+DCA-005 | Replayed Effect Request | protocol_tests/delegation_chain_harness.py:1197
+DCA-006 | Pass Used After Expiry | protocol_tests/delegation_chain_harness.py:1329
+DCA-007 | Pass Used After Revocation Epoch | protocol_tests/delegation_chain_harness.py:1394
+DCA-008 | Tool Acts Under Ambient Credentials | protocol_tests/delegation_chain_harness.py:1461
+DCA-009 | Positive Control: Correctly Attenuated Child | protocol_tests/delegation_chain_harness.py:1510
+DCA-010 | Positive Control: Parent | protocol_tests/delegation_chain_harness.py:1565
+DCA-011 | Three-Hop Chain: Intermediate Re-Widens What Its Parent Narrowed | protocol_tests/delegation_chain_harness.py:1685
 ```
 
 ### Enterprise Platforms (core) (`protocol_tests/enterprise_adapters.py`) — 31 tests

--- a/HARNESS_TEST_CATALOG.md
+++ b/HARNESS_TEST_CATALOG.md
@@ -1,8 +1,7 @@
 # Agent Security Harness — Canonical Test Catalog
 
 **Source repo:** msaleme/red-team-blue-team-agent-fabric
-**Generated:** `scripts/generate_test_catalog.py` at commit `3377b4f`
-**Generated:** `scripts/generate_test_catalog.py` at commit `381ce18`
+**Generated:** `scripts/generate_test_catalog.py` at commit `bd3ba3e`
 **Test count:** 623 unique test IDs across 46 registered harness modules (45 contain test IDs; `community_runner.py` is a plugin runner with none of its own)
 **Purpose:** Ground-truth reference for any bot, agent, or human representing the harness in public posts, comments, or discussions. Cite only tests listed here. Do not invent IDs or statistics.
 

--- a/protocol_tests/cli.py
+++ b/protocol_tests/cli.py
@@ -95,11 +95,29 @@ def _extract_test_catalog(module_path: str) -> list[dict]:
     return catalog
 
 
+def _report_path_from(args: list[str]) -> str | None:
+    """`--report PATH` or `--report=PATH` from the harness-bound argv, else None."""
+    for i, a in enumerate(args):
+        if a == "--report" and i + 1 < len(args):
+            return args[i + 1]
+        if a.startswith("--report="):
+            return a.partition("=")[2]
+    return None
+
+
 def _simulate_harness(harness_name: str, info: dict,
-                      json_output: bool, html_output: str | None) -> None:
+                      json_output: bool, html_output: str | None,
+                      report_path: str | None = None) -> None:
     """Generate synthetic results for a harness without a live target.
 
     Every row is INCONCLUSIVE, not passed.
+
+    `report_path` is honoured here because the dispatcher exits before the
+    module would ever see `--report`. `agent-security test mcp --simulate
+    --report x.json` exited 0 and wrote nothing -- silent success on a request
+    that was not performed, which is the same shape as a pass that was not
+    earned. Found by the third external review, 2026-09-07. The file carries
+    the same dict `--json` prints; a write failure is a non-zero exit.
 
     This previously emitted `"passed": True` for every test, so a simulated run
     produced 100% pass, risk score 0, AUROC 1.0000 -- a clean bill of health for
@@ -176,6 +194,17 @@ def _simulate_harness(harness_name: str, info: dict,
         # passed. Same run, two answers; the one a human reads was the wrong one.
         print(f"Result: {len(results)}/{len(results)} INCONCLUSIVE "
               f"(simulated; no target contacted, nothing exercised)")
+
+    # --report: the same document --json prints, at the path that was asked for.
+    if report_path:
+        try:
+            with open(report_path, "w", encoding="utf-8") as _rf:
+                _json.dump(report, _rf, indent=2)
+        except OSError as e:
+            print(f"error: could not write --report {report_path}: {e}",
+                  file=sys.stderr)
+            sys.exit(1)
+        print(f"Report written to {report_path}", file=sys.stderr)
 
     # --html support
     if html_output:
@@ -700,7 +729,8 @@ def main():
         # For aiuc1, pass --simulate through (it handles simulation natively).
         # For all other harnesses, intercept here and produce synthetic JSON.
         if simulate and harness_name != "aiuc1":
-            _simulate_harness(harness_name, info, json_output, html_output)
+            _simulate_harness(harness_name, info, json_output, html_output,
+                              report_path=_report_path_from(filtered_args))
             sys.exit(0)
 
         # For aiuc1 with --simulate, pass the flag through to the module

--- a/protocol_tests/delegation_chain_harness.py
+++ b/protocol_tests/delegation_chain_harness.py
@@ -686,7 +686,7 @@ class DelegationChainTests(RecordingHarness):
             "request": request.as_json(),
         }
         resp = http_post_json(self.url, payload, self.headers, timeout=8)
-        return resp, self._target_allowed(resp)
+        return resp, self._target_decision(resp) == "allow"
 
     #: The live response contract this harness grades. A conforming target
     #: answers a chain-plus-request with a JSON object carrying a boolean
@@ -698,40 +698,57 @@ class DelegationChainTests(RecordingHarness):
     def _target_decision(cls, resp: dict) -> str:
         """'allow' | 'deny' | 'undecided'. Three states, because two conflate.
 
-        `_target_allowed` returned False for an explicit `{"allowed": false}`
-        AND for `{}`, `{"allowed": "true"}`, a JSON-RPC error, or a transport
-        error. `_live_replay` read that False as "the replay was refused" and
-        graded PASS. A second response that established NOTHING was counted as
-        the control holding. Found by an external second review, 2026-09-07,
-        with a real HTTP fixture. 'deny' now requires a boolean False under a
-        decision key; anything else that is not a boolean True is undecided.
+        THE parser. Every live verdict path reads the decision through this
+        function and no other. There used to be two: this one, read by the
+        DCA-005 replay hook, and `_target_allowed`, read by `_probe_live` for
+        every other row. They agreed on well-formed responses and disagreed on
+        `{"allowed": false, "granted": true}`: this one stopped at the first
+        key and said deny; the other accepted ANY true alias and said allow.
+        So DCA-009/010 graded PASS on a response DCA-005 called a refusal.
+        Found by the third external review, 2026-09-07.
+
+        Precedence, stated: there is none. Every decision key present must
+        carry a boolean, and every boolean present must agree. One key is a
+        decision; two keys that agree are the same decision; two keys that
+        disagree are a contradiction and establish nothing. A decision key
+        carrying a non-boolean (`"true"`, `1`, an object) is a malformed
+        decision, and a malformed decision next to a well-formed one is not
+        upgraded to the well-formed one. `null` is read as not stated.
+
+        History: `_target_allowed` returned False for an explicit
+        `{"allowed": false}` AND for `{}`, `{"allowed": "true"}`, a JSON-RPC
+        error, or a transport error; `_live_replay` read that False as "the
+        replay was refused" and graded PASS (second review). 'deny' requires
+        a boolean False; anything that is not a boolean is undecided.
         """
+        return cls._decide(resp)[0]
+
+    @classmethod
+    def _decide(cls, resp: dict) -> tuple[str, str]:
+        """(state, reason). The reason is empty for allow/deny and names the
+        cause for undecided, so an INCONCLUSIVE row can say WHY on the row."""
         if not isinstance(resp, dict) or resp.get("_error") or "error" in resp:
-            return "undecided"
+            return "undecided", ""
+        seen: dict[str, bool] = {}
         for k in cls._DECISION_KEYS:
             v = resp.get(k)
-            if v is True:
-                return "allow"
-            if v is False:
-                return "deny"
-        return "undecided"
+            if v is None:
+                continue
+            if not isinstance(v, bool):
+                return "undecided", f"decision key {k!r} is not a boolean"
+            seen[k] = v
+        if not seen:
+            return "undecided", ""
+        if len(set(seen.values())) > 1:
+            stated = ", ".join(f"{k}={str(v).lower()}" for k, v in seen.items())
+            return "undecided", f"decision keys contradict each other ({stated})"
+        return ("allow" if next(iter(seen.values())) else "deny"), ""
 
     @classmethod
     def _target_allowed(cls, resp: dict) -> bool:
-        """Structural read of the decision. Booleans only, on the parsed dict.
-
-        This used to search `json.dumps(resp.get("_body", ""))` for the text
-        `"allowed": true`. `http_post_json` returns the PARSED body with
-        `_status` injected on success; `_body` exists only on HTTP errors. So a
-        target that returned exactly `{"allowed": true}` with HTTP 200 -- the
-        one unambiguous allow this module says it grades -- was classified as
-        undecided, every live row was INCONCLUSIVE, and the closed-port tests
-        could not tell, because against a closed port that is the right answer.
-        Found by an external review running a real allow-all HTTP fixture.
-        """
-        if not isinstance(resp, dict) or resp.get("_error"):
-            return False
-        return any(resp.get(k) is True for k in cls._DECISION_KEYS)
+        """`_target_decision(resp) == "allow"`, and nothing else. Kept as a
+        name so a reader who knew the old one finds the definition."""
+        return cls._target_decision(resp) == "allow"
 
     #: Why a live refusal is not a live pass. There is no interoperable wire
     #: format for a delegation pass, so a target that answers without reporting
@@ -804,6 +821,10 @@ class DelegationChainTests(RecordingHarness):
             else:
                 passed = False
                 details = f"{INCONCLUSIVE_PREFIX}{self._LIVE_UNDECIDED}"
+                _state, why = self._decide(response)
+                if why:
+                    details = f"{INCONCLUSIVE_PREFIX}{why}; no decision is read from " \
+                              f"this response. {self._LIVE_UNDECIDED}"
         r = DelegationResult(
             test_id=test_id, name=name, owasp_asi=owasp, severity=severity,
             passed=passed, details=details, category=category, stride=stride,
@@ -1216,14 +1237,20 @@ class DelegationChainTests(RecordingHarness):
         response = {"_status": worst, "first": first, "second": second}
         r1, r2 = first.get("receipt"), second.get("receipt")
         if d1 != "allow":
+            why = self._decide(first)[1]
             return (False, f"{INCONCLUSIVE_PREFIX}the target did not allow the "
-                    "legitimate first request, so there is nothing to replay. "
+                    "legitimate first request"
+                    + (f" ({why})" if why else "")
+                    + ", so there is nothing to replay. "
                     "Replay handling is not exercised by this run.",
                     response, sent)
         if d2 == "undecided":
+            why = self._decide(second)[1]
             return (False, f"{INCONCLUSIVE_PREFIX}the second presentation produced no "
-                    "decision (empty body, non-boolean decision, or an application "
-                    "error). That is not a refusal; nothing about replay handling "
+                    "decision ("
+                    + (why if why else "empty body, non-boolean decision, or an "
+                       "application error")
+                    + "). That is not a refusal; nothing about replay handling "
                     "is established.", response, sent)
         if d2 == "deny":
             return (True, "replay REFUSED by the live target: the second presentation "

--- a/protocol_tests/run_provenance.py
+++ b/protocol_tests/run_provenance.py
@@ -59,6 +59,13 @@ Redaction is best-effort and says so: it recognises a list of auth-shaped
 names, and a credential passed under a name not on that list survives. That is
 why the field is `argv_redacted` (something was replaced) and not
 `argv_is_safe` (a claim about what remains).
+
+URLs are the exception to name-matching. A query parameter's NAME is chosen by
+the target, so inside a URL query (and fragment) every value is replaced unless
+the name is on `_QUERY_PARAM_ALLOWLIST` -- a short list of protocol/format
+selectors. Scheme, host, port and path are kept as sent. The allowlist is
+stated in the block's `not_claimed`, so a `[REDACTED]` query value is read as
+"not on the allowlist", not as "a credential was here".
 """
 from __future__ import annotations
 
@@ -68,6 +75,7 @@ import platform
 import re
 import subprocess
 import sys
+import urllib.parse
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -247,6 +255,27 @@ def _split_attached_short(arg: str) -> tuple[str, str] | None:
 
 
 _URL_USERINFO_RE = re.compile(r"^([a-zA-Z][a-zA-Z0-9+.-]*://)([^/@\s]+)@")
+_URL_SHAPED_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*://")
+
+#: Query-parameter NAMES whose value survives into the record verbatim.
+#:
+#: This is an allowlist, and the only one in this module, because a URL query
+#: is the one place in argv where the NAME of a credential is chosen by the
+#: target rather than by the harness. `?api_key=` was caught by the name
+#: regex; `?sig=`, `?k=`, `?access=`, `?code=` were not, and no name list can
+#: be complete against a vocabulary someone else controls. Everything else in
+#: argv (subcommands, model tags, counts, flag names) is the harness's own
+#: vocabulary, where a deny-list of auth-shaped names is checkable and an
+#: allowlist would eat the command.
+#:
+#: The names here select a protocol or format variant. None of them can carry
+#: an authority, and none of them matches `_AUTH_NAME_RE` -- asserted below so
+#: a later edit cannot quietly allow one that does.
+_QUERY_PARAM_ALLOWLIST = frozenset({
+    "transport", "protocol", "version", "api-version", "api_version", "v",
+    "format", "mode", "stream", "model",
+})
+assert not any(_AUTH_NAME_RE.search(n) for n in _QUERY_PARAM_ALLOWLIST)
 
 
 def _strip_url_userinfo(arg: str) -> str:
@@ -256,6 +285,57 @@ def _strip_url_userinfo(arg: str) -> str:
     flag-name paths never see them because the argument is a URL, not a flag.
     """
     return _URL_USERINFO_RE.sub(rf"\1{REDACTED}@", arg)
+
+
+def _redact_query_params(query: str) -> tuple[str, bool]:
+    """Replace the value of every query parameter not on the allowlist.
+
+    Operates on the raw `name=value&name=value` text rather than through
+    `parse_qsl`/`urlencode`, so the parameters that survive are byte-for-byte
+    what was sent -- a re-encoded query is a different reproduction step.
+    Names are percent-decoded and lower-cased ONLY for the allowlist test.
+    """
+    if not query:
+        return query, False
+    out, replaced = [], False
+    for part in query.split("&"):
+        name, sep, value = part.partition("=")
+        key = urllib.parse.unquote(name).strip().lower()
+        if sep and value and key not in _QUERY_PARAM_ALLOWLIST:
+            out.append(f"{name}={REDACTED}")
+            replaced = True
+        else:
+            out.append(part)
+    return "&".join(out), replaced
+
+
+def _redact_url(arg: str) -> tuple[str, bool]:
+    """Scrub the credential-bearing parts of a URL, keep the rest.
+
+    Scheme, host, port and path survive: they are what makes a run
+    reproducible. Userinfo is replaced whole. Query and fragment values are
+    replaced unless the parameter name is on `_QUERY_PARAM_ALLOWLIST`.
+
+    `--url=http://host/?api_key=<secret>` survived the previous version with
+    `argv_redacted=False`: the userinfo strip does not look at the query, and
+    the equals-form flag hid the query's own `=` from the inline matcher (the
+    separated form `--url http://host/?api_key=...` was caught by that matcher
+    only because `partition("=")` happened to split at the right place).
+    Found by the third external review, 2026-09-07.
+    """
+    stripped = _strip_url_userinfo(arg)
+    replaced = stripped != arg
+    try:
+        parts = urllib.parse.urlsplit(stripped)
+    except ValueError:
+        return stripped, replaced
+    query, q_replaced = _redact_query_params(parts.query)
+    fragment, f_replaced = _redact_query_params(parts.fragment)
+    if not (q_replaced or f_replaced):
+        return stripped, replaced
+    rebuilt = urllib.parse.urlunsplit(
+        (parts.scheme, parts.netloc, parts.path, query, fragment))
+    return rebuilt, True
 
 
 def _split_flag(arg: str) -> tuple[str, str] | None:
@@ -297,9 +377,24 @@ def _basename_if_absolute(arg: str) -> str:
     version of this function only cleaned `argv[0]` -- which read as a rule
     about paths while enforcing one about position.
     """
-    if arg.startswith("/") or re.match(r"^[A-Za-z]:[\\/]", arg) or arg.startswith("~/"):
+    if _ABSOLUTE_PATH_RE.match(arg):
         return os.path.basename(arg.replace("\\", "/")) or arg
     return arg
+
+
+#: Every absolute-path spelling, on every host, tested as data so a Linux
+#: runner reduces a Windows path the same way a Windows runner would. The
+#: previous test knew `/`, `X:\` and `~/`; a UNC path (`\\host\share\...`)
+#: carries a HOSTNAME -- the first thing docs/PRIVACY.md says never travels --
+#: and survived. Found by the third external review, 2026-09-07.
+_ABSOLUTE_PATH_RE = re.compile(
+    r"^(?:"
+    r"/"                      # POSIX absolute
+    r"|[A-Za-z]:[\\/]"        # drive-letter absolute, either separator
+    r"|\\\\[^\\/]+[\\/]"      # UNC: \\host\share\...
+    r"|~[^/\\]*[/\\]"         # ~/ and ~user/
+    r")"
+)
 
 
 def redact_argv(argv: list[str]) -> tuple[list[str], bool]:
@@ -362,22 +457,36 @@ def redact_argv(argv: list[str]) -> tuple[list[str], bool]:
             out.append(f"{split[0]}={REDACTED}")
             redacted = True
             continue
-        # A NON-auth flag's equals value can still be a URL with userinfo:
-        # `--url=https://u:p@host/`. The userinfo strip was anchored to the
-        # start of the whole element, so the bare form was scrubbed and this
-        # form was not. Found by an external second review, 2026-09-07.
+        # A NON-auth flag's equals value is still a value: a URL gets the URL
+        # treatment (userinfo, query, fragment) and an absolute path gets the
+        # basename treatment. Both used to see only the BARE form, so
+        # `--url=https://u:p@host/` (second review) and then
+        # `--url=http://host/?api_key=...` and `--report=C:\\Users\\<user>\\...`
+        # (third review) walked through untouched while the separated
+        # spellings of the same arguments were scrubbed.
         if split and split[1]:
-            value = _strip_url_userinfo(split[1])
-            if value != split[1]:
-                out.append(f"{split[0]}={value}")
-                redacted = True
-                continue
+            value = split[1]
+            if _URL_SHAPED_RE.match(value):
+                value, replaced = _redact_url(value)
+                redacted = redacted or replaced
+            else:
+                value = _basename_if_absolute(value)
+            out.append(f"{split[0]}={value}")
+            continue
+
+        # A bare URL is parsed as one, not matched as `key=value` text. The
+        # inline matcher caught `http://host/?token=x` only because the first
+        # `=` happened to follow an auth word; `?sig=x` it would have kept.
+        if _URL_SHAPED_RE.match(arg):
+            value, replaced = _redact_url(arg)
+            redacted = redacted or replaced
+            out.append(value)
+            continue
 
         cleaned = _redact_inline(arg)
-        cleaned2 = _strip_url_userinfo(cleaned)
-        if cleaned2 != arg:
+        if cleaned != arg:
             redacted = True
-        out.append(_basename_if_absolute(cleaned2))
+        out.append(_basename_if_absolute(cleaned))
 
     # A trailing auth flag with no value after it. Nothing to redact, and
     # dropping the flag would misreport the command that was run.
@@ -608,9 +717,16 @@ def run_provenance(**overrides: Any) -> dict[str, Any]:
             "names and a credential passed under another name survives.",
             "No hostname, username, working directory or absolute path is "
             "recorded, by the rule in docs/PRIVACY.md. Every absolute path in "
-            "argv is reduced to its basename, unconditionally and without "
+            "argv -- POSIX, drive-letter, UNC and ~user forms, bare or after "
+            "--flag= -- is reduced to its basename, unconditionally and without "
             "setting argv_redacted, so a bare filename here was never a full "
             "path in this record. Their absence is a decision, not an omission.",
+            "URL query and fragment values are replaced unless the parameter "
+            "name is on a short allowlist of protocol/format selectors "
+            f"({', '.join(sorted(_QUERY_PARAM_ALLOWLIST))}). A [REDACTED] "
+            "query value is therefore not evidence that a credential was "
+            "there; it is evidence that the name was not on the allowlist. "
+            "Scheme, host, port and path are kept as sent.",
         ],
     }
     statement.update(overrides)

--- a/testing/test_delegation_live_fixtures.py
+++ b/testing/test_delegation_live_fixtures.py
@@ -292,3 +292,104 @@ class AFalseDecisionIsNotARefusal(unittest.TestCase):
         finally:
             fx.close()
         self.assertTrue(is_inconclusive(r), r.details); self.assertFalse(r.passed)
+
+
+# ---------------------------------------------------------------------------
+# Third external review, 2026-09-07: two parsers, one contradictory response.
+# ---------------------------------------------------------------------------
+
+def contradictory_deny_first(payload, fx):
+    return {"allowed": False, "granted": True, "receipt": uuid.uuid4().hex}
+
+
+def contradictory_allow_first(payload, fx):
+    return {"allowed": True, "granted": False, "receipt": uuid.uuid4().hex}
+
+
+class AContradictoryDecisionIsNoDecision(unittest.TestCase):
+    """`_target_decision` stopped at the first key ("deny"); `_target_allowed`
+    accepted ANY true alias ("allow"). `_probe_live` used the second and
+    `_live_replay` the first, so DCA-009/010 PASSED on a response DCA-005
+    called a refusal. One parser now; a contradiction is undecided, and every
+    row says so on the row."""
+
+    def _rows(self, policy):
+        fx = _Fixture(policy)
+        try:
+            rows = _run(fx)
+        finally:
+            fx.close()
+        self.assertGreaterEqual(len(fx.requests), len(ALL_IDS))
+        return rows
+
+    def _assert_every_row_undecided(self, rows):
+        for tid in sorted(ALL_IDS):
+            with self.subTest(tid):
+                r = rows[tid]
+                self.assertTrue(is_inconclusive(r), r.details)
+                self.assertFalse(r.passed, r.details)
+                self.assertNotIn("LIVE TARGET ALLOWED", r.details)
+                self.assertIn("contradict", r.details)
+                # The target answered; this is the parser's undecided, not
+                # the transport guard's.
+                self.assertNotIn("did not service", r.details)
+
+    def test_allowed_false_granted_true_every_row_inconclusive(self):
+        self._assert_every_row_undecided(self._rows(contradictory_deny_first))
+
+    def test_allowed_true_granted_false_every_row_inconclusive(self):
+        self._assert_every_row_undecided(self._rows(contradictory_allow_first))
+
+    def test_the_accept_rows_did_not_pass(self):
+        """The specific false pass: DCA-009/010 read `granted: true` as the
+        legitimate chain being allowed while DCA-005 read the same body as
+        a refusal."""
+        rows = self._rows(contradictory_deny_first)
+        for tid in sorted(ACCEPT_ROWS):
+            with self.subTest(tid):
+                self.assertFalse(rows[tid].passed, rows[tid].details)
+                self.assertIs(rows[tid].response_received.get("granted"), True)
+
+    def test_a_contradictory_second_presentation_is_not_a_refusal(self):
+        r = _Fixture(_second_response_policy({"allowed": False, "granted": True}))
+        try:
+            row = _run(r)[REPLAY_ROW]
+        finally:
+            r.close()
+        self.assertTrue(is_inconclusive(row), row.details)
+        self.assertFalse(row.passed)
+        self.assertIn("contradict", row.details)
+
+
+class OneParserForEveryLiveVerdict(unittest.TestCase):
+    """Pin the definition, not only the behaviour: the boolean read IS the
+    three-state read, on every response shape the fixtures above use."""
+
+    SHAPES = [
+        {"allowed": True}, {"granted": True}, {"allowed": False},
+        {"allowed": True, "granted": True}, {"allowed": False, "granted": True},
+        {"allowed": True, "granted": False}, {"allowed": "true"},
+        {"allowed": "true", "granted": True}, {"allowed": None, "granted": True},
+        {}, {"error": {"code": -32601}}, {"_error": "refused"},
+    ]
+
+    def test_target_allowed_is_target_decision_equals_allow(self):
+        for shape in self.SHAPES:
+            with self.subTest(shape=shape):
+                self.assertEqual(
+                    DelegationChainTests._target_allowed(shape),
+                    DelegationChainTests._target_decision(shape) == "allow")
+
+    def test_agreeing_aliases_and_null_are_a_decision(self):
+        d = DelegationChainTests._target_decision
+        self.assertEqual(d({"allowed": True, "granted": True}), "allow")
+        self.assertEqual(d({"allowed": False, "granted": False}), "deny")
+        self.assertEqual(d({"allowed": None, "granted": True}), "allow")
+        self.assertEqual(d({"granted": False}), "deny")
+
+    def test_contradiction_and_malformed_are_undecided(self):
+        d = DelegationChainTests._target_decision
+        self.assertEqual(d({"allowed": False, "granted": True}), "undecided")
+        self.assertEqual(d({"allowed": True, "granted": False}), "undecided")
+        self.assertEqual(d({"allowed": "true", "granted": True}), "undecided")
+        self.assertEqual(d({"allowed": 1}), "undecided")

--- a/tests/test_report_states_its_provenance.py
+++ b/tests/test_report_states_its_provenance.py
@@ -291,6 +291,23 @@ def test_a_bearer_header_does_not_reach_the_document():
     (["p", "--key=" + CANARY], CANARY),
     (["p", "--header=X-Custom: " + CANARY], CANARY),
     (["p", "-H" + "Authorization: Bearer " + CANARY], CANARY),
+    # --- third review, 2026-09-07: a credential in a URL QUERY ---
+    # Equals-form flag: the flag's own `=` hid the query's `=` from the
+    # inline matcher, and the userinfo strip never looks past the netloc.
+    # (`api_key` and its `=` are separate literals so the repo's own secret
+    # scanner does not read the fixture as an assignment.)
+    (["p", "--url=http://127.0.0.1:9/?api_key" + "=" + CANARY], CANARY),
+    (["p", "--url=http://127.0.0.1:9/mcp?token=" + CANARY], CANARY),
+    # Separated form was caught by accident (partition at the right `=`);
+    # pinned so the URL parser, not the accident, is what holds it.
+    (["p", "--url", "http://127.0.0.1:9/?token=" + CANARY], CANARY),
+    # Names the auth regex does not know. Only an allowlist catches these.
+    (["p", "--url", "http://127.0.0.1:9/?sig=" + CANARY], CANARY),
+    (["p", "--url=http://127.0.0.1:9/?k=" + CANARY], CANARY),
+    (["p", "--url=http://127.0.0.1:9/?transport=sse&code=" + CANARY], CANARY),
+    # Bare URL, no flag. And a fragment, which OAuth implicit flows use.
+    (["p", "http://127.0.0.1:9/?signature=" + CANARY], CANARY),
+    (["p", "http://127.0.0.1:9/cb#access_token=" + CANARY], CANARY),
 ])
 def test_credential_shapes_are_redacted(argv, secret):
     out, redacted = redact_argv(argv)
@@ -313,6 +330,35 @@ def test_ordinary_arguments_survive_intact():
     assert redacted is False
 
 
+def test_the_rest_of_the_url_survives_query_redaction():
+    """Reproducibility: scheme, host, port, path and allowlisted selectors
+    are kept byte-for-byte; only the unallowlisted VALUE is replaced."""
+    out, redacted = redact_argv(
+        ["p", "--url=http://127.0.0.1:9/mcp?transport=sse&api_key" + "=" + CANARY])
+    assert out == ["p", "--url=http://127.0.0.1:9/mcp?transport=sse&api_key=[REDACTED]"]
+    assert redacted is True
+
+
+def test_allowlisted_query_selectors_do_not_set_the_flag():
+    """`?transport=sse` is a protocol selector, not a secret. Replacing it
+    would both lose the reproduction and make `argv_redacted` mean nothing."""
+    out, redacted = redact_argv(
+        ["p", "--url", "http://localhost:8080/mcp?transport=sse&version=2"])
+    assert out == ["p", "--url", "http://localhost:8080/mcp?transport=sse&version=2"]
+    assert redacted is False
+
+
+def test_the_query_allowlist_is_stated_in_not_claimed():
+    """A reader of the published block must be able to tell a [REDACTED]
+    query value from a credential without reading this module."""
+    from protocol_tests.run_provenance import _QUERY_PARAM_ALLOWLIST
+    with mock.patch.object(sys, "argv", ["p"]):
+        text = " ".join(run_provenance()["not_claimed"])
+    for name in _QUERY_PARAM_ALLOWLIST:
+        assert name in text, name
+    assert "not evidence that a credential was there" in text
+
+
 def test_help_is_not_treated_as_a_header_flag():
     """`-H` is the header short flag; `-h` is --help. Case matters."""
     out, redacted = redact_argv(["p", "-h", "mcp"])
@@ -332,6 +378,32 @@ def test_absolute_paths_are_reduced_but_that_is_not_redaction():
     assert out == ["agent-security", "--report", "run.json"]
     assert redacted is False
     assert "alice" not in " ".join(out)
+
+
+@pytest.mark.parametrize("arg,expect", [
+    # Windows spellings, tested as DATA on whatever host runs this: the
+    # privacy rule is about the record, not about the runner's OS.
+    ("--report=C:\\Users\\SyntheticUser\\evidence\\run.json", "--report=run.json"),
+    ("C:\\Users\\SyntheticUser\\evidence\\run.json", "run.json"),
+    ("--report=C:/Users/SyntheticUser/run.json", "--report=run.json"),
+    # UNC carries a HOSTNAME, the first thing docs/PRIVACY.md excludes.
+    ("\\\\SyntheticHost\\share\\run.json", "run.json"),
+    ("--report=\\\\SyntheticHost\\share\\run.json", "--report=run.json"),
+    ("//SyntheticHost/share/run.json", "run.json"),
+    # POSIX equals form, and ~user.
+    ("--report=/home/alice/evidence/run.json", "--report=run.json"),
+    ("--report=~alice/evidence/run.json", "--report=run.json"),
+    ("~alice/evidence/run.json", "run.json"),
+])
+def test_every_absolute_path_spelling_is_reduced_in_both_forms(arg, expect):
+    """`--report=C:\\...` and `\\\\host\\share\\...` both survived while
+    `not_claimed` promised no absolute path is recorded. Path reduction saw
+    only bare arguments and only `/`, `X:\\`, `~/`. Third review, 2026-09-07."""
+    out, redacted = redact_argv(["p", arg])
+    assert out == ["p", expect], out
+    assert redacted is False, "path reduction is not redaction"
+    for leak in ("SyntheticUser", "SyntheticHost", "alice", "Users", "share"):
+        assert leak not in " ".join(out)
 
 
 def test_no_hostname_username_or_working_directory_is_recorded():
@@ -604,6 +676,11 @@ def test_the_hand_assembled_evidence_file_is_left_alone():
     (["p", "--url", "https://alice:" + CANARY + "@host.example/mcp"], CANARY),
     # equals form of the same thing; the strip was anchored to the element
     (["p", "--url=https://alice:" + CANARY + "@host.example/mcp"], CANARY),
+    # third review: a recognized credential NAME in the query, equals-form
+    # flag. Survived run_provenance() -> strip_sensitive_fields() with
+    # argv_redacted=False.
+    (["p", "--url=http://127.0.0.1:9/?api_key" + "=" + CANARY], CANARY),
+    (["p", "--url", "http://127.0.0.1:9/?sig=" + CANARY], CANARY),
 ])
 def test_no_recognized_credential_survives_into_the_publication_copy(argv, secret):
     """`run_provenance()` -> `strip_sensitive_fields()` is the path a record
@@ -617,6 +694,22 @@ def test_no_recognized_credential_survives_into_the_publication_copy(argv, secre
     published = strip_sensitive_fields({"provenance": block})
     assert secret not in json.dumps(published), published["provenance"]["invocation"]
     assert published["provenance"]["invocation"]["argv_redacted"] is True
+
+
+@pytest.mark.parametrize("argv", [
+    ["p", "--report=C:\\Users\\SyntheticUser\\evidence\\run.json"],
+    ["p", "--report", "\\\\SyntheticHost\\share\\run.json"],
+])
+def test_no_absolute_path_survives_into_the_publication_copy(argv):
+    """The `not_claimed` sentence promises no absolute path is recorded. Held
+    at the publication copy, for the two spellings that broke it."""
+    from protocol_tests.attestation_registry import strip_sensitive_fields
+    with mock.patch.object(sys, "argv", argv):
+        block = run_provenance()
+    published = json.dumps(strip_sensitive_fields({"provenance": block}))
+    assert "SyntheticUser" not in published
+    assert "SyntheticHost" not in published
+    assert "run.json" in published
 
 
 def test_innocent_arguments_are_not_redacted():

--- a/tests/test_simulate_does_not_claim_a_pass.py
+++ b/tests/test_simulate_does_not_claim_a_pass.py
@@ -111,6 +111,56 @@ class TheRenderedPageMakesNoClaim(unittest.TestCase):
         self.assertNotIn('class="badge badge-fail"', self.html)
 
 
+class ReportIsHonouredOnTheSimulatePath(unittest.TestCase):
+    """`--simulate --report x.json` exited 0 and wrote nothing: the dispatcher
+    exits before the module would see `--report`. Silent success is the
+    defect; the file must carry the same document `--json` prints. Found by
+    the third external review, 2026-09-07."""
+
+    def _run_report(self, *spelling):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = os.path.join(tmp, "sim.json")
+            done = run_cli("test", "mcp", "--simulate",
+                           *[a.replace("{out}", out) for a in spelling])
+            self.assertEqual(done.returncode, 0, done.stderr)
+            self.assertTrue(os.path.exists(out),
+                            f"--report produced no file (exit {done.returncode})"
+                            f"\n{done.stderr[-600:]}")
+            with open(out) as fh:
+                return json.load(fh), done
+
+    def test_separated_form_writes_the_file(self):
+        report, done = self._run_report("--report", "{out}")
+        self.assertEqual(report["status"], "inconclusive")
+        self.assertEqual(report["mode"], "simulation")
+        self.assertTrue(report["results"])
+        for r in report["results"]:
+            with self.subTest(test_id=r.get("test_id")):
+                self.assertFalse(r["passed"])
+                self.assertTrue(r["not_evaluated"])
+        self.assertIn("Report written to", done.stderr)
+
+    def test_equals_form_writes_the_file(self):
+        report, _ = self._run_report("--report={out}")
+        self.assertEqual(report["status"], "inconclusive")
+        self.assertEqual(report["summary"]["serviced"], 0)
+
+    def test_the_file_is_the_document_json_prints(self):
+        report, _ = self._run_report("--report", "{out}", "--json")
+        printed = json.loads(run_cli("test", "mcp", "--simulate", "--json").stdout)
+        for doc in (report, printed):
+            doc.pop("timestamp", None)
+        self.assertEqual(report, printed)
+
+    def test_an_unwritable_path_is_a_nonzero_exit_not_silence(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = os.path.join(tmp, "no-such-dir", "sim.json")
+            done = run_cli("test", "mcp", "--simulate", "--report", out)
+            self.assertNotEqual(done.returncode, 0)
+            self.assertIn("could not write --report", done.stderr)
+            self.assertFalse(os.path.exists(out))
+
+
 class HtmlIsReachableOnTheLivePath(unittest.TestCase):
     def test_html_produces_a_file_against_an_unreachable_target(self):
         """The block used to be dead code: exit 0, no file, no warning."""


### PR DESCRIPTION
From the third external review.

R3-05/06: `redact_argv` missed credentials in URL query strings (`?api_key=`) and leaked the operator's Windows username and UNC host through `--report=C:\Users\...` and `\\host\share\...`. Query params are redacted against an allowlist; equals-form and UNC paths reduce to basename. Reproduced: query key → `[REDACTED]`, both path forms → `run.json`, no username or host in the output.

R3-10: `delegation_chain_harness` read `allowed` and `granted` with a precedence order, so `{"allowed": false, "granted": true}` was decided. Single parser `_decide` with no precedence: a contradiction is `undecided`, and `_target_allowed` is False for it. Reproduced.

R3-13: `--simulate --report path` printed to console and wrote nothing. Now writes the file (exit 0, file present — reproduced).

Noted, not in this PR: `_simulate_harness` telemetry still reports `passed=len(results)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)