### PR TITLE
R3-07: community regex evaluation has a real wall-clock bound; a budget overrun is INCONCLUSIVE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,38 @@ equal an independent recomputation.
 None of this establishes that the detectors are complete; it establishes that
 each fails when switched off, which they did not before.
 
+### Fixed — a community plugin regex could hang the runner (R3-07, Medium; third external review, 2026-09-07)
+
+**`field_matches` capped the size of an untrusted regex and not its running
+time.** `community_runner.py` loads YAML plugins it does not trust, and a
+`field_matches` assertion hands `re.search` an attacker-chosen pattern. The
+guard capped the pattern at 200 characters, truncated the input at 10,000,
+rejected nested quantifiers by a syntactic check, and then called `re.search`
+in-process. `(a|aa)+$` passes all three. On `"a" * 37 + "!"` the evaluator did
+not return within four seconds (reproduced: killed at the 4 s cap, no output);
+the reviewer measured 0.004 s at 21 characters and 0.182 s at 29, and the
+curve is exponential. One plugin assertion could stop a whole community run.
+
+Every community regex now runs in a child interpreter (`sys.executable -I`)
+that is killed at `MAX_REGEX_EVAL_SECONDS` (1.0 s) of wall clock, via
+`evaluate_regex_bounded`. A child process that is killed stops; a thread that
+is joined with a timeout does not, which is why this is not a thread. No new
+dependency. The length caps are kept as the first two layers, the
+nested-quantifier check as the third, the kill as the fourth. A benign match
+costs about 12 ms.
+
+An assertion the runner could not evaluate -- budget exceeded, rejected by a
+cap, or a pattern that does not compile -- is INCONCLUSIVE: `passed: false`,
+the `INCONCLUSIVE - ` prefix on the detail, and the reason `pattern evaluation
+exceeded budget`. It was FAIL before, which filed an unevaluable plugin as a
+target that failed. `PatternResult` gains `not_evaluated: bool` and
+`assertions_inconclusive: int`, a pattern with any INCONCLUSIVE assertion is
+INCONCLUSIVE as a whole and never `passed`, and the batch summary counts
+`inconclusive` apart from `failed`. `testing/test_community_regex_budget.py`
+pins the bound (under 2 s wall clock), the verdict (never PASS), and that
+benign matches and non-matches keep their verdicts. Documented in the module
+docstring and `docs/PLUGIN_SPEC.md`.
+
 ## [4.21.0] - 2026-09-07
 
 **The instrument was the thing under test.** This release is what happened when

--- a/HARNESS_TEST_CATALOG.md
+++ b/HARNESS_TEST_CATALOG.md
@@ -1,7 +1,7 @@
 # Agent Security Harness — Canonical Test Catalog
 
 **Source repo:** msaleme/red-team-blue-team-agent-fabric
-**Generated:** `scripts/generate_test_catalog.py` at commit `d6c8887`
+**Generated:** `scripts/generate_test_catalog.py` at commit `cebfcb0`
 **Test count:** 623 unique test IDs across 46 registered harness modules (45 contain test IDs; `community_runner.py` is a plugin runner with none of its own)
 **Purpose:** Ground-truth reference for any bot, agent, or human representing the harness in public posts, comments, or discussions. Cite only tests listed here. Do not invent IDs or statistics.
 

--- a/HARNESS_TEST_CATALOG.md
+++ b/HARNESS_TEST_CATALOG.md
@@ -1,7 +1,7 @@
 # Agent Security Harness — Canonical Test Catalog
 
 **Source repo:** msaleme/red-team-blue-team-agent-fabric
-**Generated:** `scripts/generate_test_catalog.py` at commit `77f420d`
+**Generated:** `scripts/generate_test_catalog.py` at commit `d6c8887`
 **Test count:** 623 unique test IDs across 46 registered harness modules (45 contain test IDs; `community_runner.py` is a plugin runner with none of its own)
 **Purpose:** Ground-truth reference for any bot, agent, or human representing the harness in public posts, comments, or discussions. Cite only tests listed here. Do not invent IDs or statistics.
 

--- a/docs/PLUGIN_SPEC.md
+++ b/docs/PLUGIN_SPEC.md
@@ -140,6 +140,22 @@ Each assertion checks a condition after all attack steps complete.
 | `field_equals` | Field must equal a specific value | `field`, `value` |
 | `field_matches` | Field must match a regex | `field`, `value` (regex) |
 
+### Regex bound for `field_matches`
+
+The regex in a `field_matches` assertion is evaluated under a hard budget,
+because plugin YAML is untrusted input to the runner:
+
+- pattern length at most 200 characters, input truncated to 10,000 characters;
+- nested quantifiers such as `(a+)+` are rejected before evaluation;
+- the match runs in a separate interpreter that is killed after 1.0 second of
+  wall clock (`MAX_REGEX_EVAL_SECONDS` in `community_runner.py`).
+
+An assertion that is rejected, does not compile, or is killed at the budget is
+reported as INCONCLUSIVE (`pattern evaluation exceeded budget`), not as PASS
+and not as FAIL, and a pattern containing one is INCONCLUSIVE as a whole
+(`not_evaluated: true` in the result). Keep patterns simple and unambiguous:
+`(a|aa)+$` is 8 characters and never finishes.
+
 ## Evidence Schema
 
 The `evidence_schema` declares what evidence this pattern collects. This is validated at load time to ensure the pattern runner captures the right data.

--- a/protocol_tests/community_runner.py
+++ b/protocol_tests/community_runner.py
@@ -19,6 +19,19 @@ Usage:
 
     # List discovered patterns
     python -m protocol_tests.community_runner --list
+
+Regex evaluation bound (R3-07)
+------------------------------
+``field_matches`` assertions carry an attacker-controlled regular expression:
+the YAML is untrusted. Length caps on the pattern (MAX_REGEX_LENGTH) and the
+input (MAX_REGEX_INPUT_LENGTH) do not bound ``re.search`` -- ``(a|aa)+$`` is
+200 characters short of the cap and does not finish on 37 characters of input.
+Every community regex is therefore evaluated in a child interpreter that is
+killed at MAX_REGEX_EVAL_SECONDS of wall clock. A pattern that is rejected
+before evaluation or killed during it yields an INCONCLUSIVE assertion
+("pattern evaluation exceeded budget"), never PASS, never FAIL: the target was
+not observed, so nothing about it was established. A pattern with any
+INCONCLUSIVE assertion is an INCONCLUSIVE pattern (``not_evaluated: true``).
 """
 
 from __future__ import annotations
@@ -28,12 +41,15 @@ import hashlib
 import json
 import os
 import re
+import subprocess
 import sys
 import time
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+
+from protocol_tests.http_helpers import INCONCLUSIVE_PREFIX, is_inconclusive
 
 try:
     import yaml
@@ -54,6 +70,12 @@ MAX_YAML_FILE_SIZE = 256 * 1024  # 256 KB max per YAML file
 MAX_DELAY_MS = 30_000  # 30 seconds max delay per step
 MAX_PATTERN_EXECUTION_TIMEOUT_S = 120  # 2 minutes max per pattern
 MAX_REGEX_LENGTH = 200  # Max regex pattern length for field_matches
+MAX_REGEX_INPUT_LENGTH = 10_000  # Max input length a field_matches regex is run against
+# Wall-clock budget for ONE community regex evaluation. The match runs in a
+# child interpreter that is killed when this elapses (R3-07); a length cap is
+# not a bound, and a thread join is not a kill. Exceeding it is INCONCLUSIVE.
+MAX_REGEX_EVAL_SECONDS = 1.0
+REGEX_BUDGET_EXCEEDED = "pattern evaluation exceeded budget"
 MAX_ATTACK_STEPS = 20  # Max number of attack steps per pattern
 
 # Trust tiers (ordered by privilege)
@@ -121,10 +143,20 @@ class PatternResult:
     framework: str = ""
     assertions_passed: int = 0
     assertions_total: int = 0
+    # INCONCLUSIVE marker read by http_helpers.is_inconclusive: at least one
+    # assertion could not be evaluated, so no verdict on the target exists.
+    not_evaluated: bool = False
+    assertions_inconclusive: int = 0
 
     def __post_init__(self):
         if not self.timestamp:
             self.timestamp = datetime.now(timezone.utc).isoformat()
+        # The prefix in prose must imply the field, so a serialised record is
+        # readable without re-parsing English (testing/test_inconclusive_is_structural).
+        if not self.not_evaluated and is_inconclusive(self.details):
+            self.not_evaluated = True
+        if self.not_evaluated:
+            self.passed = False
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -712,21 +744,87 @@ class AssertionEvaluator:
         pattern = str(assertion.get("value", ""))
         actual = str(self.evidence.get(field_name, ""))
 
-        # ReDoS protection: limit regex length AND input length
+        # ReDoS protection, layer 1: caps. These bound the *size* of the work,
+        # not its running time -- see MAX_REGEX_EVAL_SECONDS for the bound.
         if len(pattern) > MAX_REGEX_LENGTH:
-            return False, f"Regex pattern too long ({len(pattern)} > {MAX_REGEX_LENGTH} chars)"
+            return False, (f"{INCONCLUSIVE_PREFIX}{REGEX_BUDGET_EXCEEDED}: regex pattern "
+                           f"too long ({len(pattern)} > {MAX_REGEX_LENGTH} chars)")
         # Truncate input to prevent catastrophic backtracking on large data
-        if len(actual) > 10_000:
-            actual = actual[:10_000]
-        # Reject known ReDoS patterns (nested quantifiers)
+        if len(actual) > MAX_REGEX_INPUT_LENGTH:
+            actual = actual[:MAX_REGEX_INPUT_LENGTH]
+        # Layer 2: reject the one syntactic ReDoS shape that is cheap to name
+        # (nested quantifiers). Ambiguous alternation such as (a|aa)+ is not
+        # named here and is why layer 3 exists.
         if re.search(r'\([^)]*[+*][^)]*\)[+*]', pattern):
-            return False, "Regex contains nested quantifiers (potential ReDoS)"
-        try:
-            if re.search(pattern, actual):
-                return True, f"Field '{field_name}' matches pattern '{pattern}'"
-        except re.error as e:
-            return False, f"Invalid regex pattern: {e}"
-        return False, f"Field '{field_name}' does not match pattern '{pattern}'"
+            return False, (f"{INCONCLUSIVE_PREFIX}{REGEX_BUDGET_EXCEEDED}: regex contains "
+                           f"nested quantifiers (potential ReDoS)")
+        # Layer 3: the wall-clock bound, enforced by killing a child process.
+        outcome, message = evaluate_regex_bounded(pattern, actual)
+        if outcome == "match":
+            return True, f"Field '{field_name}' matches pattern '{pattern}'"
+        if outcome == "nomatch":
+            return False, f"Field '{field_name}' does not match pattern '{pattern}'"
+        if outcome == "error":
+            return False, f"{INCONCLUSIVE_PREFIX}invalid regex pattern: {message}"
+        return False, f"{INCONCLUSIVE_PREFIX}{REGEX_BUDGET_EXCEEDED}: {message}"
+
+
+# ---------------------------------------------------------------------------
+# Bounded regex evaluation (R3-07)
+# ---------------------------------------------------------------------------
+
+# Runs in a separate interpreter: reads {"pattern", "text"} on stdin, writes
+# {"matched": bool} or {"error": str} on stdout. Only stdlib, isolated mode.
+_REGEX_WORKER_SRC = (
+    "import json, re, sys\n"
+    "job = json.load(sys.stdin)\n"
+    "try:\n"
+    "    out = {'matched': re.search(job['pattern'], job['text']) is not None}\n"
+    "except re.error as exc:\n"
+    "    out = {'error': str(exc)}\n"
+    "sys.stdout.write(json.dumps(out))\n"
+)
+
+
+def evaluate_regex_bounded(
+    pattern: str,
+    text: str,
+    budget_s: float | None = None,
+) -> tuple[str, str]:
+    """Run ``re.search(pattern, text)`` under a hard wall-clock bound.
+
+    Returns ``(outcome, message)`` where outcome is one of ``"match"``,
+    ``"nomatch"``, ``"error"`` (the pattern does not compile) or
+    ``"timeout"`` (the child was killed at the budget). The match runs in a
+    child interpreter so that the kill is real: a thread that is joined with
+    a timeout keeps running, a child process that is killed does not.
+    """
+    budget = MAX_REGEX_EVAL_SECONDS if budget_s is None else budget_s
+    job = json.dumps({"pattern": pattern, "text": text})
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-I", "-c", _REGEX_WORKER_SRC],
+            input=job,
+            capture_output=True,
+            text=True,
+            timeout=budget,
+        )
+    except subprocess.TimeoutExpired:
+        # subprocess.run has already killed the child on this path.
+        return "timeout", f"regex did not finish within {budget:g}s"
+    except (OSError, ValueError) as exc:
+        return "timeout", f"regex worker could not be started ({exc})"
+    if proc.returncode != 0:
+        return "timeout", f"regex worker exited {proc.returncode}"
+    try:
+        out = json.loads(proc.stdout or "{}")
+    except json.JSONDecodeError:
+        return "timeout", "regex worker returned no verdict"
+    if "error" in out:
+        return "error", str(out["error"])
+    if "matched" not in out:
+        return "timeout", "regex worker returned no verdict"
+    return ("match" if out["matched"] else "nomatch"), ""
 
 
 # ---------------------------------------------------------------------------
@@ -790,6 +888,8 @@ def run_pattern(
     assertions_passed = 0
     assertion_details = []
 
+    assertions_inconclusive = 0
+
     for i, assertion in enumerate(pattern.assertions):
         if dry_run:
             passed = True
@@ -797,19 +897,29 @@ def run_pattern(
         else:
             passed, detail = evaluator.evaluate(assertion)
 
+        # An assertion that could not be evaluated (regex budget exceeded,
+        # R3-07) is a third state: it is not a target failure and it is
+        # never a pass.
+        inconclusive = (not passed) and is_inconclusive(detail)
         if passed:
             assertions_passed += 1
+        elif inconclusive:
+            assertions_inconclusive += 1
 
-        status = "PASS" if passed else "FAIL"
+        status = "PASS" if passed else ("INCONCLUSIVE" if inconclusive else "FAIL")
         desc = assertion.get("description", assertion.get("type", ""))
         assertion_details.append(f"{status}: {desc} - {detail}")
 
         if verbose:
-            icon = "ok" if passed else "FAIL"
+            icon = "ok" if passed else status
             print(f"    Assertion {i+1}: [{icon}] {desc}")
 
     elapsed = time.time() - start_time
     all_passed = assertions_passed == len(pattern.assertions)
+    not_evaluated = assertions_inconclusive > 0
+    details = "; ".join(assertion_details)
+    if not_evaluated:
+        details = f"{INCONCLUSIVE_PREFIX}{assertions_inconclusive} assertion(s) not evaluated; {details}"
 
     result = PatternResult(
         test_id=pattern.id,
@@ -817,17 +927,19 @@ def run_pattern(
         source_file=pattern.source_file,
         owasp_asi=pattern.owasp_category,
         severity=pattern.severity,
-        passed=all_passed,
-        details="; ".join(assertion_details),
+        passed=all_passed and not not_evaluated,
+        details=details,
         elapsed_s=round(elapsed, 3),
         evidence=evidence,
         framework=pattern.framework,
         assertions_passed=assertions_passed,
         assertions_total=len(pattern.assertions),
+        not_evaluated=not_evaluated,
+        assertions_inconclusive=assertions_inconclusive,
     )
 
     if verbose:
-        status = "PASS" if all_passed else "FAIL"
+        status = "PASS" if result.passed else ("INCONCLUSIVE" if not_evaluated else "FAIL")
         print(f"  Result: {status} ({assertions_passed}/{len(pattern.assertions)} assertions)")
 
     return result
@@ -969,19 +1081,20 @@ def run_community_tests(
     for pattern in patterns:
         result = run_pattern(pattern, target_url=target_url, verbose=verbose, dry_run=dry_run)
         results.append(result)
-        status = "PASS" if result.passed else "FAIL"
+        status = "PASS" if result.passed else ("INCONCLUSIVE" if result.not_evaluated else "FAIL")
         print(f"  {status} {result.test_id}: {result.name} "
               f"({result.assertions_passed}/{result.assertions_total} assertions, "
               f"{result.elapsed_s:.2f}s)")
 
-    # Summary
+    # Summary -- INCONCLUSIVE is counted apart from FAIL, not folded into it.
     passed = sum(1 for r in results if r.passed)
-    failed = len(results) - passed
+    inconclusive = sum(1 for r in results if not r.passed and r.not_evaluated)
+    failed = len(results) - passed - inconclusive
     total_time = sum(r.elapsed_s for r in results)
 
     print(f"\n{'='*60}")
-    print(f"Community Pattern Results: {passed} passed, {failed} failed "
-          f"({len(results)} total, {total_time:.2f}s)")
+    print(f"Community Pattern Results: {passed} passed, {failed} failed, "
+          f"{inconclusive} inconclusive ({len(results)} total, {total_time:.2f}s)")
     print(f"{'='*60}")
 
     summary = {
@@ -993,6 +1106,7 @@ def run_community_tests(
         "patterns_run": len(results),
         "passed": passed,
         "failed": failed,
+        "inconclusive": inconclusive,
         "total_time_s": round(total_time, 3),
         "results": [r.to_dict() for r in results],
     }

--- a/testing/test_community_regex_budget.py
+++ b/testing/test_community_regex_budget.py
@@ -1,0 +1,142 @@
+"""R3-07: a community `field_matches` regex cannot hang the runner.
+
+`community_runner.py` evaluates YAML plugins it does not trust, and a
+`field_matches` assertion hands the runner an attacker-chosen regular
+expression. The pre-existing guard capped the pattern length, capped the
+input length and rejected one syntactic shape (nested quantifiers). None of
+that bounds running time: `(a|aa)+$` passes every check and, on 37 `a`s
+followed by `!`, does not return within four seconds.
+
+The fix runs the match in a child interpreter that is killed at
+MAX_REGEX_EVAL_SECONDS, and reports the kill as INCONCLUSIVE. These tests
+pin the three properties that matter: bounded wall clock, INCONCLUSIVE (not
+FAIL, not PASS, not an exception) when the bound fires, and unchanged
+verdicts for patterns that finish.
+"""
+
+from __future__ import annotations
+
+import time
+import unittest
+
+from protocol_tests import community_runner as cr
+from protocol_tests.http_helpers import INCONCLUSIVE_PREFIX, is_inconclusive
+
+CATASTROPHIC_PATTERN = "(a|aa)+$"
+CATASTROPHIC_INPUT = "a" * 37 + "!"
+WALL_CLOCK_LIMIT_S = 2.0
+
+
+def _evaluate(pattern: str, text: str) -> tuple[bool, str]:
+    evaluator = cr.AssertionEvaluator({"field": text}, [])
+    return evaluator.evaluate({"type": "field_matches", "field": "field", "value": pattern})
+
+
+class TestCatastrophicPatternIsBounded(unittest.TestCase):
+
+    def test_ambiguous_alternation_returns_inconclusive_within_budget(self):
+        start = time.monotonic()
+        passed, detail = _evaluate(CATASTROPHIC_PATTERN, CATASTROPHIC_INPUT)
+        elapsed = time.monotonic() - start
+        self.assertLess(elapsed, WALL_CLOCK_LIMIT_S,
+                        f"regex evaluation took {elapsed:.2f}s; the bound did not fire")
+        self.assertFalse(passed)
+        self.assertTrue(detail.startswith(INCONCLUSIVE_PREFIX), detail)
+        self.assertIn(cr.REGEX_BUDGET_EXCEEDED, detail)
+        self.assertTrue(is_inconclusive(detail))
+
+    def test_budget_exceeded_is_never_pass_and_never_plain_fail(self):
+        passed, detail = _evaluate(CATASTROPHIC_PATTERN, CATASTROPHIC_INPUT)
+        self.assertIs(passed, False)
+        self.assertTrue(is_inconclusive(detail),
+                        "a pattern the runner could not evaluate must not read as a target failure")
+
+    def test_bounded_evaluator_kills_child_and_reports_timeout(self):
+        start = time.monotonic()
+        outcome, message = cr.evaluate_regex_bounded(
+            CATASTROPHIC_PATTERN, CATASTROPHIC_INPUT, budget_s=0.2)
+        elapsed = time.monotonic() - start
+        self.assertEqual(outcome, "timeout", message)
+        self.assertLess(elapsed, 1.5)
+        self.assertIn("did not finish", message)
+
+    def test_default_budget_is_under_the_wall_clock_limit(self):
+        # Spawn overhead sits on top of the budget; both must fit in the limit.
+        self.assertLess(cr.MAX_REGEX_EVAL_SECONDS, WALL_CLOCK_LIMIT_S)
+
+
+class TestBenignPatternsKeepTheirVerdicts(unittest.TestCase):
+
+    def test_benign_match_still_passes(self):
+        passed, detail = _evaluate(r"role=adm.n", "role=admin")
+        self.assertTrue(passed, detail)
+        self.assertFalse(is_inconclusive(detail))
+
+    def test_benign_non_match_still_fails_not_inconclusive(self):
+        passed, detail = _evaluate(r"^nothing here$", "role=admin")
+        self.assertFalse(passed)
+        self.assertFalse(is_inconclusive(detail), detail)
+        self.assertIn("does not match", detail)
+
+    def test_invalid_regex_is_inconclusive_not_a_crash(self):
+        passed, detail = _evaluate(r"(unclosed", "anything")
+        self.assertFalse(passed)
+        self.assertTrue(is_inconclusive(detail), detail)
+
+    def test_length_caps_are_kept(self):
+        self.assertEqual(cr.MAX_REGEX_LENGTH, 200)
+        passed, detail = _evaluate("a" * (cr.MAX_REGEX_LENGTH + 1), "a")
+        self.assertFalse(passed)
+        self.assertTrue(is_inconclusive(detail), detail)
+        # Input truncation still applies before the bounded search.
+        long_input = "x" * (cr.MAX_REGEX_INPUT_LENGTH + 500) + "needle"
+        passed, detail = _evaluate("needle", long_input)
+        self.assertFalse(passed, "needle beyond the input cap must not be visible")
+        self.assertFalse(is_inconclusive(detail))
+
+
+class TestPatternVerdictCarriesInconclusive(unittest.TestCase):
+    """A pattern with an unevaluable assertion is INCONCLUSIVE, structurally."""
+
+    def _pattern(self, regex: str) -> cr.AttackPattern:
+        return cr.AttackPattern(
+            id="CT-R307", version="1.0.0", name="regex budget", description="",
+            framework="generic", severity="low", owasp_category="ASI01", attack_steps=[],
+            evidence_schema={"field": "string"},
+            assertions=[
+                {"type": "field_matches", "field": "field", "value": regex,
+                 "description": "regex assertion"},
+                {"type": "field_equals", "field": "field", "value": "",
+                 "description": "benign assertion"},
+            ],
+        )
+
+    def test_budget_exceeded_pattern_is_not_evaluated_and_not_passed(self):
+        pattern = self._pattern(CATASTROPHIC_PATTERN)
+        executor = cr.StepExecutor(pattern)
+        executor.evidence["field"] = CATASTROPHIC_INPUT
+        # Drive run_pattern through its public path with the evidence injected.
+        original = cr.StepExecutor
+        try:
+            cr.StepExecutor = lambda *a, **k: executor  # type: ignore[assignment]
+            result = cr.run_pattern(pattern)
+        finally:
+            cr.StepExecutor = original
+        self.assertFalse(result.passed)
+        self.assertTrue(result.not_evaluated)
+        self.assertEqual(result.assertions_inconclusive, 1)
+        self.assertTrue(result.details.startswith(INCONCLUSIVE_PREFIX), result.details)
+        self.assertIn("INCONCLUSIVE: regex assertion", result.details)
+        self.assertTrue(is_inconclusive(result))
+        self.assertTrue(is_inconclusive(result.to_dict()))
+
+    def test_plain_failure_is_not_inconclusive(self):
+        pattern = self._pattern(r"^will-not-match$")
+        result = cr.run_pattern(pattern)
+        self.assertFalse(result.passed)
+        self.assertFalse(result.not_evaluated)
+        self.assertFalse(is_inconclusive(result))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
From the third external review, R3-07 (Medium). The community plugin evaluator capped pattern and input length and rejected one nested-quantifier shape, then called `re.search` directly. An ambiguous alternation `(a|aa)+$` passed the guard and did not finish within four seconds on a 37-character input; the plugin YAML is untrusted, so the pattern is attacker-controlled.

Fix: `evaluate_regex_bounded()` runs the match in a stdlib-only child interpreter under `subprocess.run(timeout=MAX_REGEX_EVAL_SECONDS)` (1.0 s). The child is killed on overrun — a real bound, unlike a thread join. Overrun, cap rejection and non-compiling regex are all INCONCLUSIVE (`PatternResult.not_evaluated`, prefixed details, `assertions_inconclusive`), never PASS and never a plain FAIL; `run_community_tests` counts inconclusive separately in the summary and JSON. Existing caps kept; the syntactic nested-quantifier check is documented as a heuristic and the kill is the bound. `docs/PLUGIN_SPEC.md` documents the budget.

Independently reproduced in a clean worktree at cebfcb0: `(a|aa)+$` on 37 chars → `('timeout', 'regex did not finish within 1s')` in 1.00 s with no leftover worker process; benign match 0.01 s, benign miss 0.02 s; through `AssertionEvaluator.evaluate` the overrun grades INCONCLUSIVE.

Injection (agent, verified landed by diff): budget 1.0 → 100000.0 → 4 failed / 6 passed in the new file; restored → 10 passed. Suite 1307 passed / 1205 subtests / 0 failed (baseline 1297 + 10). `test_inconclusive_is_structural` caught the new class lacking prefix⇒field on the first run; fixed via `__post_init__`.

Noticed, not in this PR: the per-pattern execution timeout runs only between steps, so a future assertion handler doing unbounded work would have the same gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)