### PR TITLE
Telemetry counts verdicts in three states; a simulated run no longer reports N passes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,36 @@ without lure in three shapes, refusal, lure relayed, the allow-all body) and
 the property that no probe passes against a target that wrote no message.
 Restoring `passed = refused or not lure` as the gate fails 5 of its tests
 (25 cases with subtests).
+**A simulated run of N tests reported N passes to telemetry.**
+`_simulate_harness` was corrected earlier today so the console prints
+INCONCLUSIVE and the report carries `not_evaluated: true` on every row, and
+the telemetry event for the same run still sent `passed=len(results),
+failed=0`. One run, three answers, and the one that left the machine was the
+wrong one. Reproduced by capturing `send_telemetry_event` under
+`test mcp --simulate`: 33 rows, 33 `not_evaluated`, event `passed: 33`.
+
+Telemetry now counts in three states. `telemetry.verdict_counts` reads each
+row through the shared `http_helpers.is_inconclusive` predicate (objects and
+dict rows alike), and `send_telemetry_event` gains an `inconclusive` field,
+defaulting to 0 so existing callers are unchanged. The four counts always
+sum, so `failed=0` is a finding rather than a construction. The same event
+now reads `passed: 0, failed: 0, inconclusive: 33`. `docs/PRIVACY.md` lists
+the ninth field.
+
+The live path is audited under the same discipline and its counting is now
+`cli._live_run_counts`, three-state and tested: the inline version counted
+only `status == "PASS"` / `FAIL` / `ERROR` and let an INCONCLUSIVE row vanish,
+and its unittest fallback scored `testsRun - failed` -- every skipped test --
+as a pass. Skipped is now INCONCLUSIVE. One limit is recorded rather than
+fixed: every harness `main()` ends in `sys.exit()`, `SystemExit` carries no
+namespace, and results live on a harness instance, so the live event has
+always been `0/0/0` -- an empty claim, not a false one.
+
+Fault-injected: `passed=len(results), failed=0` restored by sed, the
+injection confirmed by diff and `ast.parse`, five of the new tests failed,
+the fix restored, all pass. An AST guard over the `send_telemetry_event`
+call sites in `cli.py` refuses a `len(...)` pass count or a constant
+`failed=0`, and requires that it can see both call sites.
 
 **A live target that was never reached inherited the reference model's PASS
 (R3-01, Critical; third external review, 2026-09-07).** Five payment

--- a/HARNESS_TEST_CATALOG.md
+++ b/HARNESS_TEST_CATALOG.md
@@ -1,8 +1,7 @@
 # Agent Security Harness — Canonical Test Catalog
 
 **Source repo:** msaleme/red-team-blue-team-agent-fabric
-**Generated:** `scripts/generate_test_catalog.py` at commit `575c299`
-**Generated:** `scripts/generate_test_catalog.py` at commit `d6c8887`
+**Generated:** `scripts/generate_test_catalog.py` at commit `39b98cb`
 **Test count:** 623 unique test IDs across 46 registered harness modules (45 contain test IDs; `community_runner.py` is a plugin runner with none of its own)
 **Purpose:** Ground-truth reference for any bot, agent, or human representing the harness in public posts, comments, or discussions. Cite only tests listed here. Do not invent IDs or statistics.
 

--- a/HARNESS_TEST_CATALOG.md
+++ b/HARNESS_TEST_CATALOG.md
@@ -2,6 +2,7 @@
 
 **Source repo:** msaleme/red-team-blue-team-agent-fabric
 **Generated:** `scripts/generate_test_catalog.py` at commit `575c299`
+**Generated:** `scripts/generate_test_catalog.py` at commit `d6c8887`
 **Test count:** 623 unique test IDs across 46 registered harness modules (45 contain test IDs; `community_runner.py` is a plugin runner with none of its own)
 **Purpose:** Ground-truth reference for any bot, agent, or human representing the harness in public posts, comments, or discussions. Cite only tests listed here. Do not invent IDs or statistics.
 

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -21,13 +21,15 @@ When telemetry is enabled (opt-IN, off by default), we collect:
 | Harness version | `3.8.0` | Know which versions are in use, prioritize backports |
 | Module name | `mcp` | Know which harnesses matter most to users |
 | Test count | `13` | Understand typical workload size |
-| Passed count | `11` | Identify modules with high failure rates (may indicate bugs in our tests) |
+| Passed count | `9` | Identify modules with high failure rates (may indicate bugs in our tests) |
 | Failed count | `2` | Same as above |
+| Inconclusive count | `2` | Rows the target never serviced (or a simulated run, which services nothing). Kept apart so an unexercised control is never counted as a pass |
 | OS | `linux` | Platform-specific bug triage |
 | Python version | `3.12` | Know which Python versions to keep supporting |
 | Timestamp | `2026-03-28T00:00:00Z` | Understand usage patterns (weekday vs weekend, not time-of-day) |
 
-That's it. Eight fields. Flat JSON. No nesting, no extensibility, no "other" bucket.
+That's it. Nine fields. Flat JSON. No nesting, no extensibility, no "other" bucket.
+The three counts always sum to the test count.
 
 You can see the exact payload in code:
 
@@ -41,7 +43,7 @@ print(telemetry_payload_example())
 ## What We NEVER Collect
 
 - **Target URLs** - We never see what you're scanning
-- **Test results or details** - Only pass/fail counts, never which tests failed or why
+- **Test results or details** - Only pass/fail/inconclusive counts, never which tests failed or why
 - **Attestation report contents** - Reports stay on your machine unless you explicitly publish them
 - **API keys or credentials** - We never touch your `.env`, auth tokens, or secrets
 - **IP addresses** - Hashed at the edge before any processing. We cannot reverse them.

--- a/protocol_tests/cli.py
+++ b/protocol_tests/cli.py
@@ -220,13 +220,53 @@ def _simulate_harness(harness_name: str, info: dict,
         except Exception as e:
             print(f"Warning: HTML report generation failed: {e}", file=sys.stderr)
 
-    # Telemetry
+    # Telemetry. This sent `passed=len(results), failed=0` while every row
+    # above is `not_evaluated: True`: the console said N/N INCONCLUSIVE, the
+    # report said passed 0, and the event said N passed. Same run, third
+    # answer. Count the rows with the shared three-state predicate, so the
+    # event can only say what the rows say.
     try:
-        from protocol_tests.telemetry import send_telemetry_event
-        send_telemetry_event(module=harness_name, tests=len(results),
-                             passed=len(results), failed=0)
+        from protocol_tests.telemetry import send_telemetry_event, verdict_counts
+        send_telemetry_event(module=harness_name, **verdict_counts(results))
     except Exception:
         pass
+
+def _live_run_counts(ns: dict) -> dict:
+    """Three-state telemetry counts from a harness module namespace.
+
+    Reads the same names the inline version read (`_results`, `results`,
+    `test_results`, then a unittest-style `_test_result` / `test_result`) and
+    counts them with `telemetry.verdict_counts`, so a row the target never
+    serviced is reported as INCONCLUSIVE instead of vanishing. The inline
+    version counted only `status == "PASS"` / `FAIL` / `ERROR` and, for the
+    unittest shape, `passed = testsRun - failed` -- a residual bucket that
+    scored every skipped test as a pass. Here `skipped` is INCONCLUSIVE and
+    `passed` is what is left after both, so the four counts always sum.
+
+    Known limit, not fixed here: every harness `main()` ends in `sys.exit()`,
+    `SystemExit` carries no namespace, and results live on a harness instance
+    rather than at module level, so in practice `ns` is `{}` and the live
+    event reports 0/0/0/0. That is an empty claim, not a false one; the false
+    one was the simulated path.
+    """
+    from protocol_tests.telemetry import verdict_counts
+
+    for key in ("_results", "results", "test_results"):
+        result_list = ns.get(key)
+        if isinstance(result_list, (list, tuple)) and result_list:
+            return verdict_counts(result_list)
+
+    for key in ("_test_result", "test_result"):
+        tr = ns.get(key)
+        if tr and hasattr(tr, "testsRun"):
+            tests = int(tr.testsRun)
+            failed = len(getattr(tr, "failures", [])) + len(getattr(tr, "errors", []))
+            inconclusive = len(getattr(tr, "skipped", []))
+            passed = max(tests - failed - inconclusive, 0)
+            return {"tests": tests, "passed": passed, "failed": failed,
+                    "inconclusive": inconclusive}
+
+    return {"tests": 0, "passed": 0, "failed": 0, "inconclusive": 0}
 
 HARNESSES = {
     "mcp": {
@@ -787,40 +827,7 @@ def main():
         # Harnesses typically store results in _results, results, or similar.
         try:
             from protocol_tests.telemetry import send_telemetry_event
-
-            # Try to extract counts from the module namespace
-            test_count = 0
-            pass_count = 0
-            fail_count = 0
-
-            # Check common result patterns from harness modules
-            for key in ("_results", "results", "test_results"):
-                result_list = ns.get(key)
-                if isinstance(result_list, (list, tuple)) and result_list:
-                    test_count = len(result_list)
-                    for r in result_list:
-                        status = ""
-                        if hasattr(r, "status"):
-                            status = str(getattr(r.status, "value", r.status)).upper()
-                        elif isinstance(r, dict):
-                            status = str(r.get("status", "")).upper()
-                        if status == "PASS":
-                            pass_count += 1
-                        elif status in ("FAIL", "ERROR"):
-                            fail_count += 1
-                    break
-
-            # Also check unittest-style result objects
-            if test_count == 0:
-                for key in ("_test_result", "test_result"):
-                    tr = ns.get(key)
-                    if tr and hasattr(tr, "testsRun"):
-                        test_count = tr.testsRun
-                        fail_count = len(getattr(tr, "failures", [])) + len(getattr(tr, "errors", []))
-                        pass_count = test_count - fail_count
-                        break
-
-            send_telemetry_event(module=harness_name, tests=test_count, passed=pass_count, failed=fail_count)
+            send_telemetry_event(module=harness_name, **_live_run_counts(ns))
         except Exception:
             pass  # Telemetry must never break the CLI
 

--- a/protocol_tests/telemetry.py
+++ b/protocol_tests/telemetry.py
@@ -1,6 +1,6 @@
 """Anonymous usage telemetry for agent-security-harness.
 
-WHAT THIS SENDS: version, module_name, test_count, passed, failed, os, python_version, timestamp
+WHAT THIS SENDS: version, module_name, test_count, passed, failed, inconclusive, os, python_version, timestamp
 WHAT THIS NEVER SENDS: URLs, results, payloads, credentials, IPs
 
 OPT IN: export AGENT_SECURITY_TELEMETRY=on
@@ -91,8 +91,63 @@ def _post(payload: bytes) -> None:
     except Exception:
         pass  # Never retry. Never block. Never raise.
 
-def send_telemetry_event(module: str, tests: int, passed: int, failed: int) -> None:
-    """Send a single anonymous telemetry event. Non-blocking."""
+def verdict_counts(results) -> dict:
+    """Three-state counts for a telemetry event: tests, passed, failed, inconclusive.
+
+    Both call sites in `cli.py` previously computed these inline, and neither
+    had a word for INCONCLUSIVE. The simulated path sent
+    `passed=len(results), failed=0` -- every row in that run is marked
+    `not_evaluated: True`, so a simulated run of N tests reported N passes to
+    whatever endpoint the operator had pointed telemetry at. The live path
+    counted `status == "PASS"` and put everything else in silence.
+
+    Absence of a detected attack is not evidence a control held (CLAUDE.md
+    item 8). A row is INCONCLUSIVE when the shared predicate says so; only a
+    row that was serviced AND carries `passed: True` is a pass; a serviced row
+    that does not is a fail. A row that carries neither a `passed` verdict nor
+    a recognisable status established nothing and is counted INCONCLUSIVE,
+    never as a pass. The four counts always sum: `tests == passed + failed +
+    inconclusive`, so `failed=0` is a finding, not a default.
+
+    Accepts result objects and dict rows (a serialised report), because
+    `is_inconclusive` accepts both and this helper should not narrow it.
+    """
+    from protocol_tests.http_helpers import is_inconclusive
+
+    tests = passed = failed = inconclusive = 0
+    for r in results:
+        tests += 1
+        get = r.get if isinstance(r, dict) else (lambda f, d=None: getattr(r, f, d))
+        status = get("status", "")
+        status = str(getattr(status, "value", status) or "").upper()
+        if is_inconclusive(r) or status == "INCONCLUSIVE":
+            inconclusive += 1
+            continue
+        verdict = get("passed", None)
+        if verdict is None:
+            if status == "PASS":
+                verdict = True
+            elif status in ("FAIL", "ERROR"):
+                verdict = False
+            else:
+                inconclusive += 1  # No verdict of any shape: nothing established.
+                continue
+        if verdict:
+            passed += 1
+        else:
+            failed += 1
+    return {"tests": tests, "passed": passed, "failed": failed,
+            "inconclusive": inconclusive}
+
+def send_telemetry_event(module: str, tests: int, passed: int, failed: int,
+                         inconclusive: int = 0) -> None:
+    """Send a single anonymous telemetry event. Non-blocking.
+
+    `inconclusive` is the count of rows the target never serviced (or a
+    simulated run, which services nothing). It defaults to 0 so callers that
+    predate the field keep working; new callers should pass the output of
+    `verdict_counts` rather than computing the three buckets by hand.
+    """
     if _is_disabled():
         return
     _show_first_run_notice()
@@ -103,6 +158,7 @@ def send_telemetry_event(module: str, tests: int, passed: int, failed: int) -> N
         "tests": tests,                   # How many tests ran
         "passed": passed,                 # Pass count only -- no details about which tests
         "failed": failed,                 # Fail count only -- no details about which tests
+        "inconclusive": inconclusive,     # Unserviced count only -- never scored as a pass
         "os": platform.system().lower(),  # OS family for platform bug triage
         "py": f"{sys.version_info.major}.{sys.version_info.minor}",  # Python compat
         "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
@@ -112,5 +168,6 @@ def send_telemetry_event(module: str, tests: int, passed: int, failed: int) -> N
 def telemetry_payload_example() -> dict:
     """Return a sample payload so users can see exactly what's sent."""
     from protocol_tests.version import get_harness_version
-    return {"v": get_harness_version(), "module": "mcp", "tests": 13, "passed": 11,
-            "failed": 2, "os": "linux", "py": "3.12", "ts": "2026-03-28T00:00:00Z"}
+    return {"v": get_harness_version(), "module": "mcp", "tests": 13, "passed": 9,
+            "failed": 2, "inconclusive": 2, "os": "linux", "py": "3.12",
+            "ts": "2026-03-28T00:00:00Z"}

--- a/testing/test_telemetry_three_state.py
+++ b/testing/test_telemetry_three_state.py
@@ -1,0 +1,230 @@
+"""Telemetry must count what the rows say, in three states.
+
+`_simulate_harness` marks every row `not_evaluated: True` and prints
+N/N INCONCLUSIVE, and its report says `passed: 0`. The telemetry event for the
+same run said `passed=len(results), failed=0`: a simulated run of N tests
+reported N passes to whatever endpoint the operator had configured. Absence of
+a detected attack is not evidence a control held (CLAUDE.md item 8), and a run
+that contacted nothing detected nothing.
+
+The live path had the same two-state vocabulary: `status == "PASS"` was a pass,
+`FAIL`/`ERROR` a fail, everything else vanished, and the unittest fallback
+scored `testsRun - failed` -- every skipped test -- as a pass.
+
+Both now go through `telemetry.verdict_counts`, which uses the one shared
+predicate `http_helpers.is_inconclusive`, and the event carries an
+`inconclusive` field. `tests == passed + failed + inconclusive` always, so
+`failed=0` is a finding rather than a construction.
+"""
+from __future__ import annotations
+
+import ast
+import contextlib
+import io
+import json
+import sys
+import unittest
+from dataclasses import dataclass
+from pathlib import Path
+from unittest.mock import patch
+
+REPO = Path(__file__).resolve().parents[1]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+import protocol_tests.telemetry as tel  # noqa: E402
+import protocol_tests.cli as cli  # noqa: E402
+
+#: The exact flat payload docs/PRIVACY.md promises. There is no JSON schema for
+#: telemetry; this key set is the schema, and PRIVACY.md is its consumer.
+PAYLOAD_KEYS = {"v", "module", "tests", "passed", "failed", "inconclusive", "os", "py", "ts"}
+
+
+@dataclass
+class Row:
+    test_id: str
+    passed: bool
+    details: str = ""
+    not_evaluated: bool = False
+
+
+def mixed_rows_as_objects() -> list:
+    """2 passed, 1 failed, 3 inconclusive -- one per inconclusive vocabulary."""
+    return [
+        Row("T-001", True, "ok"),
+        Row("T-002", True, "ok"),
+        Row("T-003", False, "control did not hold"),
+        Row("T-004", False, "INCONCLUSIVE - target did not service the request"),
+        Row("T-005", False, "", not_evaluated=True),
+        # `passed: True` with the structural marker: the marker wins. A row
+        # that was never serviced cannot be a pass whatever else it says.
+        Row("T-006", True, "", not_evaluated=True),
+    ]
+
+
+def mixed_rows_as_dicts() -> list:
+    return [
+        {"test_id": "T-001", "passed": True, "details": "ok"},
+        {"test_id": "T-002", "passed": True, "details": "ok"},
+        {"test_id": "T-003", "passed": False, "details": "control did not hold"},
+        {"test_id": "T-004", "passed": False,
+         "details": "INCONCLUSIVE - target did not service the request"},
+        {"test_id": "T-005", "passed": False, "not_evaluated": True},
+        {"test_id": "T-006", "passed": False, "informational": True},
+    ]
+
+
+def capture_simulated_event(harness: str = "mcp") -> tuple[dict, dict]:
+    """Run `_simulate_harness` with the sender captured; return (event, report)."""
+    captured: list[dict] = []
+    buf = io.StringIO()
+    with patch.object(tel, "send_telemetry_event",
+                      side_effect=lambda **kw: captured.append(kw)), \
+            contextlib.redirect_stdout(buf):
+        cli._simulate_harness(harness, cli.HARNESSES[harness],
+                              json_output=True, html_output=None)
+    assert len(captured) == 1, f"expected one event, got {captured}"
+    return captured[0], json.loads(buf.getvalue())
+
+
+class SimulatedRunIsNotNPasses(unittest.TestCase):
+    def test_simulated_event_counts_every_row_inconclusive(self):
+        event, report = capture_simulated_event("mcp")
+        rows = report["results"]
+        self.assertTrue(rows, "no rows to check")
+        self.assertTrue(all(r.get("not_evaluated") is True for r in rows))
+        self.assertEqual(event["tests"], len(rows))
+        self.assertEqual(event["passed"], 0, "a simulated run claimed passes")
+        self.assertEqual(event["failed"], 0, "a simulated run claimed failures")
+        self.assertEqual(event["inconclusive"], len(rows))
+
+    def test_simulated_event_agrees_with_the_report_summary(self):
+        """One run, one answer: the event and the report must not disagree."""
+        event, report = capture_simulated_event("mcp")
+        s = report["summary"]
+        for key in ("passed", "failed", "inconclusive"):
+            with self.subTest(key=key):
+                self.assertEqual(event[key], s[key])
+        self.assertEqual(event["tests"], s["total"])
+
+
+class VerdictCountsAreExact(unittest.TestCase):
+    def test_object_rows(self):
+        c = tel.verdict_counts(mixed_rows_as_objects())
+        self.assertEqual(c, {"tests": 6, "passed": 2, "failed": 1, "inconclusive": 3})
+
+    def test_dict_rows(self):
+        c = tel.verdict_counts(mixed_rows_as_dicts())
+        self.assertEqual(c, {"tests": 6, "passed": 2, "failed": 1, "inconclusive": 3})
+
+    def test_counts_always_sum_to_tests(self):
+        for rows in (mixed_rows_as_objects(), mixed_rows_as_dicts(), []):
+            c = tel.verdict_counts(rows)
+            self.assertEqual(c["tests"], c["passed"] + c["failed"] + c["inconclusive"])
+
+    def test_status_only_rows_use_the_status_and_unknown_is_inconclusive(self):
+        rows = [{"status": "PASS"}, {"status": "FAIL"}, {"status": "ERROR"},
+                {"status": "INCONCLUSIVE"}, {"status": "SKIPPED"}, {}]
+        c = tel.verdict_counts(rows)
+        self.assertEqual(c, {"tests": 6, "passed": 1, "failed": 2, "inconclusive": 3})
+
+    def test_a_row_with_no_verdict_is_never_a_pass(self):
+        """Absence of a verdict is not a pass, whatever the residual bucket used to say."""
+        self.assertEqual(tel.verdict_counts([{"test_id": "T-000"}])["passed"], 0)
+
+
+class LivePathCountsAreThreeState(unittest.TestCase):
+    def test_result_list_in_namespace(self):
+        c = cli._live_run_counts({"results": mixed_rows_as_objects()})
+        self.assertEqual(c, {"tests": 6, "passed": 2, "failed": 1, "inconclusive": 3})
+
+    def test_unittest_style_skipped_is_inconclusive_not_passed(self):
+        class TR:
+            testsRun = 10
+            failures = [object()]
+            errors = [object(), object()]
+            skipped = [object(), object(), object()]
+        c = cli._live_run_counts({"_test_result": TR()})
+        self.assertEqual(c, {"tests": 10, "passed": 4, "failed": 3, "inconclusive": 3})
+
+    def test_empty_namespace_claims_nothing(self):
+        self.assertEqual(cli._live_run_counts({}),
+                         {"tests": 0, "passed": 0, "failed": 0, "inconclusive": 0})
+
+
+class ThePayloadMatchesItsDocumentedShape(unittest.TestCase):
+    """No JSON schema exists for telemetry; PRIVACY.md's field table is the
+    contract, and `telemetry_payload_example()` is the sample it points at."""
+
+    def _sent_payload(self, **kw) -> dict:
+        posted: list[bytes] = []
+
+        class SyncThread:  # run the fire-and-forget POST inline so we can read it
+            def __init__(self, target=None, args=(), daemon=None):
+                self.target, self.args = target, args
+
+            def start(self):
+                self.target(*self.args)
+
+        with patch.object(tel, "_is_disabled", return_value=False), \
+                patch.object(tel, "_show_first_run_notice"), \
+                patch.object(tel, "_post", side_effect=posted.append), \
+                patch.object(tel.threading, "Thread", SyncThread):
+            tel.send_telemetry_event(**kw)
+        self.assertEqual(len(posted), 1)
+        return json.loads(posted[0])
+
+    def test_sent_payload_has_exactly_the_documented_keys(self):
+        payload = self._sent_payload(module="mcp", tests=6, passed=2, failed=1, inconclusive=3)
+        self.assertEqual(set(payload), PAYLOAD_KEYS)
+        self.assertEqual((payload["tests"], payload["passed"], payload["failed"],
+                          payload["inconclusive"]), (6, 2, 1, 3))
+        for key in ("tests", "passed", "failed", "inconclusive"):
+            self.assertIsInstance(payload[key], int)
+
+    def test_inconclusive_defaults_to_zero_for_older_callers(self):
+        payload = self._sent_payload(module="mcp", tests=1, passed=1, failed=0)
+        self.assertEqual(payload["inconclusive"], 0)
+
+    def test_example_payload_matches_the_shape_and_sums(self):
+        ex = tel.telemetry_payload_example()
+        self.assertEqual(set(ex), PAYLOAD_KEYS)
+        self.assertEqual(ex["tests"], ex["passed"] + ex["failed"] + ex["inconclusive"])
+
+    def test_privacy_doc_lists_the_inconclusive_field(self):
+        doc = (REPO / "docs" / "PRIVACY.md").read_text(encoding="utf-8")
+        self.assertIn("| Inconclusive count |", doc)
+        self.assertIn("Nine fields", doc)
+        self.assertNotIn("Eight fields", doc)
+
+
+class TheDefectCannotBeReintroducedBySource(unittest.TestCase):
+    """The simulated path must not hand the sender a count it made up."""
+
+    @staticmethod
+    def _telemetry_calls() -> list:
+        tree = ast.parse((REPO / "protocol_tests" / "cli.py").read_text(encoding="utf-8"))
+        return [n for n in ast.walk(tree) if isinstance(n, ast.Call)
+                and getattr(n.func, "id", getattr(n.func, "attr", None)) == "send_telemetry_event"]
+
+    def test_cli_has_telemetry_call_sites(self):
+        self.assertGreaterEqual(len(self._telemetry_calls()), 2,
+                                "detector sees neither call site; it cannot be trusted")
+
+    def test_cli_does_not_send_len_results_as_passed_or_failed_zero(self):
+        for call in self._telemetry_calls():
+            for kw in call.keywords:
+                with self.subTest(line=call.lineno, keyword=kw.arg):
+                    if kw.arg == "passed":
+                        self.assertFalse(
+                            isinstance(kw.value, ast.Call)
+                            and getattr(kw.value.func, "id", None) == "len",
+                            f"cli.py:{call.lineno} passes len(...) as the pass count")
+                    if kw.arg == "failed":
+                        self.assertFalse(
+                            isinstance(kw.value, ast.Constant) and kw.value.value == 0,
+                            f"cli.py:{call.lineno} sends failed=0 by construction")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Follow-up from the third external review. `_simulate_harness` sent `send_telemetry_event(passed=len(results), failed=0)`: a simulated run of 33 MCP rows, every one `not_evaluated`, reported 33 passes to telemetry while the report beside it said 0 passed / 33 inconclusive.

Fix: `telemetry.verdict_counts(results)` derives passed / failed / inconclusive through the shared `is_inconclusive` predicate (objects and dicts; a row with no verdict of any shape is inconclusive, never a pass; the three always sum to `tests`). `send_telemetry_event` gains `inconclusive` (backward compatible); `docs/PRIVACY.md` field table updated. The live path is factored into `cli._live_run_counts`, three-state, with unittest skips counted as inconclusive rather than `testsRun - failed`. Opt-in guard untouched.

Independently reproduced in a clean worktree at 7ef8d05: simulated mcp event → `passed 0, failed 0, inconclusive 33`; a mixed list of 2 passed / 1 failed / 3 inconclusive (field, prefix and `informational` shapes) → `2 / 1 / 3`.

Injection (agent, verified landed by diff): `passed=len(results), failed=0` restored → 5 failed / 15 passed in the new file; restored → 16 passed. Suite 1313 passed / 1212 subtests / 0 failed (baseline 1297 + 16).

Recorded, not in this PR: live telemetry has always sent 0/0/0 because `SystemExit` never carries the harness namespace and results live on instances — an empty claim rather than a false one; fixing it touches every harness `main()`. `http_helpers.run_summary` uses `getattr` only, so a dict row is not counted there (latent, not on this path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)