### PR TITLE
Serviced guard and taint audit derive their module set from the registry, and it was three modules short

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -274,6 +274,38 @@ INCONCLUSIVE as a whole and never `passed`, and the batch summary counts
 pins the bound (under 2 s wall clock), the verdict (never PASS), and that
 benign matches and non-matches keep their verdicts. Documented in the module
 docstring and `docs/PLUGIN_SPEC.md`.
+### Fixed — the serviced guard and the taint audit discovered harnesses by source text, and three registered modules were in neither (register derivation, second instance)
+
+`testing/test_serviced_guard.py::_candidate_modules` and
+`scripts/audit_verdict_taint.py::candidate_modules` each carried a copy of the
+rule R3-02 had already retired from the host sweeps that morning: a module
+recorded a response if its file contained the literal text of a `_record` def
+and the literal `response_received`. A module that inherits `_record` from
+`harness_base.RecordingHarness` -- what CLAUDE.md item 7 asks every new
+harness to do -- has no such text. So `agent_data_injection` and
+`delegation_chain_harness`, the two modules written the recommended way, were
+invisible to both: not guarded, not in `UNREVIEWED`, and absent from the
+remainder item 10 calls the progress metric. Reproduced by seeding a
+`RecordingHarness` subclass carrying neither literal beside the suite: the
+suite stayed green and the auditor reported "no candidate module".
+
+Both consumers now call one function, `asi_inventory.response_recording_modules`,
+which starts from `cli.HARNESSES` plus the shared base and reads the fact off
+the imported module: a class defined there has a callable `_record`, its own
+or inherited, and a result dataclass in its namespace carries
+`response_received`. The old set (36) is a strict subset of the new (39). The
+three that entered -- the two above and `mcp_supplychain`, which records
+`mcp_harness.MCPTestResult` and so carries the field -- are registered in
+`UNREVIEWED` with their verdicts untouched; the tripwire moves 2 -> 5 because
+the count was wrong, not because the backlog grew. The eight registered
+modules whose result type has no `response_received` field are in a new
+`NO_RESPONSE_FIELD` register, each with the place its absent-target handling
+is measured instead, and the suite asserts that the derived set and that
+register partition the registry. A floor (39), a real inheriting module
+checked by AST, and a seeded module in a temporary package guard the
+derivation against narrowing back. With its own seeded control the guard
+suite leaves the `UNCONTROLLED` queue in
+`testing/test_static_detectors_can_fire.py`, which shrinks by one.
 
 ## [4.21.0] - 2026-09-07
 

--- a/HARNESS_TEST_CATALOG.md
+++ b/HARNESS_TEST_CATALOG.md
@@ -1,8 +1,7 @@
 # Agent Security Harness — Canonical Test Catalog
 
 **Source repo:** msaleme/red-team-blue-team-agent-fabric
-**Generated:** `scripts/generate_test_catalog.py` at commit `39b98cb`
-**Generated:** `scripts/generate_test_catalog.py` at commit `d6c8887`
+**Generated:** `scripts/generate_test_catalog.py` at commit `5ccba95`
 **Test count:** 623 unique test IDs across 46 registered harness modules (45 contain test IDs; `community_runner.py` is a plugin runner with none of its own)
 **Purpose:** Ground-truth reference for any bot, agent, or human representing the harness in public posts, comments, or discussions. Cite only tests listed here. Do not invent IDs or statistics.
 

--- a/HARNESS_TEST_CATALOG.md
+++ b/HARNESS_TEST_CATALOG.md
@@ -2,6 +2,7 @@
 
 **Source repo:** msaleme/red-team-blue-team-agent-fabric
 **Generated:** `scripts/generate_test_catalog.py` at commit `39b98cb`
+**Generated:** `scripts/generate_test_catalog.py` at commit `d6c8887`
 **Test count:** 623 unique test IDs across 46 registered harness modules (45 contain test IDs; `community_runner.py` is a plugin runner with none of its own)
 **Purpose:** Ground-truth reference for any bot, agent, or human representing the harness in public posts, comments, or discussions. Cite only tests listed here. Do not invent IDs or statistics.
 

--- a/protocol_tests/asi_inventory.py
+++ b/protocol_tests/asi_inventory.py
@@ -149,3 +149,96 @@ def by_category() -> dict[str, list[str]]:
     for tid, asi in corpus_asi().items():
         inv.setdefault(asi, []).append(tid)
     return {k: sorted(v) for k, v in inv.items()}
+
+
+# ---------------------------------------------------------------------------
+# Which registered modules record a target response.
+#
+# Until 2026-09-07 two consumers -- testing/test_serviced_guard.py and
+# scripts/audit_verdict_taint.py -- each carried the same source-text rule:
+# a module recorded a response if its file contained the literal text of a
+# `_record` def AND the literal `response_received`. A module that inherits
+# `_record` from `harness_base.RecordingHarness` defines none of its own, so
+# `agent_data_injection` and `delegation_chain_harness` -- the two modules
+# written the way CLAUDE.md item 7 asks for -- were invisible to both. An
+# invisible module is neither guarded nor counted in UNREVIEWED; it drops out
+# of the remainder that CLAUDE.md item 10 says is the progress metric. The
+# same rule had already been replaced in scripts/dead_host_sweep.py the same
+# morning (R3-02); this is the same replacement for the other two.
+#
+# The denominator is the CLI registry, as in dead_host_sweep.registry_coverage,
+# plus the module that defines the shared base. The fact is read off the
+# imported module rather than its text: a class defined in the module has a
+# callable `_record` -- its own or inherited -- and a result dataclass in the
+# module's namespace carries a `response_received` field, which is the one
+# field the shared guard reads. Every module the text rule found satisfies
+# both; the two it missed satisfy both; nothing the text rule found fails.
+# ---------------------------------------------------------------------------
+
+def harness_modules() -> list[str]:
+    """Every dotted module the CLI registry names, plus the shared base.
+
+    `protocol_tests.cli.HARNESSES` is the one list a harness has to be on to
+    be runnable, and `harness_base` is where the inherited `_record` lives.
+    A module that is on neither is not a harness this package ships.
+    """
+    from protocol_tests.cli import HARNESSES
+    from protocol_tests.harness_base import RecordingHarness
+    out: list[str] = []
+    for info in HARNESSES.values():
+        if info["module"] not in out:
+            out.append(info["module"])
+    if RecordingHarness.__module__ not in out:
+        out.append(RecordingHarness.__module__)
+    return out
+
+
+def recording_facts(module: str) -> dict:
+    """The import-level facts a records-a-response classification is built on.
+
+    ``defines_record``   a class defined in the module has `_record` in its own
+                         namespace
+    ``inherits_record``  a class defined in the module has a callable `_record`
+                         it did not define
+    ``response_field``   a dataclass in the module namespace, defined or
+                         imported, has a field named `response_received`
+    ``records_response`` (defines_record or inherits_record) and response_field
+    """
+    import dataclasses
+    import importlib
+    import inspect
+
+    mod = importlib.import_module(module)
+    defines = inherits = response_field = False
+    for obj in list(vars(mod).values()):
+        if not inspect.isclass(obj):
+            continue
+        if dataclasses.is_dataclass(obj) and any(
+                f.name == "response_received" for f in dataclasses.fields(obj)):
+            response_field = True
+        if obj.__module__ != mod.__name__:
+            continue
+        if "_record" in vars(obj):
+            defines = True
+        elif callable(getattr(obj, "_record", None)):
+            inherits = True
+    return {
+        "module": module,
+        "defines_record": defines,
+        "inherits_record": inherits,
+        "response_field": response_field,
+        "records_response": (defines or inherits) and response_field,
+    }
+
+
+def response_recording_modules(modules: list[str] | None = None) -> set[str]:
+    """Stems of the modules that record a target response, from `modules`.
+
+    Defaults to `harness_modules()`. The ONE derivation behind
+    testing/test_serviced_guard.py and scripts/audit_verdict_taint.py; the
+    two used to carry a copy each of a text rule, and a copy is where a rule
+    drifts.
+    """
+    names = harness_modules() if modules is None else list(modules)
+    return {m.rsplit(".", 1)[-1] for m in names
+            if recording_facts(m)["records_response"]}

--- a/scripts/audit_verdict_taint.py
+++ b/scripts/audit_verdict_taint.py
@@ -58,6 +58,8 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 PROTOCOL_TESTS = REPO_ROOT / "protocol_tests"
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 # A floor, not the list. These cover responses that arrive as a *parameter*
 # (``def _leak(resp)``) where there is no assignment to derive from.
@@ -237,13 +239,17 @@ def audit(module_path: Path) -> list[dict]:
 
 
 def candidate_modules() -> list[Path]:
-    """Same derivation as testing/test_serviced_guard.py: records a response."""
-    out = []
-    for path in sorted(PROTOCOL_TESTS.glob("*.py")):
-        src = path.read_text(encoding="utf-8")
-        if "def _record" in src and "response_received" in src:
-            out.append(path)
-    return out
+    """Same derivation as testing/test_serviced_guard.py: records a response.
+
+    The same FUNCTION, not the same rule copied: until 2026-09-07 this held its
+    own copy of a source-text match (the literal text of a `_record` def and the
+    literal `response_received`), and so did the guard suite, and both missed
+    every module that inherits `_record` from RecordingHarness instead of
+    defining one. protocol_tests.asi_inventory.response_recording_modules starts
+    from the CLI registry and reads the fact off the imported module.
+    """
+    from protocol_tests.asi_inventory import response_recording_modules
+    return [PROTOCOL_TESTS / f"{stem}.py" for stem in sorted(response_recording_modules())]
 
 
 def main() -> int:

--- a/testing/test_serviced_guard.py
+++ b/testing/test_serviced_guard.py
@@ -12,7 +12,9 @@ the five unserviced conditions and must not yield a pass for any of them.
 
 from __future__ import annotations
 
+import ast
 import sys
+import tempfile
 import unittest
 from dataclasses import fields
 from pathlib import Path
@@ -20,6 +22,8 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT))
 
+from protocol_tests.asi_inventory import (  # noqa: E402
+    harness_modules, recording_facts, response_recording_modules)
 from protocol_tests.http_helpers import _serviced, inconclusive_detail  # noqa: E402
 
 # The five ways a target can fail to service a request. The first three are
@@ -136,13 +140,20 @@ GUARDED = [
 # Derived, never hand-written: #348 was scoped to five harnesses by reading five files, and
 # a sixth and seventh with the same defect survived it. A hand-maintained coverage list is
 # the same failure the guard exists to prevent, one level up.
+#
+# Derived HOW matters as much. Until 2026-09-07 this was a source-text rule: a
+# module was a candidate if its file contained the literal text of a `_record`
+# def AND the literal `response_received`. A module that inherits `_record` from
+# harness_base.RecordingHarness -- what CLAUDE.md item 7 asks every new harness
+# to do -- has no such text, so the two written that way (agent_data_injection,
+# delegation_chain_harness) were invisible: not guarded, not in UNREVIEWED, and
+# absent from the remainder item 10 calls the progress metric. The derivation now
+# lives in protocol_tests.asi_inventory, is the same function
+# scripts/audit_verdict_taint.py calls, starts from the CLI registry, and reads
+# the fact off the imported module. NO_RESPONSE_FIELD below carries the rest of
+# the registry, each with a reason, so the union is the whole registry.
 def _candidate_modules() -> set[str]:
-    out = set()
-    for path in sorted((REPO_ROOT / "protocol_tests").glob("*.py")):
-        src = path.read_text()
-        if "def _record" in src and "response_received" in src:
-            out.add(path.stem)
-    return out
+    return response_recording_modules()
 
 
 # Guarding a module requires THREE things to be true, not one. The #351 sweep
@@ -335,6 +346,55 @@ NO_NETWORK_TARGET = {
 UNREVIEWED = {
     "mcp_harness",
     "prompt_caching_harness",
+    # 2026-09-07: entered the derived set the day discovery stopped being a
+    # source-text rule. All three were always in the remainder; the rule could
+    # not see them. None has been read against the three preconditions, so this
+    # is the bucket, and the tripwire below moved 2 -> 5 because the count was
+    # wrong, not because the backlog grew. Their verdicts are untouched.
+    #   agent_data_injection     inherits RecordingHarness._record; synthesises
+    #                            {"_status": 200, "replies": [...]} around a model
+    #                            reply, which is precondition 1 unread
+    #   delegation_chain_harness inherits RecordingHarness._record; has a
+    #                            simulate mode whose marking is unread
+    #   mcp_supplychain          own _record, records mcp_harness.MCPTestResult
+    #                            (which carries the field); one npm-registry HEAD
+    #                            at its only network call, whose failure path is
+    #                            unread. Excused from the host sweeps as having no
+    #                            --url, which is a different question.
+    "agent_data_injection",
+    "delegation_chain_harness",
+    "mcp_supplychain",
+}
+
+#: Registered modules whose result type carries no `response_received` field, so
+#: the shared guard has nothing to read and none of the buckets above applies.
+#: NOT a clean bill of health: each reason names where that module's handling of
+#: an absent target is measured instead, or says it has no target to be absent.
+#: Every registered module is in exactly one of: the derived candidate set, or
+#: this dict. An entry that starts carrying the field, or leaves the registry,
+#: is stale and fails the suite -- the #537 shape, applied to this file.
+NO_RESPONSE_FIELD = {
+    "ap2_harness": (
+        "reference-model verdict folded with a live probe kept under "
+        "live_evidence; an unreached target is INCONCLUSIVE through "
+        "http_helpers.fold_live_verdict (R3-01), pinned through the CLI in "
+        "testing/test_live_unreached_is_inconclusive.py"),
+    "card_token_harness": "as ap2_harness: fold_live_verdict, live_evidence",
+    "ucp_acp_harness": "as ap2_harness: fold_live_verdict, live_evidence",
+    "settlement_finality_harness": "as ap2_harness: fold_live_verdict, live_evidence",
+    "x402_fireblocks_harness": "as ap2_harness: fold_live_verdict, live_evidence",
+    "hitl_harness": (
+        "v4.13.1: the site where _serviced was first written and never promoted; "
+        "keeps a module-local _serviced at every probe and records under "
+        "`evidence`. 0 against the dead and refusing hosts; 4 of 8 against the "
+        "allow-all host, in the permissive read-list register in "
+        "testing/test_permissive_host_state.py"),
+    "receipt_claim_harness": (
+        "claim-level verifier over local fixtures; no target is contacted in any "
+        "mode (also dead_host_sweep.NOT_APPLICABLE)"),
+    "community_runner": (
+        "YAML-driven runner with no _record and no result type of its own; the "
+        "per-protocol adapter it drives is what records"),
 }
 
 # Concrete subclasses for the two adapter modules, whose guard lives on an ABC base rather
@@ -543,11 +603,83 @@ class TestCoverageListIsDerived(unittest.TestCase):
             stale, set(), f"listed but no longer record a response: {sorted(stale)}")
 
     def test_unreviewed_does_not_grow(self) -> None:
-        """A tripwire on the honest number, so the backlog cannot quietly expand."""
+        """A tripwire on the honest number, so the backlog cannot quietly expand.
+
+        2 until 2026-09-07; 5 since. The three that entered were not new work,
+        they were work the text rule could not see; see the UNREVIEWED comment.
+        """
         self.assertLessEqual(
-            len(UNREVIEWED), 2,
+            len(UNREVIEWED), 5,
             "UNREVIEWED grew. A new module recording a response should be guarded or "
             "reviewed, not appended to the backlog.")
+
+    def test_every_registered_module_is_derived_or_excused(self) -> None:
+        """The denominator is the registry. Nothing registered may drop out."""
+        registry = {m.rsplit(".", 1)[1] for m in harness_modules()}
+        candidates = _candidate_modules()
+        self.assertEqual(
+            set(NO_RESPONSE_FIELD) & candidates, set(),
+            "excused as carrying no response_received field, but the derivation "
+            "says it does now: stale entry, classify it above instead")
+        self.assertEqual(
+            set(NO_RESPONSE_FIELD) - registry, set(),
+            "excused but not registered: an excuse for something that does not "
+            "exist is a stale entry")
+        self.assertEqual(
+            registry - candidates - set(NO_RESPONSE_FIELD), set(),
+            "registered, neither derived as recording a response nor excused by "
+            "name with a reason. This is the gap the text rule hid.")
+        for stem, reason in NO_RESPONSE_FIELD.items():
+            with self.subTest(stem):
+                self.assertTrue(isinstance(reason, str) and len(reason) > 20,
+                                f"{stem}: the reason has to be about the module")
+
+    def test_derivation_sees_at_least_the_population_it_saw_when_written(self) -> None:
+        """Anti-vacuity. 39 on 2026-09-07: the text rule's 36, plus the three
+        it could not see. A derivation returning fewer has narrowed, not the
+        repository."""
+        self.assertGreaterEqual(len(_candidate_modules()), 39)
+
+    def test_a_module_that_inherits_record_without_defining_it_is_seen(self) -> None:
+        """The defect, on a real module. delegation_chain_harness defines no
+        _record -- checked by AST, not by text -- and the old rule needed one."""
+        src = (REPO_ROOT / "protocol_tests" / "delegation_chain_harness.py").read_text()
+        defs = {n.name for n in ast.walk(ast.parse(src)) if isinstance(n, ast.FunctionDef)}
+        self.assertNotIn("_record", defs, "the fixture changed shape; pick another")
+        facts = recording_facts("protocol_tests.delegation_chain_harness")
+        self.assertTrue(facts["inherits_record"] and not facts["defines_record"])
+        self.assertIn("delegation_chain_harness", _candidate_modules())
+
+    def test_a_seeded_module_carrying_neither_literal_is_seen(self) -> None:
+        """Seeded, so the test does not depend on any real module keeping its
+        shape. Neither literal the old rule matched on appears in the source;
+        the field name is assembled at runtime so the assertion below is real."""
+        src = (
+            "from dataclasses import dataclass\n"
+            "from protocol_tests.harness_base import HarnessResult, RecordingHarness\n"
+            "@dataclass\n"
+            "class SeedResult(HarnessResult):\n    pass\n"
+            "class SeedTests(RecordingHarness):\n"
+            "    def run_all(self):\n"
+            "        return [self._record(SeedResult(test_id='SEED-001', name='s',\n"
+            "            category='s', owasp_asi='', severity='LOW', passed=True,\n"
+            "            details='held', **{'response_' + 'received': {'_status': 0}}))]\n"
+        )
+        self.assertNotIn("def _rec" + "ord", src)
+        self.assertNotIn("response_" + "received", src)
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = Path(tmp) / "zz_seed_pkg"
+            pkg.mkdir()
+            (pkg / "__init__.py").write_text("")
+            (pkg / "seed_harness.py").write_text(src)
+            sys.path.insert(0, tmp)
+            try:
+                seen = response_recording_modules(["zz_seed_pkg.seed_harness"])
+            finally:
+                sys.path.remove(tmp)
+                sys.modules.pop("zz_seed_pkg.seed_harness", None)
+                sys.modules.pop("zz_seed_pkg", None)
+        self.assertEqual(seen, {"seed_harness"})
 
 
 if __name__ == "__main__":

--- a/testing/test_static_detectors_can_fire.py
+++ b/testing/test_static_detectors_can_fire.py
@@ -385,9 +385,11 @@ UNCONTROLLED = {
     # Globs for `def _record` to derive the prose-graded class as a
     # DENOMINATOR for its ratchet.
     "test_refusal_establishes_a_pass.py",
-    # Globs for `_record` + `response_received` to enumerate harnesses, then
-    # FEEDS each the five unserviced conditions.
-    "test_serviced_guard.py",
+    # test_serviced_guard.py left this queue 2026-09-07. It globbed for
+    # `_record` + `response_received` to enumerate harnesses; that rule could
+    # not see a harness inheriting `_record`, and was replaced by a registry
+    # derivation in protocol_tests.asi_inventory with its own seeded control
+    # (a temporary package carrying neither literal, asserted seen).
 }
 
 


### PR DESCRIPTION
Follow-up from the third external review (A's note on #537). `testing/test_serviced_guard.py` and `scripts/audit_verdict_taint.py` each discovered "modules that record a target response" with the text rule `"def _record" in src and "response_received" in src`. A module that inherits `_record` from `RecordingHarness` — the pattern CLAUDE.md item 7 requires — has no such text and was invisible to both, so it was neither guarded nor counted in the unclassified remainder.

Fix: one derivation, `asi_inventory.response_recording_modules()`, over the same registry #537's sweeps use (`cli.HARNESSES`), classifying by an imported fact (a class with a callable `_record`, own or inherited, whose result dataclass carries `response_received`). Both consumers call it. Old set 36 ⊂ new set 39: `agent_data_injection`, `delegation_chain_harness`, `mcp_supplychain` were invisible and are now in `UNREVIEWED` (verdicts untouched; tripwire 2 → 5 because the count was wrong, not because the backlog grew). The eight registry modules that legitimately record no response field are in `NO_RESPONSE_FIELD` with per-module reasons, and a test asserts the two partition the registry with stale checks both ways. Anti-vacuity: floor ≥ 39; `delegation_chain_harness` is proven by AST to define no `_record` and asserted seen; a seeded temp-package module with neither literal is asserted seen.

Independently reproduced in a clean worktree at dda6288: old 36 / new 39, old − new = ∅, new − old = the three above; the taint audit's candidate list equals the guard's; `delegation_chain_harness` defines no `_record` and is seen; guard suite 14 passed / 132 subtests; no seed file in the commit.

Injection (agent, verified landed by diff): text rule restored in the guard → 4 failed / 10 passed; restored → 14 passed. Suite 1301 passed / 1213 subtests / 0 failed (baseline 1297 / 1205). `test_static_detectors_can_fire` caught that `test_serviced_guard.py` sat in the `UNCONTROLLED` queue for exactly this glob; it now has its own control and is retired from the queue.

Noticed, not in this PR: `testing/test_harness_base_adoption.py::_modules_with_own_record` is still a `"def _record" in text` rule (#536 added a floor, not a derivation); the three new UNREVIEWED rows need reading against the three preconditions (`agent_data_injection` synthesises a 200 around a model reply; `delegation_chain_harness` simulate mode has no `_simulated` marker; `mcp_supplychain`'s npm HEAD failure path); the taint audit's 0/0 on the three is "not reached", not clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)