### PR TITLE
Release v4.21.1 — the published wheel reported 17/17 against a host that did not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.21.1] - 2026-09-07
+
+A patch release for the third external review of v4.21.0, run against the
+published wheel. Its Critical finding: five payment harnesses graded a live
+target that never answered by the reference model's verdict, so `pip install
+agent-security-harness==4.21.0` reported 17/17, 17/17, 12/12, 12/12 and 8/8
+PASS against a closed port. Every finding below was reproduced on the installed
+package or a clean worktree before it was fixed, and each fix was fault-injected
+to show its test fails without it. No test IDs were added or removed; the count
+stays at 623.
+
 ### Fixed
 
 **HITL-005..008 passed against a target that said nothing (absence read as

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you cite this work in research, please use this metadata."
 title: "Agent Security Harness"
-version: "4.21.0"
+version: "4.21.1"
 abstract: "Multi-protocol agent security testing framework. 623 executable security tests across 45 test-bearing modules covering MCP, A2A, L402, and x402 wire protocols. Decision-layer attack scenarios, AIUC-1 pre-certification mapping, NIST AI 800-2 aligned."
 type: software
 authors:

--- a/HARNESS_TEST_CATALOG.md
+++ b/HARNESS_TEST_CATALOG.md
@@ -1,7 +1,7 @@
 # Agent Security Harness — Canonical Test Catalog
 
 **Source repo:** msaleme/red-team-blue-team-agent-fabric
-**Generated:** `scripts/generate_test_catalog.py` at commit `c0fdc71`
+**Generated:** `scripts/generate_test_catalog.py` at commit `884db0e`
 **Test count:** 623 unique test IDs across 46 registered harness modules (45 contain test IDs; `community_runner.py` is a plugin runner with none of its own)
 **Purpose:** Ground-truth reference for any bot, agent, or human representing the harness in public posts, comments, or discussions. Cite only tests listed here. Do not invent IDs or statistics.
 

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ modification · v4.6–v4.9 payment-stack depth (AP2 mandate chain, UCP/ACP merc
 agentic tokens, settlement finality, Fireblocks x402) · v4.10 benchmark integrity · v4.11–v4.12
 decision-governance corpus currency and provenance repair · **v4.13 OWASP Agentic v1.1 T1–T17 coverage
 mapping and the human-in-the-loop harness** · v4.13.1 a correctness fix to that harness · v4.14.0
-endpoint provenance · v4.16.0 three target shapes: a verdict must be able to be wrong AND to be right · v4.17.0 eight modules could not tell a refusal from a compliance · v4.18.0 INCONCLUSIVE became a field, and the read-list emptied · v4.19.0 a correctness disclosure: verdicts moved in both directions · v4.20.0 the last absence-graded verdicts got a positive control · **v4.21.0 the instrument was the thing under test: 7 of 9 defects were in the measurement apparatus** · v4.15.0 unserviced requests are no longer recorded as passes (see
+endpoint provenance · v4.16.0 three target shapes: a verdict must be able to be wrong AND to be right · v4.17.0 eight modules could not tell a refusal from a compliance · v4.18.0 INCONCLUSIVE became a field, and the read-list emptied · v4.19.0 a correctness disclosure: verdicts moved in both directions · v4.20.0 the last absence-graded verdicts got a positive control · v4.21.0 the instrument was the thing under test: 7 of 9 defects were in the measurement apparatus · **v4.21.1 the published wheel reported 17/17 against a host that did not exist: the third external review's nine findings, each reproduced before it was fixed** · v4.15.0 unserviced requests are no longer recorded as passes (see
 [CHANGELOG.md](CHANGELOG.md)).
 
 The release carries **623** tests; `main` is at **623**. At v4.21.0 they agree: MCP-021, the MCP

--- a/docs/OWASP-AGENTIC-T1-T15-SUBMISSION-COVERAGE.md
+++ b/docs/OWASP-AGENTIC-T1-T15-SUBMISSION-COVERAGE.md
@@ -11,7 +11,7 @@
 | Report view | Submission (T1–T15) |
 | Report version | 1.0 |
 | Project | Agent Security Harness |
-| Harness version | `4.21.0` |
+| Harness version | `4.21.1` |
 | Assessed commit | [`8d8bc08933637381a32fc32041f139d34eb6271f`](https://github.com/msaleme/red-team-blue-team-agent-fabric/commit/8d8bc08933637381a32fc32041f139d34eb6271f) |
 | Assessed at | 2026-08-02T18:30:00Z |
 | Repository tests | 623 (`python scripts/count_tests.py`) |

--- a/docs/OWASP-AGENTIC-V1.1-COVERAGE.md
+++ b/docs/OWASP-AGENTIC-V1.1-COVERAGE.md
@@ -9,7 +9,7 @@
 | Report view | Complete (T1–T17) |
 | Report version | 1.0 |
 | Project | Agent Security Harness |
-| Harness version | `4.21.0` |
+| Harness version | `4.21.1` |
 | Assessed commit | [`8d8bc08933637381a32fc32041f139d34eb6271f`](https://github.com/msaleme/red-team-blue-team-agent-fabric/commit/8d8bc08933637381a32fc32041f139d34eb6271f) |
 | Assessed at | 2026-08-02T18:30:00Z |
 | Repository tests | 623 (`python scripts/count_tests.py`) |

--- a/docs/coverage/owasp-agentic-v1.1.json
+++ b/docs/coverage/owasp-agentic-v1.1.json
@@ -34,7 +34,7 @@
   "assessment": {
     "project": "Agent Security Harness",
     "repository": "https://github.com/msaleme/red-team-blue-team-agent-fabric",
-    "harness_version": "4.21.0",
+    "harness_version": "4.21.1",
     "git_commit": "8d8bc08933637381a32fc32041f139d34eb6271f",
     "assessed_at": "2026-08-02T18:30:00Z",
     "reverified_at": "2026-08-03T01:05:00Z",

--- a/docs/coverage/owasp-agentic-v1.1.yaml
+++ b/docs/coverage/owasp-agentic-v1.1.yaml
@@ -52,7 +52,7 @@ framework:
 assessment:
   project: Agent Security Harness
   repository: https://github.com/msaleme/red-team-blue-team-agent-fabric
-  harness_version: "4.21.0"
+  harness_version: "4.21.1"
   git_commit: "8d8bc08933637381a32fc32041f139d34eb6271f"
   assessed_at: '2026-08-02T18:30:00Z'
   reverified_at: '2026-08-03T01:05:00Z'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-security-harness"
-version = "4.21.0"
+version = "4.21.1"
 description = "623 security tests for AI agent systems - MCP, A2A, L402, x402, UCP/ACP merchant-journey, AP2 mandate + Fireblocks x402 hardening + Visa TAP / Mastercard Agentic Tokens + denial-of-settlement finality, decision governance, AIUC-1 compliance, NIST AI 800-2 aligned"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
Patch release for the third external review of v4.21.0, run against the published package.

R3-01 (Critical): five payment harnesses graded an unreachable live target by the reference model's verdict, so the installed 4.21.0 reported 17/17, 17/17, 12/12, 12/12 and 8/8 PASS against a closed port. Fixed in #537. R3-02..R3-13 and the review's follow-up notes: #536, #538, #539, #540, #541, #542, #543, #544. Each was reproduced on the installed package or a clean worktree before its fix and fault-injected after; the CHANGELOG entry under 4.21.1 carries the per-finding record.

This PR: version bump in `pyproject.toml`, `CITATION.cff`, the two OWASP coverage documents and the coverage manifest pair; README timeline extended; CHANGELOG Unreleased → 4.21.1. Test count unchanged at 623. The release-test-count claim stays bound to v4.21.0 until the tag exists (same sequence as #533).

Suite on this branch: 1358 passed, 1330 subtests passed in 219.30s (0:03:39).

🤖 Generated with [Claude Code](https://claude.com/claude-code)