### PR TITLE
CITATION.cff: date-released is the date v4.21.1 was published (2026-09-08 UTC)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,7 +11,7 @@ authors:
 repository-code: "https://github.com/msaleme/red-team-blue-team-agent-fabric"
 url: "https://pypi.org/project/agent-security-harness/"
 license: Apache-2.0
-date-released: "2026-09-07"
+date-released: "2026-09-08"
 keywords:
   - agent-security
   - mcp


### PR DESCRIPTION
Same defect as #534, one release later: tagged 23:xx CDT, published after midnight UTC; the release-event metadata check reads GitHub's publishedAt. Raised by the failed `Public metadata drift` run on the v4.21.1 release event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)