### PR TITLE
R4-06/07/08/14: two wrappers that turned their own errors into security results, and a community runner that passed without contacting anything

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,6 +201,89 @@ Fault injections, each restored: `_refused` back to scanning the whole reply
 `AIUC-C004a` back to reading `response`/`_body` (4 fail).
 
 No test IDs were added or removed; the count stays at 623.
+### Fixed — wrapper errors reported as security results, community "live" and dry-run PASS without contact, discarded CLI exit codes, community validation gaps (R4-06, R4-07, R4-08 High; R4-14 Medium; fourth external review, 2026-09-08)
+
+Every finding below was reproduced on a clean worktree before it was fixed,
+and each fix was fault-injected to show its test fails without it. No test
+IDs were added or removed; the count stays at 623.
+
+**The free scan reported five vulnerabilities when its own result-reading
+code failed (R4-06).** `scripts/free_scan.py::run_free_scan` called five
+`MCPSecurityTests` methods that record their result on the suite and return
+`None`, dereferenced `.status` on that `None`, caught its own
+`AttributeError` and published it as five `ERROR` rows, `tests_failed: 5`,
+grade **F** and "The scan detected 5 issue(s)" with remediation advice --
+against the shipped mock and against a closed port alike. The MCP server
+exposes the same function as the `scan_mcp_server` tool. The wrapper now
+runs the MCP handshake the methods assume (as `run_all` does), reads each
+recorded result back by test id, and reports anything the scanner itself
+could not do as `INCONCLUSIVE` with the detail "the scanner could not
+evaluate this test". An INCONCLUSIVE row is never counted in `tests_failed`
+and never named as a detected issue; when any row is INCONCLUSIVE the
+report carries `grade: null` and `grade_status: "not established"`. New
+fields `tests_evaluated`, `tests_inconclusive`, `grade_status`. The script
+exits 2 in that state. Per-test console lines no longer land on stdout ahead
+of the JSON. `testing/test_free_scan_controls.py` holds the two controls a
+public wrapper needs: the shipped mock on loopback (MCP-001 and MCP-008
+FAIL, MCP-003/004/010 PASS, grade C -- the mock's real shape) and a closed
+port (five INCONCLUSIVE, no grade), plus a synthetic wrapper fault that must
+land as INCONCLUSIVE, not as an issue.
+
+**Community "live" and dry-run runs published PASS without contacting a
+target (R4-07).** `_do_send_message`, `_do_send_jsonrpc` and `_do_call_tool`
+returned `{"status": "sent", "response": None}` ("Populated by harness
+integration"), so `--url` never opened a socket and an absence assertion
+passed against a host that was never reached; dry-run assigned
+`passed = True` outright. A synthetic plugin against `http://127.0.0.1:9`
+produced one PASS and zero inconclusive in both modes. The three actions now
+go through one real adapter, `HttpJsonRpcAdapter` -- JSON-RPC 2.0 over HTTP
+POST to `--url` via `http_helpers.http_post_json` -- for frameworks `mcp`,
+`a2a` and `generic` (`send_message` as A2A `message/send`, `call_tool` as
+MCP `tools/call`, `send_jsonrpc` verbatim). The runner refuses to evaluate
+any assertion when no adapter is bound (no `--url`, or a framework with no
+wire protocol: autogen, crewai, langgraph, x402, l402), when no step
+contacted the target, or when the target answered none of the requests
+sent: every assertion is INCONCLUSIVE with the reason, and the result
+carries `requests_sent` / `requests_answered`. Dry-run assertions are
+`passed=False`, `not_evaluated=True`, detail `(dry run — not evaluated)`,
+counted under `inconclusive`. The CLI exits 2 when nothing failed but
+something is INCONCLUSIVE. `testing/test_community_live_adapter.py` proves
+a hash-bound synthetic plugin actually reaches the shipped mock on loopback
+(2 sent, 2 answered, assertions evaluated, a presence assertion the mock
+does not satisfy is a real FAIL) and that a closed port, no URL, an
+unsupported framework, simulation-only steps and dry-run are each
+INCONCLUSIVE, never PASS.
+
+**The CLI discarded child failures, including usage errors (R4-08).**
+`protocol_tests/cli.py` stored the child's exit code in `_harness_exit`
+and then called `sys.exit(0)` unconditionally, under a comment promising
+to "exit with the code the harness asked for". `agent-security test
+skill-security --url http://127.0.0.1:9 --report out.json` printed
+argparse's "unrecognized arguments", wrote no report, and exited 0. The
+dispatcher now exits with the child's code after the HTML and telemetry
+post-processing; when `--report` or `--html` was requested and no file
+appeared it says so on stderr and exits non-zero; the throwaway side
+report `--html` asks for is removed afterwards.
+`testing/test_cli_exit_propagation.py` drives the public entry point: an
+unsupported flag exits 2 and names the missing report, a failing child's
+code equals the module's own exit, `--html` against a closed port still
+writes the file and still exits non-zero, and a good run exits 0.
+
+**Community validation and the pattern budget were incomplete (R4-14).**
+Validation accepted a non-object `evidence_schema`, an unknown action and
+an unknown assertion type; the pattern budget was checked only before each
+step, so a final step or the whole assertion phase ran unbounded, and
+nothing capped the assertion count. `evidence_schema` must now be an
+object; `action` and assertion `type` are validated against
+`VALID_ACTIONS` / `VALID_ASSERTION_TYPES`, derived from the two dispatch
+tables rather than written down a second time; `MAX_ASSERTIONS = 50`. The
+deadline (`MAX_PATTERN_EXECUTION_TIMEOUT_S`, 120 s) is checked before and
+after every step, after every assertion and once at the end, and an overrun
+is INCONCLUSIVE (`pattern execution exceeded budget`, with where it was
+detected), never PASS. Tested with a 50 ms budget and a 200 ms `wait` step,
+and with a slow assertion phase. `docs/PLUGIN_SPEC.md` documents the closed
+vocabularies, the caps, the adapter and dry-run semantics, and the exit
+codes.
 
 ## [4.21.1] - 2026-09-07
 

--- a/HARNESS_TEST_CATALOG.md
+++ b/HARNESS_TEST_CATALOG.md
@@ -1,8 +1,7 @@
 # Agent Security Harness — Canonical Test Catalog
 
 **Source repo:** msaleme/red-team-blue-team-agent-fabric
-**Generated:** `scripts/generate_test_catalog.py` at commit `f7b2e6c`
-**Generated:** `scripts/generate_test_catalog.py` at commit `52cb5e1`
+**Generated:** `scripts/generate_test_catalog.py` at commit `464805c`
 **Test count:** 623 unique test IDs across 46 registered harness modules (45 contain test IDs; `community_runner.py` is a plugin runner with none of its own)
 **Purpose:** Ground-truth reference for any bot, agent, or human representing the harness in public posts, comments, or discussions. Cite only tests listed here. Do not invent IDs or statistics.
 

--- a/HARNESS_TEST_CATALOG.md
+++ b/HARNESS_TEST_CATALOG.md
@@ -2,6 +2,7 @@
 
 **Source repo:** msaleme/red-team-blue-team-agent-fabric
 **Generated:** `scripts/generate_test_catalog.py` at commit `f7b2e6c`
+**Generated:** `scripts/generate_test_catalog.py` at commit `52cb5e1`
 **Test count:** 623 unique test IDs across 46 registered harness modules (45 contain test IDs; `community_runner.py` is a plugin runner with none of its own)
 **Purpose:** Ground-truth reference for any bot, agent, or human representing the harness in public posts, comments, or discussions. Cite only tests listed here. Do not invent IDs or statistics.
 

--- a/docs/PLUGIN_SPEC.md
+++ b/docs/PLUGIN_SPEC.md
@@ -2,7 +2,7 @@
 
 **Version:** 1.0.0
 **Status:** Draft
-**Last Updated:** 2026-03-30
+**Last Updated:** 2026-09-08
 
 ## Overview
 
@@ -103,17 +103,48 @@ Each step in `attack_steps` is an object with:
 
 | Action | Description | Payload Fields |
 |--------|-------------|---------------|
-| `send_message` | Send a message to the target | `role`, `content`, `metadata` |
-| `send_jsonrpc` | Send a raw JSON-RPC 2.0 message | `method`, `params`, `id` |
-| `call_tool` | Invoke a tool by name | `tool_name`, `arguments` |
-| `inject_description` | Modify a tool description | `tool_name`, `injected_text` |
-| `register_tool` | Register a new tool | `tool_name`, `description`, `schema` |
-| `modify_context` | Alter agent context/memory | `context_key`, `new_value` |
-| `http_request` | Send an arbitrary HTTP request | `method`, `url`, `headers`, `body` |
+| `send_message` | Send a message to the target (live: A2A `message/send`) | `role`, `content`, `metadata` |
+| `send_jsonrpc` | Send a raw JSON-RPC 2.0 message (live) | `method`, `params`, `id` |
+| `call_tool` | Invoke a tool by name (live: MCP `tools/call`) | `tool_name`, `arguments` |
+| `inject_description` | Modify a tool description (simulated) | `tool_name`, `injected_text` |
+| `register_tool` | Register a new tool (simulated) | `tool_name`, `description`, `schema` |
+| `modify_context` | Alter agent context/memory (simulated) | `context_key`, `new_value` |
+| `http_request` | Record an outbound HTTP request (simulated, never sent) | `method`, `url`, `headers`, `body` |
 | `wait` | Pause execution | `duration_ms` |
-| `assert_state` | Check intermediate state | `condition`, `expected` |
+| `assert_state` | Check intermediate state (local) | `condition`, `expected` |
 
-Custom actions are allowed. The runner will attempt to map them to the appropriate harness method. If no mapping exists, the step is skipped with a warning.
+The action vocabulary is closed: `action` must be one of the names above, and
+validation rejects any other. The set is derived from the runner's dispatch
+table (`VALID_ACTIONS` in `community_runner.py`), so a new action is valid the
+moment it has a handler and not before.
+
+### Live execution and the adapter
+
+Only three actions contact the target: `send_message`, `send_jsonrpc` and
+`call_tool`. They are sent through one adapter, JSON-RPC 2.0 over HTTP POST to
+the `--url` given on the command line, and only for patterns whose
+`framework` is `mcp`, `a2a` or `generic`. `send_message` is sent as an A2A
+`message/send` request (`role`, one text part holding `content`, `metadata`);
+`call_tool` as an MCP `tools/call` request (`name`, `arguments`);
+`send_jsonrpc` verbatim. The other actions are local simulations and say so
+in their step record (`"live": false`); they never open a socket.
+
+A pattern's assertions are evaluated only when the target was actually
+reached. Each of the following is INCONCLUSIVE for every assertion, never a
+PASS, and the result carries `requests_sent` and `requests_answered` so a
+reader can see why:
+
+- no `--url` was given (`no adapter bound; the target was not contacted`);
+- the `framework` has no live adapter (`autogen`, `crewai`, `langgraph`,
+  `x402`, `l402`): these have no wire protocol the runner can speak;
+- every step was a simulated action, so nothing was sent;
+- requests were sent and the target answered none of them (closed port, DNS
+  failure, timeout). Any HTTP status counts as an answer.
+
+Before the fourth external review (2026-09-08) the three live actions returned a fabricated `sent` status
+with `response: null`, so a run with `--url` never contacted the target and
+an absence assertion passed against a host that was never reached. That is
+the defect this section exists to make impossible to reintroduce.
 
 ## Assertions
 
@@ -140,6 +171,11 @@ Each assertion checks a condition after all attack steps complete.
 | `field_equals` | Field must equal a specific value | `field`, `value` |
 | `field_matches` | Field must match a regex | `field`, `value` (regex) |
 
+The assertion vocabulary is closed in the same way as actions
+(`VALID_ASSERTION_TYPES`, derived from the evaluator's dispatch table); an
+unknown `type` is a validation error. A pattern may declare at most **50**
+assertions (`MAX_ASSERTIONS`).
+
 ### Regex bound for `field_matches`
 
 The regex in a `field_matches` assertion is evaluated under a hard budget,
@@ -155,6 +191,26 @@ reported as INCONCLUSIVE (`pattern evaluation exceeded budget`), not as PASS
 and not as FAIL, and a pattern containing one is INCONCLUSIVE as a whole
 (`not_evaluated: true` in the result). Keep patterns simple and unambiguous:
 `(a|aa)+$` is 8 characters and never finishes.
+
+### Whole-pattern budget
+
+Independently of the per-regex bound, a pattern has **120 seconds** of wall
+clock (`MAX_PATTERN_EXECUTION_TIMEOUT_S`) across all of its steps and all of
+its assertions. The deadline is checked before and after every step, after
+every assertion, and once at the end. Overrunning it is INCONCLUSIVE
+(`pattern execution exceeded budget`, with where it was detected), never a
+PASS and never a FAIL. The per-regex timeout is not a whole-pattern deadline;
+fifty bounded regexes can still exceed the pattern budget, and now do so
+visibly.
+
+### Dry run
+
+`--dry-run` walks the pattern without executing any step or evaluating any
+assertion. Every assertion is reported as `INCONCLUSIVE - (dry run — not
+evaluated)`, the pattern is INCONCLUSIVE (`not_evaluated: true`,
+`assertions_passed: 0`), the summary counts it under `inconclusive`, and the
+CLI exits 2. A dry run cannot produce a PASS: it never asked the target
+anything.
 
 ## Evidence Schema
 
@@ -216,8 +272,11 @@ The runner validates each pattern before execution:
 6. `assertions` must have at least one assertion.
 7. Each attack step must have `action`, `target`, and `payload`.
 8. Each assertion must have `type`.
-9. `evidence_schema` keys must map to valid types.
+9. `evidence_schema` must be an object whose keys map to valid types.
 10. `id` must be unique across all loaded patterns.
+11. Each step's `action` must be one of the action types above.
+12. Each assertion's `type` must be one of the assertion types above.
+13. `attack_steps` has at most 20 entries; `assertions` has at most 50.
 
 Validation errors are reported with the file path and field name. Invalid patterns are skipped (not executed).
 
@@ -242,6 +301,10 @@ agent-security-harness validate --community
 # List all discovered community patterns
 agent-security-harness list --community
 ```
+
+Exit codes: `0` every pattern passed; `1` at least one pattern failed; `2`
+none failed but at least one is INCONCLUSIVE (a dry run, a target never
+contacted, a budget overrun). An unevaluated pattern is not a green run.
 
 ## Appendix: OWASP Agentic Top 10 Categories
 

--- a/docs/free-scan.md
+++ b/docs/free-scan.md
@@ -58,9 +58,12 @@ Returns a structured object with:
   "target_url": "http://...",
   "timestamp": "2026-03-28T15:00:00+00:00",
   "tests_run": 5,
+  "tests_evaluated": 5,
   "tests_passed": 4,
   "tests_failed": 1,
+  "tests_inconclusive": 0,
   "grade": "B",
+  "grade_status": "established",
   "recommendation": "The scan detected 1 issue(s)...",
   "results": [
     {"id": "MCP-001", "name": "Tool Discovery Poisoning", "status": "PASS", "detail": "..."},
@@ -68,6 +71,15 @@ Returns a structured object with:
   ]
 }
 ```
+
+A row's `status` is `PASS`, `FAIL` or `INCONCLUSIVE`. INCONCLUSIVE means the
+scanner could not evaluate that test -- the target did not complete the MCP
+handshake, or the scanner itself failed -- and its `detail` says so. It is
+never counted in `tests_failed` and never reported as a detected issue. When
+any row is INCONCLUSIVE, `grade` is `null` and `grade_status` is
+`"not established"`: a grade is a claim over all five tests, and no such
+claim exists over a test that was not evaluated. Against a closed port every
+row is INCONCLUSIVE and there is no grade.
 
 ### Markdown
 
@@ -86,7 +98,8 @@ Produces a human-readable report with a results table, grade, and recommendation
 ## Exit Code
 
 - `0` if all 5 tests pass
-- `1` if any test fails or errors
+- `1` if any test fails
+- `2` if the scanner could not evaluate every test (no grade established)
 
 This makes the script usable in CI/CD pipelines.
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -116,6 +116,12 @@ Quick 5-test security scan with A-F grading.
 }
 ```
 
+A test the scanner could not evaluate (the target did not complete the MCP
+handshake, or the scanner itself failed) has `status: "INCONCLUSIVE"`, is
+counted in `tests_inconclusive` rather than `tests_failed`, and is never a
+detected issue. When any test is INCONCLUSIVE the response carries
+`"grade": null` and `"grade_status": "not established"`.
+
 ### full_security_audit
 
 Full harness run with attestation report.

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -176,8 +176,14 @@ def create_server(
         """Quick 5-test MCP security scan with A-F grading.
 
         Runs the five most critical MCP protocol tests against a target server
-        and returns a grade (A-F), per-test pass/fail results, a recommendation,
-        and scan duration.
+        and returns a grade (A-F), per-test PASS/FAIL/INCONCLUSIVE results, a
+        recommendation, and scan duration.
+
+        A test the scanner could not evaluate -- the target did not complete
+        the MCP handshake, or the scanner itself failed -- is INCONCLUSIVE:
+        it is not counted in tests_failed, and when any test is INCONCLUSIVE
+        the grade is null with grade_status "not established". An
+        INCONCLUSIVE row is never a detected issue.
 
         Args:
             url: The MCP server URL to scan (e.g. http://host:port/mcp).
@@ -185,8 +191,9 @@ def create_server(
                        'stdio' for stdio-based servers.
 
         Returns:
-            dict with keys: grade, tests_passed, tests_run, results,
-            recommendation, scan_time, target_url, timestamp.
+            dict with keys: grade (A-F or null), grade_status, tests_run,
+            tests_evaluated, tests_passed, tests_failed, tests_inconclusive,
+            results, recommendation, scan_time, target_url, timestamp.
         """
         # Test-only execution witness for the public Streamable HTTP boundary
         # regression. It is inert unless an isolated test supplies a path.

--- a/protocol_tests/cli.py
+++ b/protocol_tests/cli.py
@@ -798,6 +798,9 @@ def main():
         # --html needs a report to render. If the operator asked for HTML but
         # not JSON, ask the harness for a throwaway report we can read back.
         _side_report = None
+        # The operator's own --report path, read before the --html side report
+        # is appended so the two are never confused (R4-08).
+        _operator_report = _report_path_from(filtered_args)
         if html_output and _module_declares_flag(harness_name, "--report") and not any(
                 a == "--report" or a.startswith("--report=") for a in filtered_args):
             _side_report = os.path.join(
@@ -900,7 +903,31 @@ def main():
             except Exception as e:
                 print(f"Warning: HTML report generation failed: {e}", file=sys.stderr)
 
-        sys.exit(0)
+        if _side_report:
+            try:
+                os.remove(_side_report)
+            except OSError:
+                pass
+
+        # The comment above promised "exit with the code the harness asked
+        # for", and the line here was `sys.exit(0)`. A usage error inside the
+        # harness (argparse exit 2, no report written) therefore became a
+        # successful run to any CI job reading the status; an independent
+        # review reproduced it with
+        #     agent-security test skill-security --url ... --report out.json
+        # (R4-08, fourth external review, 2026-09-08). Propagate the child's
+        # code, and when the operator asked for a file that never appeared,
+        # say so and refuse to exit 0.
+        _problems = []
+        if _harness_exit != 0:
+            _problems.append(f"harness `{harness_name}` exited {_harness_exit}")
+        if _operator_report and not os.path.exists(_operator_report):
+            _problems.append(f"--report {_operator_report} was requested and no file was written")
+        if html_output and not os.path.exists(html_output):
+            _problems.append(f"--html {html_output} was requested and no file was written")
+        if _problems:
+            print("error: " + "; ".join(_problems), file=sys.stderr)
+        sys.exit(_harness_exit if _harness_exit != 0 else (1 if _problems else 0))
 
     print(f"Error: unknown command '{args[0]}'")
     print("Use 'agent-security --help' for usage.")

--- a/protocol_tests/community_runner.py
+++ b/protocol_tests/community_runner.py
@@ -44,12 +44,13 @@ import re
 import subprocess
 import sys
 import time
+import uuid
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from protocol_tests.http_helpers import INCONCLUSIVE_PREFIX, is_inconclusive
+from protocol_tests.http_helpers import INCONCLUSIVE_PREFIX, http_post_json, is_inconclusive
 
 try:
     import yaml
@@ -77,6 +78,18 @@ MAX_REGEX_INPUT_LENGTH = 10_000  # Max input length a field_matches regex is run
 MAX_REGEX_EVAL_SECONDS = 1.0
 REGEX_BUDGET_EXCEEDED = "pattern evaluation exceeded budget"
 MAX_ATTACK_STEPS = 20  # Max number of attack steps per pattern
+MAX_ASSERTIONS = 50  # Max number of assertions per pattern (R4-14)
+PATTERN_BUDGET_EXCEEDED = "pattern execution exceeded budget"
+
+#: Frameworks for which a live adapter exists. The adapter speaks JSON-RPC 2.0
+#: over HTTP POST to ``--url``: MCP and A2A are JSON-RPC protocols and
+#: ``generic`` is the plugin author saying "an HTTP JSON-RPC endpoint". The
+#: agent frameworks (autogen, crewai, langgraph) have no wire protocol of
+#: their own, and the payment protocols (x402, l402) are HTTP 402 flows, not
+#: JSON-RPC; a live run against those is INCONCLUSIVE, never a PASS.
+LIVE_ADAPTER_FRAMEWORKS = frozenset({"mcp", "a2a", "generic"})
+NO_ADAPTER_DETAIL = "no adapter bound; the target was not contacted"
+DRY_RUN_DETAIL = "(dry run \u2014 not evaluated)"
 
 # Trust tiers (ordered by privilege)
 TRUST_CORE = "core"          # Maintained by project maintainers
@@ -147,6 +160,10 @@ class PatternResult:
     # assertion could not be evaluated, so no verdict on the target exists.
     not_evaluated: bool = False
     assertions_inconclusive: int = 0
+    # How many steps reached the target and how many the target answered.
+    # Zero answered means no assertion can be evaluated (R4-07).
+    requests_sent: int = 0
+    requests_answered: int = 0
 
     def __post_init__(self):
         if not self.timestamp:
@@ -453,12 +470,23 @@ def validate_pattern(data: dict, file_path: str) -> tuple[AttackPattern | None, 
                         file_path, f"attack_steps[{i}].{req}",
                         f"Required step field '{req}' is missing"
                     ))
+            action = step.get("action")
+            if action is not None and str(action) not in VALID_ACTIONS:
+                errors.append(ValidationError(
+                    file_path, f"attack_steps[{i}].action",
+                    f"Action '{action}' is not valid. Must be one of: {', '.join(sorted(VALID_ACTIONS))}"
+                ))
 
     # Validate assertions
     assertions = data.get("assertions", [])
     if not isinstance(assertions, list) or len(assertions) == 0:
         errors.append(ValidationError(file_path, "assertions", "Must have at least one assertion"))
     else:
+        if len(assertions) > MAX_ASSERTIONS:
+            errors.append(ValidationError(
+                file_path, "assertions",
+                f"Too many assertions ({len(assertions)} > {MAX_ASSERTIONS})"
+            ))
         for i, assertion in enumerate(assertions):
             if not isinstance(assertion, dict):
                 errors.append(ValidationError(file_path, f"assertions[{i}]", "Assertion must be an object"))
@@ -469,10 +497,22 @@ def validate_pattern(data: dict, file_path: str) -> tuple[AttackPattern | None, 
                         file_path, f"assertions[{i}].{req}",
                         f"Required assertion field '{req}' is missing"
                     ))
+            atype = assertion.get("type")
+            if atype is not None and str(atype) not in VALID_ASSERTION_TYPES:
+                errors.append(ValidationError(
+                    file_path, f"assertions[{i}].type",
+                    f"Assertion type '{atype}' is not valid. Must be one of: {', '.join(sorted(VALID_ASSERTION_TYPES))}"
+                ))
 
-    # Validate evidence_schema
+    # Validate evidence_schema: it must be an object. A string or list here
+    # was accepted and later iterated as characters/items (R4-14).
     schema = data.get("evidence_schema", {})
-    if isinstance(schema, dict):
+    if not isinstance(schema, dict):
+        errors.append(ValidationError(
+            file_path, "evidence_schema",
+            f"Must be an object mapping field names to types, got {type(schema).__name__}"
+        ))
+    else:
         for key, type_name in schema.items():
             if str(type_name).lower() not in VALID_EVIDENCE_TYPES:
                 errors.append(ValidationError(
@@ -523,19 +563,87 @@ FRAMEWORK_HARNESS_MAP = {
 }
 
 
+class HttpJsonRpcAdapter:
+    """The one live adapter: JSON-RPC 2.0 over HTTP POST to ``--url``.
+
+    Before this existed, ``send_message``, ``send_jsonrpc`` and ``call_tool``
+    returned ``{"status": "sent", "response": None}`` with the comment
+    "Populated by harness integration", so a "live" run with ``--url`` never
+    opened a socket and an absence assertion passed against a target that
+    was never reached (R4-07, fourth external review, 2026-09-08).
+
+    Every call returns the namespaced dict ``http_post_json`` produces:
+    ``_status`` when the target answered (any HTTP status is an answer),
+    ``_exception`` when it did not.
+    """
+
+    def __init__(self, url: str, timeout_s: int = 15):
+        self.url = url
+        self.timeout_s = timeout_s
+
+    def send_jsonrpc(self, message: dict) -> dict:
+        return http_post_json(self.url, message, timeout=self.timeout_s)
+
+    @staticmethod
+    def answered(resp: dict) -> bool:
+        return isinstance(resp, dict) and "_status" in resp and "_exception" not in resp
+
+
+def bind_adapter(framework: str, target_url: str):
+    """Return the live adapter for *framework* at *target_url*, or None."""
+    if not target_url:
+        return None
+    if framework not in LIVE_ADAPTER_FRAMEWORKS:
+        return None
+    return HttpJsonRpcAdapter(target_url)
+
+
 class StepExecutor:
     """Executes individual attack steps.
 
     This is the bridge between YAML-declared steps and the harness infrastructure.
     Each action type maps to a method that delegates to the appropriate harness.
+
+    Three actions contact the target through ``self.adapter``: ``send_message``,
+    ``send_jsonrpc`` and ``call_tool``. The rest are local simulations that
+    never open a socket, and say so in their result. With no adapter bound the
+    three record ``not_sent`` and count nothing as answered, which run_pattern
+    turns into INCONCLUSIVE for every assertion.
     """
 
-    def __init__(self, pattern: AttackPattern, target_url: str = "", verbose: bool = False):
+    def __init__(self, pattern: AttackPattern, target_url: str = "",
+                 verbose: bool = False, adapter=None):
         self.pattern = pattern
         self.target_url = target_url
         self.verbose = verbose
         self.evidence: dict[str, Any] = {}
         self.responses: list[dict] = []
+        self.adapter = adapter if adapter is not None else bind_adapter(
+            pattern.framework, target_url)
+        self.requests_sent = 0
+        self.requests_answered = 0
+
+    def _live(self, target: str, message: dict, extra: dict) -> dict:
+        """Send *message* through the adapter and record whether it was answered."""
+        if self.adapter is None:
+            return {"status": "not_sent", "target": target,
+                    "reason": NO_ADAPTER_DETAIL, **extra}
+        self.requests_sent += 1
+        resp = self.adapter.send_jsonrpc(message)
+        answered = HttpJsonRpcAdapter.answered(resp)
+        if answered:
+            self.requests_answered += 1
+        record = {
+            "status": "sent" if answered else "unanswered",
+            "target": target,
+            "request_sent": message,
+            "response": resp.get("response") if isinstance(resp, dict) else None,
+            "http_status": resp.get("_status") if isinstance(resp, dict) else None,
+            **extra,
+        }
+        if not answered:
+            record["error"] = resp.get("_exception", "no answer") if isinstance(resp, dict) else "no answer"
+        return record
 
     def execute_step(self, step: dict) -> dict:
         """Execute a single attack step and return the result."""
@@ -565,53 +673,66 @@ class StepExecutor:
             return error_result
 
     def _do_send_message(self, target: str, payload: dict) -> dict:
-        """Simulate sending a message to an agent or server."""
-        return {
-            "status": "sent",
-            "target": target,
-            "role": payload.get("role", ""),
-            "content_length": len(str(payload.get("content", ""))),
-            "response": None,  # Populated by harness integration
+        """Send a message to the target as an A2A ``message/send`` request."""
+        content = str(payload.get("content", ""))
+        message = {
+            "jsonrpc": "2.0",
+            "method": "message/send",
+            "params": {
+                "message": {
+                    "role": payload.get("role") or "user",
+                    "parts": [{"kind": "text", "text": content}],
+                    "messageId": f"community-{uuid.uuid4().hex[:12]}",
+                    "metadata": payload.get("metadata", {}) or {},
+                },
+            },
+            "id": payload.get("id", "community-test-1"),
         }
+        return self._live(target, message, {
+            "role": payload.get("role", ""),
+            "content_length": len(content),
+        })
 
     def _do_send_jsonrpc(self, target: str, payload: dict) -> dict:
-        """Send a JSON-RPC 2.0 message."""
+        """Send a raw JSON-RPC 2.0 message to the target."""
         message = {
             "jsonrpc": "2.0",
             "method": payload.get("method", ""),
             "params": payload.get("params", {}),
             "id": payload.get("id", "community-test-1"),
         }
-        return {
-            "status": "sent",
-            "target": target,
-            "message": message,
-            "response": None,
-        }
+        return self._live(target, message, {})
 
     def _do_call_tool(self, target: str, payload: dict) -> dict:
-        """Invoke a tool by name."""
-        return {
-            "status": "called",
-            "target": target,
-            "tool_name": payload.get("tool_name", ""),
-            "arguments": payload.get("arguments", {}),
-            "response": None,
+        """Invoke a tool by name as an MCP ``tools/call`` request."""
+        message = {
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "params": {
+                "name": payload.get("tool_name", ""),
+                "arguments": payload.get("arguments", {}) or {},
+            },
+            "id": payload.get("id", "community-test-1"),
         }
+        return self._live(target, message, {
+            "tool_name": payload.get("tool_name", ""),
+        })
 
     def _do_inject_description(self, target: str, payload: dict) -> dict:
-        """Simulate injecting a modified tool description."""
+        """Simulate injecting a modified tool description (never contacts the target)."""
         return {
             "status": "injected",
+            "live": False,
             "target": target,
             "tool_name": payload.get("tool_name", ""),
             "injected_length": len(str(payload.get("injected_text", ""))),
         }
 
     def _do_register_tool(self, target: str, payload: dict) -> dict:
-        """Simulate registering a new tool."""
+        """Simulate registering a new tool (never contacts the target)."""
         return {
             "status": "registered",
+            "live": False,
             "target": target,
             "tool_name": payload.get("tool_name", ""),
             "description_length": len(str(payload.get("description", ""))),
@@ -619,17 +740,19 @@ class StepExecutor:
         }
 
     def _do_modify_context(self, target: str, payload: dict) -> dict:
-        """Simulate modifying agent context."""
+        """Simulate modifying agent context (never contacts the target)."""
         return {
             "status": "modified",
+            "live": False,
             "target": target,
             "context_key": payload.get("context_key", ""),
         }
 
     def _do_http_request(self, target: str, payload: dict) -> dict:
-        """Simulate an HTTP request (for exfiltration detection)."""
+        """Simulate an HTTP request (for exfiltration detection; never sent)."""
         return {
             "status": "simulated",
+            "live": False,
             "method": payload.get("method", "GET"),
             "url": payload.get("url", ""),
             "note": "HTTP request simulated - not actually sent during dry run",
@@ -642,9 +765,10 @@ class StepExecutor:
         return {"status": "waited", "duration_ms": duration_ms}
 
     def _do_assert_state(self, target: str, payload: dict) -> dict:
-        """Check intermediate state."""
+        """Check intermediate state (local; never contacts the target)."""
         return {
             "status": "checked",
+            "live": False,
             "condition": payload.get("condition", ""),
             "expected": payload.get("expected", ""),
         }
@@ -769,6 +893,16 @@ class AssertionEvaluator:
         return False, f"{INCONCLUSIVE_PREFIX}{REGEX_BUDGET_EXCEEDED}: {message}"
 
 
+#: The action and assertion vocabularies, derived from the two dispatch tables
+#: rather than written down a second time: a handler that exists is valid, a
+#: name with no handler is rejected at validation instead of being skipped or
+#: reported "Unknown assertion type" at run time (R4-14).
+VALID_ACTIONS = frozenset(
+    name[len("_do_"):] for name in vars(StepExecutor) if name.startswith("_do_"))
+VALID_ASSERTION_TYPES = frozenset(
+    name[len("_check_"):] for name in vars(AssertionEvaluator) if name.startswith("_check_"))
+
+
 # ---------------------------------------------------------------------------
 # Bounded regex evaluation (R3-07)
 # ---------------------------------------------------------------------------
@@ -831,46 +965,82 @@ def evaluate_regex_bounded(
 # Pattern runner
 # ---------------------------------------------------------------------------
 
+def _budget_result(pattern: AttackPattern, elapsed: float, where: str,
+                   executor: "StepExecutor | None" = None) -> PatternResult:
+    """INCONCLUSIVE: the pattern ran past its budget, so nothing was verified."""
+    return PatternResult(
+        test_id=pattern.id,
+        name=pattern.name,
+        source_file=pattern.source_file,
+        owasp_asi=pattern.owasp_category,
+        severity=pattern.severity,
+        passed=False,
+        details=(f"{INCONCLUSIVE_PREFIX}{PATTERN_BUDGET_EXCEEDED}: {elapsed:.2f}s "
+                 f"elapsed (limit: {MAX_PATTERN_EXECUTION_TIMEOUT_S}s) at {where}; "
+                 f"no assertion verdict was recorded"),
+        elapsed_s=round(elapsed, 3),
+        framework=pattern.framework,
+        assertions_total=len(pattern.assertions),
+        assertions_inconclusive=len(pattern.assertions),
+        not_evaluated=True,
+        requests_sent=executor.requests_sent if executor else 0,
+        requests_answered=executor.requests_answered if executor else 0,
+    )
+
+
 def run_pattern(
     pattern: AttackPattern,
     target_url: str = "",
     verbose: bool = False,
     dry_run: bool = False,
+    adapter=None,
 ) -> PatternResult:
     """Execute a community attack pattern and return the result.
 
-    Each pattern is capped at MAX_PATTERN_EXECUTION_TIMEOUT_S seconds.
-    """
-    start_time = time.time()
+    Each pattern is capped at MAX_PATTERN_EXECUTION_TIMEOUT_S seconds of
+    wall clock across ALL steps and ALL assertions. The deadline is checked
+    before and after every step, after every assertion and once at the end;
+    overrunning it is INCONCLUSIVE (R4-14). It used to be checked only before
+    each step, so a final step or the assertion phase could run unbounded.
 
-    executor = StepExecutor(pattern, target_url=target_url, verbose=verbose)
+    Verdict rules (R4-07):
+
+    * dry run: no step runs, every assertion is INCONCLUSIVE with
+      ``(dry run \u2014 not evaluated)``; the pattern is INCONCLUSIVE.
+    * no adapter bound (no ``--url``, or a framework with no live adapter):
+      every assertion is INCONCLUSIVE with ``no adapter bound; the target was
+      not contacted``.
+    * adapter bound but the target answered none of the requests sent (or no
+      step contacts the target at all): every assertion is INCONCLUSIVE.
+    * otherwise the assertions are evaluated against what the target said.
+    """
+    start_time = time.monotonic()
+
+    def over_budget() -> float | None:
+        elapsed = time.monotonic() - start_time
+        return elapsed if elapsed > MAX_PATTERN_EXECUTION_TIMEOUT_S else None
+
+    executor = StepExecutor(pattern, target_url=target_url, verbose=verbose, adapter=adapter)
 
     # Execute attack steps
     if verbose:
         print(f"\n  Running: {pattern.id} - {pattern.name}")
         print(f"  Framework: {pattern.framework} | Severity: {pattern.severity}")
         print(f"  Steps: {len(pattern.attack_steps)} | Assertions: {len(pattern.assertions)}")
+        if not dry_run and executor.adapter is None:
+            print(f"  WARNING: {NO_ADAPTER_DETAIL}")
 
+    n_steps = len(pattern.attack_steps)
     for i, step in enumerate(pattern.attack_steps):
-        # Enforce per-pattern execution timeout
-        elapsed = time.time() - start_time
-        if elapsed > MAX_PATTERN_EXECUTION_TIMEOUT_S:
+        elapsed = over_budget()
+        if elapsed is not None:
             if verbose:
                 print(f"    TIMEOUT: Pattern exceeded {MAX_PATTERN_EXECUTION_TIMEOUT_S}s limit")
-            return PatternResult(
-                test_id=pattern.id,
-                name=pattern.name,
-                source_file=pattern.source_file,
-                severity=pattern.severity,
-                passed=False,
-                details=f"Pattern execution timed out after {elapsed:.1f}s (limit: {MAX_PATTERN_EXECUTION_TIMEOUT_S}s)",
-                elapsed_s=round(elapsed, 3),
-                framework=pattern.framework,
-            )
+            return _budget_result(pattern, elapsed, f"before step {i + 1}/{n_steps}", executor)
 
         if verbose:
             desc = step.get("description", step.get("action", "step"))
-            print(f"    Step {i+1}/{len(pattern.attack_steps)}: {step['action']} -> {step['target']}")
+            print(f"    Step {i+1}/{n_steps}: {step['action']} -> {step['target']}")
 
         if not dry_run:
             executor.execute_step(step)
@@ -878,10 +1048,31 @@ def run_pattern(
             if verbose:
                 print("      (dry run - skipped)")
 
+        elapsed = over_budget()
+        if elapsed is not None:
+            if verbose:
+                print(f"    TIMEOUT: Pattern exceeded {MAX_PATTERN_EXECUTION_TIMEOUT_S}s limit")
+            return _budget_result(pattern, elapsed, f"after step {i + 1}/{n_steps}", executor)
+
     # Build evidence from schema defaults
     evidence = {}
     for key, type_name in pattern.evidence_schema.items():
         evidence[key] = executor.evidence.get(key, _default_for_type(type_name))
+
+    # Decide, once, whether any assertion can be evaluated at all.
+    unevaluable: str | None = None
+    if dry_run:
+        unevaluable = DRY_RUN_DETAIL
+    elif executor.adapter is None:
+        why = ("no --url given" if not target_url
+               else f"no live adapter for framework '{pattern.framework}'")
+        unevaluable = f"{NO_ADAPTER_DETAIL} ({why})"
+    elif executor.requests_sent == 0:
+        unevaluable = ("no step contacts the target (only simulated actions); "
+                       "the target was not contacted")
+    elif executor.requests_answered == 0:
+        unevaluable = (f"the target answered none of {executor.requests_sent} "
+                       f"request(s); nothing to evaluate")
 
     # Evaluate assertions
     evaluator = AssertionEvaluator(evidence, executor.responses)
@@ -890,16 +1081,17 @@ def run_pattern(
 
     assertions_inconclusive = 0
 
+    n_assertions = len(pattern.assertions)
     for i, assertion in enumerate(pattern.assertions):
-        if dry_run:
-            passed = True
-            detail = "(dry run - assertion not evaluated)"
+        if unevaluable is not None:
+            passed = False
+            detail = f"{INCONCLUSIVE_PREFIX}{unevaluable}"
         else:
             passed, detail = evaluator.evaluate(assertion)
 
         # An assertion that could not be evaluated (regex budget exceeded,
-        # R3-07) is a third state: it is not a target failure and it is
-        # never a pass.
+        # R3-07; no target contact, R4-07) is a third state: it is not a
+        # target failure and it is never a pass.
         inconclusive = (not passed) and is_inconclusive(detail)
         if passed:
             assertions_passed += 1
@@ -914,7 +1106,17 @@ def run_pattern(
             icon = "ok" if passed else status
             print(f"    Assertion {i+1}: [{icon}] {desc}")
 
-    elapsed = time.time() - start_time
+        elapsed = over_budget()
+        if elapsed is not None:
+            if verbose:
+                print(f"    TIMEOUT: Pattern exceeded {MAX_PATTERN_EXECUTION_TIMEOUT_S}s limit")
+            return _budget_result(pattern, elapsed, f"after assertion {i + 1}/{n_assertions}", executor)
+
+    elapsed = over_budget()
+    if elapsed is not None:
+        return _budget_result(pattern, elapsed, "end of pattern", executor)
+
+    elapsed = time.monotonic() - start_time
     all_passed = assertions_passed == len(pattern.assertions)
     not_evaluated = assertions_inconclusive > 0
     details = "; ".join(assertion_details)
@@ -936,6 +1138,8 @@ def run_pattern(
         assertions_total=len(pattern.assertions),
         not_evaluated=not_evaluated,
         assertions_inconclusive=assertions_inconclusive,
+        requests_sent=executor.requests_sent,
+        requests_answered=executor.requests_answered,
     )
 
     if verbose:
@@ -1076,6 +1280,20 @@ def run_community_tests(
 
     # Execute patterns
     print(f"\nRunning {len(patterns)} community pattern(s)...\n")
+    if dry_run:
+        print("  DRY RUN: no step is executed and no assertion is evaluated; "
+              "every pattern below is INCONCLUSIVE.")
+    elif not target_url:
+        print(f"  WARNING: {NO_ADAPTER_DETAIL} (no --url given). Every assertion "
+              "below is INCONCLUSIVE. Pass --url to run live, or --dry-run to "
+              "say so explicitly.")
+    else:
+        unsupported = sorted({p.framework for p in patterns
+                              if p.framework not in LIVE_ADAPTER_FRAMEWORKS})
+        if unsupported:
+            print(f"  WARNING: no live adapter for framework(s) "
+                  f"{', '.join(unsupported)}; those patterns are INCONCLUSIVE "
+                  f"(live adapters: {', '.join(sorted(LIVE_ADAPTER_FRAMEWORKS))}).")
     results: list[PatternResult] = []
 
     for pattern in patterns:
@@ -1144,13 +1362,16 @@ Examples:
     parser.add_argument("--severity", type=str,
                         help="Filter by severity (comma-separated)")
     parser.add_argument("--url", type=str, default="",
-                        help="Target URL for live testing")
+                        help="Target URL for live testing (JSON-RPC 2.0 over HTTP POST; "
+                             "frameworks mcp, a2a, generic). Without it no target is "
+                             "contacted and every assertion is INCONCLUSIVE.")
     parser.add_argument("--validate", action="store_true",
                         help="Validate patterns without running them")
     parser.add_argument("--list", action="store_true",
                         help="List discovered patterns")
     parser.add_argument("--dry-run", action="store_true",
-                        help="Execute steps but skip live interactions")
+                        help="Walk the pattern without executing steps or evaluating "
+                             "assertions; every result is INCONCLUSIVE, never PASS")
     parser.add_argument("--no-strict", action="store_true",
                         help="Allow patterns not in MANIFEST.yaml (not recommended)")
     parser.add_argument("--update-manifest", action="store_true",
@@ -1224,9 +1445,13 @@ Examples:
             json.dump(summary, f, indent=2)
         print(f"\nReport written to {args.report}", file=sys.stderr)
 
-    # Exit code: 0 if all passed, 1 if any failed
-    if "failed" in summary and summary["failed"] > 0:
+    # Exit code: 0 all passed, 1 any failed, 2 none failed but at least one
+    # INCONCLUSIVE (a dry run, a target never contacted, a budget overrun).
+    # An unevaluated pattern is not a green run.
+    if summary.get("failed", 0) > 0:
         sys.exit(1)
+    if summary.get("inconclusive", 0) > 0:
+        sys.exit(2)
 
 
 if __name__ == "__main__":

--- a/scripts/free_scan.py
+++ b/scripts/free_scan.py
@@ -28,11 +28,18 @@ from urllib.parse import urlparse
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, REPO_ROOT)
 
+from protocol_tests.http_helpers import is_inconclusive
 from protocol_tests.mcp_harness import (
     MCPSecurityTests,
     MCPTestResult,
     StreamableHTTPTransport,
 )
+
+#: Row status when the scanner itself could not reach a verdict. It is never
+#: a failed test and never a detected issue.
+INCONCLUSIVE = "INCONCLUSIVE"
+COULD_NOT_EVALUATE = "the scanner could not evaluate this test"
+GRADE_NOT_ESTABLISHED = "not established"
 
 # ── SSRF Protection ────────────────────────────────────────────────────────
 
@@ -126,10 +133,14 @@ FREE_SCAN_TESTS = [
 
 # ── Grading ────────────────────────────────────────────────────────────────
 
-def compute_grade(passed: int, total: int) -> str:
-    """Return a letter grade A-F based on pass ratio."""
+def compute_grade(passed: int, total: int) -> str | None:
+    """Return a letter grade A-F based on pass ratio.
+
+    ``None`` when nothing was evaluated: zero tests is not an F, it is no
+    grade at all (R4-06).
+    """
     if total == 0:
-        return "F"
+        return None
     ratio = passed / total
     if ratio >= 1.0:
         return "A"
@@ -143,9 +154,31 @@ def compute_grade(passed: int, total: int) -> str:
         return "F"
 
 
-def build_recommendation(results: list[dict], grade: str) -> str:
-    """Generate a 1-paragraph recommendation based on scan results."""
-    failed = [r for r in results if r["status"] != "PASS"]
+def build_recommendation(results: list[dict], grade: str | None) -> str:
+    """Generate a 1-paragraph recommendation based on scan results.
+
+    Only a row the scanner actually evaluated can be a detected issue. A row
+    the scanner could not evaluate is reported as exactly that, and no grade
+    is claimed over it.
+    """
+    failed = [r for r in results if r["status"] == "FAIL"]
+    unevaluated = [r for r in results if r["status"] == INCONCLUSIVE]
+    if unevaluated:
+        names = ", ".join(r["name"] for r in unevaluated)
+        text = (
+            f"The scanner could not evaluate {len(unevaluated)} of {len(results)} "
+            f"tests ({names}), so no grade is established. This is not evidence "
+            f"that the server is vulnerable, and it is not evidence that it is "
+            f"secure. Check that the target URL is a reachable Streamable HTTP "
+            f"MCP endpoint and re-run the scan."
+        )
+        if failed:
+            fail_names = ", ".join(r["name"] for r in failed)
+            text += (
+                f" Of the tests that were evaluated, {len(failed)} failed: "
+                f"{fail_names}. Remediate those before re-running."
+            )
+        return text
     if not failed:
         return (
             "All five quick-scan tests passed. This MCP server demonstrates solid "
@@ -166,12 +199,36 @@ def build_recommendation(results: list[dict], grade: str) -> str:
 
 # ── Run scan ───────────────────────────────────────────────────────────────
 
+def _row(test_def: dict, status: str, detail: str) -> dict:
+    return {
+        "id": test_def["id"],
+        "name": test_def["name"],
+        "status": status,
+        "detail": detail or "",
+    }
+
+
+def _status_of(result: MCPTestResult) -> str:
+    if is_inconclusive(result):
+        return INCONCLUSIVE
+    return "PASS" if result.passed else "FAIL"
+
+
 def run_free_scan(url: str, transport: str = "http") -> dict:
     """Execute the 5 free-scan tests and return structured results.
 
     Args:
         url: Target MCP server URL.
         transport: Transport type - 'http' (default) or 'stdio'.
+
+    The selected ``MCPSecurityTests`` methods record their result on the
+    suite and return ``None``. This wrapper used to dereference that ``None``,
+    catch its own ``AttributeError`` and publish it as five failed tests,
+    grade F and "The scan detected 5 issue(s)" -- against the shipped mock and
+    against a closed port alike (R4-06, fourth external review, 2026-09-08).
+    It now reads the recorded result back by test id, runs the MCP handshake
+    the methods assume (as ``run_all`` does), and reports anything the
+    scanner itself could not do as INCONCLUSIVE with no grade.
     """
     # #110 - Wire transport parameter through
     if transport == "stdio":
@@ -179,46 +236,72 @@ def run_free_scan(url: str, transport: str = "http") -> dict:
         _transport = StdioTransport(url)
     else:
         _transport = StreamableHTTPTransport(url)
-    harness = MCPSecurityTests(_transport)
+    # json_output silences the per-test console lines, which would otherwise
+    # land on stdout ahead of the JSON this script prints.
+    harness = MCPSecurityTests(_transport, json_output=True)
 
     scan_results: list[dict] = []
-    passed = 0
     total = len(FREE_SCAN_TESTS)
 
-    for test_def in FREE_SCAN_TESTS:
-        test_method = getattr(harness, test_def["method"], None)
-        if test_method is None:
-            scan_results.append({
-                "id": test_def["id"],
-                "name": test_def["name"],
-                "status": "ERROR",
-                "detail": "Test method not found in harness.",
-            })
-            continue
-
+    try:
+        # The test methods assume the handshake ran; run_all() aborts when it
+        # does not. Against a closed port that is the whole verdict.
+        init_error: str | None = None
         try:
-            result: MCPTestResult = test_method()
-            status = result.status.value if hasattr(result.status, "value") else str(result.status)
-            is_pass = status.upper() == "PASS"
-            if is_pass:
-                passed += 1
-            scan_results.append({
-                "id": test_def["id"],
-                "name": test_def["name"],
-                "status": status.upper(),
-                "detail": result.detail or "",
-            })
-        except Exception as exc:
-            scan_results.append({
-                "id": test_def["id"],
-                "name": test_def["name"],
-                "status": "ERROR",
-                "detail": str(exc),
-            })
+            initialized = bool(harness.initialize())
+        except Exception as exc:  # the transport raised rather than reporting
+            initialized = False
+            init_error = f"{type(exc).__name__}: {exc}"
+        if not initialized:
+            reason = (getattr(harness, "_connection_error", None) or init_error
+                      or "MCP initialize did not succeed")
+            for test_def in FREE_SCAN_TESTS:
+                scan_results.append(_row(
+                    test_def, INCONCLUSIVE,
+                    f"INCONCLUSIVE - {COULD_NOT_EVALUATE}: {reason}"))
+        else:
+            for test_def in FREE_SCAN_TESTS:
+                test_method = getattr(harness, test_def["method"], None)
+                if test_method is None:
+                    scan_results.append(_row(
+                        test_def, INCONCLUSIVE,
+                        f"INCONCLUSIVE - {COULD_NOT_EVALUATE}: test method "
+                        f"{test_def['method']} not found in harness"))
+                    continue
 
-    _transport.close()
+                before = len(harness.results)
+                try:
+                    test_method()
+                except Exception as exc:
+                    scan_results.append(_row(
+                        test_def, INCONCLUSIVE,
+                        f"INCONCLUSIVE - {COULD_NOT_EVALUATE}: "
+                        f"{type(exc).__name__}: {exc}"))
+                    continue
 
-    grade = compute_grade(passed, total)
+                recorded = [r for r in harness.results[before:]
+                            if r.test_id == test_def["id"]]
+                if not recorded:
+                    scan_results.append(_row(
+                        test_def, INCONCLUSIVE,
+                        f"INCONCLUSIVE - {COULD_NOT_EVALUATE}: the harness "
+                        f"recorded no result for {test_def['id']}"))
+                    continue
+                result = recorded[-1]
+                scan_results.append(_row(test_def, _status_of(result), result.details))
+    finally:
+        try:
+            _transport.close()
+        except Exception:
+            pass
+
+    passed = sum(1 for r in scan_results if r["status"] == "PASS")
+    failed = sum(1 for r in scan_results if r["status"] == "FAIL")
+    inconclusive = sum(1 for r in scan_results if r["status"] == INCONCLUSIVE)
+
+    # A grade is a claim over all five tests. If any of them was not
+    # evaluated, no such claim exists.
+    grade = compute_grade(passed, total) if inconclusive == 0 else None
     recommendation = build_recommendation(scan_results, grade)
 
     return {
@@ -226,9 +309,12 @@ def run_free_scan(url: str, transport: str = "http") -> dict:
         "target_url": url,
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "tests_run": total,
+        "tests_evaluated": total - inconclusive,
         "tests_passed": passed,
-        "tests_failed": total - passed,
+        "tests_failed": failed,
+        "tests_inconclusive": inconclusive,
         "grade": grade,
+        "grade_status": "established" if grade is not None else GRADE_NOT_ESTABLISHED,
         "recommendation": recommendation,
         "results": scan_results,
     }
@@ -246,8 +332,10 @@ def format_markdown(report: dict) -> str:
         "",
         f"**Target:** `{report['target_url']}`",
         f"**Date:** {report['timestamp']}",
-        f"**Grade:** {report['grade']}",
-        f"**Passed:** {report['tests_passed']}/{report['tests_run']}",
+        f"**Grade:** {report['grade'] or GRADE_NOT_ESTABLISHED}",
+        f"**Passed:** {report['tests_passed']}/{report['tests_run']}"
+        + (f" ({report['tests_inconclusive']} not evaluated)"
+           if report.get('tests_inconclusive') else ""),
         "",
         "## Results",
         "",
@@ -256,7 +344,7 @@ def format_markdown(report: dict) -> str:
     ]
 
     for r in report["results"]:
-        icon = "PASS" if r["status"] == "PASS" else "FAIL" if r["status"] == "FAIL" else "ERROR"
+        icon = r["status"]
         detail = r["detail"][:80].replace("|", "/") if r["detail"] else "-"
         lines.append(f"| {r['id']} | {r['name']} | {icon} | {detail} |")
 
@@ -280,7 +368,8 @@ def format_markdown(report: dict) -> str:
 def send_email_stub(email: str, report_text: str) -> None:
     """Stub for email delivery. Replace with actual SMTP/SES integration."""
     print(f"\nWould email to: {email}")
-    print(f"Subject: MCP Security Scan Report - Grade {json.loads(report_text)['grade'] if '{' in report_text else 'N/A'}")
+    grade = json.loads(report_text).get("grade") if "{" in report_text else None
+    print(f"Subject: MCP Security Scan Report - Grade {grade or GRADE_NOT_ESTABLISHED}")
     print("(Email sending is stubbed - integrate with your email provider to enable)")
 
 
@@ -337,8 +426,11 @@ def main():
     if args.email:
         send_email_stub(args.email, format_json(report))
 
-    # Exit with non-zero if any tests failed
-    sys.exit(0 if report["tests_passed"] == report["tests_run"] else 1)
+    # Exit code: 0 all passed, 1 a test failed, 2 the scanner could not
+    # evaluate every test (no grade established).
+    if report["tests_inconclusive"]:
+        sys.exit(2)
+    sys.exit(0 if report["tests_failed"] == 0 else 1)
 
 
 if __name__ == "__main__":

--- a/testing/test_cli_exit_propagation.py
+++ b/testing/test_cli_exit_propagation.py
@@ -1,0 +1,83 @@
+"""The CLI dispatcher exits with the code the harness asked for.
+
+`protocol_tests/cli.py` caught the child's SystemExit into `_harness_exit`,
+finished the HTML and telemetry work, and then called `sys.exit(0)`
+unconditionally. Its own comment promised to "exit with the code the harness
+asked for". So
+
+    agent-security test skill-security --url http://127.0.0.1:9 --report out.json
+
+printed argparse's "unrecognized arguments" from the child, wrote no report,
+and exited 0 (R4-08, fourth external review, 2026-09-08). Invalid syntax
+must not become a successful run, and a requested file that never appeared
+must not be silent.
+
+All three shapes are exercised through the public entry point.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CLOSED = "http://127.0.0.1:9/mcp"
+
+
+def _run(*args: str, timeout: int = 180) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "protocol_tests.cli", *args],
+        cwd=REPO_ROOT, capture_output=True, text=True, timeout=timeout, check=False,
+        env=dict(os.environ, AGENT_SECURITY_TELEMETRY="off"),
+    )
+
+
+class TestUsageErrorsAreNotSuccess(unittest.TestCase):
+    def test_unsupported_flag_exits_with_the_childs_code_and_names_the_missing_report(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = os.path.join(tmp, "out.json")
+            r = _run("test", "skill-security", "--url", CLOSED, "--report", out)
+            self.assertEqual(r.returncode, 2,
+                             f"argparse exits 2 in the child; the parent exited {r.returncode}\n{r.stderr[-400:]}")
+            self.assertIn("unrecognized arguments", r.stderr)
+            self.assertIn("no file was written", r.stderr)
+            self.assertFalse(os.path.exists(out))
+
+
+class TestAFailingChildKeepsItsCode(unittest.TestCase):
+    def test_the_cli_exit_equals_the_modules_own_exit(self):
+        direct = subprocess.run(
+            [sys.executable, "-m", "protocol_tests.mcp_harness",
+             "--transport", "http", "--url", CLOSED, "--json"],
+            cwd=REPO_ROOT, capture_output=True, text=True, timeout=180, check=False,
+            env=dict(os.environ, AGENT_SECURITY_TELEMETRY="off"),
+        )
+        via_cli = _run("test", "mcp", "--url", CLOSED, "--json")
+        self.assertNotEqual(direct.returncode, 0, "the module itself must refuse a closed port")
+        self.assertEqual(via_cli.returncode, direct.returncode,
+                         f"module exited {direct.returncode}, CLI exited {via_cli.returncode}")
+
+    def test_html_is_still_written_and_the_failure_is_still_visible(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = os.path.join(tmp, "live.html")
+            r = _run("test", "mcp", "--url", CLOSED, "--html", out)
+            self.assertTrue(os.path.exists(out), r.stderr[-400:])
+            self.assertNotEqual(r.returncode, 0)
+
+
+class TestAGoodRunExitsZero(unittest.TestCase):
+    def test_a_local_fixture_harness_exits_zero(self):
+        r = _run("test", "receipt-claim", "--json")
+        self.assertEqual(r.returncode, 0, r.stderr[-400:])
+        self.assertIn('"passed": true', r.stdout)
+
+    def test_the_childs_own_help_exit_is_zero(self):
+        r = _run("test", "skill-security", "--help")
+        self.assertEqual(r.returncode, 0, r.stderr[-400:])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/testing/test_community_live_adapter.py
+++ b/testing/test_community_live_adapter.py
@@ -1,0 +1,364 @@
+"""Community runner: a "live" run contacts the target or says it did not.
+
+`_do_send_message`, `_do_send_jsonrpc` and `_do_call_tool` returned
+`{"status": "sent", "response": None}` with the comment "Populated by
+harness integration". A run with `--url http://127.0.0.1:9` therefore never
+opened a socket, and an absence assertion ("response must not contain X")
+searched a synthetic structure and PASSED against a target that was never
+reached. Dry-run assigned `passed = True` outright. A synthetic plugin
+produced one PASS and zero inconclusive in both modes (R4-07, fourth
+external review, 2026-09-08).
+
+Validation also accepted a non-object evidence schema, an unknown action
+and an unknown assertion type; the pattern time budget was checked only
+before each step; and nothing capped the assertion count (R4-14).
+
+The fixture plugin here is synthetic and assembled at run time under a
+temporary directory with a hash-bound MANIFEST.yaml, the way the runner
+trusts any plugin; it contains no credentials and is never committed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import textwrap
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from protocol_tests import community_runner as cr  # noqa: E402
+from protocol_tests.http_helpers import is_inconclusive  # noqa: E402
+
+CLOSED = "http://127.0.0.1:9/mcp"
+SYNTHETIC_TOKEN = "zq7hunter2wq"  # appears nowhere but in the assertion
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _wait_for(port: int, timeout: float = 10.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        with socket.socket() as s:
+            if s.connect_ex(("127.0.0.1", port)) == 0:
+                return True
+        time.sleep(0.05)
+    return False
+
+
+def _pattern(**over) -> cr.AttackPattern:
+    base = dict(
+        id="CP-9901", version="1.0.0", name="synthetic absence probe", description="",
+        framework="mcp", severity="low", owasp_category="OWASP-AGENT-01",
+        attack_steps=[{"action": "send_jsonrpc", "target": "server",
+                       "payload": {"method": "tools/list", "params": {}}}],
+        assertions=[{"type": "response_must_not_contain", "field": "response",
+                     "value": SYNTHETIC_TOKEN, "description": "token absent"}],
+        evidence_schema={"response_received": "object"},
+    )
+    base.update(over)
+    return cr.AttackPattern(**base)
+
+
+PLUGIN_YAML = textwrap.dedent(f"""\
+    id: CP-9901
+    version: "1.0.0"
+    name: Synthetic absence probe (test fixture)
+    description: Asks that a synthetic token not appear, and that a real tool name does.
+    framework: mcp
+    severity: low
+    owasp_category: OWASP-AGENT-01
+    attack_steps:
+      - action: send_jsonrpc
+        target: server
+        payload:
+          method: tools/list
+          params: {{}}
+      - action: call_tool
+        target: server
+        payload:
+          tool_name: get_safety_procedures
+          arguments:
+            pipeline_id: fixture-1
+    assertions:
+      - type: response_must_not_contain
+        field: response
+        value: "{SYNTHETIC_TOKEN}"
+      - type: response_must_contain
+        field: response
+        value: "vulnerable_tool_discovery"
+    evidence_schema:
+      response_received: object
+    """)
+
+
+def _write_fixture(root: Path) -> tuple[str, str]:
+    """A hash-bound, community-tier plugin under *root*; returns (dir, file)."""
+    cdir = root / "community_modules"
+    (cdir / "contrib").mkdir(parents=True)
+    pfile = cdir / "contrib" / "synthetic_absence.yaml"
+    pfile.write_text(PLUGIN_YAML, encoding="utf-8")
+    digest = hashlib.sha256(pfile.read_bytes()).hexdigest()
+    (cdir / cr.MANIFEST_FILE).write_text(textwrap.dedent(f"""\
+        spec_version: '1.0'
+        patterns:
+        - file: contrib/synthetic_absence.yaml
+          id: CP-9901
+          sha256: {digest}
+          trust: community
+          reviewed_by: test-fixture
+          reviewed_at: '2026-09-08'
+        """), encoding="utf-8")
+    return str(cdir), str(pfile)
+
+
+class _MockServer(unittest.TestCase):
+    proc = None
+    url = ""
+
+    @classmethod
+    def setUpClass(cls):
+        port = _free_port()
+        cls.proc = subprocess.Popen(
+            [sys.executable, "-m", "protocol_tests.mock_mcp_server",
+             "--port", str(port), "--host", "127.0.0.1"],
+            cwd=REPO_ROOT, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+        if not _wait_for(port):
+            cls._stop()
+            raise RuntimeError(f"mock MCP server did not start on {port}")
+        cls.url = f"http://127.0.0.1:{port}/mcp"
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._stop()
+
+    @classmethod
+    def _stop(cls):
+        if cls.proc and cls.proc.poll() is None:
+            cls.proc.terminate()
+            try:
+                cls.proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                cls.proc.kill()
+
+
+class TestALivePluginActuallySends(_MockServer):
+    def test_the_manifest_bound_plugin_reaches_the_loopback_mock(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cdir, pfile = _write_fixture(Path(tmp))
+            with mock.patch("sys.stdout"):
+                summary = cr.run_community_tests(
+                    community_dir=cdir, pattern_file=pfile, target_url=self.url)
+        self.assertEqual(summary["patterns_run"], 1, summary)
+        row = summary["results"][0]
+        self.assertEqual(row["requests_sent"], 2, row)
+        self.assertEqual(row["requests_answered"], 2, row)
+        self.assertFalse(row["not_evaluated"], row["details"])
+        self.assertTrue(row["passed"], row["details"])
+        self.assertEqual(row["assertions_passed"], 2)
+        self.assertEqual((summary["passed"], summary["failed"], summary["inconclusive"]), (1, 0, 0))
+
+    def test_a_presence_assertion_that_the_target_does_not_satisfy_is_a_real_fail(self):
+        pat = _pattern(assertions=[{"type": "response_must_contain", "field": "response",
+                                    "value": SYNTHETIC_TOKEN}])
+        r = cr.run_pattern(pat, target_url=self.url)
+        self.assertEqual((r.requests_sent, r.requests_answered), (1, 1))
+        self.assertFalse(r.passed)
+        self.assertFalse(r.not_evaluated, "a target that answered and lacked the value is FAIL")
+        self.assertFalse(is_inconclusive(r))
+
+    def test_send_message_is_an_a2a_request_on_the_wire(self):
+        seen: list[dict] = []
+
+        class Spy(cr.HttpJsonRpcAdapter):
+            def send_jsonrpc(self, message):
+                seen.append(message)
+                return super().send_jsonrpc(message)
+
+        pat = _pattern(attack_steps=[{"action": "send_message", "target": "agent",
+                                      "payload": {"role": "user", "content": "hello"}}])
+        r = cr.run_pattern(pat, target_url=self.url, adapter=Spy(self.url))
+        self.assertEqual(seen[0]["method"], "message/send")
+        self.assertEqual(seen[0]["params"]["message"]["parts"][0]["text"], "hello")
+        self.assertEqual(r.requests_sent, 1)
+
+
+class TestNoContactIsNeverAPass(unittest.TestCase):
+    def test_closed_port_is_inconclusive(self):
+        r = cr.run_pattern(_pattern(), target_url=CLOSED)
+        self.assertGreaterEqual(r.requests_sent, 1)
+        self.assertEqual(r.requests_answered, 0)
+        self.assertFalse(r.passed)
+        self.assertTrue(r.not_evaluated)
+        self.assertEqual(r.assertions_inconclusive, 1)
+        self.assertIn("answered none of", r.details)
+
+    def test_no_url_means_no_adapter_and_says_so(self):
+        r = cr.run_pattern(_pattern(), target_url="")
+        self.assertFalse(r.passed)
+        self.assertTrue(r.not_evaluated)
+        self.assertIn(cr.NO_ADAPTER_DETAIL, r.details)
+        self.assertEqual(r.requests_sent, 0)
+
+    def test_a_framework_without_a_live_adapter_is_inconclusive_even_with_a_url(self):
+        r = cr.run_pattern(_pattern(framework="crewai"), target_url=CLOSED)
+        self.assertFalse(r.passed)
+        self.assertTrue(r.not_evaluated)
+        self.assertIn("no live adapter for framework 'crewai'", r.details)
+        self.assertEqual(r.requests_sent, 0)
+
+    def test_only_simulated_steps_never_contact_the_target(self):
+        pat = _pattern(attack_steps=[{"action": "register_tool", "target": "server",
+                                      "payload": {"tool_name": "t", "description": "d"}}])
+        r = cr.run_pattern(pat, target_url=CLOSED)
+        self.assertFalse(r.passed)
+        self.assertTrue(r.not_evaluated)
+        self.assertIn("the target was not contacted", r.details)
+
+
+class TestDryRunIsInconclusive(unittest.TestCase):
+    def test_dry_run_assertions_are_not_evaluated_and_not_passed(self):
+        r = cr.run_pattern(_pattern(), target_url=CLOSED, dry_run=True)
+        self.assertFalse(r.passed)
+        self.assertTrue(r.not_evaluated)
+        self.assertEqual(r.assertions_passed, 0)
+        self.assertEqual(r.assertions_inconclusive, 1)
+        self.assertIn("(dry run", r.details)
+        self.assertIn("not evaluated)", r.details)
+        self.assertEqual(r.requests_sent, 0)
+
+    def test_the_summary_counts_a_dry_run_as_inconclusive_and_the_cli_exits_nonzero(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cdir, pfile = _write_fixture(Path(tmp))
+            with mock.patch("sys.stdout"):
+                summary = cr.run_community_tests(
+                    community_dir=cdir, pattern_file=pfile, dry_run=True)
+            self.assertEqual((summary["passed"], summary["failed"], summary["inconclusive"]), (0, 0, 1))
+            proc = subprocess.run(
+                [sys.executable, "-m", "protocol_tests.community_runner",
+                 "--pattern", os.path.relpath(pfile, tmp), "--community-dir", cdir, "--dry-run"],
+                cwd=tmp, capture_output=True, text=True, timeout=120, check=False,
+                env=dict(os.environ, PYTHONPATH=REPO_ROOT, AGENT_SECURITY_TELEMETRY="off"),
+            )
+        self.assertEqual(proc.returncode, 2, proc.stdout[-400:] + proc.stderr[-400:])
+        self.assertIn("INCONCLUSIVE CP-9901", proc.stdout)
+
+
+class TestValidationEnums(unittest.TestCase):
+    """R4-14: enums derived from the dispatch tables, not hand-written twice."""
+
+    def _data(self, **over) -> dict:
+        base = dict(id="CP-9902", version="1", name="n", description="d", framework="generic",
+                    severity="low", owasp_category="OWASP-AGENT-01",
+                    attack_steps=[{"action": "send_message", "target": "agent", "payload": {}}],
+                    assertions=[{"type": "no_data_exfiltration"}],
+                    evidence_schema={"x": "string"})
+        base.update(over)
+        return base
+
+    def _errors(self, data) -> list[str]:
+        _, errs = cr.validate_pattern(data, "case.yaml")
+        return [str(e) for e in errs]
+
+    def test_the_baseline_is_accepted(self):
+        self.assertEqual(self._errors(self._data()), [])
+
+    def test_non_object_evidence_schema_is_rejected(self):
+        errs = self._errors(self._data(evidence_schema="string"))
+        self.assertTrue(any("[evidence_schema]" in e and "object" in e for e in errs), errs)
+
+    def test_unknown_action_is_rejected(self):
+        errs = self._errors(self._data(attack_steps=[{"action": "teleport", "target": "agent", "payload": {}}]))
+        self.assertTrue(any("[attack_steps[0].action]" in e and "teleport" in e for e in errs), errs)
+
+    def test_unknown_assertion_type_is_rejected(self):
+        errs = self._errors(self._data(assertions=[{"type": "vibes_ok"}]))
+        self.assertTrue(any("[assertions[0].type]" in e and "vibes_ok" in e for e in errs), errs)
+
+    def test_enums_are_the_dispatch_tables(self):
+        self.assertEqual(cr.VALID_ACTIONS, {n[4:] for n in vars(cr.StepExecutor) if n.startswith("_do_")})
+        self.assertEqual(cr.VALID_ASSERTION_TYPES,
+                         {n[7:] for n in vars(cr.AssertionEvaluator) if n.startswith("_check_")})
+        for name in ("send_message", "send_jsonrpc", "call_tool", "wait"):
+            self.assertIn(name, cr.VALID_ACTIONS)
+        for name in ("response_must_not_contain", "field_matches"):
+            self.assertIn(name, cr.VALID_ASSERTION_TYPES)
+
+    def test_assertion_count_is_capped(self):
+        ok = [{"type": "no_data_exfiltration"}] * cr.MAX_ASSERTIONS
+        self.assertEqual(self._errors(self._data(assertions=ok)), [])
+        errs = self._errors(self._data(assertions=ok + [{"type": "no_data_exfiltration"}]))
+        self.assertTrue(any("Too many assertions" in e for e in errs), errs)
+        self.assertEqual(cr.MAX_ASSERTIONS, 50)
+
+    def test_the_shipped_plugins_still_validate(self):
+        with mock.patch("sys.stdout"):
+            summary = cr.run_community_tests(
+                community_dir=os.path.join(REPO_ROOT, "community_modules"), validate_only=True)
+        self.assertEqual(summary["patterns_valid"], summary["patterns_found"], summary["errors"])
+
+
+class _AnsweringAdapter:
+    """Answers every request instantly so the assertion phase is reachable."""
+
+    def __init__(self):
+        self.calls = 0
+
+    def send_jsonrpc(self, message):
+        self.calls += 1
+        return {"_status": 200, "_body": "{}", "response": {"result": {}}}
+
+
+class TestPatternDeadlineCoversStepsAndAssertions(unittest.TestCase):
+    """R4-14: with a 50 ms budget, a 200 ms wait step must not end in PASS."""
+
+    def test_overrun_after_the_last_step_is_inconclusive(self):
+        pat = _pattern(framework="generic",
+                       attack_steps=[{"action": "wait", "target": "server",
+                                      "payload": {"duration_ms": 200}}])
+        with mock.patch.object(cr, "MAX_PATTERN_EXECUTION_TIMEOUT_S", 0.05):
+            r = cr.run_pattern(pat, target_url=CLOSED, adapter=_AnsweringAdapter())
+        self.assertFalse(r.passed)
+        self.assertTrue(r.not_evaluated)
+        self.assertIn(cr.PATTERN_BUDGET_EXCEEDED, r.details)
+        self.assertIn("after step 1/1", r.details)
+        self.assertEqual(r.assertions_inconclusive, r.assertions_total)
+
+    def test_overrun_during_assertions_is_inconclusive(self):
+        pat = _pattern(framework="generic",
+                       assertions=[{"type": "no_data_exfiltration"}, {"type": "no_data_exfiltration"}])
+
+        def slow(self, assertion):
+            time.sleep(0.1)
+            return True, "ok"
+
+        with mock.patch.object(cr, "MAX_PATTERN_EXECUTION_TIMEOUT_S", 0.05), \
+                mock.patch.object(cr.AssertionEvaluator, "evaluate", slow):
+            r = cr.run_pattern(pat, target_url=CLOSED, adapter=_AnsweringAdapter())
+        self.assertFalse(r.passed)
+        self.assertTrue(r.not_evaluated)
+        self.assertIn("after assertion 1/2", r.details)
+
+    def test_within_budget_a_pattern_still_passes(self):
+        r = cr.run_pattern(_pattern(framework="generic"), target_url=CLOSED,
+                           adapter=_AnsweringAdapter())
+        self.assertTrue(r.passed, r.details)
+        self.assertFalse(r.not_evaluated)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/testing/test_community_regex_budget.py
+++ b/testing/test_community_regex_budget.py
@@ -25,6 +25,8 @@ from protocol_tests.http_helpers import INCONCLUSIVE_PREFIX, is_inconclusive
 CATASTROPHIC_PATTERN = "(a|aa)+$"
 CATASTROPHIC_INPUT = "a" * 37 + "!"
 WALL_CLOCK_LIMIT_S = 2.0
+#: Never connected to: the adapter below answers in place of a real target.
+TARGET = "http://127.0.0.1:9/rpc"
 
 
 def _evaluate(pattern: str, text: str) -> tuple[bool, str]:
@@ -95,13 +97,40 @@ class TestBenignPatternsKeepTheirVerdicts(unittest.TestCase):
         self.assertFalse(is_inconclusive(detail))
 
 
+class _AnsweringAdapter:
+    """A target that answers every request, so the assertion phase is reachable.
+
+    These two tests used to call ``run_pattern`` on a pattern with no attack
+    steps and no target URL, and read the verdict its assertions produced.
+    Since R4-07 that is INCONCLUSIVE by construction: a pattern that contacted
+    nothing has no verdict to give about a target, so the evaluator is never
+    reached and the regex-budget property below would be tested vacuously --
+    "INCONCLUSIVE" for the wrong reason. The second test in particular pinned
+    the defect directly: it asserted that a non-matching regex is a FAIL of a
+    target the runner never asked (CLAUDE.md item 8).
+
+    Binding a stub target that answers restores exactly what these tests are
+    for -- what the runner concludes about a regex it could or could not
+    evaluate -- with the target contact that conclusion requires.
+    """
+
+    def send_jsonrpc(self, message):
+        return {"_status": 200, "_body": "{}", "response": {"result": {}}}
+
+
 class TestPatternVerdictCarriesInconclusive(unittest.TestCase):
     """A pattern with an unevaluable assertion is INCONCLUSIVE, structurally."""
+
+    #: One live step, so the target is contacted and the assertions are
+    #: evaluated on what it said.
+    STEP = {"action": "send_jsonrpc", "target": "server",
+            "payload": {"method": "tools/list", "params": {}}}
 
     def _pattern(self, regex: str) -> cr.AttackPattern:
         return cr.AttackPattern(
             id="CT-R307", version="1.0.0", name="regex budget", description="",
-            framework="generic", severity="low", owasp_category="ASI01", attack_steps=[],
+            framework="generic", severity="low", owasp_category="ASI01",
+            attack_steps=[self.STEP],
             evidence_schema={"field": "string"},
             assertions=[
                 {"type": "field_matches", "field": "field", "value": regex,
@@ -111,17 +140,22 @@ class TestPatternVerdictCarriesInconclusive(unittest.TestCase):
             ],
         )
 
-    def test_budget_exceeded_pattern_is_not_evaluated_and_not_passed(self):
-        pattern = self._pattern(CATASTROPHIC_PATTERN)
-        executor = cr.StepExecutor(pattern)
-        executor.evidence["field"] = CATASTROPHIC_INPUT
+    def _run(self, pattern: cr.AttackPattern, evidence: str | None = None) -> cr.PatternResult:
+        executor = cr.StepExecutor(pattern, target_url=TARGET, adapter=_AnsweringAdapter())
+        if evidence is not None:
+            executor.evidence["field"] = evidence
         # Drive run_pattern through its public path with the evidence injected.
         original = cr.StepExecutor
         try:
             cr.StepExecutor = lambda *a, **k: executor  # type: ignore[assignment]
-            result = cr.run_pattern(pattern)
+            return cr.run_pattern(pattern, target_url=TARGET)
         finally:
             cr.StepExecutor = original
+
+    def test_budget_exceeded_pattern_is_not_evaluated_and_not_passed(self):
+        result = self._run(self._pattern(CATASTROPHIC_PATTERN), CATASTROPHIC_INPUT)
+        self.assertEqual((result.requests_sent, result.requests_answered), (1, 1),
+                         "the regex verdict must be reached through a contacted target")
         self.assertFalse(result.passed)
         self.assertTrue(result.not_evaluated)
         self.assertEqual(result.assertions_inconclusive, 1)
@@ -131,11 +165,19 @@ class TestPatternVerdictCarriesInconclusive(unittest.TestCase):
         self.assertTrue(is_inconclusive(result.to_dict()))
 
     def test_plain_failure_is_not_inconclusive(self):
-        pattern = self._pattern(r"^will-not-match$")
-        result = cr.run_pattern(pattern)
+        result = self._run(self._pattern(r"^will-not-match$"))
+        self.assertEqual((result.requests_sent, result.requests_answered), (1, 1))
         self.assertFalse(result.passed)
         self.assertFalse(result.not_evaluated)
         self.assertFalse(is_inconclusive(result))
+        self.assertIn("does not match", result.details)
+
+    def test_the_same_pattern_without_a_target_is_inconclusive_not_a_fail(self):
+        """The R4-07 half: no contact, so no verdict -- not even a FAIL."""
+        result = cr.run_pattern(self._pattern(r"^will-not-match$"))
+        self.assertFalse(result.passed)
+        self.assertTrue(result.not_evaluated)
+        self.assertIn(cr.NO_ADAPTER_DETAIL, result.details)
 
 
 if __name__ == "__main__":

--- a/testing/test_free_scan_controls.py
+++ b/testing/test_free_scan_controls.py
@@ -1,0 +1,199 @@
+"""Known-good and deliberately-broken controls for the public free-scan wrapper.
+
+`scripts/free_scan.py::run_free_scan` called five `MCPSecurityTests` methods
+that record their result on the suite and return None, dereferenced
+`.status` on that None, caught its own AttributeError and published it as
+five failed tests, grade F and "The scan detected 5 issue(s)" -- against
+the shipped mock and against a closed port alike. `mcp_server/server.py`
+exposes the same function as the `scan_mcp_server` tool (R4-06, fourth
+external review, 2026-09-08).
+
+The underlying methods had tests. The wrapper had none, so a wrapper error
+masqueraded as a security result. These are the two controls every public
+wrapper needs: a target whose shape is known (the shipped mock: MCP-001 and
+MCP-008 FAIL, the rest PASS) and a target that cannot be evaluated (a closed
+port: every row INCONCLUSIVE, no grade, no detected issue).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import os
+import socket
+import subprocess
+import sys
+import time
+import unittest
+from unittest import mock
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from scripts import free_scan  # noqa: E402
+
+CLOSED_PORT_URL = "http://127.0.0.1:9/mcp"
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _wait_for(port: int, timeout: float = 10.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        with socket.socket() as s:
+            if s.connect_ex(("127.0.0.1", port)) == 0:
+                return True
+        time.sleep(0.05)
+    return False
+
+
+class _MockServer(unittest.TestCase):
+    """The shipped `protocol_tests.mock_mcp_server` on a free loopback port."""
+
+    proc = None
+    url = ""
+
+    @classmethod
+    def setUpClass(cls):
+        port = _free_port()
+        cls.proc = subprocess.Popen(
+            [sys.executable, "-m", "protocol_tests.mock_mcp_server",
+             "--port", str(port), "--host", "127.0.0.1"],
+            cwd=REPO_ROOT, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            env=dict(os.environ, AGENT_SECURITY_TELEMETRY="off"),
+        )
+        if not _wait_for(port):
+            cls._stop()
+            raise RuntimeError(f"mock MCP server did not start on {port}")
+        cls.url = f"http://127.0.0.1:{port}/mcp"
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._stop()
+
+    @classmethod
+    def _stop(cls):
+        if cls.proc and cls.proc.poll() is None:
+            cls.proc.terminate()
+            try:
+                cls.proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                cls.proc.kill()
+
+    @staticmethod
+    def _scan(url: str) -> tuple[dict, str]:
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            report = free_scan.run_free_scan(url)
+        return report, out.getvalue()
+
+
+class TestKnownGoodControl(_MockServer):
+    """The shipped mock has a known shape; the wrapper must report exactly it."""
+
+    def test_the_mock_is_graded_by_what_it_did(self):
+        report, stdout = self._scan(self.url)
+        by_id = {r["id"]: r for r in report["results"]}
+        self.assertEqual(sorted(by_id), ["MCP-001", "MCP-003", "MCP-004", "MCP-008", "MCP-010"])
+        # The mock ships a tool whose description exfiltrates, and handles
+        # 3 of 7 malformed messages: both are real FAILs of the target.
+        self.assertEqual(by_id["MCP-001"]["status"], "FAIL", by_id["MCP-001"])
+        self.assertEqual(by_id["MCP-008"]["status"], "FAIL", by_id["MCP-008"])
+        for tid in ("MCP-003", "MCP-004", "MCP-010"):
+            self.assertEqual(by_id[tid]["status"], "PASS", by_id[tid])
+        for row in report["results"]:
+            self.assertNotIn("NoneType", row["detail"])
+            self.assertNotEqual(row["status"], "ERROR")
+        self.assertEqual(report["tests_passed"], 3)
+        self.assertEqual(report["tests_failed"], 2)
+        self.assertEqual(report["tests_inconclusive"], 0)
+        self.assertEqual(report["tests_evaluated"], 5)
+        self.assertEqual(report["grade"], "C")
+        self.assertEqual(report["grade_status"], "established")
+        self.assertTrue(report["recommendation"].startswith("The scan detected 2 issue(s)"),
+                        report["recommendation"])
+        self.assertEqual(stdout, "", "the wrapper must not write console lines to stdout")
+
+
+class TestDeliberatelyBrokenControl(unittest.TestCase):
+    """A closed port cannot be evaluated: no grade, no detected issue."""
+
+    def test_closed_port_is_inconclusive_with_no_grade(self):
+        report, _ = _MockServer._scan(CLOSED_PORT_URL)
+        self.assertEqual(len(report["results"]), 5)
+        for row in report["results"]:
+            self.assertEqual(row["status"], "INCONCLUSIVE", row)
+            self.assertIn(free_scan.COULD_NOT_EVALUATE, row["detail"])
+            self.assertNotIn("NoneType", row["detail"])
+        self.assertEqual(report["tests_passed"], 0)
+        self.assertEqual(report["tests_failed"], 0)
+        self.assertEqual(report["tests_inconclusive"], 5)
+        self.assertEqual(report["tests_evaluated"], 0)
+        self.assertIsNone(report["grade"])
+        self.assertEqual(report["grade_status"], free_scan.GRADE_NOT_ESTABLISHED)
+        self.assertIn("could not evaluate", report["recommendation"])
+        self.assertNotIn("detected", report["recommendation"])
+
+    def test_markdown_renders_the_state_without_inventing_an_error(self):
+        report, _ = _MockServer._scan(CLOSED_PORT_URL)
+        md = free_scan.format_markdown(report)
+        self.assertIn("**Grade:** not established", md)
+        self.assertIn("| INCONCLUSIVE |", md)
+        self.assertNotIn("| ERROR |", md)
+
+
+class TestWrapperFaultsAreNotSecurityResults(_MockServer):
+    """The R4-06 mechanism: the wrapper's own failure must never grade the target."""
+
+    def test_a_method_that_raises_is_inconclusive_not_a_detected_issue(self):
+        def boom(self):
+            raise RuntimeError("synthetic wrapper fault")
+        with mock.patch.object(free_scan.MCPSecurityTests, "test_mcp_malformed_jsonrpc", boom):
+            report, _ = self._scan(self.url)
+        by_id = {r["id"]: r for r in report["results"]}
+        self.assertEqual(by_id["MCP-008"]["status"], "INCONCLUSIVE")
+        self.assertIn(free_scan.COULD_NOT_EVALUATE, by_id["MCP-008"]["detail"])
+        self.assertIn("synthetic wrapper fault", by_id["MCP-008"]["detail"])
+        # The other four were still evaluated against the real mock.
+        self.assertEqual(by_id["MCP-001"]["status"], "FAIL")
+        self.assertEqual(report["tests_failed"], 1)
+        self.assertEqual(report["tests_inconclusive"], 1)
+        self.assertIsNone(report["grade"])
+        self.assertIn("could not evaluate 1 of 5", report["recommendation"])
+
+    def test_a_method_that_records_nothing_is_inconclusive(self):
+        with mock.patch.object(free_scan.MCPSecurityTests, "test_mcp_tool_argument_injection",
+                               lambda self: None):
+            report, _ = self._scan(self.url)
+        by_id = {r["id"]: r for r in report["results"]}
+        self.assertEqual(by_id["MCP-010"]["status"], "INCONCLUSIVE")
+        self.assertIn("recorded no result", by_id["MCP-010"]["detail"])
+        self.assertIsNone(report["grade"])
+
+    def test_the_wrapper_reads_the_recorded_result_not_a_return_value(self):
+        """Every selected method returns None by contract; the wrapper must not care."""
+        for test_def in free_scan.FREE_SCAN_TESTS:
+            self.assertTrue(hasattr(free_scan.MCPSecurityTests, test_def["method"]), test_def)
+        report, _ = self._scan(self.url)
+        self.assertEqual(report["tests_inconclusive"], 0, report["results"])
+
+
+class TestGradeIsAClaimOverEvaluatedTests(unittest.TestCase):
+    def test_zero_evaluated_is_no_grade_not_an_f(self):
+        self.assertIsNone(free_scan.compute_grade(0, 0))
+
+    def test_recommendation_never_calls_an_unevaluated_row_an_issue(self):
+        rows = [{"id": "MCP-001", "name": "A", "status": "INCONCLUSIVE", "detail": ""},
+                {"id": "MCP-003", "name": "B", "status": "PASS", "detail": ""}]
+        text = free_scan.build_recommendation(rows, None)
+        self.assertIn("could not evaluate 1 of 2", text)
+        self.assertNotIn("detected", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
From the fourth external review, three Highs and a Medium — all in code that sits *above* the harnesses and speaks for them.

**R4-06.** `scripts/free_scan.py` called MCP methods that record on the suite and return `None`, dereferenced `.status` on that `None`, and published grade **F**, `tests_failed: 5`, "The scan detected 5 issue(s)" with remediation advice — against the shipped mock *and* a closed port. Its own crash, attributed to the scanned server. It now reads the recorded results; an unevaluable target yields INCONCLUSIVE rows, `grade: null`, `grade_status: "not established"` and no issue claimed. Known-good and deliberately-broken controls added.

**R4-08.** The CLI dispatcher computed `_harness_exit` and then called `sys.exit(0)` unconditionally: `test skill-security --url ... --report out.json` produced an argparse error from the child, exit 0, no report, no warning. It now propagates the child's code and names both the code and the missing report on stderr.

**R4-07.** `community_runner`'s three send helpers returned `{"status": "sent", "response": None}` — "populated by harness integration" — so live mode with `--url` never contacted the target and absence assertions PASSED against a URL never reached; dry-run set `passed = True`. The agent **bound a real adapter** rather than only refusing: `HttpJsonRpcAdapter` (JSON-RPC 2.0 over the existing `http_post_json`) for mcp/a2a/generic, proven against the shipped mock — 2 sent, 2 answered, and a presence assertion the mock does not satisfy comes back a real FAIL. Frameworks with no wire protocol (autogen, crewai, langgraph, x402, l402) refuse honestly as INCONCLUSIVE naming the framework. Dry-run rows are `not_evaluated`.

**R4-14.** Validation now rejects a non-object evidence schema, an unknown action and an unknown assertion type (enums derived from the dispatch tables); assertion count capped; the pattern deadline is enforced after every step and every assertion, not only before steps.

Independently reproduced in a clean worktree at 2722d97: free scan vs the shipped mock → grade C, 2 FAIL / 3 PASS (the mock's real shape); vs a closed port → 5 INCONCLUSIVE, `grade: None`, `grade_status: 'not established'`, 0 failed; `test skill-security --url` → exit 2, no report; a good run → exit 0; against a real contrib pattern as baseline (ACCEPTED), the three malformed mutations are each REJECTED with a field-named message.

**The two suite failures the agent hit are the interesting part.** Both were in `test_community_regex_budget.py`, and one was pinning the defect: it asserted that a non-matching regex is a **FAIL of a target the runner never contacted** — CLAUDE.md item 8, inside a test written yesterday. The gate was not weakened; both tests now bind a stub adapter so they reach the assertion phase, plus a third case pinning that the same pattern with no target is INCONCLUSIVE rather than FAIL.

Injections (diff-confirmed, four): `sys.exit(0)` → 3 fail; None-dereference → 3 fail; dry-run `passed=True` → 2 fail; after-step deadline removed → 1 fail. Suite 1391 passed / 1330 subtests / 0 failed (baseline 1358 + 33 new).

Noticed, not in this PR: `scripts/discord_scan_bot.py` keeps its **own** copy of the five-test list and grading, a second wrapper that can drift the same way; `docs/free-scan.md` documents a Flask wrapper that reads `report["grade"]` directly and will now see `null`; `mcp_server/server.py` carries 8 pre-existing ruff F401/F841 findings (CI gates only F821).

🤖 Generated with [Claude Code](https://claude.com/claude-code)