### PR TITLE
chore(gitguardian): ignore the redaction test's credential fixtures

### DIFF
--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -14,7 +14,22 @@
 #   * they sign fictional test authorities, never a real trust anchor
 #
 # Removing them would make the fixtures unverifiable, which is their purpose.
+#
+# The provenance redaction tests must construct credential-shaped strings in
+# order to assert that they are stripped from the published report. GitGuardian
+# classified the `https://alice:...@host.example/mcp` fixture as a "Basic Auth
+# String" (PR #530, commit f4e3f5b) -- it scanned the test that proves we redact.
+#
+# They are not secrets:
+#   * every value is a self-labelling fake: `...NOTAREALKEY...`,
+#     `correct-horse-battery-staple`, and the reserved `host.example` domain
+#   * they are asserted ABSENT from output; a fixture that leaked would fail the
+#     test rather than expose anything
+#   * no value has ever authenticated against any service
+#
+# Removing them would delete the redaction coverage they exist to provide.
 version: 2
 secret:
   ignored-paths:
     - fixtures/rcl/*.json
+    - tests/test_report_states_its_provenance.py


### PR DESCRIPTION
GitGuardian raised an internal incident on `tests/test_report_states_its_provenance.py` (PR #530, commit `f4e3f5b`), classifying the `https://alice:...@host.example/mcp` fixture as a **Basic Auth String**.

It scanned the test that proves we redact credentials.

## Why this is a false positive

- Every value is a self-labelling fake: `...NOTAREALKEY...`, `correct-horse-battery-staple`, and the reserved `host.example` domain.
- Each is asserted **absent** from the published report. A fixture that leaked would fail the test, not expose anything.
- None has ever authenticated against any service.

Removing them would delete the redaction coverage they exist to provide.

## Exposure

`f4e3f5b` is **not reachable from `main`** — #530 was squash-merged and the branch deleted. There is nothing to revoke.

## Change

Adds the path to `.gitguardian.yaml` with the rationale inline, matching the treatment the RCL oracle fixtures already have in that file (incident 35238730, PR #300).

The dashboard incident still needs to be resolved by hand — no API token is configured in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)