### PR TITLE
R4-09/11/12/13/15/16: the release now tests the wheel it publishes, and five contracts say what they actually do

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,10 @@ jobs:
 
       - name: Run pytest
         run: |
-          pip install pytest pyyaml
+          # cryptography and jsonschema are optional at run time and required
+          # here: without them the registry signature and schema-validity tests
+          # importorskip, and a skipped contract test is a contract nothing checks.
+          pip install pytest pyyaml cryptography jsonschema
           python -m pytest tests/ -v --tb=short
 
       - name: Verify all harness --list commands
@@ -112,8 +115,67 @@ jobs:
       - name: Run self-tests
         if: hashFiles('testing/') != ''
         run: |
-          pip install pytest
+          pip install pytest cryptography jsonschema
           python -m pytest testing/ -v --tb=short
+
+  # Fourth external review (2026-09-08, R4-16): the pinned reference-server
+  # calibration skips when the npm cache lacks the package, and a skip reads
+  # green. This job populates the cache with the exact pin the script declares,
+  # proves the server launches offline, and then fails on ANY skip. A skipped
+  # calibration is UNMEASURED, and unmeasured is not clean.
+  mcp-reference-calibration:
+    name: MCP reference-server calibration (pinned, non-skippable)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install package and test tools
+        run: pip install -e . pyyaml pytest
+
+      # The pin is read from the one place it is declared, so this step cannot
+      # drift from the script; test_the_pin_is_a_fixed_version refuses a
+      # floating tag there.
+      - name: Populate the npm cache with the exact pinned reference server
+        run: |
+          set -euo pipefail
+          pin=$(python -c "from scripts.mcp_reference_calibration import REFERENCE_SERVER; print(REFERENCE_SERVER)")
+          case "$pin" in
+            @modelcontextprotocol/server-everything@20[0-9][0-9].[0-9]*.[0-9]*) echo "pin: $pin" ;;
+            *) echo "::error::REFERENCE_SERVER is not the pinned package: $pin"; exit 1 ;;
+          esac
+          npx -y -p "$pin" -c true
+          echo "$pin" > "$RUNNER_TEMP/reference-server.pin"
+
+      - name: Prove the pinned server launches offline
+        run: |
+          set -euo pipefail
+          pin=$(cat "$RUNNER_TEMP/reference-server.pin")
+          printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"ci","version":"0"}}}' > "$RUNNER_TEMP/init.json"
+          timeout 30 npx --offline -y "$pin" stdio < "$RUNNER_TEMP/init.json" > "$RUNNER_TEMP/init.out" 2> "$RUNNER_TEMP/init.err" || true
+          grep -q '"serverInfo"' "$RUNNER_TEMP/init.out" || {
+            echo "::error::the pinned server did not answer initialize offline"
+            cat "$RUNNER_TEMP/init.err"; exit 1; }
+          head -c 200 "$RUNNER_TEMP/init.out"; echo
+
+      - name: Run the calibration and fail on any skip
+        run: |
+          set -euo pipefail
+          python -m pytest testing/test_mcp_reference_calibration.py \
+            -p no:cacheprovider -rs -v --tb=short \
+            --junitxml="$RUNNER_TEMP/calibration.xml"
+          if grep -q '<skipped' "$RUNNER_TEMP/calibration.xml"; then
+            echo "::error::the reference calibration reported a skip: UNMEASURED, not clean"
+            grep -o '<skipped[^>]*>' "$RUNNER_TEMP/calibration.xml"
+            exit 1
+          fi
+          ran=$(grep -o '<testcase ' "$RUNNER_TEMP/calibration.xml" | wc -l)
+          echo "testcases run: $ran"
+          [ "$ran" -ge 5 ] || { echo "::error::expected at least 5 calibration testcases, saw $ran"; exit 1; }
 
   lint:
     name: Lint

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -132,9 +132,109 @@ jobs:
           name: provenance
           path: provenance.json
 
+  # Fourth external review (2026-09-08, R4-16): publish depended on `build`
+  # and on nothing that had run a test against the artifact being published.
+  # CI is a separate push/PR workflow, and its install check runs inside the
+  # checkout, where `import protocol_tests` can resolve to the source tree
+  # instead of the installed wheel. Provenance and OIDC establish who built
+  # the wheel; neither establishes that it works. This job installs the exact
+  # wheel the publish job uploads, into a fresh venv, from a directory that is
+  # NOT the checkout, and runs it there.
+  test-wheel:
+    name: Test the built wheel from a neutral directory
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      # The checkout is here for tests/ and nothing else. No step below runs
+      # with the checkout as its working directory.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Download the built distributions
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Install the wheel into a fresh venv, outside the checkout
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          wheels=("$GITHUB_WORKSPACE"/dist/*.whl)
+          [ "${#wheels[@]}" -eq 1 ] || { echo "::error::expected one wheel, found ${#wheels[@]}"; exit 1; }
+          cd "$RUNNER_TEMP"
+          python -m venv wheel-venv
+          ./wheel-venv/bin/pip install -q "${wheels[0]}" pytest pyyaml cryptography jsonschema
+          # The import must resolve inside the venv, not to the checkout.
+          ./wheel-venv/bin/python -c '
+          import protocol_tests, scripts
+          for m in (protocol_tests, scripts):
+              d = list(m.__path__)[0]
+              assert "site-packages" in d, f"{m.__name__} resolved to {d}, not the installed wheel"
+              print(m.__name__, "->", d)
+          '
+
+      - name: Smoke the installed package
+        run: |
+          set -euo pipefail
+          cd "$RUNNER_TEMP"
+          PY=./wheel-venv/bin/python
+          ./wheel-venv/bin/agent-security --version
+          "$PY" -m protocol_tests.mock_mcp_server --help > /dev/null
+          "$PY" -m scripts.registry_reference_server --help > /dev/null
+
+      # R3-01 reproduction, now a release gate: the installed 4.21.0 reported
+      # 17/17 PASS for this exact invocation against a port nothing listens on.
+      - name: A payment harness against a closed port passes nothing
+        run: |
+          set -euo pipefail
+          cd "$RUNNER_TEMP"
+          rc=0
+          ./wheel-venv/bin/agent-security test ap2 --url http://127.0.0.1:9 \
+            --report "$RUNNER_TEMP/ap2-closed-port.json" || rc=$?
+          echo "harness exit code: $rc"
+          ./wheel-venv/bin/python - <<'EOF'
+          import json, os, sys
+          report = json.load(open(os.path.join(os.environ["RUNNER_TEMP"], "ap2-closed-port.json")))
+          s = report["summary"]
+          print("summary:", s)
+          if s.get("total", 0) < 1:
+              sys.exit("the closed-port run produced no verdicts: unmeasured, not clean")
+          if s.get("passed", 0) != 0:
+              sys.exit(f"{s['passed']} of {s['total']} PASS against a port nothing listens on (R3-01)")
+          EOF
+
+      # The packaged-behaviour tests that can run against an installed copy.
+      # Copied out of the checkout so `sys.path.insert(0, parents[1])` in each
+      # file points at a directory with no source tree in it. The other files
+      # in tests/ read checkout-only resources (docs/, benchmarks/, git) and
+      # belong to CI, not to this gate.
+      - name: Packaged-behaviour tests against the installed wheel
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/neutral"
+          cp -r "$GITHUB_WORKSPACE/tests" "$RUNNER_TEMP/neutral/tests"
+          cd "$RUNNER_TEMP/neutral"
+          "$RUNNER_TEMP/wheel-venv/bin/python" -m pytest -q -p no:cacheprovider -rs \
+            tests/test_auroc.py \
+            tests/test_evidence_pack_declares_its_denominator.py \
+            tests/test_fallback_validator_matches_schema.py \
+            tests/test_fb013_quorum_binds_distinct_approvers.py \
+            tests/test_fria_evidence.py \
+            tests/test_imported_risk_score_needs_a_denominator.py \
+            tests/test_mcp021_auth_fail_open.py \
+            tests/test_registry_schema_validity_is_enforced.py \
+            tests/test_simulate_does_not_claim_a_pass.py
+
   publish:
     name: Publish to PyPI
-    needs: build
+    needs: [build, test-wheel]
     runs-on: ubuntu-latest
     environment:
       name: pypi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -355,6 +355,109 @@ fields, and use plain objects now. Fault-injected: restoring the old counting
 fails them.
 
 No test IDs were added or removed; the count stays at 623.
+### Fixed — release gate, contract enforcement and script surfaces (R4-09, R4-11, R4-12, R4-13, R4-15, R4-16 Medium; fourth external review, 2026-09-08)
+
+Six Medium findings. Each was reproduced before it was fixed -- on the installed
+wheel, on a loopback server, or by quoting the line -- and each fix was
+fault-injected to show its test fails without it. No test IDs were added or
+removed; the count stays at 623.
+
+**Release publication was not gated on any test of the artifact being published
+(R4-16).** `publish` depended on `build` and on nothing else. The workflow built
+distributions, wrote and attested a provenance statement, and uploaded -- so it
+established who built the artifact and that it corresponds to the tagged source,
+and nothing about whether the artifact works. CI is a separate push/PR workflow
+whose install check runs inside the checkout, where `import protocol_tests` can
+resolve to the source tree instead of to the installed wheel: a wheel missing a
+file entirely can pass a check performed next to the sources. A new `test-wheel`
+job downloads the built wheel, installs it into a fresh venv from `$RUNNER_TEMP`,
+asserts both packages resolve under `site-packages`, runs `agent-security
+--version` and `python -m protocol_tests.mock_mcp_server --help`, reproduces
+R3-01 (a payment harness against `http://127.0.0.1:9` must pass nothing, and a
+run that produced no verdicts fails as unmeasured), and runs nine packaged-
+behaviour test files against the installed copy. `publish` now needs
+`[build, test-wheel]`. Identity is not QA.
+
+**The pinned MCP reference calibration could skip, and a skip read green
+(R4-16).** `testing/test_mcp_reference_calibration.py` skips when the npm cache
+lacks `@modelcontextprotocol/server-everything@2026.8.18` -- correctly, because
+unmeasured is not clean -- but nothing made it run. A new required CI job reads
+the pin from the script rather than restating it, populates the npm cache with
+that exact version, proves the server answers `initialize` offline, then runs
+the file with `--junitxml` and fails on any `<skipped` element or fewer than
+five testcases. CI also installs `cryptography` and `jsonschema`, without which
+the registry contract tests `importorskip` and report green having run nothing.
+
+**A correctly signed report with an unknown `evidence_class` was stored with 201
+(R4-11).** `scripts/registry_reference_server.py` implemented contract 5 step 5
+-- "validate `payload.report` against `schemas/attestation-report.json`, reject
+422" -- as a check that the schema's required TOP-LEVEL keys were present. A
+signed submission carrying `evidence_class: "E9"`, a value no version of the
+enum has contained, was stored, returned on GET, and issued the claim label
+"Tested with Agent Security Harness". The server now runs full JSON Schema
+validation before storage and rejects with 422 carrying the validator's own
+message (an `anyOf` failure names its sub-rules rather than echoing the whole
+document back). Every stored record carries `validation_level`, `"schema"` or
+`"required-keys"`, so a consumer on a host without `jsonschema` cannot mistake
+the weaker answer for the stronger one. A signature establishes who sent the
+bytes; required-key presence is not report conformance. The fixture in
+`tests/test_registry_server_contract.py` was itself schema-invalid, which is why
+the wire tests passed throughout.
+
+**Live telemetry reported an empty run for a report with 17 rows (R4-12).**
+Every harness `main()` ends in `sys.exit()`, `SystemExit` carries no namespace,
+and results live on a harness instance, so `_live_run_counts` received `{}` and
+sent `tests:0, passed:0, failed:0, inconclusive:0` for a run whose report held
+17 inconclusive rows. Zero observations and unavailable counts are different
+states. When a report was requested and written, the counts are now read from it
+-- real data the CLI already had. With neither, the event omits the four count
+fields entirely and carries `counts_available: false` and one fixed `reason`
+token from a closed list, so a consumer summing `tests` sees a missing key
+rather than a zero. `docs/PRIVACY.md` documents both payload shapes.
+
+**The harness-base detector matched one spelling of a definition (R4-13).**
+`_modules_with_own_record` was `"def _record" in text`. A module written
+`def  _record(` -- two spaces, valid Python -- was invisible, so a 45th parallel
+recording implementation could land with all twelve tests green. It now walks
+the AST for a `_record` method on a class, which also stops counting a comment,
+a string or a call site as an implementation. Seeded controls cover two spaces,
+a tab, `async def` and a decorated form, and the detector is cross-checked
+against `asi_inventory.recording_facts()` on every registered harness, so the
+two derivations of one fact cannot drift.
+
+**Published provenance kept secret-bearing URL paths and contradicted its own
+hostname claim (R4-09).** The parameter-name allowlist could not settle four
+shapes: a token as a path segment (`/v1/<token>/run`), a token as the fragment,
+a bare query token with no `=`, and a token under an allowlisted name
+(`format=<token>`). An allowlist of names cannot prove an allowed value is
+nonsecret. The rule is now positional and the same for every URL: **scheme, host
+and port are kept; path, query and fragment are each replaced whole.**
+Reproducibility needs what was contacted, not what was asked for. The block's
+`not_claimed` and the schema description said "no hostname is recorded" while
+argv retained a URL host; both now state the actual contract -- the hostname IS
+recorded, deliberately; the path, query and fragment are not -- and that a
+`[REDACTED]` component means the component was present and removed by the rule,
+never that a credential was found there. Userinfo removal now happens after the
+split, because substituting `[REDACTED]@` first made `urlsplit` raise "invalid
+IPv6 URL" and return early on exactly the arguments that carried a credential.
+
+**Installed documentation and script contracts were uneven (R4-15).**
+`docs/QUICKSTART.md` told a pip user to run `python scripts/free_scan.py` and
+`python scripts/aiuc1_prep.py`, paths that do not exist outside a checkout; they
+are now `python -m scripts.free_scan` and `python -m scripts.aiuc1_prep`, as are
+the operator invocations in `ADVANCED.md` and `AUROC-METHODOLOGY.md`.
+`scripts/auroc.py` read `sys.argv[1]` directly and answered `--help` with a
+`FileNotFoundError` traceback; it and `verify_attestation_record.py` now use
+argparse. `compliance_crosswalk.py` exited 0 having printed nothing -- the same
+observable as a command that worked -- and now declares itself a library module
+and prints the commands that use it. `discord_scan_bot.py` answered a help
+request with its missing optional dependency; the help page no longer requires
+it. `generate_test_catalog --check` and a default `monthly_security_report` now
+implement the same one-line "checkout-only resource missing" message and exit 2
+that the other gated scripts use. The ratchet in
+`testing/test_packaged_scripts_resolve.py` is extended: every shipped
+`scripts/*.py` must exit 0 on `--help` with something on stdout, or be on a
+documented library-module list whose entries say so in their own docstrings.
 
 ## [4.21.1] - 2026-09-07
 

--- a/HARNESS_TEST_CATALOG.md
+++ b/HARNESS_TEST_CATALOG.md
@@ -1,8 +1,7 @@
 # Agent Security Harness — Canonical Test Catalog
 
 **Source repo:** msaleme/red-team-blue-team-agent-fabric
-**Generated:** `scripts/generate_test_catalog.py` at commit `e532169`
-**Generated:** `scripts/generate_test_catalog.py` at commit `52cb5e1`
+**Generated:** `scripts/generate_test_catalog.py` at commit `c673b95`
 **Test count:** 623 unique test IDs across 46 registered harness modules (45 contain test IDs; `community_runner.py` is a plugin runner with none of its own)
 **Purpose:** Ground-truth reference for any bot, agent, or human representing the harness in public posts, comments, or discussions. Cite only tests listed here. Do not invent IDs or statistics.
 

--- a/HARNESS_TEST_CATALOG.md
+++ b/HARNESS_TEST_CATALOG.md
@@ -2,6 +2,7 @@
 
 **Source repo:** msaleme/red-team-blue-team-agent-fabric
 **Generated:** `scripts/generate_test_catalog.py` at commit `e532169`
+**Generated:** `scripts/generate_test_catalog.py` at commit `52cb5e1`
 **Test count:** 623 unique test IDs across 46 registered harness modules (45 contain test IDs; `community_runner.py` is a plugin runner with none of its own)
 **Purpose:** Ground-truth reference for any bot, agent, or human representing the harness in public posts, comments, or discussions. Cite only tests listed here. Do not invent IDs or statistics.
 

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -71,10 +71,10 @@ Compare test runs to detect behavioral drift, compute stability and risk scores,
 
 ```bash
 # Compare two runs
-python scripts/behavioral_profile.py --baseline run1.json --current run2.json
+python -m scripts.behavioral_profile --baseline run1.json --current run2.json
 
 # Trend analysis over multiple runs
-python scripts/behavioral_profile.py --history run1.json run2.json run3.json --output profile/
+python -m scripts.behavioral_profile --history run1.json run2.json run3.json --output profile/
 ```
 
 Produces stability score (0-100), drift detection (PASS->FAIL regressions), risk score with transparent formula, and trend analysis for 3+ runs. This is what static scanners cannot see -- behavioral change over time.
@@ -87,10 +87,10 @@ Generate signed, audit-ready evidence packages from harness test results:
 
 ```bash
 # Generate evidence pack from a harness report
-python scripts/evidence_pack.py --report report.json --output evidence/
+python -m scripts.evidence_pack --report report.json --output evidence/
 
 # Generate and sign with HMAC-SHA256
-python scripts/evidence_pack.py --report report.json --output evidence/ --sign --zip
+python -m scripts.evidence_pack --report report.json --output evidence/ --sign --zip
 ```
 
 Produces four files: `evidence-summary.json` (machine-readable), `test-results.json` (raw data), `aiuc1-mapping.json` (per-requirement coverage), and `evidence-summary.md` (human-readable for auditors). Usable as CI gate artifacts, procurement questionnaire attachments, or audit packet exhibits.

--- a/docs/AUROC-METHODOLOGY.md
+++ b/docs/AUROC-METHODOLOGY.md
@@ -44,7 +44,7 @@ No sklearn dependency — implemented with the trapezoidal rule for zero-depende
 python -m protocol_tests.cli --url http://your-agent --report results.json
 
 # Compute AUROC from the report
-python scripts/auroc.py results.json
+python -m scripts.auroc results.json
 ```
 
 The AUROC computation is deterministic given the same test results. Multi-trial runs (`--trials N`) produce confidence intervals on the AUROC via Wilson score.

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -20,22 +20,36 @@ When telemetry is enabled (opt-IN, off by default), we collect:
 |-------|---------|-----|
 | Harness version | `3.8.0` | Know which versions are in use, prioritize backports |
 | Module name | `mcp` | Know which harnesses matter most to users |
+| Counts available | `true` | Whether the four count fields below are present. `false` means the run happened and its size is not known to the sender; the four counts are then **omitted**, never sent as zero |
 | Test count | `13` | Understand typical workload size |
 | Passed count | `9` | Identify modules with high failure rates (may indicate bugs in our tests) |
 | Failed count | `2` | Same as above |
 | Inconclusive count | `2` | Rows the target never serviced (or a simulated run, which services nothing). Kept apart so an unexercised control is never counted as a pass |
+| Reason | `results_not_exposed_and_no_report_written` | Only when counts are unavailable: one fixed token from a closed list saying why. Never free text |
 | OS | `linux` | Platform-specific bug triage |
 | Python version | `3.12` | Know which Python versions to keep supporting |
 | Timestamp | `2026-03-28T00:00:00Z` | Understand usage patterns (weekday vs weekend, not time-of-day) |
 
-That's it. Nine fields. Flat JSON. No nesting, no extensibility, no "other" bucket.
-The three counts always sum to the test count.
+That's it. Ten fields when the counts are available, seven when they are not
+(`counts_available: false` plus `reason`, and no count fields at all). Flat
+JSON. No nesting, no extensibility, no "other" bucket. When present, the three
+counts always sum to the test count.
 
-You can see the exact payload in code:
+Zero observations and unavailable counts are different states. A live run
+whose harness keeps its results in `main()` and writes no report used to be
+sent as `tests: 0, passed: 0, failed: 0, inconclusive: 0` -- a measured-looking
+claim about a run that had, in the reviewed case, 17 rows. It is now sent with
+`counts_available: false`. When the run wrote a report (`--report PATH`, or
+the throwaway report `--html` asks for), the counts are read from that report
+and sent as measured.
+
+You can see both exact payloads in code:
 
 ```python
-from protocol_tests.telemetry import telemetry_payload_example
+from protocol_tests.telemetry import (telemetry_payload_example,
+                                      telemetry_payload_example_counts_unavailable)
 print(telemetry_payload_example())
+print(telemetry_payload_example_counts_unavailable())
 ```
 
 ---

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -93,15 +93,19 @@ Works in single-run and multi-trial modes.
 Quick 5-test scan with A-F grading:
 
 ```bash
-python scripts/free_scan.py --url http://server:port/mcp --format markdown
+python -m scripts.free_scan --url http://server:port/mcp --format markdown
 ```
+
+`python -m scripts.free_scan` works from an installed package and from a
+checkout. `python scripts/free_scan.py` is a checkout-only spelling: a pip
+install has no `scripts/` directory in the working directory to point at.
 
 ---
 
 ## AIUC-1 Certification Prep
 
 ```bash
-python scripts/aiuc1_prep.py --url http://your-agent --simulate
+python -m scripts.aiuc1_prep --url http://your-agent --simulate
 ```
 
 Maps results to all 24 AIUC-1 requirements with gap analysis.

--- a/protocol_tests/cli.py
+++ b/protocol_tests/cli.py
@@ -231,8 +231,34 @@ def _simulate_harness(harness_name: str, info: dict,
     except Exception:
         pass
 
-def _live_run_counts(ns: dict) -> dict:
-    """Three-state telemetry counts from a harness module namespace.
+#: The one reason a live event can give for carrying no counts. A fixed
+#: token, not free text: the payload is documented field by field in
+#: docs/PRIVACY.md and a free-text field is an undocumented one.
+COUNTS_UNAVAILABLE_REASON = "results_not_exposed_and_no_report_written"
+
+
+def _report_counts(report_path: str | None) -> dict | None:
+    """Three-state counts read back from a report the harness wrote, or None.
+
+    The rows are counted with the same `verdict_counts` the namespace path
+    uses, so a written report and an in-memory result list can only give one
+    answer for one run."""
+    if not report_path:
+        return None
+    try:
+        with open(report_path, encoding="utf-8") as fh:
+            report = _json.load(fh)
+    except (OSError, ValueError):
+        return None
+    rows = report.get("results") if isinstance(report, dict) else None
+    if not isinstance(rows, list) or not rows:
+        return None
+    from protocol_tests.telemetry import verdict_counts
+    return verdict_counts(rows)
+
+
+def _live_run_counts(ns: dict, report_path: str | None = None) -> dict:
+    """Three-state telemetry counts for a live run, or an explicit absence.
 
     Reads the same names the inline version read (`_results`, `results`,
     `test_results`, then a unittest-style `_test_result` / `test_result`) and
@@ -243,18 +269,29 @@ def _live_run_counts(ns: dict) -> dict:
     scored every skipped test as a pass. Here `skipped` is INCONCLUSIVE and
     `passed` is what is left after both, so the four counts always sum.
 
-    Known limit, not fixed here: every harness `main()` ends in `sys.exit()`,
-    `SystemExit` carries no namespace, and results live on a harness instance
-    rather than at module level, so in practice `ns` is `{}` and the live
-    event reports 0/0/0/0. That is an empty claim, not a false one; the false
-    one was the simulated path.
+    Every harness `main()` ends in `sys.exit()`, `SystemExit` carries no
+    namespace, and results live on a harness instance rather than at module
+    level, so in practice `ns` is `{}`. Until 2026-09-08 that case returned
+    0/0/0/0: an installed AP2 run whose report held 17 rows sent
+    `tests:0, passed:0, failed:0, inconclusive:0` (fourth external review,
+    R4-12). Zero observations and unavailable counts are different states,
+    and an event about a known non-empty run must not publish measured-looking
+    zeros. So, in order:
+
+    1. results in the namespace -- counted;
+    2. a unittest result in the namespace -- counted;
+    3. a report the harness wrote to `report_path` -- its rows counted, which
+       is real data the CLI already has;
+    4. otherwise `counts_available: False` with a fixed `reason`, and NO
+       count fields. The sender omits them rather than sending null, so a
+       consumer summing `tests` across events cannot read absence as zero.
     """
     from protocol_tests.telemetry import verdict_counts
 
     for key in ("_results", "results", "test_results"):
         result_list = ns.get(key)
         if isinstance(result_list, (list, tuple)) and result_list:
-            return verdict_counts(result_list)
+            return {**verdict_counts(result_list), "counts_available": True}
 
     for key in ("_test_result", "test_result"):
         tr = ns.get(key)
@@ -264,9 +301,13 @@ def _live_run_counts(ns: dict) -> dict:
             inconclusive = len(getattr(tr, "skipped", []))
             passed = max(tests - failed - inconclusive, 0)
             return {"tests": tests, "passed": passed, "failed": failed,
-                    "inconclusive": inconclusive}
+                    "inconclusive": inconclusive, "counts_available": True}
 
-    return {"tests": 0, "passed": 0, "failed": 0, "inconclusive": 0}
+    from_report = _report_counts(report_path)
+    if from_report is not None:
+        return {**from_report, "counts_available": True}
+
+    return {"counts_available": False, "reason": COUNTS_UNAVAILABLE_REASON}
 
 HARNESSES = {
     "mcp": {
@@ -826,11 +867,15 @@ def main():
             ns = getattr(exc, "_ns", None) or {}
 
         # Send anonymous telemetry after harness completes (#112).
-        # Extract actual test counts from the harness namespace if available.
-        # Harnesses typically store results in _results, results, or similar.
+        # Extract actual test counts from the harness namespace if available;
+        # failing that, from the report the harness wrote (`--report PATH`, or
+        # the throwaway one --html asked for). With neither, the event says
+        # the counts are unavailable rather than zero (R4-12).
         try:
             from protocol_tests.telemetry import send_telemetry_event
-            send_telemetry_event(module=harness_name, **_live_run_counts(ns))
+            send_telemetry_event(
+                module=harness_name,
+                **_live_run_counts(ns, report_path=_report_path_from(filtered_args)))
         except Exception:
             pass  # Telemetry must never break the CLI
 

--- a/protocol_tests/run_provenance.py
+++ b/protocol_tests/run_provenance.py
@@ -37,13 +37,18 @@ Two things are forbidden and both have bitten this repository:
 
 ## What is deliberately NOT recorded
 
-No hostname, no username, no working directory, no absolute paths.
-`docs/PRIVACY.md` lists "Hostnames, paths, or any part of your infrastructure
-topology" under what is never collected, and a report a user is invited to
-publish is held to the same line as telemetry. EVERY absolute path in argv is
-reduced to its basename for that reason -- not only `argv[0]`. On a developer
-machine `--report /home/<username>/evidence/run.json` carries a username and a
-directory tree just as surely as the interpreter path does.
+No username, no working directory, no absolute paths, and no URL path, query
+or fragment. EVERY absolute path in argv is reduced to its basename -- not only
+`argv[0]`. On a developer machine `--report /home/<username>/evidence/run.json`
+carries a username and a directory tree just as surely as the interpreter path
+does.
+
+A URL's scheme, host and port ARE recorded, deliberately, and this module does
+not claim otherwise. `docs/PRIVACY.md` says telemetry never collects hostnames;
+telemetry sends counts and this block records the command that was run, and a
+run whose target cannot be named is not reproducible by anyone. The line is
+drawn at the URL authority: what was contacted travels, what was asked for
+does not.
 
 ## Argv redaction is the load-bearing part
 
@@ -60,12 +65,29 @@ names, and a credential passed under a name not on that list survives. That is
 why the field is `argv_redacted` (something was replaced) and not
 `argv_is_safe` (a claim about what remains).
 
-URLs are the exception to name-matching. A query parameter's NAME is chosen by
-the target, so inside a URL query (and fragment) every value is replaced unless
-the name is on `_QUERY_PARAM_ALLOWLIST` -- a short list of protocol/format
-selectors. Scheme, host, port and path are kept as sent. The allowlist is
-stated in the block's `not_claimed`, so a `[REDACTED]` query value is read as
-"not on the allowlist", not as "a credential was here".
+## The URL contract, stated once
+
+A published record keeps **scheme, host and port, and nothing else** of a URL.
+Path, query and fragment are each replaced whole with `[REDACTED]`.
+
+That is one rule, and it replaces an allowlist of parameter NAMES that could
+not settle the question. An allowlist works on the half of a URL whose
+vocabulary someone else controls only if every secret arrives as `name=value`
+under a name nobody chose adversarially, and the fourth external review walked
+four shapes through it: a token as a PATH segment (`/v1/<token>/run`), a token
+as a FRAGMENT (`#<token>`), a bare query token with no `=` at all, and a token
+as the value of an allowlisted name (`format=<token>`). None of the four is
+exotic; the third and fourth are not even unusual.
+
+Reproducibility does not need the secret half. Scheme, host and port say what
+was contacted and which service answered; a path that is a capability URL is
+not a reproduction step a third party can use anyway.
+
+The same review noted the previous text claimed "no hostname is recorded" while
+argv retained a URL host. Both cannot be true. The hostname IS recorded, and
+the record now says so: hostname yes, path/query/fragment no. `not_claimed`
+carries that sentence, so a reader is not left to reconcile a promise with the
+document beside it.
 """
 from __future__ import annotations
 
@@ -257,25 +279,11 @@ def _split_attached_short(arg: str) -> tuple[str, str] | None:
 _URL_USERINFO_RE = re.compile(r"^([a-zA-Z][a-zA-Z0-9+.-]*://)([^/@\s]+)@")
 _URL_SHAPED_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*://")
 
-#: Query-parameter NAMES whose value survives into the record verbatim.
-#:
-#: This is an allowlist, and the only one in this module, because a URL query
-#: is the one place in argv where the NAME of a credential is chosen by the
-#: target rather than by the harness. `?api_key=` was caught by the name
-#: regex; `?sig=`, `?k=`, `?access=`, `?code=` were not, and no name list can
-#: be complete against a vocabulary someone else controls. Everything else in
-#: argv (subcommands, model tags, counts, flag names) is the harness's own
-#: vocabulary, where a deny-list of auth-shaped names is checkable and an
-#: allowlist would eat the command.
-#:
-#: The names here select a protocol or format variant. None of them can carry
-#: an authority, and none of them matches `_AUTH_NAME_RE` -- asserted below so
-#: a later edit cannot quietly allow one that does.
-_QUERY_PARAM_ALLOWLIST = frozenset({
-    "transport", "protocol", "version", "api-version", "api_version", "v",
-    "format", "mode", "stream", "model",
-})
-assert not any(_AUTH_NAME_RE.search(n) for n in _QUERY_PARAM_ALLOWLIST)
+#: What survives from a URL, in one sentence, so `not_claimed` and this module
+#: cannot drift: the AUTHORITY (scheme, host, port). Path, query and fragment
+#: are replaced whole.
+URL_RETAINED = "scheme, host and port"
+URL_REPLACED = "path, query and fragment"
 
 
 def _strip_url_userinfo(arg: str) -> str:
@@ -283,58 +291,57 @@ def _strip_url_userinfo(arg: str) -> str:
 
     Credentials in URL userinfo are a credential under another name; the
     flag-name paths never see them because the argument is a URL, not a flag.
+    Still applied first, so a record never carries userinfo even in the
+    degenerate case where `urlsplit` refuses the rest of the string.
     """
     return _URL_USERINFO_RE.sub(rf"\1{REDACTED}@", arg)
 
 
-def _redact_query_params(query: str) -> tuple[str, bool]:
-    """Replace the value of every query parameter not on the allowlist.
-
-    Operates on the raw `name=value&name=value` text rather than through
-    `parse_qsl`/`urlencode`, so the parameters that survive are byte-for-byte
-    what was sent -- a re-encoded query is a different reproduction step.
-    Names are percent-decoded and lower-cased ONLY for the allowlist test.
-    """
-    if not query:
-        return query, False
-    out, replaced = [], False
-    for part in query.split("&"):
-        name, sep, value = part.partition("=")
-        key = urllib.parse.unquote(name).strip().lower()
-        if sep and value and key not in _QUERY_PARAM_ALLOWLIST:
-            out.append(f"{name}={REDACTED}")
-            replaced = True
-        else:
-            out.append(part)
-    return "&".join(out), replaced
-
-
 def _redact_url(arg: str) -> tuple[str, bool]:
-    """Scrub the credential-bearing parts of a URL, keep the rest.
+    """Keep the URL authority; replace path, query and fragment whole.
 
-    Scheme, host, port and path survive: they are what makes a run
-    reproducible. Userinfo is replaced whole. Query and fragment values are
-    replaced unless the parameter name is on `_QUERY_PARAM_ALLOWLIST`.
+    The previous version kept the path as sent and replaced query and fragment
+    VALUES whose parameter name was off an allowlist. Four shapes walked
+    through it (fourth external review, 2026-09-08):
 
-    `--url=http://host/?api_key=<secret>` survived the previous version with
-    `argv_redacted=False`: the userinfo strip does not look at the query, and
-    the equals-form flag hid the query's own `=` from the inline matcher (the
-    separated form `--url http://host/?api_key=...` was caught by that matcher
-    only because `partition("=")` happened to split at the right place).
-    Found by the third external review, 2026-09-07.
+        http://host/v1/<token>/run     the token is a path segment
+        http://host/cb#<token>         the token is the fragment, no `name=`
+        http://host/?<token>           a bare query token, no `=` to split on
+        http://host/?format=<token>    the name was on the allowlist
+
+    The first two the allowlist never looked at; the third has no name to test;
+    the fourth was allowed by name while its value was chosen by whoever
+    issued the credential. An allowlist of names cannot prove an allowed
+    VALUE is nonsecret, which is what an auditor needs from this field.
+
+    So the rule is positional rather than lexical, and it is the same rule for
+    every URL: `scheme://host:port` is kept, and each of path, query and
+    fragment that was present becomes `[REDACTED]`. Replacing a present
+    component sets `argv_redacted`, because something was removed; a URL with
+    no path, query or fragment is returned unchanged and sets nothing.
     """
-    stripped = _strip_url_userinfo(arg)
-    replaced = stripped != arg
+    # Split BEFORE removing userinfo. Substituting `[REDACTED]@` first puts
+    # brackets in the netloc and `urlsplit` then raises "invalid IPv6 URL", so
+    # the old order returned early on exactly the arguments that carried a
+    # credential -- and left their path intact.
     try:
-        parts = urllib.parse.urlsplit(stripped)
+        parts = urllib.parse.urlsplit(arg)
     except ValueError:
-        return stripped, replaced
-    query, q_replaced = _redact_query_params(parts.query)
-    fragment, f_replaced = _redact_query_params(parts.fragment)
-    if not (q_replaced or f_replaced):
-        return stripped, replaced
+        return _strip_url_userinfo(arg), True
+    netloc, replaced = parts.netloc, False
+    if "@" in netloc:
+        netloc = f"{REDACTED}@{netloc.rsplit('@', 1)[1]}"
+        replaced = True
+    # `urlsplit` gives "" for an absent component and "/" for a bare root; a
+    # bare root carries nothing, so it is kept rather than redacted to noise.
+    path = REDACTED if parts.path not in ("", "/") else parts.path
+    query = REDACTED if parts.query else ""
+    fragment = REDACTED if parts.fragment else ""
+    if not replaced and (path, query, fragment) == (
+            parts.path, parts.query, parts.fragment):
+        return arg, False
     rebuilt = urllib.parse.urlunsplit(
-        (parts.scheme, parts.netloc, parts.path, query, fragment))
+        (parts.scheme, netloc, path, query, fragment))
     return rebuilt, True
 
 
@@ -714,19 +721,23 @@ def run_provenance(**overrides: Any) -> dict[str, Any]:
             "operator intended, or that anything about the target is secure.",
             "argv_redacted true means something was replaced. It is not a claim "
             "that no credential remains: redaction matches a list of auth-shaped "
-            "names and a credential passed under another name survives.",
-            "No hostname, username, working directory or absolute path is "
-            "recorded, by the rule in docs/PRIVACY.md. Every absolute path in "
-            "argv -- POSIX, drive-letter, UNC and ~user forms, bare or after "
-            "--flag= -- is reduced to its basename, unconditionally and without "
-            "setting argv_redacted, so a bare filename here was never a full "
-            "path in this record. Their absence is a decision, not an omission.",
-            "URL query and fragment values are replaced unless the parameter "
-            "name is on a short allowlist of protocol/format selectors "
-            f"({', '.join(sorted(_QUERY_PARAM_ALLOWLIST))}). A [REDACTED] "
-            "query value is therefore not evidence that a credential was "
-            "there; it is evidence that the name was not on the allowlist. "
-            "Scheme, host, port and path are kept as sent.",
+            "names and a credential passed under another name survives. Nor is "
+            "it a claim that a credential was FOUND: a URL carrying any path, "
+            "query or fragment sets it, because that component was removed by "
+            "the rule below whatever it contained.",
+            "No username, working directory or absolute filesystem path is "
+            "recorded. Every absolute path in argv -- POSIX, drive-letter, UNC "
+            "and ~user forms, bare or after --flag= -- is reduced to its "
+            "basename, unconditionally and without setting argv_redacted, so a "
+            "bare filename here was never a full path in this record. Their "
+            "absence is a decision, not an omission.",
+            f"A URL keeps {URL_RETAINED} and nothing else: {URL_REPLACED} are "
+            f"each replaced whole with {REDACTED}. So a target HOSTNAME IS "
+            f"recorded here, deliberately, because a run whose target cannot "
+            f"be named is not reproducible; what was asked of that target is "
+            f"not. A {REDACTED} URL component means the component was present "
+            f"and removed by this rule -- never that a credential was found "
+            f"there, and never that the component was absent.",
         ],
     }
     statement.update(overrides)

--- a/protocol_tests/telemetry.py
+++ b/protocol_tests/telemetry.py
@@ -1,11 +1,12 @@
 """Anonymous usage telemetry for agent-security-harness.
 
-WHAT THIS SENDS: version, module_name, test_count, passed, failed, inconclusive, os, python_version, timestamp
+WHAT THIS SENDS: version, module_name, counts_available, test_count, passed, failed, inconclusive, os, python_version, timestamp
+  (when the counts are unavailable the four count fields are OMITTED and a fixed `reason` token is sent instead)
 WHAT THIS NEVER SENDS: URLs, results, payloads, credentials, IPs
 
 OPT IN: export AGENT_SECURITY_TELEMETRY=on
 
-This module is intentionally small (<100 lines) so you can audit it in 2 minutes.
+This module is intentionally small so you can audit it in a few minutes.
 Source: https://github.com/msaleme/red-team-blue-team-agent-fabric/blob/main/protocol_tests/telemetry.py
 """
 from __future__ import annotations
@@ -139,35 +140,71 @@ def verdict_counts(results) -> dict:
     return {"tests": tests, "passed": passed, "failed": failed,
             "inconclusive": inconclusive}
 
-def send_telemetry_event(module: str, tests: int, passed: int, failed: int,
-                         inconclusive: int = 0) -> None:
+#: The only `reason` values an event may carry. Closed, so the field cannot
+#: become a free-text channel; docs/PRIVACY.md lists each one.
+COUNTS_UNAVAILABLE_REASONS = frozenset({"results_not_exposed_and_no_report_written"})
+
+
+def send_telemetry_event(module: str, tests: int | None = None, passed: int | None = None,
+                         failed: int | None = None, inconclusive: int = 0, *,
+                         counts_available: bool = True, reason: str | None = None) -> None:
     """Send a single anonymous telemetry event. Non-blocking.
 
     `inconclusive` is the count of rows the target never serviced (or a
     simulated run, which services nothing). It defaults to 0 so callers that
     predate the field keep working; new callers should pass the output of
     `verdict_counts` rather than computing the three buckets by hand.
+
+    `counts_available=False` is the state the live path is in when a harness
+    kept its results in `main()`'s locals and wrote no report: the run
+    happened and its size is not known here. Until 2026-09-08 that was sent
+    as `tests:0, passed:0, failed:0, inconclusive:0` -- a measured-looking
+    claim about a run with 17 rows (fourth external review, R4-12). Now the
+    four count fields are OMITTED, `counts_available` is false and `reason`
+    is one fixed token from COUNTS_UNAVAILABLE_REASONS. A consumer that sums
+    `tests` sees a missing key, not a zero.
     """
     if _is_disabled():
         return
     _show_first_run_notice()
     from protocol_tests.version import get_harness_version
-    payload = json.dumps({
+    event: dict = {
         "v": get_harness_version(),      # Which version is running
         "module": module,                 # Which harness (e.g. "mcp") -- NOT a URL
-        "tests": tests,                   # How many tests ran
-        "passed": passed,                 # Pass count only -- no details about which tests
-        "failed": failed,                 # Fail count only -- no details about which tests
-        "inconclusive": inconclusive,     # Unserviced count only -- never scored as a pass
+        "counts_available": bool(counts_available),  # False: the four counts are absent, not zero
+    }
+    if counts_available:
+        if tests is None or passed is None or failed is None:
+            raise ValueError("counts_available is true but a count is missing; "
+                             "pass counts_available=False and a reason instead")
+        event.update({
+            "tests": tests,               # How many tests ran
+            "passed": passed,             # Pass count only -- no details about which tests
+            "failed": failed,             # Fail count only -- no details about which tests
+            "inconclusive": inconclusive, # Unserviced count only -- never scored as a pass
+        })
+    else:
+        if reason not in COUNTS_UNAVAILABLE_REASONS:
+            raise ValueError(f"reason must be one of {sorted(COUNTS_UNAVAILABLE_REASONS)}")
+        event["reason"] = reason          # A fixed token naming why, never free text
+    event.update({
         "os": platform.system().lower(),  # OS family for platform bug triage
         "py": f"{sys.version_info.major}.{sys.version_info.minor}",  # Python compat
         "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-    }).encode()
+    })
+    payload = json.dumps(event).encode()
     threading.Thread(target=_post, args=(payload,), daemon=True).start()
 
 def telemetry_payload_example() -> dict:
     """Return a sample payload so users can see exactly what's sent."""
     from protocol_tests.version import get_harness_version
-    return {"v": get_harness_version(), "module": "mcp", "tests": 13, "passed": 9,
-            "failed": 2, "inconclusive": 2, "os": "linux", "py": "3.12",
-            "ts": "2026-03-28T00:00:00Z"}
+    return {"v": get_harness_version(), "module": "mcp", "counts_available": True,
+            "tests": 13, "passed": 9, "failed": 2, "inconclusive": 2,
+            "os": "linux", "py": "3.12", "ts": "2026-03-28T00:00:00Z"}
+
+def telemetry_payload_example_counts_unavailable() -> dict:
+    """The other shape: the run happened, its size is not known to the sender."""
+    from protocol_tests.version import get_harness_version
+    return {"v": get_harness_version(), "module": "ap2", "counts_available": False,
+            "reason": "results_not_exposed_and_no_report_written",
+            "os": "linux", "py": "3.12", "ts": "2026-03-28T00:00:00Z"}

--- a/schemas/attestation-report.json
+++ b/schemas/attestation-report.json
@@ -723,7 +723,7 @@
           "description": "What this block does not establish, in plain words."
         }
       },
-      "description": "What produced this run. Every key is always present; absence of knowledge is null paired with an `_absent_reason`. Deliberately NOT recorded: hostname, username, working directory and absolute paths. docs/PRIVACY.md lists infrastructure topology under what never travels, and a report a user is invited to publish is held to the same line as telemetry. Their absence is a decision, not an omission."
+      "description": "What produced this run. Every key is always present; absence of knowledge is null paired with an `_absent_reason`. Deliberately NOT recorded: username, working directory, absolute filesystem paths, and the path, query and fragment of any URL in argv -- each URL keeps its scheme, host and port and nothing else. A target hostname IS therefore recorded, deliberately: a run whose target cannot be named is not reproducible, and claiming otherwise while embedding one is the contradiction this wording removes. Their absence is a decision, not an omission."
     },
     "subject": {
       "type": "object",

--- a/scripts/auroc.py
+++ b/scripts/auroc.py
@@ -17,6 +17,7 @@ Tracks GitHub issue #155.
 from __future__ import annotations
 
 import json
+import sys
 from typing import Any
 
 
@@ -171,12 +172,36 @@ _METHODOLOGY = (
 )
 
 
+def main(argv: "list[str] | None" = None) -> int:
+    """`--help` is a request for help, not a filename.
+
+    This read `sys.argv[1]` directly, so `python -m scripts.auroc --help`
+    opened a file called `--help` and raised FileNotFoundError -- the only one
+    of 29 shipped scripts that answered a help request with a traceback
+    (fourth external review, R4-15).
+    """
+    import argparse
+
+    ap = argparse.ArgumentParser(
+        prog="python -m scripts.auroc",
+        description="Compute trapezoidal AUROC from a harness report.")
+    ap.add_argument("report", help="path to a harness report JSON file, or - for stdin")
+    args = ap.parse_args(argv)
+
+    try:
+        if args.report == "-":
+            data = json.load(sys.stdin)
+        else:
+            with open(args.report, encoding="utf-8") as fh:
+                data = json.load(fh)
+    except (OSError, ValueError) as exc:
+        print(f"auroc: could not read a JSON report from {args.report!r}: {exc}",
+              file=sys.stderr)
+        return 2
+
+    print(json.dumps(compute_all_auroc(data), indent=2))
+    return 0
+
+
 if __name__ == "__main__":
-    import sys
-    if len(sys.argv) < 2:
-        print("Usage: python scripts/auroc.py <report.json>")
-        sys.exit(1)
-    with open(sys.argv[1]) as f:
-        data = json.load(f)
-    result = compute_all_auroc(data)
-    print(json.dumps(result, indent=2))
+    sys.exit(main())

--- a/scripts/compliance_crosswalk.py
+++ b/scripts/compliance_crosswalk.py
@@ -1,6 +1,13 @@
 #!/usr/bin/env python3
 """Compliance framework crosswalk loader and mapper.
 
+**This is a LIBRARY MODULE, not an operator CLI.** It is imported by
+`scripts/compliance_report.py` and by the CLI; running it directly does no
+work, and before 2026-09-08 running it with `--help` printed nothing at all
+and exited 0, which is indistinguishable from a command that succeeded
+(fourth external review, R4-15). Its `__main__` now prints what it is and
+which commands do the work.
+
 Loads crosswalk YAML files and maps harness test results to framework
 controls for EU AI Act, ISO 42001, and AIUC-1 compliance reporting.
 
@@ -205,3 +212,24 @@ def compliance_summary(crosswalk: dict[str, Any], results: list[dict[str, Any]])
 def list_frameworks() -> list[str]:
     """Return list of available framework identifiers."""
     return list(FRAMEWORK_FILES.keys())
+
+
+def _usage() -> int:
+    """What this module is, and where the operator commands live."""
+    print(__doc__.strip().splitlines()[0])
+    print()
+    print("This is a library module, not a command. It has no operator behaviour")
+    print("of its own; importing it is the supported use:")
+    print()
+    print("    from scripts.compliance_crosswalk import load_crosswalk, apply_crosswalk")
+    print()
+    print(f"Frameworks available: {', '.join(list_frameworks())}")
+    print()
+    print("The commands that use it:")
+    print("    python -m scripts.compliance_report --report REPORT --output OUTPUT")
+    print("    agent-security test aiuc1 --url URL")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_usage())

--- a/scripts/discord_scan_bot.py
+++ b/scripts/discord_scan_bot.py
@@ -40,11 +40,23 @@ from protocol_tests.version import get_harness_version
 
 HARNESS_VERSION = get_harness_version()
 
+# A help page must not require the optional dependency. This module answered
+# `--help` with "Error: discord.py is required" and exit 1 -- true, and not an
+# answer to the question asked (fourth external review, R4-15). The check is
+# here, above the import, because the bot's command decorators run at import
+# time and there is no later point that is still before the failure.
+if any(a in ("-h", "--help") for a in sys.argv[1:]):
+    print(__doc__.strip())
+    print()
+    print("Requires the optional dependency discord.py: pip install discord.py python-dotenv")
+    sys.exit(0)
+
 try:
     import discord
     from discord.ext import commands
 except ImportError:
-    print("Error: discord.py is required. Install with: pip install discord.py")
+    print("Error: discord.py is required. Install with: pip install discord.py",
+          file=sys.stderr)
     sys.exit(1)
 
 try:

--- a/scripts/generate_test_catalog.py
+++ b/scripts/generate_test_catalog.py
@@ -11,10 +11,17 @@ Extraction constants are imported from scripts/count_tests.py rather than
 redefined here, so catalog membership and the canonical count are derived from
 one set of patterns and cannot disagree.
 
+Checkout-only resources: `HARNESS_TEST_CATALOG.md` and
+`benchmarks/decision_behavior_corpus.py` are not shipped in the wheel. Writing
+or checking the catalog therefore needs a clone; from an installed package the
+command prints one line naming the missing resource and exits 2, rather than
+producing an empty catalog or a confident FAIL about drift that was really an
+absence (fourth external review, R4-15).
+
 Usage:
-    python scripts/generate_test_catalog.py                 # write the catalog
-    python scripts/generate_test_catalog.py --check         # verify, exit 1 on drift
-    python scripts/generate_test_catalog.py --out PATH      # write elsewhere
+    python -m scripts.generate_test_catalog                 # write the catalog
+    python -m scripts.generate_test_catalog --check         # verify, exit 1 on drift
+    python -m scripts.generate_test_catalog --out PATH      # write elsewhere
 """
 
 from __future__ import annotations
@@ -218,12 +225,24 @@ def main() -> int:
     ap.add_argument("--out", type=Path, default=DEFAULT_OUT)
     args = ap.parse_args()
 
+    # One line, exit 2, no traceback -- the same gate the other checkout-only
+    # scripts use. `--out PATH` is an explicit destination and is not gated;
+    # the DEFAULT destination and `--check` both live in the checkout.
+    if args.out == DEFAULT_OUT and not DEFAULT_OUT.parent.is_dir():
+        print(f"generate_test_catalog.py: checkout-only resource missing: "
+              f"HARNESS_TEST_CATALOG.md (expected at {DEFAULT_OUT}). The catalog "
+              f"and benchmarks/ are not shipped in the wheel; run from a clone or "
+              f"pass --out PATH.", file=sys.stderr)
+        return 2
+    if args.check and not args.out.exists():
+        print(f"generate_test_catalog.py: checkout-only resource missing: "
+              f"{args.out.name} (expected at {args.out}). There is nothing to check "
+              f"against; run from a clone.", file=sys.stderr)
+        return 2
+
     content, total, unnamed = build()
 
     if args.check:
-        if not args.out.exists():
-            print(f"FAIL: {args.out} does not exist", file=sys.stderr)
-            return 1
         current = args.out.read_text(encoding="utf-8")
 
         # Compare the WHOLE generated body, not just which IDs appear.

--- a/scripts/monthly_security_report.py
+++ b/scripts/monthly_security_report.py
@@ -5,10 +5,17 @@ Reads MCP server targets from configs/monthly_targets.yaml, runs the full
 MCP security harness against each, and produces a combined monthly report
 in markdown.
 
+Checkout-only resource: the DEFAULT config is the repository's
+`configs/monthly_targets.yaml`, whose entries are example targets, and the
+default output directory is `reports/monthly/` under the checkout. Neither
+exists in an installed wheel. Run with no arguments from an installed package
+and the command prints one line naming the missing resource and exits 2
+(fourth external review, R4-15). Supply `--config` and `--output-dir` and it
+runs anywhere.
+
 Usage:
-    python scripts/monthly_security_report.py
-    python scripts/monthly_security_report.py --config configs/monthly_targets.yaml
-    python scripts/monthly_security_report.py --month 2026-03
+    python -m scripts.monthly_security_report --config targets.yaml --output-dir out/
+    python -m scripts.monthly_security_report --month 2026-03 --config targets.yaml
 """
 
 from __future__ import annotations
@@ -281,8 +288,20 @@ def main():
     # Determine month
     month = args.month or datetime.now(timezone.utc).strftime("%Y-%m")
 
-    # Load config
+    # Load config. The DEFAULT config lives in the checkout and is not shipped;
+    # missing it is a one-line exit 2 naming the resource, not a generic error,
+    # because "run this from a clone or pass --config" is the actionable half.
+    # `parser.get_default` rather than rebuilding the path: one more
+    # REPO_ROOT join here would raise this script's floor in
+    # testing/test_packaged_scripts_resolve.py, which is a list that shrinks.
     if not os.path.exists(args.config):
+        if os.path.abspath(args.config) == os.path.abspath(parser.get_default("config")):
+            print(f"monthly_security_report.py: checkout-only resource missing: "
+                  f"configs/monthly_targets.yaml (expected at {args.config}). The "
+                  f"default target list and reports/ directory are not shipped in "
+                  f"the wheel; run from a clone or pass --config PATH "
+                  f"--output-dir DIR.", file=sys.stderr)
+            sys.exit(2)
         print(f"Error: Config file not found: {args.config}", file=sys.stderr)
         sys.exit(1)
 

--- a/scripts/registry_reference_server.py
+++ b/scripts/registry_reference_server.py
@@ -9,6 +9,11 @@ This is a CONFORMANCE REFERENCE, not a deployment target. No persistence, no
 auth, no TLS, no rate limiting, in-memory store. Run it to check a client or a
 second server implementation against the contract.
 
+`payload.report` is validated against `schemas/attestation-report.json` in full
+when `jsonschema` is importable, which is what contract 5 step 5 asks for. Where
+it is not, only the schema's required top-level keys are checked, and the stored
+record says which of the two happened in `validation_level`.
+
     python3 scripts/registry_reference_server.py --port 8787
     export AGENT_SECURITY_REGISTRY_URL="http://localhost:8787"
 
@@ -32,6 +37,25 @@ try:  # optional: only needed to actually verify a signature
     _CRYPTO = True
 except ImportError:  # pragma: no cover - environment dependent
     _CRYPTO = False
+
+try:  # optional: full JSON Schema validation (contract 5 step 5)
+    import jsonschema as _jsonschema
+    _JSONSCHEMA = True
+except ImportError:  # pragma: no cover - environment dependent
+    _JSONSCHEMA = False
+
+#: What was actually checked before a record was stored. Contract 5 step 5 says
+#: validate `payload.report` against `schemas/attestation-report.json`; until
+#: 2026-09-08 this server checked only that the schema's REQUIRED keys were
+#: present, and a correctly signed report carrying `evidence_class: "E9"` -- a
+#: value no version of the enum has ever contained -- was stored with 201 and
+#: issued the claim label (fourth external review, R4-11).
+#:
+#: The level travels in the record because the two are different claims and a
+#: consumer cannot tell them apart from the outside. "The required keys were
+#: present" is not "the report conforms".
+VALIDATION_SCHEMA = "schema"
+VALIDATION_REQUIRED_KEYS = "required-keys"
 
 # A checkout puts the repo root on sys.path only when run as a module; run
 # as a script (`python3 scripts/registry_reference_server.py`) it is not.
@@ -104,30 +128,67 @@ class SchemaUnavailable(RuntimeError):
     """
 
 
-def load_schema_required(schema_path: "Path | str | None" = None) -> list[str]:
-    """Required top-level keys of the attestation report.
+def load_schema(schema_path: "Path | str | None" = None) -> dict:
+    """The whole attestation schema, or SchemaUnavailable.
 
-    Deliberately a required-key check, not full JSON Schema validation: the repo
-    has no jsonschema dependency and a server that claims schema validation it
-    does not perform is the same class of defect as claiming a signature check it
-    skipped. A production server SHOULD validate fully.
-
-    Raises SchemaUnavailable when the schema cannot be read, does not parse, or
-    declares no required keys. It never returns an empty list.
+    Raises rather than returning a permissive default for the same reason
+    `load_schema_required` never returns `[]`: missing validation configuration
+    must not mean no requirements.
     """
     path = Path(schema_path) if schema_path is not None else Path(SCHEMA_PATH)
     try:
-        required = json.loads(path.read_text()).get("required")
+        schema = json.loads(path.read_text())
     except (OSError, json.JSONDecodeError) as exc:
         raise SchemaUnavailable(
             f"cannot load the attestation schema at {path}: {exc}; refusing to "
             f"validate submissions without it") from exc
+    required = schema.get("required") if isinstance(schema, dict) else None
     if not isinstance(required, list) or not required \
             or not all(isinstance(k, str) for k in required):
         raise SchemaUnavailable(
             f"the attestation schema at {path} declares no required keys; refusing "
             f"to treat an absent requirement list as no requirements")
-    return list(required)
+    return schema
+
+
+def load_schema_required(schema_path: "Path | str | None" = None) -> list[str]:
+    """Required top-level keys of the attestation report.
+
+    The required-key list is the FLOOR, not the check: contract 5 step 5 asks
+    for full JSON Schema validation and `validate_and_build` performs it
+    whenever `jsonschema` is importable. This list is what remains enforceable
+    on a host without it, and a record validated only against it says so in
+    `validation_level`.
+
+    Raises SchemaUnavailable when the schema cannot be read, does not parse, or
+    declares no required keys. It never returns an empty list.
+    """
+    return list(load_schema(schema_path)["required"])
+
+
+def schema_errors(report: dict, schema: dict) -> "list[str] | None":
+    """Full JSON Schema errors for `report`, or None when jsonschema is absent.
+
+    None and `[]` are different answers and the caller must not conflate them:
+    `[]` is "the validator ran and found nothing", None is "the validator did
+    not run". That distinction is the whole of R4-11 one level down.
+    """
+    if not _JSONSCHEMA:
+        return None
+
+    def render(err) -> str:
+        where = ".".join(str(p) for p in err.absolute_path) or "(root)"
+        # An `anyOf` failure's own message is the entire instance, which tells a
+        # submitter nothing about which alternative it missed. The sub-errors
+        # name the rules (`'producer' is a required property`), so say those.
+        if err.context:
+            reasons = "; ".join(sorted({sub.message for sub in err.context}))
+            return f"{where}: does not match any allowed form ({reasons})"
+        return f"{where}: {err.message}"
+
+    validator = _jsonschema.Draft202012Validator(schema)
+    return [render(err) for err in
+            sorted(validator.iter_errors(report), key=lambda e: list(e.path))]
 
 
 class Store:
@@ -159,6 +220,7 @@ def validate_and_build(
     submission: dict,
     required_keys: list[str],
     *,
+    schema: dict | None = None,
     test_only_accept_invalid_class: str | None = None,
 ) -> dict:
     """Contract section 5. Eight checks, in order. Raises Rejected.
@@ -214,10 +276,28 @@ def validate_and_build(
     if leaked:
         raise Rejected(422, f"report contains sensitive keys: {', '.join(sorted(leaked)[:8])}")
 
-    # 5. Schema required keys
+    # 5. Schema. The required-key check first, because its message names the
+    # missing fields plainly; then full JSON Schema validation, which is what
+    # contract 5 step 5 actually asks for.
     missing = [k for k in required_keys if k not in report]
     if missing:
         raise Rejected(422, f"report missing schema-required keys: {', '.join(missing)}")
+
+    # A correctly signed report with `evidence_class: "E9"` passed the check
+    # above and was stored with the claim label. A signature establishes who
+    # sent the bytes; it says nothing about whether the document conforms.
+    validation_level = VALIDATION_REQUIRED_KEYS
+    if schema is not None:
+        errors = schema_errors(report, schema)
+        if errors is not None:
+            if errors:
+                raise Rejected(
+                    422,
+                    "report does not validate against the attestation schema: "
+                    + "; ".join(errors[:5])
+                    + (f" (+{len(errors) - 5} more)" if len(errors) > 5 else ""),
+                )
+            validation_level = VALIDATION_SCHEMA
 
     # 6. Signature
     public_key = submission.get("public_key")
@@ -286,6 +366,20 @@ def validate_and_build(
         ),
         "received_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "claim_label": CLAIM_LABEL,
+        # "schema": the whole report validated against
+        # schemas/attestation-report.json. "required-keys": only the schema's
+        # required top-level keys were checked, because no JSON Schema
+        # validator was available here. A consumer must be able to tell those
+        # apart; before 2026-09-08 the record said neither and the weaker one
+        # was what happened (R4-11).
+        "validation_level": validation_level,
+        "validation_level_basis": (
+            "payload.report validated against schemas/attestation-report.json "
+            "(contract 5 step 5)" if validation_level == VALIDATION_SCHEMA else
+            "jsonschema was not importable on this server; only the schema's "
+            "required top-level keys were checked. Required-key presence is NOT "
+            "report conformance."
+        ),
     }
 
 
@@ -301,6 +395,7 @@ BADGE_SVG = (
 class Handler(BaseHTTPRequestHandler):
     store: Store
     required_keys: list[str]
+    schema: dict | None = None
     test_only_accept_invalid_class: str | None = None
     server_version = "agent-security-registry-reference/1.0"
 
@@ -330,6 +425,7 @@ class Handler(BaseHTTPRequestHandler):
             record = validate_and_build(
                 submission,
                 self.required_keys,
+                schema=self.schema,
                 test_only_accept_invalid_class=self.test_only_accept_invalid_class,
             )
         except Rejected as rej:
@@ -384,7 +480,8 @@ def build_server(
     if test_only_accept_invalid_class not in (None, *TEST_ONLY_ACCEPT_INVALID_CLASSES):
         raise ValueError("unsupported test-only invalid-acceptance class")
     Handler.store = Store()
-    Handler.required_keys = load_schema_required()
+    Handler.schema = load_schema()
+    Handler.required_keys = list(Handler.schema["required"])
     Handler.test_only_accept_invalid_class = test_only_accept_invalid_class
     return ThreadingHTTPServer(("127.0.0.1", port), Handler)
 
@@ -410,6 +507,10 @@ def main() -> int:
     if not _CRYPTO:
         print("  WARNING: 'cryptography' not importable; signed envelopes will be "
               "rejected with 501 rather than silently unverified")
+    if not _JSONSCHEMA:
+        print("  WARNING: 'jsonschema' not importable; records will be stored with "
+              "validation_level='required-keys'. Required-key presence is not report "
+              "conformance -- install jsonschema for contract 5 step 5.")
     try:
         httpd.serve_forever()
     except KeyboardInterrupt:

--- a/scripts/verify_attestation_record.py
+++ b/scripts/verify_attestation_record.py
@@ -142,11 +142,22 @@ def verify(record: dict) -> bool:
     return failures == 0
 
 
-def main() -> int:
-    if len(sys.argv) != 2:
-        print(__doc__)
-        return 2
-    source = sys.argv[1]
+def main(argv: "list[str] | None" = None) -> int:
+    """`--help` was read as a filename and answered with a one-line error.
+
+    Correct in that it did not traceback, wrong in that a help request is not
+    a failed read (R4-15). argparse answers it and exits 0.
+    """
+    import argparse
+
+    ap = argparse.ArgumentParser(
+        prog="python -m scripts.verify_attestation_record",
+        description=(__doc__ or "").strip().splitlines()[0] if __doc__ else None,
+        epilog="Exit 0: all applicable checks passed. 1: verification failed. "
+               "2: the record could not be read.")
+    ap.add_argument("record", help="path to a registry record JSON file, or - for stdin")
+    args = ap.parse_args(argv)
+    source = args.record
     try:
         text = sys.stdin.read() if source == "-" else open(source, encoding="utf-8").read()
         record = json.loads(text)

--- a/testing/test_harness_base_adoption.py
+++ b/testing/test_harness_base_adoption.py
@@ -25,7 +25,9 @@ of rewriting what already works.
 
 from __future__ import annotations
 
+import ast
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -86,9 +88,37 @@ GRANDFATHERED = {
 }
 
 
-def _modules_with_own_record() -> set[str]:
-    return {p.stem for p in sorted((REPO_ROOT / "protocol_tests").glob("*.py"))
-            if "def _record" in p.read_text()}
+def _defines_own_record(source: str) -> bool:
+    """A class in `source` defines a method named `_record`, read from the AST.
+
+    Until 2026-09-08 this was the substring test `"def _record" in text`. A
+    module spelling it `def  _record(` -- two spaces, valid Python -- was
+    invisible to it, so a 45th parallel implementation could be added and
+    every test in this file stayed green (fourth external review, R4-13). The
+    floor below proves the familiar files remain visible; it says nothing
+    about syntax the rule never matched. The AST does not care about
+    whitespace, comments, decorators or `async`.
+    """
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef):
+            for member in node.body:
+                if isinstance(member, (ast.FunctionDef, ast.AsyncFunctionDef)) \
+                        and member.name == "_record":
+                    return True
+    return False
+
+
+def _modules_with_own_record(package_dir: Path | None = None) -> set[str]:
+    """Stems of the modules in `package_dir` whose classes define `_record`.
+
+    `package_dir` defaults to the shipped package; it is a parameter so the
+    anti-vacuity tests below can point the same detector at a seeded module
+    instead of writing into the package.
+    """
+    package_dir = package_dir if package_dir is not None else REPO_ROOT / "protocol_tests"
+    return {p.stem for p in sorted(package_dir.glob("*.py"))
+            if _defines_own_record(p.read_text(encoding="utf-8"))}
 
 
 class TestGrandfatherListOnlyShrinks(unittest.TestCase):
@@ -125,6 +155,67 @@ class TestGrandfatherListOnlyShrinks(unittest.TestCase):
         missing = {m for m in GRANDFATHERED
                    if not (REPO_ROOT / "protocol_tests" / f"{m}.py").exists()}
         self.assertEqual(missing, set(), f"grandfathered but gone: {sorted(missing)}")
+
+
+class TestTheDetectorReadsSyntaxNotText(unittest.TestCase):
+    """R4-13. A detector that matches one spelling of a definition is a
+    detector of that spelling. Each seed here is a module that DOES define its
+    own `_record`, written the way the old substring rule could not see."""
+
+    SEEDS = {
+        "two_spaces": "class Seed:\n    def  _record(self, result):\n        pass\n",
+        "tab": "class Seed:\n    def\t_record(self, result):\n        pass\n",
+        "async": "class Seed:\n    async def _record(self, result):\n        pass\n",
+        "decorated": ("class Seed:\n    @staticmethod\n    def _record(result):\n"
+                      "        pass\n"),
+        "nested_class": ("class Outer:\n    class Inner:\n        def  _record(self, r):\n"
+                         "            pass\n"),
+        "plain": "class Seed:\n    def _record(self, result):\n        pass\n",
+    }
+
+    def test_every_seeded_spelling_is_seen(self) -> None:
+        for label, src in self.SEEDS.items():
+            with self.subTest(seed=label):
+                self.assertTrue(_defines_own_record(src), f"{label!r} seed is invisible")
+
+    def test_a_seeded_module_in_a_temp_package_enters_the_set(self) -> None:
+        """The whole path, on disk: the exact shape the review seeded."""
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = Path(tmp)
+            (pkg / "zz_whitespace_seed.py").write_text(self.SEEDS["two_spaces"], encoding="utf-8")
+            (pkg / "zz_inherits.py").write_text(
+                "from protocol_tests.harness_base import RecordingHarness\n"
+                "class Fine(RecordingHarness):\n    pass\n", encoding="utf-8")
+            seen = _modules_with_own_record(pkg)
+        self.assertIn("zz_whitespace_seed", seen)
+        self.assertNotIn("zz_inherits", seen, "inheriting the base is not defining _record")
+
+    def test_a_record_that_is_not_a_method_is_not_counted(self) -> None:
+        """The rule is about harness classes. A module-level helper, a call
+        site, a string or a comment mentioning `def _record` is not a 45th
+        implementation, and the old text rule counted all four."""
+        for label, src in {
+            "call": "class H:\n    def run(self):\n        self._record(1)\n",
+            "comment": "# def _record lives in harness_base\nclass H:\n    pass\n",
+            "string": 'DOC = "def _record"\nclass H:\n    pass\n',
+            "module_level": "def _record(result):\n    pass\n",
+        }.items():
+            with self.subTest(shape=label):
+                self.assertFalse(_defines_own_record(src))
+
+    def test_the_detector_agrees_with_the_inventory_facts(self) -> None:
+        """#543 reads the same fact off the imported module
+        (`asi_inventory.recording_facts()["defines_record"]`). Two derivations
+        of one fact must agree on every registered harness, or one of them is
+        a naming convention again."""
+        from protocol_tests.asi_inventory import harness_modules, recording_facts
+        seen = _modules_with_own_record()
+        disagreements = []
+        for dotted in harness_modules():
+            stem = dotted.rsplit(".", 1)[-1]
+            if recording_facts(dotted)["defines_record"] != (stem in seen):
+                disagreements.append(stem)
+        self.assertEqual(disagreements, [])
 
 
 class TestRecordingHarnessBehaviour(unittest.TestCase):

--- a/testing/test_packaged_scripts_resolve.py
+++ b/testing/test_packaged_scripts_resolve.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 import ast
 import fnmatch
 import re
+import subprocess
 import sys
 import unittest
 from pathlib import Path
@@ -71,6 +72,31 @@ R3_12_SCRIPTS = (
     "validate_result_semantics",
     "validate_owasp_agentic_mapping",
     "verify_release_claims",
+)
+
+#: Shipped modules that are LIBRARIES, not operator commands. The only
+#: exemption from the `--help` contract below, and every entry must say so in
+#: its own docstring -- asserted, so the list cannot become a way to excuse a
+#: broken CLI. SHRINK ONLY in the sense that matters: an entry here is a claim
+#: about the module, not a waiver.
+LIBRARY_MODULES = {
+    "compliance_crosswalk",
+    "count_tests",
+}
+
+#: Every shipped script whose real work needs a resource the wheel does not
+#: carry. Each must say "checkout-only" in its docstring and answer with the
+#: one-line "checkout-only resource missing" message and exit 2, never a
+#: traceback and never an empty success. `generate_test_catalog` (--check and
+#: the default destination) and `monthly_security_report` (the default target
+#: list) joined this list on 2026-09-08 (R4-15); before that their messages
+#: were understandable but inconsistent with the contract the other four use.
+CHECKOUT_ONLY_GATED = (
+    "validate_result_semantics",
+    "validate_owasp_agentic_mapping",
+    "verify_release_claims",
+    "generate_test_catalog",
+    "monthly_security_report",
 )
 
 
@@ -345,14 +371,135 @@ class TestShippedScriptsDoNotBypassPackageData(unittest.TestCase):
 
     def test_the_checkout_only_scripts_say_so_and_exit_two(self) -> None:
         """A missing checkout resource is one line and exit 2, never a traceback."""
-        for stem in ("validate_result_semantics", "validate_owasp_agentic_mapping",
-                     "verify_release_claims"):
+        for stem in CHECKOUT_ONLY_GATED:
             src = (REPO_ROOT / "scripts" / f"{stem}.py").read_text(encoding="utf-8")
             doc = ast.get_docstring(ast.parse(src)) or ""
             with self.subTest(script=stem):
                 self.assertIn("checkout-only", doc.lower(),
                               "docstring must state which resources are checkout-only")
                 self.assertIn("checkout-only resource missing", src)
+                # Exit 2, however each script spells it: `sys.exit(2)`,
+                # `raise SystemExit(2)`, `return 2`, or a named constant whose
+                # value is 2. The code is the contract; the spelling is not.
+                self.assertRegex(
+                    src, r"(SystemExit|sys\.exit|return)\s*\(?\s*(2\b|EXIT_CANNOT_CHECK)",
+                    f"scripts/{stem}.py names the missing resource but does not exit 2")
+
+    def test_the_two_new_gates_actually_exit_two_from_a_non_checkout_root(self) -> None:
+        """R4-15. `generate_test_catalog --check` and a default
+        `monthly_security_report` printed understandable messages and exited 1,
+        which is the same code a real drift or a real missing config uses. The
+        gate is exercised here rather than asserted from source: the module
+        constants are pointed at a directory with no checkout in it, which is
+        what site-packages looks like."""
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            catalog = (
+                "import pathlib, sys\n"
+                f"sys.path.insert(0, {str(REPO_ROOT)!r})\n"
+                "import scripts.generate_test_catalog as g\n"
+                f"g.DEFAULT_OUT = pathlib.Path({tmp!r}) / 'HARNESS_TEST_CATALOG.md'\n"
+                "sys.argv = ['generate_test_catalog', '--check']\n"
+                "print('rc', g.main())\n")
+            done = subprocess.run([sys.executable, "-c", catalog], cwd=tmp,
+                                  capture_output=True, text=True, timeout=120)
+            self.assertIn("rc 2", done.stdout, done.stderr[-400:])
+            self.assertIn("checkout-only resource missing", done.stderr)
+            self.assertNotIn("Traceback", done.stderr)
+
+            monthly = (
+                "import sys\n"
+                f"sys.path.insert(0, {str(REPO_ROOT)!r})\n"
+                "import scripts.monthly_security_report as m\n"
+                f"m.REPO_ROOT = {tmp!r}\n"
+                "sys.argv = ['monthly_security_report']\n"
+                "try:\n"
+                "    m.main()\n"
+                "except SystemExit as exc:\n"
+                "    print('rc', exc.code)\n")
+            done = subprocess.run([sys.executable, "-c", monthly], cwd=tmp,
+                                  capture_output=True, text=True, timeout=120)
+            self.assertIn("rc 2", done.stdout, done.stderr[-400:])
+            self.assertIn("checkout-only resource missing", done.stderr)
+            self.assertNotIn("Traceback", done.stderr)
+
+
+# --------------------------------------------------------------------------
+# Every shipped script answers --help, or is a declared library module
+# --------------------------------------------------------------------------
+
+class TestEveryShippedScriptAnswersHelp(unittest.TestCase):
+    """R4-15. A help page is the cheapest observable contract a command has.
+
+    Of the 29 shipped script modules, `auroc` treated `--help` as a filename
+    and raised FileNotFoundError, `verify_attestation_record` treated it as a
+    filename and returned a one-line error, `discord_scan_bot` answered with
+    its missing optional dependency, and `compliance_crosswalk` printed
+    nothing and exited 0 -- indistinguishable from a command that worked.
+
+    The rule is derived, not listed: every `scripts/*.py` the wheel carries
+    must exit 0 on `--help`, or be in LIBRARY_MODULES and say in its own
+    docstring that it is a library. A script added tomorrow is covered
+    without anyone remembering this file.
+    """
+
+    @staticmethod
+    def _help(stem: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [sys.executable, "-m", f"scripts.{stem}", "--help"],
+            cwd=REPO_ROOT, capture_output=True, text=True, timeout=120)
+
+    def test_the_set_under_test_is_derived_and_nonempty(self) -> None:
+        stems = {p.stem for p in shipped_scripts()}
+        self.assertGreater(len(stems), 20, "the derived set collapsed; this would be vacuous")
+        for stem in LIBRARY_MODULES:
+            self.assertIn(stem, stems, f"{stem} is not a shipped script; remove the entry")
+
+    def test_every_shipped_script_exits_zero_on_help(self) -> None:
+        for path in shipped_scripts():
+            if path.stem in LIBRARY_MODULES:
+                continue
+            with self.subTest(script=path.stem):
+                done = self._help(path.stem)
+                self.assertEqual(
+                    done.returncode, 0,
+                    f"scripts/{path.name} --help exited {done.returncode}. A help "
+                    f"request is not a failed read and not a missing dependency; "
+                    f"answer it before anything else, or declare the module a "
+                    f"library in LIBRARY_MODULES.\n{done.stdout[-400:]}\n{done.stderr[-400:]}")
+                self.assertTrue(done.stdout.strip(),
+                                f"scripts/{path.name} --help printed nothing; silence "
+                                f"reads as a command that succeeded")
+
+    def test_the_four_named_scripts_answer_help_with_a_usage_page(self) -> None:
+        """The specific ones the review found. `auroc` raised a traceback."""
+        for stem in ("auroc", "verify_attestation_record", "discord_scan_bot", "free_scan"):
+            with self.subTest(script=stem):
+                done = self._help(stem)
+                self.assertEqual(done.returncode, 0, done.stderr[-400:])
+                self.assertNotIn("Traceback", done.stderr)
+                self.assertNotIn("FileNotFoundError", done.stderr)
+
+    def test_library_modules_say_they_are_libraries(self) -> None:
+        """The exemption is a claim about the module, so the module must make
+        it. Otherwise this list is a place to hide a broken command."""
+        for stem in LIBRARY_MODULES:
+            src = (REPO_ROOT / "scripts" / f"{stem}.py").read_text(encoding="utf-8")
+            doc = (ast.get_docstring(ast.parse(src)) or "").lower()
+            with self.subTest(script=stem):
+                self.assertTrue(
+                    "library module" in doc or "single source of truth" in doc
+                    or "not an operator" in doc,
+                    f"scripts/{stem}.py claims a library exemption its docstring "
+                    f"does not state")
+
+    def test_the_library_module_still_says_what_it_is(self) -> None:
+        """`compliance_crosswalk` exited 0 having printed NOTHING, which is the
+        same observable as a command that ran and had no work to do."""
+        done = self._help("compliance_crosswalk")
+        self.assertEqual(done.returncode, 0)
+        self.assertIn("library module", done.stdout.lower())
+        self.assertIn("compliance_report", done.stdout)
 
 
 # --------------------------------------------------------------------------

--- a/testing/test_release_is_gated_on_the_wheel.py
+++ b/testing/test_release_is_gated_on_the_wheel.py
@@ -1,0 +1,182 @@
+"""A release must not publish a wheel nothing tested, and calibration must run.
+
+Fourth external review, 2026-09-08 (R4-16). `publish` depended on `build` and
+on nothing else. The workflow built distributions, wrote and attested a
+provenance statement, and uploaded -- so it established WHO built the artifact
+and that it corresponds to the tagged source, and nothing about whether the
+artifact works. CI is a separate push/PR workflow whose install check runs
+inside the checkout, where `import protocol_tests` can resolve to the source
+tree rather than to the installed wheel; a wheel that ships nothing at all can
+pass a check performed next to the sources.
+
+Actions cannot run here, so these are static assertions on the workflow text,
+in the style of `TestTheWorkflowWiring` in test_release_provenance.py. Each one
+names the property it is standing in for:
+
+    publish is unreachable unless the wheel was tested   `needs`
+    the test ran outside the checkout                    `cd "$RUNNER_TEMP"`
+    the R3-01 reproduction is in the release path        closed-port assertion
+    the pinned calibration cannot skip quietly           junit `<skipped` gate
+    fork PRs stay read-only                              permissions
+
+A workflow assertion is weaker than an execution. It is what is available for a
+job that fires on `release: published`, and the alternative -- asserting
+nothing -- is how this dependency edge went missing in the first place.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+PUBLISH = REPO / ".github" / "workflows" / "publish-pypi.yml"
+CI = REPO / ".github" / "workflows" / "ci.yml"
+
+
+def _load(path: Path) -> dict:
+    try:
+        import yaml
+    except ImportError:  # pragma: no cover - environment dependent
+        raise unittest.SkipTest("pyyaml not installed")
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _steps(job: dict) -> list[dict]:
+    return job.get("steps", [])
+
+
+def _runs(job: dict) -> str:
+    return "\n".join(s.get("run") or "" for s in _steps(job))
+
+
+class TestPublishIsGatedOnTestingTheWheel(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.doc = _load(PUBLISH)
+        cls.jobs = cls.doc["jobs"]
+
+    def test_a_wheel_test_job_exists(self):
+        self.assertIn("test-wheel", self.jobs,
+                      "no job tests the built wheel; publish would gate on nothing")
+
+    def test_publish_needs_the_wheel_test(self):
+        """The edge itself. Without it the job can exist and never run."""
+        needs = self.jobs["publish"]["needs"]
+        needs = [needs] if isinstance(needs, str) else list(needs)
+        self.assertIn("test-wheel", needs,
+                      f"publish needs {needs}; a failing wheel test would not stop "
+                      f"the upload")
+        self.assertIn("build", needs)
+
+    def test_the_wheel_test_consumes_the_built_artifact_not_a_fresh_build(self):
+        """Testing a rebuild tests a different file than the one published."""
+        job = self.jobs["test-wheel"]
+        downloads = [s for s in _steps(job)
+                     if "download-artifact" in (s.get("uses") or "")]
+        self.assertTrue(downloads, "test-wheel builds or invents its own wheel")
+        self.assertEqual(downloads[0]["with"]["name"], "dist")
+        self.assertNotIn("python -m build", _runs(job),
+                         "test-wheel rebuilds instead of testing what publish uploads")
+
+    def test_the_wheel_is_installed_and_run_outside_the_checkout(self):
+        """Source shadowing is the reason the CI smoke check proves less than
+        it looks like it proves."""
+        runs = _runs(self.jobs["test-wheel"])
+        self.assertIn('cd "$RUNNER_TEMP"', runs,
+                      "every step must leave the checkout before importing")
+        self.assertIn("python -m venv", runs, "a fresh interpreter, not the runner's")
+        self.assertIn("site-packages", runs,
+                      "nothing asserts the import resolved to the installed wheel")
+
+    def test_the_smoke_commands_are_the_documented_entry_points(self):
+        runs = _runs(self.jobs["test-wheel"])
+        for command in ("agent-security --version",
+                        "protocol_tests.mock_mcp_server --help"):
+            with self.subTest(command=command):
+                self.assertIn(command, runs)
+
+    def test_the_closed_port_reproduction_is_in_the_release_path(self):
+        """R3-01: installed 4.21.0 reported 17/17 PASS against a dead port. The
+        reproduction is a release gate now, not a story in a changelog."""
+        runs = _runs(self.jobs["test-wheel"])
+        self.assertIn("http://127.0.0.1:9", runs, "no closed-port run")
+        self.assertIn("test ap2", runs, "the reproduction names no payment harness")
+        self.assertIn("PASS against a port nothing listens on", runs,
+                      "the closed-port run does not assert anything about passes")
+        self.assertIn("unmeasured, not clean", runs,
+                      "a run that produced no verdicts would read as zero passes")
+
+    def test_packaged_behaviour_tests_run_against_the_installed_copy(self):
+        runs = _runs(self.jobs["test-wheel"])
+        self.assertIn("pytest", runs, "no test suite runs against the wheel")
+        self.assertIn("tests/test_registry_schema_validity_is_enforced.py", runs)
+        named = [line.strip().rstrip(" \\")
+                 for line in runs.splitlines() if line.strip().startswith("tests/")]
+        self.assertGreaterEqual(len(named), 5,
+                                f"only {len(named)} packaged test file(s) run from the wheel")
+        for rel in named:
+            with self.subTest(test=rel):
+                self.assertTrue((REPO / rel).is_file(), f"{rel} does not exist")
+
+    def test_the_wheel_test_job_does_not_widen_permissions(self):
+        self.assertEqual(self.jobs["test-wheel"].get("permissions"),
+                         {"contents": "read"})
+
+
+class TestTheCalibrationIsRequiredNotOptional(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.doc = _load(CI)
+        cls.jobs = cls.doc["jobs"]
+
+    def test_a_calibration_job_exists(self):
+        self.assertIn("mcp-reference-calibration", self.jobs)
+
+    def test_it_populates_the_cache_with_the_pin_the_script_declares(self):
+        """A pin typed into the workflow drifts from the pin in the script."""
+        runs = _runs(self.jobs["mcp-reference-calibration"])
+        self.assertIn("from scripts.mcp_reference_calibration import REFERENCE_SERVER", runs,
+                      "the workflow hard-codes a version instead of reading the pin")
+        self.assertIn("npx -y -p", runs, "nothing populates the npm cache")
+
+    def test_the_pin_is_still_a_fixed_version_in_the_script(self):
+        import sys
+        sys.path.insert(0, str(REPO / "scripts"))
+        from mcp_reference_calibration import REFERENCE_SERVER
+        self.assertRegex(REFERENCE_SERVER, r"^@modelcontextprotocol/server-everything@\d{4}\.\d{1,2}\.\d{1,2}$")
+
+    def test_a_skip_fails_the_job(self):
+        """The whole finding: the calibration skips when the package is not
+        cached, and a skip reads green. Unmeasured is not clean."""
+        runs = _runs(self.jobs["mcp-reference-calibration"])
+        self.assertIn("--junitxml", runs, "nothing records what actually ran")
+        self.assertIn("<skipped", runs, "nothing inspects the run for skips")
+        self.assertIn("UNMEASURED", runs.upper())
+        self.assertIn("testing/test_mcp_reference_calibration.py", runs)
+
+    def test_the_job_asserts_a_floor_on_testcases_run(self):
+        """A junit file with no testcases contains no `<skipped` either."""
+        self.assertIn("<testcase ", _runs(self.jobs["mcp-reference-calibration"]))
+
+    def test_pull_request_jobs_stay_read_only(self):
+        self.assertEqual(self.doc.get("permissions"), {"contents": "read"})
+        for name, job in self.jobs.items():
+            with self.subTest(job=name):
+                perms = job.get("permissions")
+                if perms is not None:
+                    self.assertEqual(perms, {"contents": "read"})
+
+    def test_the_test_job_installs_what_the_contract_tests_need(self):
+        """`pytest.importorskip` turns a missing optional dependency into a
+        silent pass, and the registry contract tests are behind two of them."""
+        runs = _runs(self.jobs["test"])
+        for dep in ("cryptography", "jsonschema"):
+            with self.subTest(dependency=dep):
+                self.assertIn(dep, runs,
+                              f"{dep} is not installed in CI, so every test behind "
+                              f"importorskip({dep!r}) skips and reads as green")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/testing/test_telemetry_three_state.py
+++ b/testing/test_telemetry_three_state.py
@@ -35,9 +35,12 @@ if str(REPO) not in sys.path:
 import protocol_tests.telemetry as tel  # noqa: E402
 import protocol_tests.cli as cli  # noqa: E402
 
-#: The exact flat payload docs/PRIVACY.md promises. There is no JSON schema for
-#: telemetry; this key set is the schema, and PRIVACY.md is its consumer.
-PAYLOAD_KEYS = {"v", "module", "tests", "passed", "failed", "inconclusive", "os", "py", "ts"}
+#: The exact flat payloads docs/PRIVACY.md promises. There is no JSON schema for
+#: telemetry; these key sets are the schema, and PRIVACY.md is its consumer.
+#: Two shapes (R4-12): counts present, or counts absent with a fixed reason.
+PAYLOAD_KEYS = {"v", "module", "counts_available", "tests", "passed", "failed",
+                "inconclusive", "os", "py", "ts"}
+PAYLOAD_KEYS_UNAVAILABLE = {"v", "module", "counts_available", "reason", "os", "py", "ts"}
 
 
 @dataclass
@@ -136,7 +139,8 @@ class VerdictCountsAreExact(unittest.TestCase):
 class LivePathCountsAreThreeState(unittest.TestCase):
     def test_result_list_in_namespace(self):
         c = cli._live_run_counts({"results": mixed_rows_as_objects()})
-        self.assertEqual(c, {"tests": 6, "passed": 2, "failed": 1, "inconclusive": 3})
+        self.assertEqual(c, {"tests": 6, "passed": 2, "failed": 1, "inconclusive": 3,
+                             "counts_available": True})
 
     def test_unittest_style_skipped_is_inconclusive_not_passed(self):
         class TR:
@@ -145,11 +149,57 @@ class LivePathCountsAreThreeState(unittest.TestCase):
             errors = [object(), object()]
             skipped = [object(), object(), object()]
         c = cli._live_run_counts({"_test_result": TR()})
-        self.assertEqual(c, {"tests": 10, "passed": 4, "failed": 3, "inconclusive": 3})
+        self.assertEqual(c, {"tests": 10, "passed": 4, "failed": 3, "inconclusive": 3,
+                             "counts_available": True})
 
-    def test_empty_namespace_claims_nothing(self):
-        self.assertEqual(cli._live_run_counts({}),
-                         {"tests": 0, "passed": 0, "failed": 0, "inconclusive": 0})
+    def test_empty_namespace_and_no_report_is_unavailable_not_zero(self):
+        """R4-12. An installed AP2 run whose report held 17 rows was sent as
+        0/0/0/0. Zero observations and unavailable counts are different
+        states; the event must carry no count at all, with a fixed reason."""
+        c = cli._live_run_counts({})
+        self.assertEqual(c, {"counts_available": False,
+                             "reason": cli.COUNTS_UNAVAILABLE_REASON})
+        for key in ("tests", "passed", "failed", "inconclusive"):
+            self.assertNotIn(key, c, f"{key} present: absence sent as a number")
+        self.assertIn(cli.COUNTS_UNAVAILABLE_REASON, tel.COUNTS_UNAVAILABLE_REASONS)
+
+    def test_a_written_report_is_read_when_the_namespace_is_empty(self):
+        """The CLI already has the report the harness wrote; that is real data."""
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "run.json"
+            path.write_text(json.dumps({"summary": {"total": 6},
+                                        "results": mixed_rows_as_dicts()}))
+            c = cli._live_run_counts({}, report_path=str(path))
+        self.assertEqual(c, {"tests": 6, "passed": 2, "failed": 1, "inconclusive": 3,
+                             "counts_available": True})
+
+    def test_a_missing_or_empty_report_is_unavailable_not_zero(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = Path(tmp) / "never-written.json"
+            self.assertFalse(cli._live_run_counts({}, report_path=str(missing))["counts_available"])
+            empty = Path(tmp) / "empty.json"
+            empty.write_text(json.dumps({"summary": {"total": 0}, "results": []}))
+            self.assertFalse(cli._live_run_counts({}, report_path=str(empty))["counts_available"])
+            junk = Path(tmp) / "junk.json"
+            junk.write_text("{not json")
+            self.assertFalse(cli._live_run_counts({}, report_path=str(junk))["counts_available"])
+
+    def test_namespace_results_win_over_a_report(self):
+        """One run, one answer: the in-memory rows are the primary source."""
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "run.json"
+            path.write_text(json.dumps({"results": [{"test_id": "T", "passed": True}]}))
+            c = cli._live_run_counts({"results": mixed_rows_as_objects()}, report_path=str(path))
+        self.assertEqual(c["tests"], 6)
+
+    def test_the_live_call_site_passes_the_report_path(self):
+        """Source-level: the dispatcher must hand the report path to the
+        counter, or the report branch is dead code and 0/0/0/0 is back."""
+        src = (REPO / "protocol_tests" / "cli.py").read_text(encoding="utf-8")
+        self.assertIn("_live_run_counts(ns, report_path=_report_path_from(filtered_args))", src)
 
 
 class ThePayloadMatchesItsDocumentedShape(unittest.TestCase):
@@ -177,25 +227,63 @@ class ThePayloadMatchesItsDocumentedShape(unittest.TestCase):
     def test_sent_payload_has_exactly_the_documented_keys(self):
         payload = self._sent_payload(module="mcp", tests=6, passed=2, failed=1, inconclusive=3)
         self.assertEqual(set(payload), PAYLOAD_KEYS)
+        self.assertIs(payload["counts_available"], True)
         self.assertEqual((payload["tests"], payload["passed"], payload["failed"],
                           payload["inconclusive"]), (6, 2, 1, 3))
         for key in ("tests", "passed", "failed", "inconclusive"):
             self.assertIsInstance(payload[key], int)
 
+    def test_unavailable_counts_are_omitted_not_zero(self):
+        """R4-12. The event for a run of unknown size carries NO count field.
+        `tests: 0` and `tests` absent are different facts, and the first one
+        was being sent for a 17-row run."""
+        payload = self._sent_payload(module="ap2", counts_available=False,
+                                     reason=cli.COUNTS_UNAVAILABLE_REASON)
+        self.assertEqual(set(payload), PAYLOAD_KEYS_UNAVAILABLE)
+        self.assertIs(payload["counts_available"], False)
+        self.assertEqual(payload["reason"], cli.COUNTS_UNAVAILABLE_REASON)
+        for key in ("tests", "passed", "failed", "inconclusive"):
+            self.assertNotIn(key, payload)
+
+    def test_the_live_counter_output_is_sendable_in_both_states(self):
+        """What `_live_run_counts` returns is exactly what the sender takes."""
+        for state in (cli._live_run_counts({}),
+                      cli._live_run_counts({"results": mixed_rows_as_objects()})):
+            with self.subTest(counts_available=state["counts_available"]):
+                payload = self._sent_payload(module="mcp", **state)
+                self.assertEqual(payload["counts_available"], state["counts_available"])
+
+    def test_the_reason_is_a_closed_vocabulary(self):
+        with self.assertRaises(ValueError):
+            self._sent_payload(module="mcp", counts_available=False, reason="target was slow")
+        with self.assertRaises(ValueError):
+            self._sent_payload(module="mcp", counts_available=False, reason=None)
+
+    def test_available_counts_cannot_be_sent_with_a_count_missing(self):
+        with self.assertRaises(ValueError):
+            self._sent_payload(module="mcp", tests=None, passed=None, failed=None)
+
     def test_inconclusive_defaults_to_zero_for_older_callers(self):
         payload = self._sent_payload(module="mcp", tests=1, passed=1, failed=0)
         self.assertEqual(payload["inconclusive"], 0)
 
-    def test_example_payload_matches_the_shape_and_sums(self):
+    def test_example_payloads_match_both_shapes(self):
         ex = tel.telemetry_payload_example()
         self.assertEqual(set(ex), PAYLOAD_KEYS)
         self.assertEqual(ex["tests"], ex["passed"] + ex["failed"] + ex["inconclusive"])
+        ex2 = tel.telemetry_payload_example_counts_unavailable()
+        self.assertEqual(set(ex2), PAYLOAD_KEYS_UNAVAILABLE)
+        self.assertIn(ex2["reason"], tel.COUNTS_UNAVAILABLE_REASONS)
 
-    def test_privacy_doc_lists_the_inconclusive_field(self):
+    def test_privacy_doc_lists_both_shapes(self):
         doc = (REPO / "docs" / "PRIVACY.md").read_text(encoding="utf-8")
         self.assertIn("| Inconclusive count |", doc)
-        self.assertIn("Nine fields", doc)
+        self.assertIn("| Counts available |", doc)
+        self.assertIn("| Reason |", doc)
+        self.assertIn("Ten fields when the counts are available, seven when they are not", doc)
+        self.assertNotIn("Nine fields", doc)
         self.assertNotIn("Eight fields", doc)
+        self.assertIn(cli.COUNTS_UNAVAILABLE_REASON, doc)
 
 
 class TheDefectCannotBeReintroducedBySource(unittest.TestCase):

--- a/tests/test_registry_schema_validity_is_enforced.py
+++ b/tests/test_registry_schema_validity_is_enforced.py
@@ -1,0 +1,259 @@
+"""A signed record whose report is schema-invalid must not get the claim label.
+
+Fourth external review, 2026-09-08 (R4-11). `scripts/registry_reference_server.py`
+implemented contract 5 step 5 -- "validate `payload.report` against
+`schemas/attestation-report.json`, reject 422" -- as a check that the schema's
+required TOP-LEVEL keys were present. Reproduced against the server on loopback
+before this file existed:
+
+    submission                              HTTP  stored
+    schema-valid report, signed             201   yes
+    empty report                            422   no
+    unknown evidence_class "E9", signed     201   yes   <-- the finding
+    content/hash mismatch                   400   no
+    invalid signature                       400   no
+
+`E9` is a value no version of the evidence-class enum has contained. The record
+was stored, returned on GET, and carried "Tested with Agent Security Harness".
+A signature establishes who sent the bytes. It establishes nothing about
+whether the document conforms, and required-key presence is not conformance.
+
+Two properties are pinned here:
+
+  (a) full schema validation runs before storage, and a schema-invalid report is
+      422 with the validator's own message rather than a stored record;
+  (b) the record states which check actually ran, in `validation_level`, so a
+      consumer on a host without `jsonschema` cannot mistake the weaker answer
+      for the stronger one.
+
+The five rows above are asserted over the wire, not against the validator
+function, because the finding was about what the SERVER stored.
+"""
+import hashlib
+import json
+import sys
+import threading
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO))
+
+from scripts.registry_reference_server import (  # noqa: E402
+    VALIDATION_REQUIRED_KEYS,
+    VALIDATION_SCHEMA,
+    Rejected,
+    build_server,
+    canonical_bytes,
+    load_schema,
+    load_schema_required,
+    schema_errors,
+    validate_and_build,
+)
+
+cryptography = pytest.importorskip("cryptography")
+jsonschema = pytest.importorskip("jsonschema")
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (  # noqa: E402
+    Ed25519PrivateKey,
+)
+from cryptography.hazmat.primitives.serialization import (  # noqa: E402
+    Encoding,
+    PublicFormat,
+)
+
+SCHEMA = load_schema()
+REQUIRED = load_schema_required()
+
+
+def valid_report(**overrides):
+    report = {
+        "schema_version": "1.0.0",
+        "harness_version": "4.21.1",
+        "suite": "mcp",
+        "timestamp": "2026-09-08T12:00:00Z",
+        "summary": {"total": 1, "passed": 0, "failed": 0, "inconclusive": 1},
+        "entries": [{
+            "test_id": "MCP-001",
+            "name": "Tool List Integrity Check",
+            "category": "tool_poisoning",
+            "result": "inconclusive",
+            "severity": "P2-Medium",
+            "scope": {"protocol": "mcp", "layer": "protocol"},
+            "timestamp": "2026-09-08T12:00:00Z",
+        }],
+    }
+    report.update(overrides)
+    return report
+
+
+def signed_envelope(report, *, tamper=None, wrong_signature=False):
+    """A correctly signed v2 envelope. Key generated per call, never stored."""
+    key = Ed25519PrivateKey.generate()
+    pub = key.public_key().public_bytes(
+        Encoding.PEM, PublicFormat.SubjectPublicKeyInfo).decode()
+    payload = {"server_name": "demo-server", "contact": None, "report": report,
+               "published_at": "2026-09-08T12:00:00Z"}
+    raw = canonical_bytes(payload)
+    envelope = {
+        "payload": payload,
+        "envelope_version": "2",
+        "signature": (key.sign(b"a different message") if wrong_signature
+                      else key.sign(raw)).hex(),
+        "verification_hash": hashlib.sha256(raw).hexdigest(),
+        "public_key": pub,
+        "public_key_fingerprint": hashlib.sha256(pub.encode()).hexdigest()[:16],
+    }
+    if tamper is not None:
+        envelope["payload"]["server_name"] = tamper  # after signing: hash no longer matches
+    return envelope
+
+
+@pytest.fixture
+def live_server():
+    httpd = build_server(0)
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    yield f"http://127.0.0.1:{httpd.server_address[1]}"
+    httpd.shutdown()
+    httpd.server_close()
+
+
+def post(base, envelope):
+    req = urllib.request.Request(
+        base, data=json.dumps(envelope).encode(),
+        headers={"Content-Type": "application/json"}, method="POST")
+    try:
+        resp = urllib.request.urlopen(req, timeout=10)
+        return resp.status, json.loads(resp.read())
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read())
+
+
+def fetch(base, registry_id):
+    with urllib.request.urlopen(f"{base}/{registry_id}", timeout=10) as resp:
+        return json.loads(resp.read())
+
+
+# --- the five rows, over the wire -------------------------------------------
+
+def test_a_schema_valid_signed_report_is_201(live_server):
+    status, body = post(live_server, signed_envelope(valid_report()))
+    assert status == 201, body
+    record = fetch(live_server, body["id"])
+    assert record["signature_verifiable"] is True
+    assert record["validation_level"] == VALIDATION_SCHEMA
+
+
+@pytest.mark.parametrize("report,fragment", [
+    (valid_report(evidence_class="E9"), "evidence_class"),
+    (valid_report(schema_version="1.0"), "schema_version"),
+    (valid_report(entries=[{"test_id": "MCP-001", "result": "pass"}]), "entries"),
+    (valid_report(summary={"total": 1, "passed": 1, "failed": 0, "bogus": 1}), "summary"),
+    (valid_report(entries=[dict(valid_report()["entries"][0], result="probably")]), "result"),
+])
+def test_a_schema_invalid_signed_report_is_422_and_is_not_stored(live_server, report, fragment):
+    """The finding: correctly signed, schema-invalid, stored with 201.
+
+    The response must carry the validator's own message, so an operator can see
+    WHICH rule the document broke rather than being told the shape is wrong.
+    """
+    status, body = post(live_server, signed_envelope(report))
+    assert status == 422, body
+    assert fragment in body["error"], body["error"]
+    assert "attestation schema" in body["error"]
+
+
+def test_an_empty_report_is_422(live_server):
+    status, body = post(live_server, signed_envelope({}))
+    assert status == 422, body
+    assert "schema-required keys" in body["error"]
+
+
+def test_a_content_hash_mismatch_is_400(live_server):
+    status, body = post(live_server, signed_envelope(valid_report(), tamper="tampered"))
+    assert status == 400, body
+    assert "canonical payload bytes" in body["error"]
+
+
+def test_an_invalid_signature_is_400(live_server):
+    status, body = post(live_server, signed_envelope(valid_report(), wrong_signature=True))
+    assert status == 400, body
+    assert "signature verification failed" in body["error"]
+
+
+def test_the_unknown_enum_never_reaches_the_store(live_server):
+    """Nothing with an off-enum evidence_class is fetchable afterwards."""
+    envelope = signed_envelope(valid_report(evidence_class="E9"))
+    status, _ = post(live_server, envelope)
+    assert status == 422
+    derived_id = envelope["verification_hash"][:12]
+    with pytest.raises(urllib.error.HTTPError) as exc:
+        urllib.request.urlopen(f"{live_server}/{derived_id}", timeout=10)
+    assert exc.value.code == 404
+
+
+# --- the level is stated, not implied ---------------------------------------
+
+def test_the_record_says_which_check_ran():
+    with_schema = validate_and_build(signed_envelope(valid_report()), REQUIRED, schema=SCHEMA)
+    assert with_schema["validation_level"] == VALIDATION_SCHEMA
+    assert "attestation-report.json" in with_schema["validation_level_basis"]
+
+    # A host with no jsonschema: the weaker answer, said out loud.
+    without = validate_and_build(signed_envelope(valid_report()), REQUIRED)
+    assert without["validation_level"] == VALIDATION_REQUIRED_KEYS
+    assert "NOT report conformance" in without["validation_level_basis"]
+
+
+def test_the_two_levels_are_distinguishable_and_not_the_same_string():
+    assert VALIDATION_SCHEMA != VALIDATION_REQUIRED_KEYS
+
+
+def test_the_validator_distinguishes_did_not_run_from_found_nothing():
+    """`None` (no validator here) and `[]` (validated clean) are different
+    answers. Collapsing them is R4-11 one level down."""
+    assert schema_errors(valid_report(), SCHEMA) == []
+    assert schema_errors(valid_report(evidence_class="E9"), SCHEMA)
+
+
+def test_an_anyof_failure_names_the_rule_not_the_whole_document():
+    """`producer` OR `harness_version` is an anyOf, and jsonschema's own message
+    for a failed anyOf is the entire instance echoed back -- which tells a
+    submitter nothing. The sub-errors name the rules; those are what is sent."""
+    report = valid_report()
+    del report["harness_version"]
+    errors = schema_errors(report, SCHEMA)
+    assert errors, "the report is invalid; the validator must say so"
+    joined = " ".join(errors)
+    assert "does not match any allowed form" in joined
+    assert "'producer' is a required property" in joined
+    assert "'harness_version' is a required property" in joined
+    assert "MCP-001" not in joined, "the whole instance was echoed back as the message"
+
+
+def test_required_keys_alone_would_have_accepted_the_unknown_enum():
+    """Anti-vacuity: the old rule is exercised here and shown to be weaker.
+
+    Without this, a test that the new rule rejects E9 proves nothing about
+    what changed -- it could have been rejected by the required-key check all
+    along, and the review's 201 would be unexplained.
+    """
+    report = valid_report(evidence_class="E9")
+    assert all(k in report for k in REQUIRED)
+    record = validate_and_build(signed_envelope(report), REQUIRED)  # no schema
+    assert record["evidence_class"] == "E9"
+    assert record["validation_level"] == VALIDATION_REQUIRED_KEYS
+    with pytest.raises(Rejected) as exc:
+        validate_and_build(signed_envelope(report), REQUIRED, schema=SCHEMA)
+    assert exc.value.status == 422
+
+
+def test_the_server_validates_against_the_shipped_schema_not_a_fork():
+    """The schema the handler validates against is the one the package ships."""
+    import scripts.registry_reference_server as srv
+    assert Path(srv.SCHEMA_PATH).is_file()
+    assert load_schema()["$id"].endswith("/schemas/attestation-report.json")

--- a/tests/test_registry_server_contract.py
+++ b/tests/test_registry_server_contract.py
@@ -46,13 +46,30 @@ REQUIRED = load_schema_required()
 
 
 def _report():
+    """A report that validates against schemas/attestation-report.json in full.
+
+    It did not, until 2026-09-08: `schema_version: "1.0"` (the schema pins the
+    const "1.0.0") and an entry of `{"id": ..., "result": ...}` missing five
+    required fields. The wire tests still passed, because the server checked
+    only that the schema's required TOP-LEVEL keys were present (R4-11). A
+    fixture that cannot pass the check the contract asks for cannot demonstrate
+    that the check runs.
+    """
     return {
-        "schema_version": "1.0",
+        "schema_version": "1.0.0",
         "harness_version": "4.15.0",
         "suite": "mcp",
         "timestamp": "2026-08-14T12:00:00Z",
         "summary": {"total": 1, "passed": 1, "failed": 0},
-        "entries": [{"id": "MCP-001", "result": "pass"}],
+        "entries": [{
+            "test_id": "MCP-001",
+            "name": "Tool List Integrity Check",
+            "category": "tool_poisoning",
+            "result": "pass",
+            "severity": "P2-Medium",
+            "scope": {"protocol": "mcp", "layer": "protocol"},
+            "timestamp": "2026-08-14T12:00:00Z",
+        }],
     }
 
 

--- a/tests/test_report_states_its_provenance.py
+++ b/tests/test_report_states_its_provenance.py
@@ -301,7 +301,8 @@ def test_a_bearer_header_does_not_reach_the_document():
     # Separated form was caught by accident (partition at the right `=`);
     # pinned so the URL parser, not the accident, is what holds it.
     (["p", "--url", "http://127.0.0.1:9/?token=" + CANARY], CANARY),
-    # Names the auth regex does not know. Only an allowlist catches these.
+    # Names the auth regex does not know. These were the case for the query
+    # allowlist; the authority-only rule (R4-09) covers them positionally.
     (["p", "--url", "http://127.0.0.1:9/?sig=" + CANARY], CANARY),
     (["p", "--url=http://127.0.0.1:9/?k=" + CANARY], CANARY),
     (["p", "--url=http://127.0.0.1:9/?transport=sse&code=" + CANARY], CANARY),
@@ -319,44 +320,101 @@ def test_ordinary_arguments_survive_intact():
     """Over-redaction that eats the command is its own failure.
 
     A provenance record that cannot say which model or which target was used
-    has replaced one unverifiable claim with another.
+    has replaced one unverifiable claim with another. Under the URL contract
+    (R4-09) the target is `scheme://host:port`; the path is not part of it.
     """
     out, redacted = redact_argv(
         ["p", "test", "agent-data-injection", "--model", "qwen3.5:latest",
          "--trials", "3", "--url", "http://localhost:8080/mcp"])
     assert out == ["p", "test", "agent-data-injection", "--model",
                    "qwen3.5:latest", "--trials", "3", "--url",
-                   "http://localhost:8080/mcp"]
-    assert redacted is False
-
-
-def test_the_rest_of_the_url_survives_query_redaction():
-    """Reproducibility: scheme, host, port, path and allowlisted selectors
-    are kept byte-for-byte; only the unallowlisted VALUE is replaced."""
-    out, redacted = redact_argv(
-        ["p", "--url=http://127.0.0.1:9/mcp?transport=sse&api_key" + "=" + CANARY])
-    assert out == ["p", "--url=http://127.0.0.1:9/mcp?transport=sse&api_key=[REDACTED]"]
+                   "http://localhost:8080/[REDACTED]"]
+    # A component was removed, so the flag is true. It is not a claim that a
+    # credential was found -- `not_claimed` says exactly that.
     assert redacted is True
 
 
-def test_allowlisted_query_selectors_do_not_set_the_flag():
-    """`?transport=sse` is a protocol selector, not a secret. Replacing it
-    would both lose the reproduction and make `argv_redacted` mean nothing."""
+def test_the_url_authority_survives_and_nothing_else_does():
+    """Reproducibility needs what was contacted, not what was asked for.
+
+    Scheme, host and port are kept byte-for-byte; path, query and fragment are
+    each replaced whole. The previous contract kept the path as sent and
+    replaced query/fragment values by parameter NAME, which four shapes walked
+    through (R4-09).
+    """
     out, redacted = redact_argv(
-        ["p", "--url", "http://localhost:8080/mcp?transport=sse&version=2"])
-    assert out == ["p", "--url", "http://localhost:8080/mcp?transport=sse&version=2"]
-    assert redacted is False
+        ["p", "--url=http://127.0.0.1:9/mcp?transport=sse&api_key" + "=" + CANARY])
+    assert out == ["p", "--url=http://127.0.0.1:9/[REDACTED]?[REDACTED]"]
+    assert redacted is True
 
 
-def test_the_query_allowlist_is_stated_in_not_claimed():
-    """A reader of the published block must be able to tell a [REDACTED]
-    query value from a credential without reading this module."""
-    from protocol_tests.run_provenance import _QUERY_PARAM_ALLOWLIST
+@pytest.mark.parametrize("argv,expect", [
+    # A token as a PATH segment. The allowlist never looked here.
+    (["p", "--url", "http://127.0.0.1:9/v1/" + CANARY + "/run"],
+     ["p", "--url", "http://127.0.0.1:9/[REDACTED]"]),
+    # A token as the FRAGMENT with no `name=` to split on.
+    (["p", "--url=http://127.0.0.1:9/cb#" + CANARY],
+     ["p", "--url=http://127.0.0.1:9/[REDACTED]#[REDACTED]"]),
+    # A bare query token: no `=`, so the name/value split found nothing.
+    (["p", "--url", "http://127.0.0.1:9/?" + CANARY],
+     ["p", "--url", "http://127.0.0.1:9/?[REDACTED]"]),
+    # A token under an ALLOWLISTED name. An allowlist of names cannot prove an
+    # allowed value is nonsecret; this is the shape that retired the allowlist.
+    (["p", "--url=http://127.0.0.1:9/?format=" + CANARY],
+     ["p", "--url=http://127.0.0.1:9/?[REDACTED]"]),
+])
+def test_the_four_opaque_url_shapes_do_not_survive(argv, expect):
+    """R4-09, one case per shape the fourth external review walked through."""
+    out, redacted = redact_argv(argv)
+    assert CANARY not in " ".join(out), out
+    assert out == expect
+    assert redacted is True
+
+
+def test_the_authority_is_kept_so_the_run_is_still_locatable():
+    """The other half of the contract: over-redaction that removes the target
+    is a different failure, not a safer one."""
+    out, _ = redact_argv(["p", "--url", "https://target.example:8443/v1/x?y=1#z"])
+    assert out == ["p", "--url", "https://target.example:8443/[REDACTED]?[REDACTED]#[REDACTED]"]
+    assert "target.example:8443" in out[2]
+
+
+def test_a_url_with_no_path_query_or_fragment_is_untouched():
+    """Nothing was removed, so nothing is claimed to have been."""
+    for url in ("http://127.0.0.1:9", "http://127.0.0.1:9/", "https://host.example"):
+        out, redacted = redact_argv(["p", "--url", url])
+        assert out == ["p", "--url", url]
+        assert redacted is False
+
+
+def test_userinfo_is_still_removed_when_the_path_is_too():
+    """Splitting before the userinfo substitution matters: replacing it first
+    puts brackets in the netloc, `urlsplit` raises 'invalid IPv6 URL', and the
+    old order returned early on exactly the arguments carrying a credential."""
+    out, redacted = redact_argv(
+        ["p", "--url", "https://alice:" + FAKE_PASSWORD + "@host.example/mcp"])
+    assert out == ["p", "--url", "https://[REDACTED]@host.example/[REDACTED]"]
+    assert FAKE_PASSWORD not in " ".join(out)
+    assert redacted is True
+
+
+def test_an_ipv6_authority_survives_intact():
+    out, _ = redact_argv(["p", "--url", "http://[::1]:8080/mcp"])
+    assert out == ["p", "--url", "http://[::1]:8080/[REDACTED]"]
+
+
+def test_the_url_contract_is_stated_in_not_claimed():
+    """A reader of the published block must be able to tell a [REDACTED] URL
+    component from a credential -- and must not be told that no hostname is
+    recorded while a hostname sits in argv beside the sentence (R4-09)."""
+    from protocol_tests.run_provenance import URL_REPLACED, URL_RETAINED
     with mock.patch.object(sys, "argv", ["p"]):
         text = " ".join(run_provenance()["not_claimed"])
-    for name in _QUERY_PARAM_ALLOWLIST:
-        assert name in text, name
-    assert "not evidence that a credential was there" in text
+    assert URL_RETAINED in text and URL_REPLACED in text
+    assert "HOSTNAME IS recorded" in text
+    assert "never that a credential was found" in text
+    # The contradiction the review named: the old sentence promised this.
+    assert "No hostname" not in text
 
 
 def test_help_is_not_treated_as_a_header_flag():
@@ -712,10 +770,22 @@ def test_no_absolute_path_survives_into_the_publication_copy(argv):
     assert "run.json" in published
 
 
-def test_innocent_arguments_are_not_redacted():
-    """Over-redaction hides what was run; the flag must mean 'a secret was here'."""
-    out, redacted = redact_argv(["p", "--url", "http://localhost:8080/mcp",
-                                 "--trials", "5", "--report", "/home/alice/out.json"])
-    assert redacted is False, out
-    assert out == ["p", "--url", "http://localhost:8080/mcp", "--trials", "5",
+def test_innocent_arguments_are_not_eaten():
+    """Over-redaction hides what was run.
+
+    Everything outside a URL and outside an absolute path survives verbatim;
+    the URL keeps its authority; the absolute path keeps its basename.
+    """
+    out, _ = redact_argv(["p", "--url", "http://localhost:8080/mcp",
+                          "--trials", "5", "--report", "/home/alice/out.json"])
+    assert out == ["p", "--url", "http://localhost:8080/[REDACTED]", "--trials", "5",
                    "--report", "out.json"], out
+
+
+def test_a_run_with_no_url_still_sets_no_flag():
+    """The flag must not become universally true: without a URL and without a
+    credential, nothing was replaced."""
+    out, redacted = redact_argv(["p", "test", "mcp", "--trials", "5",
+                                 "--report", "/home/alice/out.json"])
+    assert redacted is False, out
+    assert out == ["p", "test", "mcp", "--trials", "5", "--report", "out.json"]


### PR DESCRIPTION
From the fourth external review, six Mediums — the contract layer around the harness.

**R4-16.** `publish-pypi.yml` had `publish: needs: build`: nothing installed the built wheel or ran a test against it before upload, and ci.yml's install check ran inside the checkout where source shadowing hides a packaging defect. New `test-wheel` job between them (`publish: needs: [build, test-wheel]`) that downloads the `dist` artifact rather than rebuilding, `cd $RUNNER_TEMP`, fresh venv, asserts `protocol_tests`/`scripts` resolve under `site-packages`, runs `--version`, the shipped mock, the registry server, **the R3-01 closed-port reproduction** (fails on any pass and on zero verdicts), then pytest over nine packaged test files. ci.yml gains a required `mcp-reference-calibration` job that reads the pin from the script, populates the npm cache, proves an offline `initialize`, and fails on any `&lt;skipped` in the junit XML — a skip can no longer read as a pass. CI also installs `cryptography` and `jsonschema` so the registry contract tests cannot `importorskip` into green.

**R4-13.** `_modules_with_own_record` was a `"def _record" in text` rule; `def  _record` (two spaces) evaded it. Now an AST walk cross-checked against `asi_inventory.recording_facts()`, with seeds for two-spaces / tab / async / decorated / nested and negative seeds for call sites, comments and strings.

**R4-12.** Live telemetry sent `0/0/0/0` for a run whose report had 17 rows. Now: counts read from the written report when one was requested (`{'tests': 17, 'passed': 0, 'inconclusive': 17, 'counts_available': True}`), otherwise `{'counts_available': False, 'reason': 'results_not_exposed_and_no_report_written'}` with the count fields omitted from the wire payload. Zero observations and unavailable counts are now different states.

**R4-11.** A correctly-signed record with an unknown `evidence_class` was stored with 201. Now full JSON Schema validation before storage (422 on failure) and `validation_level` in the stored record. The contract already required this at §5 step 5 — and the reason the wire tests never caught it is that **`tests/test_registry_server_contract.py`'s own fixture was schema-invalid**, so it could not tell validation from its absence. Fixed.

**R4-09.** Path segments, fragments, bare query tokens and values under allowlisted names all survived the publication stripper, while the provenance block claimed no hostname was recorded. The contract is now explicit and enforced: `scheme://host:port` is kept, path / query / fragment are each `[REDACTED]`, and `not_claimed` says the hostname *is* recorded. Found while doing it: `_strip_url_userinfo` ran before `urlsplit`, which then raised "invalid IPv6 URL" and returned early, so `https://user:pass@host/mcp` kept its path.

**R4-15.** `python -m scripts.auroc --help` raised `FileNotFoundError: '--help'`. All 29 shipped scripts now exit 0 on `--help`; the quickstart and two other docs use `python -m scripts.…`; `compliance_crosswalk` declares itself a library; `generate_test_catalog --check` and `monthly_security_report` exit 2 with the one-line checkout-only message, exercised from a non-checkout root rather than asserted from source. The ratchet gained a derived `--help` contract and a `LIBRARY_MODULES` list whose entries must say so in their own docstrings.

Independently reproduced in a clean worktree at 1b3672d: `publish` needs `[build, test-wheel]` and `mcp-reference-calibration` is a CI job; all five URL shapes redact clean (including the userinfo case); a live `def  _record` seed **is** seen by the detector (45 vs 44) and the ratchet correctly goes red because the grandfather list grew; 29/29 scripts exit 0 on `--help`; the registry schema-validity suite passes 16/16; telemetry reports `counts_available: False` with a reason rather than zeros.

Injections (agent, diff-confirmed, six): text rule back → 7 fail; path redaction removed → 8 fail; registry `errors = None` → 9 fail; telemetry zeros back → 2 fail; `needs: [build, test-wheel]` → `needs: build` → 1 fail; ci.yml skip gate deleted → 1 fail. Suite 1415 passed / 1397 subtests / 0 failed (baseline 1358).

Noticed, not fixed: `argv_redacted` is now true for almost any run with a URL path (kept, with the semantics documented, because not setting it would weaken the credential-shape tests); `count_tests.py` satisfies the `--help` ratchet by ignoring argv and printing its report; of `tests/` run against the installed wheel, 14 of 30 files need checkout-only resources, which is why the wheel job names nine files rather than the directory — and nothing marks which are which.

🤖 Generated with [Claude Code](https://claude.com/claude-code)