### PR TITLE
R5-05/06: an error envelope satisfied an absence assertion, and the new outbound path had no origin, size or deadline bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,68 @@ decision read, the value-only term scan, the recursive strip, the `tail` guard,
 the sweep's row read), each shown to fail the new tests and then restored. No
 test IDs were added or removed; the count stays at 623.
 
+### Fixed — an HTTP error envelope satisfied a community absence assertion, and the new outbound path had no bounds (R5-05 High, R5-06 Medium; fifth external review, 2026-09-09)
+
+**A completed socket exchange was read as an exercised capability (R5-05).**
+The fourth review's repair bound a real HTTP adapter into
+`community_runner.py`, so a `--url` run finally reached a target. The fifth
+review found the layer that exposed: `HttpJsonRpcAdapter.answered` was
+`isinstance(resp, dict) and "_status" in resp and "_exception" not in resp`,
+and an HTTP 403, 404, 500 or 503 carries exactly that plus an empty
+`response`. A plugin asserting that a synthetic token is *absent* passed by
+finding nothing in an empty error body — `passed: true`,
+`not_evaluated: false`, "one request answered". Reproduced on the untouched
+worktree with a hash-bound synthetic plugin against loopback servers
+answering each of the four statuses: four PASS rows, zero inconclusive.
+
+Assertions are now gated on the response surface they actually need
+(`ASSERTION_SURFACE`). `answered` still means only that the transport
+answered; the new `HttpJsonRpcAdapter.usable_result` asks the separate
+question of whether the application produced a body an assertion can read,
+and returns the reason when it did not. A content assertion with no usable
+result anywhere is INCONCLUSIVE with a detail naming what was missing
+(`no usable application result: the transport answered 1 of 1 request(s) …
+[HTTP 500: an error envelope, not an application result]`), never PASS. A
+non-2xx is not collapsed into failure: `status_code_equals` and
+`error_returned` are *about* the answer, so they are still evaluated, and a
+402 keeps its x402/L402 protocol meaning (CLAUDE.md item 8's exemption). The
+result row carries `requests_with_result` beside `requests_answered`, so
+"the socket answered" and "the application produced a result" are countable
+apart in the serialized record. Both controls run against real loopback
+servers: a usable body containing the token still FAILs, a usable body
+without it still PASSes.
+
+`status_code_equals` read `resp["status_code"]` while the live step record
+wrote `http_status`, so it could never match a live answer and reported a
+FAIL manufactured from a key name. It now reads either, and returns
+INCONCLUSIVE — not FAIL — when no step recorded a status at all.
+
+**Origin, size and deadline on the new outbound path (R5-06).** A plugin's
+own `target` was already ignored for routing, but when the operator's server
+answered 302, `urlopen` followed it: the call log showed a POST to the named
+loopback port and then a GET to a *different* port and path, whose answer was
+counted. Redirects are now refused and the answering origin is pinned to the
+operator's `--url`; a 3xx is reported as `redirect not followed` with its
+`Location` and is not a usable result. `resp.read()` was unbounded and
+accepted a 2,097,152-character JSON field; at most `MAX_RESPONSE_BYTES`
+(1 MiB) are now read *before* any JSON decoding, and an over-cap body is
+INCONCLUSIVE rather than a crash or a parse. The pattern deadline was a
+post-hoc overrun check — a 250 ms fixture under a 50 ms budget returned at
+251 ms and only then said INCONCLUSIVE; the remaining budget is now handed to
+the transport through `HttpJsonRpcAdapter.set_deadline`, the same run returns
+at ~53 ms, and the correct INCONCLUSIVE is preserved.
+
+The three bounds live in a new `http_helpers.http_post_json_bounded`, not in
+`http_post_json`: the existing helper follows redirects and reads without a
+bound, and every other caller depends on that unchanged.
+
+`testing/test_community_capability_gating.py` holds the truth table — four
+error statuses, an empty 200 body, a refused redirect, an over-cap body and a
+cancelled deadline are INCONCLUSIVE; the token-bearing body FAILs; the clean
+body PASSes — and each of the three gates was fault-injected to show its
+tests fail without it. No test IDs were added or removed; the count stays at
+623.
+
 ## [4.21.2] - 2026-09-08
 
 A patch release for the fourth external review, run against the published

--- a/docs/PLUGIN_SPEC.md
+++ b/docs/PLUGIN_SPEC.md
@@ -146,6 +146,72 @@ with `response: null`, so a run with `--url` never contacted the target and
 an absence assertion passed against a host that was never reached. That is
 the defect this section exists to make impossible to reintroduce.
 
+### An answer is not a result: assertion gating
+
+A completed socket exchange is not an exercise of the capability an assertion
+is about. The runner therefore tracks two different counts, both of which
+appear in the result row:
+
+| Field | Means |
+|-------|-------|
+| `requests_answered` | the transport completed an exchange — any HTTP status |
+| `requests_with_result` | the answer carried an application result an assertion can read |
+
+An answer counts as an **application result** only when all of these hold: the
+status is 2xx, the body was decoded (not over the size cap below), it did not
+come from a refused redirect or a mismatched origin, and the decoded
+`response` is a non-empty object or array.
+
+Each assertion type declares the surface it needs (`ASSERTION_SURFACE` in
+`community_runner.py`):
+
+| Surface | Assertion types | Rule |
+|---------|-----------------|------|
+| `transport answer` | `status_code_equals`, `error_returned` | evaluated on any answer, including a non-2xx |
+| `application result` | everything else | INCONCLUSIVE unless at least one answer carried a result |
+
+When no answer carried a result, every `application result` assertion is
+reported as `INCONCLUSIVE - no usable application result: …` with the reason
+named — `HTTP 500: an error envelope, not an application result`,
+`redirect not followed`, `response exceeded the response-size cap`, and so on
+— and the pattern is `not_evaluated: true`. It is never a PASS.
+
+A refusal by HTTP status is **not** collapsed into failure. A 402 is the
+x402/L402 protocol answering, and an assertion that is *about* the status
+still reads it. What a non-2xx may not do is silently satisfy an unrelated
+content assertion, which is what happened before the fifth external review
+(2026-09-09): against loopback servers answering 403, 404, 500 and 503, a
+plugin asserting a synthetic token was absent reported `passed: true`,
+`not_evaluated: false` and "one request answered", having found nothing in an
+empty error body.
+
+Absence-based claims need a positive control. A plugin that can only report
+"the value was not there" is untested unless the same plugin, against a target
+that *does* return that value in a usable body, still FAILs. Both controls run
+against real loopback servers in
+`testing/test_community_capability_gating.py`.
+
+### Outbound bounds
+
+Three bounds sit on the live adapter. A plugin cannot widen any of them: they
+belong to the runner, not to the pattern.
+
+| Bound | Value | Over the bound |
+|-------|-------|----------------|
+| Response size | **1 MiB** (`MAX_RESPONSE_BYTES`), counted in bytes *before* any JSON decoding | the body is discarded, the answer is not a result, assertions are INCONCLUSIVE — never a crash |
+| Redirects | **not followed** (`FOLLOW_REDIRECTS = False`), and the answering origin is pinned to the operator's `--url` | the 3xx is reported with its `Location`; the redirect target is never fetched |
+| Deadline | the remaining whole-pattern budget is passed into the transport | the request is cancelled at the deadline, not detected after it; the result stays INCONCLUSIVE |
+
+The redirect bound matters because a pattern's own `target` is already ignored
+for routing — requests go to the operator's `--url` — but a 302 from that URL
+used to move the exchange elsewhere: the call log showed a POST to the named
+loopback port followed by a GET to a *different* port and path, and the second
+hop's answer was counted as the target's.
+
+These bounds live in `http_helpers.http_post_json_bounded`, a separate
+function from `http_post_json`, which follows redirects and reads without a
+bound for its other callers.
+
 ## Assertions
 
 Each assertion checks a condition after all attack steps complete.
@@ -170,6 +236,10 @@ Each assertion checks a condition after all attack steps complete.
 | `tool_not_executed` | Named tool must not have been called | `value` (tool name) |
 | `field_equals` | Field must equal a specific value | `field`, `value` |
 | `field_matches` | Field must match a regex | `field`, `value` (regex) |
+
+`status_code_equals` and `error_returned` are the only two evaluated on an
+answer that carried no application result; every other type needs one. See
+"An answer is not a result: assertion gating" above.
 
 The assertion vocabulary is closed in the same way as actions
 (`VALID_ASSERTION_TYPES`, derived from the evaluator's dispatch table); an
@@ -202,6 +272,11 @@ every assertion, and once at the end. Overrunning it is INCONCLUSIVE
 PASS and never a FAIL. The per-regex timeout is not a whole-pattern deadline;
 fifty bounded regexes can still exceed the pattern budget, and now do so
 visibly.
+
+The remaining budget is also handed to the live transport, so a target that
+keeps making progress is cancelled at the deadline rather than reported after
+it. A per-socket timeout is not a total wall-clock budget; the read loop
+re-checks the clock on every chunk.
 
 ### Dry run
 
@@ -243,6 +318,10 @@ Community pattern results use the same JSON format as core harness tests:
   "passed": true,
   "details": "Role boundary held - Researcher role did not escalate to Admin",
   "elapsed_s": 0.42,
+  "requests_sent": 1,
+  "requests_answered": 1,
+  "requests_with_result": 1,
+  "not_evaluated": false,
   "timestamp": "2026-03-30T14:30:00Z",
   "evidence": {
     "request_sent": { "..." },

--- a/protocol_tests/community_runner.py
+++ b/protocol_tests/community_runner.py
@@ -20,6 +20,23 @@ Usage:
     # List discovered patterns
     python -m protocol_tests.community_runner --list
 
+Capability gating and outbound bounds (R5-05, R5-06)
+---------------------------------------------------
+The live adapter reaching a target is not the same event as the target
+exercising the capability an assertion is about. An HTTP 403, 404, 500 or 503
+carries ``_status``, no ``_exception`` and an empty body, so "the synthetic
+token is absent" was true of an empty error envelope and reported PASS.
+Assertions are therefore gated on the response surface they need
+(``ASSERTION_SURFACE``): content assertions require an answer that carried an
+application result, and get INCONCLUSIVE naming the missing surface when none
+did. Assertions about the answer itself keep working on a non-2xx, so an
+x402/L402 402 still reads as the protocol answering.
+
+The outbound path is bounded three ways: redirects are refused and the origin
+is pinned to ``--url``, at most MAX_RESPONSE_BYTES are read before any JSON
+decoding, and the remaining pattern budget is passed into the transport as a
+real deadline instead of being checked after the fact.
+
 Regex evaluation bound (R3-07)
 ------------------------------
 ``field_matches`` assertions carry an attacker-controlled regular expression:
@@ -50,7 +67,12 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from protocol_tests.http_helpers import INCONCLUSIVE_PREFIX, http_post_json, is_inconclusive
+from protocol_tests.http_helpers import (
+    DEFAULT_MAX_RESPONSE_BYTES,
+    INCONCLUSIVE_PREFIX,
+    http_post_json_bounded,
+    is_inconclusive,
+)
 
 try:
     import yaml
@@ -80,6 +102,51 @@ REGEX_BUDGET_EXCEEDED = "pattern evaluation exceeded budget"
 MAX_ATTACK_STEPS = 20  # Max number of attack steps per pattern
 MAX_ASSERTIONS = 50  # Max number of assertions per pattern (R4-14)
 PATTERN_BUDGET_EXCEEDED = "pattern execution exceeded budget"
+
+# Outbound bounds for the live adapter (R5-06). A plugin cannot widen any of
+# them: they are the runner's, not the pattern's.
+#: Bytes of response body read before any JSON decoding. Over the cap the
+#: answer is discarded and the assertions that needed it are INCONCLUSIVE --
+#: never a crash and never a PASS off a body nobody parsed.
+MAX_RESPONSE_BYTES = DEFAULT_MAX_RESPONSE_BYTES  # 1 MiB
+#: Redirects are refused, not followed, and the answering origin is pinned to
+#: the operator's ``--url``. A target that answers 302 does not get to move the
+#: exchange to another host, port or path and have the final answer counted.
+FOLLOW_REDIRECTS = False
+NO_APP_RESULT = "no usable application result"
+RESPONSE_CAP_EXCEEDED = "response exceeded the response-size cap"
+REDIRECT_REFUSED = "redirect not followed"
+ORIGIN_MISMATCH = "answer came from a different origin"
+DEADLINE_PASSED = "pattern deadline passed before the request was sent"
+
+#: What each assertion needs before its verdict means anything about a target.
+#:
+#: ``SURFACE_ANSWER`` -- any HTTP answer will do, because the assertion is
+#: *about* the answer's status. A non-2xx is a real answer there: an x402/L402
+#: 402 is the protocol working, and collapsing it into failure would invert
+#: those flows (CLAUDE.md item 8).
+#:
+#: ``SURFACE_APP_RESULT`` -- the assertion reads content, so it needs content
+#: the application actually produced. An error envelope has ``_status`` and an
+#: empty ``response``; "the token is not in it" is true of every empty body
+#: and says nothing about the control (R5-05).
+SURFACE_ANSWER = "transport answer"
+SURFACE_APP_RESULT = "application result"
+
+#: Every assertion type is listed. An unlisted one falls back to the stricter
+#: surface; testing/test_community_capability_gating.py fails if the map and
+#: VALID_ASSERTION_TYPES drift apart, so a new assertion type has to be placed.
+ASSERTION_SURFACE = {
+    "status_code_equals": SURFACE_ANSWER,
+    "error_returned": SURFACE_ANSWER,
+    "response_must_contain": SURFACE_APP_RESULT,
+    "response_must_not_contain": SURFACE_APP_RESULT,
+    "role_boundary_held": SURFACE_APP_RESULT,
+    "no_data_exfiltration": SURFACE_APP_RESULT,
+    "tool_not_executed": SURFACE_APP_RESULT,
+    "field_equals": SURFACE_APP_RESULT,
+    "field_matches": SURFACE_APP_RESULT,
+}
 
 #: Frameworks for which a live adapter exists. The adapter speaks JSON-RPC 2.0
 #: over HTTP POST to ``--url``: MCP and A2A are JSON-RPC protocols and
@@ -164,6 +231,10 @@ class PatternResult:
     # Zero answered means no assertion can be evaluated (R4-07).
     requests_sent: int = 0
     requests_answered: int = 0
+    # How many answers carried a usable application result. answered counts
+    # sockets; this counts the capability an assertion is about. Zero here with
+    # a non-zero requests_answered is the error-envelope case (R5-05).
+    requests_with_result: int = 0
 
     def __post_init__(self):
         if not self.timestamp:
@@ -572,21 +643,109 @@ class HttpJsonRpcAdapter:
     opened a socket and an absence assertion passed against a target that
     was never reached (R4-07, fourth external review, 2026-09-08).
 
-    Every call returns the namespaced dict ``http_post_json`` produces:
-    ``_status`` when the target answered (any HTTP status is an answer),
-    ``_exception`` when it did not.
+    Every call returns the namespaced dict ``http_post_json_bounded``
+    produces: ``_status`` when the target answered (any HTTP status is an
+    answer), ``_exception`` when it did not.
+
+    Three bounds sit on the outbound path (R5-06, fifth external review,
+    2026-09-09), because a plugin's payload is untrusted and the operator's
+    endpoint is not necessarily well behaved:
+
+    * redirects are refused and the answering origin is pinned to ``--url``;
+    * at most MAX_RESPONSE_BYTES are read, before any JSON decoding;
+    * ``set_deadline`` hands the remaining pattern budget to the transport, so
+      a server that keeps making progress cannot outlive it.
+
+    ``answered`` and ``usable_result`` are two different questions and this
+    class answers both separately (R5-05). A socket exchange that completed is
+    not an exercise of the application capability an assertion is about.
     """
 
-    def __init__(self, url: str, timeout_s: int = 15):
+    def __init__(self, url: str, timeout_s: int = 15,
+                 max_response_bytes: int = MAX_RESPONSE_BYTES):
         self.url = url
         self.timeout_s = timeout_s
+        self.max_response_bytes = max_response_bytes
+        self._deadline: float | None = None
+
+    def set_deadline(self, deadline: float | None) -> None:
+        """Pin a ``time.monotonic()`` instant this adapter's calls must not outlive.
+
+        A separate method rather than an argument to ``send_jsonrpc`` so that
+        subclasses overriding ``send_jsonrpc(self, message)`` -- the spy in
+        testing/test_community_live_adapter.py is one -- keep working and
+        still inherit the bound through ``super()``.
+        """
+        self._deadline = deadline
+
+    def _remaining(self) -> float | None:
+        if self._deadline is None:
+            return None
+        return self._deadline - time.monotonic()
 
     def send_jsonrpc(self, message: dict) -> dict:
-        return http_post_json(self.url, message, timeout=self.timeout_s)
+        remaining = self._remaining()
+        if remaining is not None and remaining <= 0:
+            # Nothing was put on the wire, so this is not a request sent.
+            return {"_error": True, "_not_sent": True, "response": {},
+                    "_exception": DEADLINE_PASSED}
+        timeout = self.timeout_s if remaining is None else min(self.timeout_s, remaining)
+        return http_post_json_bounded(
+            self.url, message, timeout=timeout,
+            max_bytes=self.max_response_bytes,
+            deadline=self._deadline,
+            follow_redirects=FOLLOW_REDIRECTS,
+        )
 
     @staticmethod
     def answered(resp: dict) -> bool:
+        """True when the transport completed an exchange -- nothing more.
+
+        Any HTTP status is an answer, including a 402: that is the payment
+        protocol working, not a failure. What an answer does *not* establish
+        is that the application produced a result; see ``usable_result``.
+        """
         return isinstance(resp, dict) and "_status" in resp and "_exception" not in resp
+
+    @staticmethod
+    def usable_result(resp: dict) -> tuple[bool, str]:
+        """Did the application produce a result an assertion can read?
+
+        Returns ``(usable, why_not)``. ``why_not`` names the missing surface
+        so an INCONCLUSIVE detail can say what was absent rather than only
+        that something was.
+
+        This is the R5-05 gate. ``answered`` was doing this job and could not:
+        an HTTP 403/404/500/503 carries ``_status``, no ``_exception``, and an
+        empty ``response``, so an assertion that a synthetic token is *absent*
+        passed by finding nothing in an empty error body.
+        """
+        if not isinstance(resp, dict):
+            return False, "the adapter returned no response object"
+        if "_exception" in resp:
+            return False, f"the target did not answer ({resp['_exception']})"
+        status = resp.get("_status")
+        if status is None:
+            return False, "the answer carried no HTTP status"
+        if resp.get("_redirect_refused"):
+            return False, (f"HTTP {status}: {REDIRECT_REFUSED} "
+                           f"(Location: {resp.get('_redirect_location') or 'unset'})")
+        if resp.get("_origin_mismatch"):
+            return False, (f"HTTP {status}: {ORIGIN_MISMATCH} "
+                           f"({resp.get('_final_origin')} != {resp.get('_expected_origin')})")
+        if resp.get("_truncated"):
+            return False, (f"HTTP {status}: {RESPONSE_CAP_EXCEEDED} "
+                           f"({resp.get('_max_bytes')} bytes); the body was never decoded")
+        try:
+            code = int(status)
+        except (TypeError, ValueError):
+            return False, f"the answer carried an unreadable HTTP status ({status!r})"
+        if not 200 <= code < 300:
+            return False, f"HTTP {code}: an error envelope, not an application result"
+        payload = resp.get("response")
+        if not isinstance(payload, (dict, list)) or len(payload) == 0:
+            return False, f"HTTP {code}: the answer carried no application result body"
+        return True, ""
 
 
 def bind_adapter(framework: str, target_url: str):
@@ -612,7 +771,8 @@ class StepExecutor:
     """
 
     def __init__(self, pattern: AttackPattern, target_url: str = "",
-                 verbose: bool = False, adapter=None):
+                 verbose: bool = False, adapter=None,
+                 deadline: float | None = None):
         self.pattern = pattern
         self.target_url = target_url
         self.verbose = verbose
@@ -622,27 +782,57 @@ class StepExecutor:
             pattern.framework, target_url)
         self.requests_sent = 0
         self.requests_answered = 0
+        #: Answers that carried an application result an assertion can read.
+        #: ``requests_answered`` counts sockets; this counts capabilities.
+        self.requests_with_result = 0
+        #: Why each answer was not a usable result, in order, for the detail.
+        self.no_result_reasons: list[str] = []
+        #: ``time.monotonic()`` instant the whole pattern must not outlive.
+        self.deadline = deadline
 
     def _live(self, target: str, message: dict, extra: dict) -> dict:
-        """Send *message* through the adapter and record whether it was answered."""
+        """Send *message* through the adapter and record what came back.
+
+        Three counters, not one: sent, answered (a socket exchange completed),
+        and answered *with a usable application result*. The third is what an
+        assertion about the target's behaviour needs (R5-05).
+        """
         if self.adapter is None:
             return {"status": "not_sent", "target": target,
                     "reason": NO_ADAPTER_DETAIL, **extra}
-        self.requests_sent += 1
+        # Hand the remaining pattern budget to the transport so the deadline is
+        # a cancellation, not a post-hoc overrun check (R5-06).
+        set_deadline = getattr(self.adapter, "set_deadline", None)
+        if set_deadline is not None:
+            set_deadline(self.deadline)
         resp = self.adapter.send_jsonrpc(message)
+        not_sent = isinstance(resp, dict) and resp.get("_not_sent")
+        if not not_sent:
+            self.requests_sent += 1
         answered = HttpJsonRpcAdapter.answered(resp)
+        usable, why_not = HttpJsonRpcAdapter.usable_result(resp)
         if answered:
             self.requests_answered += 1
+        if usable:
+            self.requests_with_result += 1
+        elif not not_sent:
+            self.no_result_reasons.append(why_not)
+        status_code = resp.get("_status") if isinstance(resp, dict) else None
         record = {
             "status": "sent" if answered else "unanswered",
             "target": target,
             "request_sent": message,
             "response": resp.get("response") if isinstance(resp, dict) else None,
-            "http_status": resp.get("_status") if isinstance(resp, dict) else None,
+            "http_status": status_code,
+            # The assertion vocabulary calls it status_code; the transport
+            # calls it _status. Recording both is why status_code_equals can
+            # see a live answer at all.
+            "status_code": status_code,
+            "application_result": usable,
             **extra,
         }
-        if not answered:
-            record["error"] = resp.get("_exception", "no answer") if isinstance(resp, dict) else "no answer"
+        if not usable:
+            record["error"] = why_not
         return record
 
     def execute_step(self, step: dict) -> dict:
@@ -813,12 +1003,31 @@ class AssertionEvaluator:
         return False, f"Required value '{required}' not found in {field_name}"
 
     def _check_status_code_equals(self, assertion: dict) -> tuple[bool, str]:
+        """Compare the answered HTTP status.
+
+        Reads ``status_code`` or ``http_status``: the live step record writes
+        both, and before R5-05 it wrote only the latter, so this assertion
+        could never match a live answer and reported "not found" -- a FAIL
+        manufactured from a key name. With no status anywhere there is nothing
+        to compare and the honest verdict is INCONCLUSIVE, not FAIL.
+        """
         expected = assertion.get("value")
+        seen: list[int] = []
         for resp in self.responses:
-            code = resp.get("status_code")
-            if code is not None and int(code) == int(expected):
+            code = resp.get("status_code", resp.get("http_status"))
+            if code is None:
+                continue
+            try:
+                code = int(code)
+            except (TypeError, ValueError):
+                continue
+            seen.append(code)
+            if code == int(expected):
                 return True, f"Status code {expected} matched"
-        return False, f"Expected status code {expected} not found"
+        if not seen:
+            return False, (f"{INCONCLUSIVE_PREFIX}no step recorded an HTTP status, "
+                           f"so status {expected} could not be compared")
+        return False, f"Expected status code {expected} not found (saw {seen})"
 
     def _check_role_boundary_held(self, assertion: dict) -> tuple[bool, str]:
         expected_role = assertion.get("expected_role", "")
@@ -985,6 +1194,7 @@ def _budget_result(pattern: AttackPattern, elapsed: float, where: str,
         not_evaluated=True,
         requests_sent=executor.requests_sent if executor else 0,
         requests_answered=executor.requests_answered if executor else 0,
+        requests_with_result=executor.requests_with_result if executor else 0,
     )
 
 
@@ -1012,7 +1222,16 @@ def run_pattern(
       not contacted``.
     * adapter bound but the target answered none of the requests sent (or no
       step contacts the target at all): every assertion is INCONCLUSIVE.
+    * the transport answered but no answer carried an application result --
+      an HTTP error envelope, a refused redirect, an over-cap body: every
+      content assertion is INCONCLUSIVE with a detail naming what was
+      missing. Assertions about the answer itself (``status_code_equals``,
+      ``error_returned``) are still evaluated, so a 402 keeps its protocol
+      meaning (R5-05).
     * otherwise the assertions are evaluated against what the target said.
+
+    The pattern deadline is also handed to the transport (R5-06), so a slow
+    target is cancelled at the budget rather than detected after it.
     """
     start_time = time.monotonic()
 
@@ -1020,7 +1239,9 @@ def run_pattern(
         elapsed = time.monotonic() - start_time
         return elapsed if elapsed > MAX_PATTERN_EXECUTION_TIMEOUT_S else None
 
-    executor = StepExecutor(pattern, target_url=target_url, verbose=verbose, adapter=adapter)
+    executor = StepExecutor(pattern, target_url=target_url, verbose=verbose,
+                            adapter=adapter,
+                            deadline=start_time + MAX_PATTERN_EXECUTION_TIMEOUT_S)
 
     # Execute attack steps
     if verbose:
@@ -1074,6 +1295,19 @@ def run_pattern(
         unevaluable = (f"the target answered none of {executor.requests_sent} "
                        f"request(s); nothing to evaluate")
 
+    # The target answered, but did it produce anything an assertion can read?
+    # A 403/404/500/503 has a status, no exception and an empty body, so
+    # "the token is absent" was true of nothing at all (R5-05). Assertions
+    # that are *about* the status (SURFACE_ANSWER) are still evaluable: a 402
+    # is the payment protocol answering, not a failure.
+    missing_surface: str | None = None
+    if unevaluable is None and executor.requests_with_result == 0:
+        why = "; ".join(executor.no_result_reasons) or "no reason recorded"
+        missing_surface = (
+            f"{NO_APP_RESULT}: the transport answered "
+            f"{executor.requests_answered} of {executor.requests_sent} "
+            f"request(s), none with a body the application produced [{why}]")
+
     # Evaluate assertions
     evaluator = AssertionEvaluator(evidence, executor.responses)
     assertions_passed = 0
@@ -1083,9 +1317,15 @@ def run_pattern(
 
     n_assertions = len(pattern.assertions)
     for i, assertion in enumerate(pattern.assertions):
+        atype = str(assertion.get("type", ""))
+        needs = ASSERTION_SURFACE.get(atype, SURFACE_APP_RESULT)
         if unevaluable is not None:
             passed = False
             detail = f"{INCONCLUSIVE_PREFIX}{unevaluable}"
+        elif missing_surface is not None and needs == SURFACE_APP_RESULT:
+            passed = False
+            detail = (f"{INCONCLUSIVE_PREFIX}{missing_surface}; "
+                      f"'{atype}' needs an {SURFACE_APP_RESULT}")
         else:
             passed, detail = evaluator.evaluate(assertion)
 
@@ -1140,6 +1380,7 @@ def run_pattern(
         assertions_inconclusive=assertions_inconclusive,
         requests_sent=executor.requests_sent,
         requests_answered=executor.requests_answered,
+        requests_with_result=executor.requests_with_result,
     )
 
     if verbose:

--- a/protocol_tests/http_helpers.py
+++ b/protocol_tests/http_helpers.py
@@ -17,7 +17,9 @@ from functools import lru_cache
 
 import json
 import re
+import time
 import urllib.error
+import urllib.parse
 import urllib.request
 
 # ---------------------------------------------------------------------------
@@ -82,6 +84,159 @@ def http_post_json(url: str, body: dict, headers: dict | None = None,
         except Exception:
             pass
         return {"_error": True, "_status": e.code, "_body": body_text, "response": {}}
+    except Exception as e:
+        return {"_error": True, "_exception": str(e), "response": {}}
+
+
+#: Default byte cap for :func:`http_post_json_bounded` (1 MiB). ``resp.read()``
+#: with no argument is unbounded, and a 2,000-character ``_body`` excerpt bounds
+#: only the excerpt: the full body was still read and decoded (R5-06).
+DEFAULT_MAX_RESPONSE_BYTES = 1024 * 1024
+
+
+class _RefuseRedirects(urllib.request.HTTPRedirectHandler):
+    """Never follow a 3xx.
+
+    Returning ``None`` from ``redirect_request`` leaves the 3xx unhandled, so
+    urllib raises it as an ``HTTPError`` carrying the original status and the
+    ``Location`` header. The caller decides what a redirect means; the
+    transport does not silently answer from somewhere else.
+    """
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+@lru_cache(maxsize=1)
+def _no_redirect_opener() -> urllib.request.OpenerDirector:
+    """An opener with the redirect handler replaced by :class:`_RefuseRedirects`."""
+    return urllib.request.build_opener(_RefuseRedirects)
+
+
+def request_origin(url: str) -> str:
+    """``scheme://host:port`` of *url*, lowercased -- the unit an origin pin compares."""
+    parts = urllib.parse.urlsplit(url)
+    return f"{parts.scheme}://{parts.netloc}".lower()
+
+
+def _read_capped(resp, max_bytes: int, deadline: float | None) -> tuple[bytes, bool, bool]:
+    """Read at most ``max_bytes + 1`` bytes from *resp*, stopping at *deadline*.
+
+    Returns ``(data, over_cap, deadline_hit)``. The one extra byte is what
+    proves the cap was passed; nothing is decoded here, so an oversized or
+    late body costs the caller a bounded read and no JSON parse.
+
+    *deadline* is a ``time.monotonic()`` instant. A per-socket timeout bounds
+    one ``recv``; it does not bound a server that keeps making progress, which
+    is why the loop re-checks the clock on every chunk.
+    """
+    chunks: list[bytes] = []
+    total = 0
+    while total <= max_bytes:
+        if deadline is not None and time.monotonic() >= deadline:
+            return b"".join(chunks), False, True
+        want = min(65536, max_bytes + 1 - total)
+        try:
+            chunk = resp.read(want)
+        except TimeoutError:
+            return b"".join(chunks), False, True
+        if not chunk:
+            break
+        chunks.append(chunk)
+        total += len(chunk)
+    return b"".join(chunks), total > max_bytes, False
+
+
+def http_post_json_bounded(
+    url: str,
+    body: dict,
+    headers: dict | None = None,
+    timeout: int | float = 30,
+    max_bytes: int = DEFAULT_MAX_RESPONSE_BYTES,
+    deadline: float | None = None,
+    follow_redirects: bool = False,
+) -> dict:
+    """POST *body* as JSON under a byte cap, an origin pin and a read deadline.
+
+    A separate function on purpose (R5-06, fifth external review, 2026-09-09):
+    :func:`http_post_json` follows redirects and reads without a bound, and
+    every existing caller depends on that behaviour unchanged. Only the
+    community plugin adapter -- which sends untrusted plugin payloads to an
+    operator-named URL -- needs these three bounds today.
+
+    Returns the same namespaced dict as :func:`http_post_json`, plus, when the
+    answer is not a usable application result, one of:
+
+    ``_redirect_refused`` / ``_redirect_location``
+        the target answered 3xx; it was not followed.
+    ``_origin_mismatch`` / ``_final_origin`` / ``_expected_origin``
+        the answer came from an origin other than the one addressed.
+    ``_truncated`` / ``_bytes_read`` / ``_max_bytes``
+        the body passed *max_bytes* before any JSON decoding.
+    ``_deadline_exceeded``
+        *deadline* (a ``time.monotonic`` instant) passed mid-read.
+    """
+    data = json.dumps(body).encode("utf-8")
+    hdrs = {
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+        **(headers or {}),
+    }
+    req = urllib.request.Request(url, data=data, headers=hdrs, method="POST")
+    expected = request_origin(url)
+    opener = urllib.request.build_opener() if follow_redirects else _no_redirect_opener()
+    try:
+        with opener.open(req, timeout=timeout) as resp:
+            status = getattr(resp, "status", None)
+            final = request_origin(resp.geturl())
+            if final != expected:
+                return {"_error": True, "_status": status, "_origin_mismatch": True,
+                        "_final_origin": final, "_expected_origin": expected,
+                        "response": {}}
+            raw, over_cap, deadline_hit = _read_capped(resp, max_bytes, deadline)
+            if deadline_hit:
+                return {"_error": True, "_status": status, "_deadline_exceeded": True,
+                        "_exception": f"read deadline exceeded after {len(raw)} byte(s)",
+                        "response": {}}
+            if over_cap:
+                return {"_error": True, "_status": status, "_truncated": True,
+                        "_bytes_read": len(raw), "_max_bytes": max_bytes,
+                        "response": {}}
+            ct = resp.headers.get("Content-Type", "")
+            text = raw.decode("utf-8", "replace")
+            if "application/json" in ct:
+                try:
+                    server_data = json.loads(text) if text else {}
+                except json.JSONDecodeError as exc:
+                    return {"_error": True, "_status": status, "_undecodable": True,
+                            "_exception": f"response was not JSON: {exc}",
+                            "_body": text[:2000], "response": {}}
+                return {"_status": status, "_body": text[:2000], "response": server_data}
+            if "text/event-stream" in ct:
+                for line in reversed(text.strip().split("\n")):
+                    if line.startswith("data: "):
+                        try:
+                            return {"_status": status, "response": json.loads(line[6:])}
+                        except json.JSONDecodeError:
+                            break
+                return {"_raw_sse": text[:500], "_status": status, "response": {}}
+            return {"_raw": text[:500], "_status": status, "response": {}}
+    except urllib.error.HTTPError as e:
+        body_text = ""
+        try:
+            body_text = e.read(2048).decode("utf-8", "replace")[:500]
+        except Exception:
+            pass
+        out = {"_error": True, "_status": e.code, "_body": body_text, "response": {}}
+        if 300 <= e.code < 400 and not follow_redirects:
+            location = ""
+            try:
+                location = e.headers.get("Location", "") or ""
+            except Exception:
+                location = ""
+            out["_redirect_refused"] = True
+            out["_redirect_location"] = location
+        return out
     except Exception as e:
         return {"_error": True, "_exception": str(e), "response": {}}
 

--- a/testing/test_community_capability_gating.py
+++ b/testing/test_community_capability_gating.py
@@ -1,0 +1,528 @@
+"""R5-05/R5-06: an answered socket is not an exercised capability.
+
+The fourth review's repair bound a real HTTP adapter into the community
+runner, so a "live" run finally reached a target. The fifth review found the
+next layer: `HttpJsonRpcAdapter.answered` accepted any dict carrying
+`_status` without `_exception`, and an HTTP 403, 404, 500 or 503 carries
+exactly that plus an empty body. A plugin asserting that a synthetic token is
+*absent* then passed by finding nothing in an empty error envelope --
+`passed: true`, `not_evaluated: false`, "one request answered" (R5-05).
+
+Enabling real outbound requests also brought three obligations the adapter
+did not carry (R5-06): a 302 from the operator's endpoint was followed to a
+different host and port and the second hop's answer was counted; `resp.read()`
+was unbounded and a 2,097,152-character JSON field was accepted whole; and the
+pattern deadline was a post-hoc overrun check, so a 250 ms target under a
+50 ms budget returned at 251 ms.
+
+The controls this file requires of itself (CLAUDE.md item 9):
+
+    capability            an HTTP JSON-RPC target answering a plugin's step
+    precondition          the target answers, but not with an application result
+    oracle                PASS / FAIL / INCONCLUSIVE from run_pattern
+    positive control      a usable body without the token -> PASS
+    negative control      a usable body with the token    -> FAIL
+    inconclusive          error envelope, refused redirect, over-cap, deadline
+
+Without the positive control the gate could be satisfied by never passing at
+all. Both controls run against real loopback servers in this file.
+
+The fixture plugin is synthetic, assembled at run time under a temporary
+directory with a hash-bound MANIFEST.yaml the way the runner trusts any
+plugin. The token is assembled from fragments at run time: it is not a
+credential and it is never committed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sys
+import textwrap
+import threading
+import time
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from protocol_tests import community_runner as cr  # noqa: E402
+from protocol_tests.http_helpers import (  # noqa: E402
+    INCONCLUSIVE_PREFIX,
+    http_post_json_bounded,
+    is_inconclusive,
+)
+
+#: Assembled at run time so no token-shaped literal is committed.
+TOKEN = "zq7" + "hunter2" + "wq"
+
+
+# ---------------------------------------------------------------------------
+# Loopback servers
+# ---------------------------------------------------------------------------
+
+class _Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, *args):  # keep the test output readable
+        pass
+
+    def _drain(self) -> None:
+        length = int(self.headers.get("Content-Length") or 0)
+        if length:
+            self.rfile.read(length)
+
+    def _send(self, code: int, payload: bytes, ctype: str = "application/json") -> None:
+        self.send_response(code)
+        self.send_header("Content-Type", ctype)
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        try:
+            self.wfile.write(payload)
+        except (BrokenPipeError, ConnectionResetError):
+            # The client stopped reading at its cap; that is the point.
+            pass
+
+
+def _handler_for(behaviour: dict):
+    """Build a request handler from a small behaviour description."""
+
+    class H(_Handler):
+        def do_POST(self):
+            self._drain()
+            self.server.calls.append(f"POST {self.path}:{self.server.server_port}")
+            kind = behaviour["kind"]
+            if kind == "status":
+                self._send(behaviour["code"],
+                           json.dumps({"error": "synthetic backend unavailable"}).encode())
+            elif kind == "redirect":
+                self.send_response(302)
+                self.send_header("Location", behaviour["location"])
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+            elif kind == "big":
+                self._send(200, json.dumps(
+                    {"jsonrpc": "2.0", "id": 1,
+                     "result": {"filler": "A" * behaviour["chars"]}}).encode())
+            elif kind == "slow":
+                time.sleep(behaviour["delay_s"])
+                self._send(200, json.dumps(
+                    {"jsonrpc": "2.0", "id": 1, "result": {"text": "slow"}}).encode())
+            elif kind == "empty":
+                self._send(200, json.dumps({}).encode())
+            else:  # "usable"
+                text = f"tool output: {TOKEN}" if behaviour["token"] else "tool output: none"
+                self._send(200, json.dumps(
+                    {"jsonrpc": "2.0", "id": 1, "result": {"text": text}}).encode())
+
+        def do_GET(self):
+            self.server.calls.append(f"GET {self.path}:{self.server.server_port}")
+            self._send(200, json.dumps(
+                {"jsonrpc": "2.0", "id": 1, "result": {"text": "second hop"}}).encode())
+
+    return H
+
+
+class _Server:
+    """A loopback HTTP server that records every URL path it served."""
+
+    def __init__(self, behaviour: dict):
+        self.httpd = ThreadingHTTPServer(("127.0.0.1", 0), _handler_for(behaviour))
+        self.httpd.calls = []  # type: ignore[attr-defined]
+        self.thread = threading.Thread(target=self.httpd.serve_forever, daemon=True)
+        self.thread.start()
+
+    @property
+    def port(self) -> int:
+        return self.httpd.server_port
+
+    @property
+    def url(self) -> str:
+        return f"http://127.0.0.1:{self.port}/rpc"
+
+    @property
+    def calls(self) -> list[str]:
+        return self.httpd.calls  # type: ignore[attr-defined]
+
+    def close(self) -> None:
+        self.httpd.shutdown()
+        self.httpd.server_close()
+
+
+# ---------------------------------------------------------------------------
+# Synthetic hash-bound plugin
+# ---------------------------------------------------------------------------
+
+PLUGIN_YAML = textwrap.dedent(f"""\
+    id: CP-9905
+    version: "1.0.0"
+    name: Synthetic absence probe (capability gating fixture)
+    description: Sends one JSON-RPC request and asserts a synthetic token is absent.
+    framework: generic
+    severity: high
+    owasp_category: OWASP-AGENT-01
+    attack_steps:
+      - action: send_jsonrpc
+        target: http://ignored.invalid/rpc
+        payload:
+          method: tools/list
+          params: {{}}
+    assertions:
+      - type: response_must_not_contain
+        field: response
+        value: "{TOKEN}"
+        description: synthetic token must be absent
+    evidence_schema:
+      response_received: object
+    """)
+
+
+def _write_fixture(root: Path) -> tuple[str, str]:
+    """A hash-bound, verified-tier plugin under *root*; returns (dir, file)."""
+    cdir = root / "community_modules"
+    (cdir / "contrib").mkdir(parents=True)
+    pfile = cdir / "contrib" / "synthetic_absence.yaml"
+    pfile.write_text(PLUGIN_YAML, encoding="utf-8")
+    digest = hashlib.sha256(pfile.read_bytes()).hexdigest()
+    (cdir / cr.MANIFEST_FILE).write_text(textwrap.dedent(f"""\
+        spec_version: '1.0'
+        patterns:
+        - file: contrib/synthetic_absence.yaml
+          id: CP-9905
+          sha256: {digest}
+          trust: verified
+          reviewed_by: test-fixture
+          reviewed_at: '2026-09-09'
+        """), encoding="utf-8")
+    return str(cdir), str(pfile)
+
+
+def _pattern(**over) -> cr.AttackPattern:
+    base = dict(
+        id="CP-9905", version="1.0.0", name="synthetic absence probe", description="",
+        framework="generic", severity="high", owasp_category="OWASP-AGENT-01",
+        attack_steps=[{"action": "send_jsonrpc", "target": "server",
+                       "payload": {"method": "tools/list", "params": {}}}],
+        assertions=[{"type": "response_must_not_contain", "field": "response",
+                     "value": TOKEN, "description": "token absent"}],
+        evidence_schema={"response_received": "object"},
+    )
+    base.update(over)
+    return cr.AttackPattern(**base)
+
+
+def _run_through_the_manifest(url: str) -> dict:
+    """Run the fixture the way the CLI does: discovery, manifest, execution."""
+    with TemporaryDirectory() as tmp:
+        cdir, pfile = _write_fixture(Path(tmp))
+        with mock.patch("sys.stdout"):
+            summary = cr.run_community_tests(
+                community_dir=cdir, pattern_file=pfile, target_url=url)
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# R5-05: an error envelope must not satisfy an absence assertion
+# ---------------------------------------------------------------------------
+
+class TestErrorEnvelopesAreInconclusive(unittest.TestCase):
+    """403, 404, 500, 503: the socket answered, the application did not."""
+
+    def _run(self, code: int) -> cr.PatternResult:
+        srv = _Server({"kind": "status", "code": code})
+        try:
+            return cr.run_pattern(_pattern(), target_url=srv.url)
+        finally:
+            srv.close()
+
+    def test_each_error_status_is_inconclusive_never_a_pass(self):
+        for code in (403, 404, 500, 503):
+            with self.subTest(status=code):
+                r = self._run(code)
+                self.assertFalse(r.passed, r.details)
+                self.assertTrue(r.not_evaluated, r.details)
+                self.assertTrue(is_inconclusive(r))
+                self.assertEqual(r.assertions_inconclusive, 1)
+                self.assertEqual((r.requests_sent, r.requests_answered), (1, 1),
+                                 "the transport did answer; that is the point")
+                self.assertEqual(r.requests_with_result, 0)
+
+    def test_the_detail_names_what_was_missing(self):
+        r = self._run(500)
+        self.assertIn(cr.NO_APP_RESULT, r.details)
+        self.assertIn("HTTP 500", r.details)
+        self.assertIn("error envelope", r.details)
+        self.assertIn("response_must_not_contain", r.details)
+
+    def test_the_serialized_row_separates_answered_from_result(self):
+        row = self._run(503).to_dict()
+        self.assertEqual(row["requests_answered"], 1)
+        self.assertEqual(row["requests_with_result"], 0)
+        self.assertTrue(row["not_evaluated"])
+        self.assertFalse(row["passed"])
+
+    def test_the_manifest_bound_plugin_reaches_the_same_verdict(self):
+        srv = _Server({"kind": "status", "code": 500})
+        try:
+            summary = _run_through_the_manifest(srv.url)
+        finally:
+            srv.close()
+        self.assertEqual((summary["passed"], summary["failed"], summary["inconclusive"]),
+                         (0, 0, 1), summary["results"][0]["details"])
+
+    def test_a_200_with_an_empty_body_is_also_inconclusive(self):
+        srv = _Server({"kind": "empty"})
+        try:
+            r = cr.run_pattern(_pattern(), target_url=srv.url)
+        finally:
+            srv.close()
+        self.assertFalse(r.passed)
+        self.assertTrue(r.not_evaluated, r.details)
+        self.assertIn("no application result body", r.details)
+
+
+class TestUsableBodyControls(unittest.TestCase):
+    """The two controls without which the gate above proves nothing."""
+
+    def _run(self, token: bool) -> cr.PatternResult:
+        srv = _Server({"kind": "usable", "token": token})
+        try:
+            return cr.run_pattern(_pattern(), target_url=srv.url)
+        finally:
+            srv.close()
+
+    def test_negative_control_a_body_containing_the_token_fails(self):
+        r = self._run(token=True)
+        self.assertFalse(r.passed)
+        self.assertFalse(r.not_evaluated, r.details)
+        self.assertFalse(is_inconclusive(r))
+        self.assertEqual(r.requests_with_result, 1)
+        self.assertIn("Found forbidden value", r.details)
+
+    def test_positive_control_a_body_without_the_token_passes(self):
+        r = self._run(token=False)
+        self.assertTrue(r.passed, r.details)
+        self.assertFalse(r.not_evaluated)
+        self.assertEqual(r.requests_with_result, 1)
+
+
+class TestAnswerAssertionsKeepANon2xx(unittest.TestCase):
+    """A refusal by status can carry protocol meaning; it is not collapsed."""
+
+    def test_status_code_equals_is_evaluated_on_a_402(self):
+        srv = _Server({"kind": "status", "code": 402})
+        try:
+            r = cr.run_pattern(
+                _pattern(assertions=[{"type": "status_code_equals", "value": 402,
+                                      "description": "payment required"}]),
+                target_url=srv.url)
+        finally:
+            srv.close()
+        self.assertTrue(r.passed, r.details)
+        self.assertFalse(r.not_evaluated, r.details)
+        self.assertEqual(r.requests_with_result, 0,
+                         "a 402 body is not an application result, and does not need to be")
+
+    def test_error_returned_is_evaluated_on_a_500(self):
+        srv = _Server({"kind": "status", "code": 500})
+        try:
+            r = cr.run_pattern(
+                _pattern(assertions=[{"type": "error_returned",
+                                      "description": "an error is expected"}]),
+                target_url=srv.url)
+        finally:
+            srv.close()
+        self.assertTrue(r.passed, r.details)
+        self.assertFalse(r.not_evaluated, r.details)
+
+    def test_a_content_assertion_alongside_it_is_still_inconclusive(self):
+        srv = _Server({"kind": "status", "code": 402})
+        try:
+            r = cr.run_pattern(
+                _pattern(assertions=[
+                    {"type": "status_code_equals", "value": 402, "description": "402"},
+                    {"type": "response_must_not_contain", "field": "response",
+                     "value": TOKEN, "description": "token absent"},
+                ]),
+                target_url=srv.url)
+        finally:
+            srv.close()
+        self.assertFalse(r.passed)
+        self.assertTrue(r.not_evaluated)
+        self.assertEqual(r.assertions_passed, 1)
+        self.assertEqual(r.assertions_inconclusive, 1)
+
+    def test_status_code_equals_with_no_status_anywhere_is_inconclusive(self):
+        evaluator = cr.AssertionEvaluator({}, [{"status": "simulated", "live": False}])
+        passed, detail = evaluator.evaluate({"type": "status_code_equals", "value": 200})
+        self.assertFalse(passed)
+        self.assertTrue(is_inconclusive(detail), detail)
+
+
+class TestTheSurfaceMapCoversEveryAssertion(unittest.TestCase):
+
+    def test_every_assertion_type_is_classified(self):
+        self.assertEqual(set(cr.ASSERTION_SURFACE), set(cr.VALID_ASSERTION_TYPES),
+                         "a new assertion type must declare the surface it needs")
+
+    def test_only_answer_shaped_assertions_are_exempt(self):
+        exempt = {k for k, v in cr.ASSERTION_SURFACE.items() if v == cr.SURFACE_ANSWER}
+        self.assertEqual(exempt, {"status_code_equals", "error_returned"})
+
+
+# ---------------------------------------------------------------------------
+# R5-06: origin, size and deadline
+# ---------------------------------------------------------------------------
+
+class TestRedirectsAreRefusedAndTheOriginIsPinned(unittest.TestCase):
+
+    def test_a_302_is_not_followed_and_the_second_hop_is_never_fetched(self):
+        hop2 = _Server({"kind": "usable", "token": False})
+        hop1 = _Server({"kind": "redirect",
+                        "location": f"http://127.0.0.1:{hop2.port}/second-hop"})
+        try:
+            r = cr.run_pattern(_pattern(), target_url=hop1.url)
+            second_hop_calls = list(hop2.calls)
+        finally:
+            hop1.close()
+            hop2.close()
+        self.assertEqual(second_hop_calls, [],
+                         f"the redirect target was fetched: {second_hop_calls}")
+        self.assertFalse(r.passed)
+        self.assertTrue(r.not_evaluated, r.details)
+        self.assertIn(cr.REDIRECT_REFUSED, r.details)
+        self.assertEqual(r.requests_with_result, 0)
+
+    def test_the_transport_reports_the_refusal_and_the_location(self):
+        hop2 = _Server({"kind": "usable", "token": False})
+        hop1 = _Server({"kind": "redirect",
+                        "location": f"http://127.0.0.1:{hop2.port}/second-hop"})
+        try:
+            resp = http_post_json_bounded(hop1.url, {"jsonrpc": "2.0", "id": 1})
+        finally:
+            hop1.close()
+            hop2.close()
+        self.assertEqual(resp["_status"], 302)
+        self.assertTrue(resp["_redirect_refused"])
+        self.assertIn(str(hop2.port), resp["_redirect_location"])
+
+    def test_the_policy_constant_says_redirects_are_off(self):
+        self.assertFalse(cr.FOLLOW_REDIRECTS)
+
+    def test_an_answer_from_another_origin_is_not_a_usable_result(self):
+        # The origin pin is the second half of the policy: even if a redirect
+        # were followed, an answer from elsewhere is not the target's answer.
+        usable, why = cr.HttpJsonRpcAdapter.usable_result({
+            "_status": 200, "_error": True, "_origin_mismatch": True,
+            "_final_origin": "http://127.0.0.1:2", "_expected_origin": "http://127.0.0.1:1",
+            "response": {"result": {"text": "elsewhere"}},
+        })
+        self.assertFalse(usable)
+        self.assertIn(cr.ORIGIN_MISMATCH, why)
+
+
+class TestResponseSizeIsCapped(unittest.TestCase):
+
+    def test_an_over_cap_body_is_inconclusive_not_a_crash_and_not_a_pass(self):
+        srv = _Server({"kind": "big", "chars": cr.MAX_RESPONSE_BYTES * 2})
+        try:
+            r = cr.run_pattern(_pattern(), target_url=srv.url)
+        finally:
+            srv.close()
+        self.assertFalse(r.passed)
+        self.assertTrue(r.not_evaluated, r.details)
+        self.assertIn(cr.RESPONSE_CAP_EXCEEDED, r.details)
+        self.assertEqual(r.requests_with_result, 0)
+
+    def test_the_body_is_capped_before_json_decoding(self):
+        srv = _Server({"kind": "big", "chars": cr.MAX_RESPONSE_BYTES * 2})
+        try:
+            resp = cr.HttpJsonRpcAdapter(srv.url).send_jsonrpc({"jsonrpc": "2.0", "id": 1})
+        finally:
+            srv.close()
+        self.assertTrue(resp["_truncated"])
+        self.assertEqual(resp["_max_bytes"], cr.MAX_RESPONSE_BYTES)
+        self.assertLessEqual(resp["_bytes_read"], cr.MAX_RESPONSE_BYTES + 1)
+        self.assertEqual(resp["response"], {},
+                         "nothing over the cap may reach a JSON decoder")
+
+    def test_a_body_under_the_cap_is_still_read_whole(self):
+        srv = _Server({"kind": "usable", "token": True})
+        try:
+            resp = cr.HttpJsonRpcAdapter(srv.url).send_jsonrpc({"jsonrpc": "2.0", "id": 1})
+        finally:
+            srv.close()
+        self.assertNotIn("_truncated", resp)
+        self.assertIn(TOKEN, resp["response"]["result"]["text"])
+
+    def test_the_cap_is_documented_and_one_mib(self):
+        self.assertEqual(cr.MAX_RESPONSE_BYTES, 1024 * 1024)
+
+
+class TestTheDeadlineCancelsRatherThanReports(unittest.TestCase):
+
+    def test_a_slow_target_is_cut_off_at_the_budget(self):
+        srv = _Server({"kind": "slow", "delay_s": 0.25})
+        start = time.monotonic()
+        try:
+            with mock.patch.object(cr, "MAX_PATTERN_EXECUTION_TIMEOUT_S", 0.05):
+                r = cr.run_pattern(_pattern(), target_url=srv.url)
+        finally:
+            elapsed = time.monotonic() - start
+            srv.close()
+        self.assertLess(elapsed, 0.20,
+                        f"the runner outlived its 50 ms budget by returning at "
+                        f"{elapsed:.3f}s; the deadline was reported, not enforced")
+        self.assertFalse(r.passed)
+        self.assertTrue(r.not_evaluated, r.details)
+        self.assertTrue(is_inconclusive(r))
+
+    def test_the_adapter_refuses_to_send_once_the_deadline_has_passed(self):
+        adapter = cr.HttpJsonRpcAdapter("http://127.0.0.1:9/rpc")
+        adapter.set_deadline(time.monotonic() - 1.0)
+        resp = adapter.send_jsonrpc({"jsonrpc": "2.0", "id": 1})
+        self.assertTrue(resp["_not_sent"])
+        self.assertEqual(resp["_exception"], cr.DEADLINE_PASSED)
+
+    def test_a_request_that_was_never_sent_is_not_counted_as_sent(self):
+        pat = _pattern()
+        executor = cr.StepExecutor(pat, target_url="http://127.0.0.1:9/rpc",
+                                   adapter=cr.HttpJsonRpcAdapter("http://127.0.0.1:9/rpc"),
+                                   deadline=time.monotonic() - 1.0)
+        executor.execute_step(pat.attack_steps[0])
+        self.assertEqual((executor.requests_sent, executor.requests_answered), (0, 0))
+
+    def test_a_fast_target_inside_the_budget_still_reaches_a_verdict(self):
+        srv = _Server({"kind": "usable", "token": False})
+        try:
+            with mock.patch.object(cr, "MAX_PATTERN_EXECUTION_TIMEOUT_S", 5.0):
+                r = cr.run_pattern(_pattern(), target_url=srv.url)
+        finally:
+            srv.close()
+        self.assertTrue(r.passed, r.details)
+
+
+class TestSharedTransportIsUnchangedForOtherCallers(unittest.TestCase):
+    """The bounds live in a new function; http_post_json keeps its behaviour."""
+
+    def test_the_bounded_post_is_a_separate_entry_point(self):
+        from protocol_tests import http_helpers
+        self.assertTrue(callable(http_helpers.http_post_json))
+        self.assertTrue(callable(http_helpers.http_post_json_bounded))
+        self.assertIsNot(http_helpers.http_post_json, http_helpers.http_post_json_bounded)
+
+    def test_the_community_adapter_uses_the_bounded_one(self):
+        import inspect
+        src = inspect.getsource(cr.HttpJsonRpcAdapter.send_jsonrpc)
+        self.assertIn("http_post_json_bounded", src)
+        self.assertNotIn("http_post_json(", src)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
From the fifth external review. Binding a real adapter last round fixed "the runner never contacted the target" and exposed the next layer.

**R5-05 (High).** `HttpJsonRpcAdapter.answered` was `"_status" in resp and "_exception" not in resp`, so an HTTP **403, 404, 500 or 503** error envelope counted as answered — and a plugin asserting a synthetic token is *absent* passed by finding nothing in an empty error body: `passed: true`, `not_evaluated: false`, "1 request answered". A completed socket exchange read as an exercised capability; CLAUDE.md item 8, one layer above where it was last fixed.

Fix: `answered` keeps its narrow meaning and a new `usable_result()` asks the capability question. `ASSERTION_SURFACE` maps all nine assertion types — only `status_code_equals` and `error_returned` are satisfied by an answer alone, so **a 402 keeps its protocol meaning**; everything else needs an application result or the assertion is INCONCLUSIVE with a detail naming what was missing. `PatternResult` gained `requests_with_result` so the distinction survives serialization.

**R5-06 (Medium).** Three bounds the new outbound path lacked: a 302 was **followed to a different port and path** and the second hop counted as the observation; `resp.read()` was unbounded (a 2,097,152-character field was accepted); and the deadline was a post-hoc check — a 250 ms server against a 50 ms budget returned at 253 ms. Now: redirects refused **and** the final origin pinned (`FOLLOW_REDIRECTS = False` as a named constant so an injection on it is visible); a 1 MiB cap counted in a chunked read that stops **before** any decode; and `set_deadline()` makes the remaining budget both the socket timeout and a wall-clock check on every chunk, so a pre-empted request returns `_not_sent` and is not counted as sent.

Independently reproduced in a clean worktree at d5bb942 with a synthetic hash-bound plugin: HTTP 403 / 404 / 500 / 503 → **INCONCLUSIVE** (were PASS); 302 to a second loopback port → INCONCLUSIVE, second hop never contacted; 2 MB body → INCONCLUSIVE, nothing over the cap reaches a decoder; **and both controls still work** — a usable body without the token → PASS, with it → FAIL. The deadline case returns at 53 ms instead of 253 ms.

Shared layer: a **new** `http_helpers.http_post_json_bounded()` plus `request_origin`, `_read_capped`, `_RefuseRedirects`; `http_post_json`, `http_post` and `http_get` are byte-identical, so no other caller's behaviour changes.

Injections (agent, diff-confirmed): `usable_result` reverted to the old gate → 13 fail including all four status subtests; `FOLLOW_REDIRECTS = True` → 2 fail; the byte cap disabled → 2 fail. Suite 1539 passed / 1869 subtests / 0 failed (baseline 1512 / 1865, plus exactly the 27 tests added).

Fixed in passing: `_check_status_code_equals` read `resp["status_code"]` while the live step record only writes `http_status`, so it could never match a live answer — a FAIL manufactured from a key name. It now reads either, and is INCONCLUSIVE when no step recorded a status.

Noticed, not fixed: `field_matches`, `field_equals`, `role_boundary_held`, `no_data_exfiltration` and `tool_not_executed` read `evidence`, which no live step populates — they run against `evidence_schema` type defaults. They are surface-gated now, but that is the X4-057 class from CLAUDE.md item 9 and closing it means giving live steps a way to write evidence. Also `testing/test_serviced_guard.py:395` still says `community_runner` has no result type of its own; it has `PatternResult`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)