### PR TITLE
R5-01/07: the gate's tests searched shell text, and the gate itself never traversed the native writer

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -140,6 +140,15 @@ jobs:
   # the wheel; neither establishes that it works. This job installs the exact
   # wheel the publish job uploads, into a fresh venv, from a directory that is
   # NOT the checkout, and runs it there.
+  # Fifth external review (2026-09-09, R5-01/R5-07): this job's checks lived in
+  # shell here, and the regression file that guarded them searched that shell
+  # for phrases. Wrapping every `run:` step in `if false; then … fi` left every
+  # phrase in place, executed nothing, and all 15 tests still passed. The
+  # checks now live in `scripts/verify_wheel_gate.py`, which this job runs
+  # against the installed wheel and which
+  # `testing/test_release_is_gated_on_the_wheel.py` runs against deliberately
+  # bad artifacts. One implementation, two callers, and neither can pass by
+  # containing the right words.
   test-wheel:
     name: Test the built wheel from a neutral directory
     needs: build
@@ -147,8 +156,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      # The checkout is here for tests/ and nothing else. No step below runs
-      # with the checkout as its working directory.
+      # The checkout is here for tests/ and for the gate script, and nothing
+      # else. No step below runs with the checkout as its working directory,
+      # and the gate refuses to run next to a source tree.
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python
@@ -162,6 +172,11 @@ jobs:
           name: dist
           path: dist/
 
+      # An sdist-only build leaves nothing to install and so nothing to test;
+      # a stray file in dist/ is how v4.16.0 failed to publish on 2026-08-30.
+      - name: The built artifact is one wheel and one sdist and nothing else
+        run: python "$GITHUB_WORKSPACE/scripts/verify_wheel_gate.py" dist-shape --dist "$GITHUB_WORKSPACE/dist"
+
       - name: Install the wheel into a fresh venv, outside the checkout
         run: |
           set -euo pipefail
@@ -170,71 +185,100 @@ jobs:
           [ "${#wheels[@]}" -eq 1 ] || { echo "::error::expected one wheel, found ${#wheels[@]}"; exit 1; }
           cd "$RUNNER_TEMP"
           python -m venv wheel-venv
-          ./wheel-venv/bin/pip install -q "${wheels[0]}" pytest pyyaml cryptography jsonschema
-          # The import must resolve inside the venv, not to the checkout.
-          ./wheel-venv/bin/python -c '
-          import protocol_tests, scripts
-          for m in (protocol_tests, scripts):
-              d = list(m.__path__)[0]
-              assert "site-packages" in d, f"{m.__name__} resolved to {d}, not the installed wheel"
-              print(m.__name__, "->", d)
-          '
+          # The mcp-server extra is installed on purpose: without it the three
+          # MCP server/SDK boundary contracts collect-error in a neutral
+          # directory, and a file that cannot be collected is not a file that
+          # was excluded for needing the checkout.
+          ./wheel-venv/bin/pip install -q "${wheels[0]}[mcp-server]" \
+            pytest pytest-subtests pyyaml cryptography jsonschema
 
-      - name: Smoke the installed package
-        run: |
-          set -euo pipefail
-          cd "$RUNNER_TEMP"
-          PY=./wheel-venv/bin/python
-          ./wheel-venv/bin/agent-security --version
-          "$PY" -m protocol_tests.mock_mcp_server --help > /dev/null
-          "$PY" -m scripts.registry_reference_server --help > /dev/null
-
-      # R3-01 reproduction, now a release gate: the installed 4.21.0 reported
-      # 17/17 PASS for this exact invocation against a port nothing listens on.
-      - name: A payment harness against a closed port passes nothing
-        run: |
-          set -euo pipefail
-          cd "$RUNNER_TEMP"
-          rc=0
-          ./wheel-venv/bin/agent-security test ap2 --url http://127.0.0.1:9 \
-            --report "$RUNNER_TEMP/ap2-closed-port.json" || rc=$?
-          echo "harness exit code: $rc"
-          ./wheel-venv/bin/python - <<'EOF'
-          import json, os, sys
-          report = json.load(open(os.path.join(os.environ["RUNNER_TEMP"], "ap2-closed-port.json")))
-          s = report["summary"]
-          print("summary:", s)
-          if s.get("total", 0) < 1:
-              sys.exit("the closed-port run produced no verdicts: unmeasured, not clean")
-          if s.get("passed", 0) != 0:
-              sys.exit(f"{s['passed']} of {s['total']} PASS against a port nothing listens on (R3-01)")
-          EOF
-
-      # The packaged-behaviour tests that can run against an installed copy.
-      # Copied out of the checkout so `sys.path.insert(0, parents[1])` in each
-      # file points at a directory with no source tree in it. The other files
-      # in tests/ read checkout-only resources (docs/, benchmarks/, git) and
-      # belong to CI, not to this gate.
-      - name: Packaged-behaviour tests against the installed wheel
+      # Everything the gate asserts, executed by the venv's interpreter from a
+      # directory with no source tree in it: that the imports resolve to
+      # site-packages, that the documented entry points run, that a payment
+      # harness against a closed port passes nothing (R3-01), that the six
+      # native `--simulate` entry points the CLI facade never reaches publish
+      # no pass anywhere a row is read (R4-05, and R5-07's escape from it), and
+      # that every file in tests/ behaves as it is classified.
+      #
+      # The gate script comes from the checkout, not from the wheel: a wheel
+      # that ships a broken gate would otherwise certify itself.
+      - name: Run the release gate against the installed wheel
         run: |
           set -euo pipefail
           mkdir -p "$RUNNER_TEMP/neutral"
           cp -r "$GITHUB_WORKSPACE/tests" "$RUNNER_TEMP/neutral/tests"
           cd "$RUNNER_TEMP/neutral"
-          "$RUNNER_TEMP/wheel-venv/bin/python" -m pytest -q -p no:cacheprovider -rs \
-            tests/test_auroc.py \
-            tests/test_evidence_pack_declares_its_denominator.py \
-            tests/test_fallback_validator_matches_schema.py \
-            tests/test_fb013_quorum_binds_distinct_approvers.py \
-            tests/test_fria_evidence.py \
-            tests/test_imported_risk_score_needs_a_denominator.py \
-            tests/test_mcp021_auth_fail_open.py \
-            tests/test_registry_schema_validity_is_enforced.py \
-            tests/test_simulate_does_not_claim_a_pass.py
+          "$RUNNER_TEMP/wheel-venv/bin/python" \
+            "$GITHUB_WORKSPACE/scripts/verify_wheel_gate.py" verify --tests tests
+
+  # Fifth external review, section E: "a release from a tag with no green
+  # ordinary CI can still enter this release workflow; the wheel gate must
+  # pass, but the separate CI calibration is not a dependency of publish."
+  # That was true. `needs:` cannot cross workflows, and CI fires on push and
+  # pull_request, so a Release cut from any ref reached `publish` without the
+  # pinned reference-server calibration ever having run on that ref. This job
+  # is the same calibration, in the release graph, so the dependency is real
+  # rather than assumed from branch protection nobody verified.
+  #
+  # The two copies are held identical by
+  # `test_the_release_calibration_is_the_same_job_as_the_ci_one`; a divergent
+  # copy is worse than none, because it reads as coverage.
+  calibration:
+    name: MCP reference-server calibration (pinned, non-skippable)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install package and test tools
+        run: pip install -e . pyyaml pytest
+
+      - name: Populate the npm cache with the exact pinned reference server
+        run: |
+          set -euo pipefail
+          pin=$(python -c "from scripts.mcp_reference_calibration import REFERENCE_SERVER; print(REFERENCE_SERVER)")
+          case "$pin" in
+            @modelcontextprotocol/server-everything@20[0-9][0-9].[0-9]*.[0-9]*) echo "pin: $pin" ;;
+            *) echo "::error::REFERENCE_SERVER is not the pinned package: $pin"; exit 1 ;;
+          esac
+          npx -y -p "$pin" -c true
+          echo "$pin" > "$RUNNER_TEMP/reference-server.pin"
+
+      - name: Prove the pinned server launches offline
+        run: |
+          set -euo pipefail
+          pin=$(cat "$RUNNER_TEMP/reference-server.pin")
+          printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"ci","version":"0"}}}' > "$RUNNER_TEMP/init.json"
+          timeout 30 npx --offline -y "$pin" stdio < "$RUNNER_TEMP/init.json" > "$RUNNER_TEMP/init.out" 2> "$RUNNER_TEMP/init.err" || true
+          grep -q '"serverInfo"' "$RUNNER_TEMP/init.out" || {
+            echo "::error::the pinned server did not answer initialize offline"
+            cat "$RUNNER_TEMP/init.err"; exit 1; }
+          head -c 200 "$RUNNER_TEMP/init.out"; echo
+
+      - name: Run the calibration and fail on any skip
+        run: |
+          set -euo pipefail
+          python -m pytest testing/test_mcp_reference_calibration.py \
+            -p no:cacheprovider -rs -v --tb=short \
+            --junitxml="$RUNNER_TEMP/calibration.xml"
+          if grep -q '<skipped' "$RUNNER_TEMP/calibration.xml"; then
+            echo "::error::the reference calibration reported a skip: UNMEASURED, not clean"
+            grep -o '<skipped[^>]*>' "$RUNNER_TEMP/calibration.xml"
+            exit 1
+          fi
+          ran=$(grep -o '<testcase ' "$RUNNER_TEMP/calibration.xml" | wc -l)
+          echo "testcases run: $ran"
+          [ "$ran" -ge 5 ] || { echo "::error::expected at least 5 calibration testcases, saw $ran"; exit 1; }
 
   publish:
     name: Publish to PyPI
-    needs: [build, test-wheel]
+    needs: [build, test-wheel, calibration]
     runs-on: ubuntu-latest
     environment:
       name: pypi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,6 +242,58 @@ the seed and set no repair date; a label is not a completed control.
 
 No test IDs were added or removed; the count stays at 623.
 
+### Fixed — the release gate now runs, instead of being described (R5-01, R5-07 Medium; fifth external review, 2026-09-09)
+
+Both findings had the same shape: the gate's strength was asserted somewhere
+other than where the gate ran.
+
+- **R5-01 — the workflow contract tests accepted a disabled test job.**
+  `testing/test_release_is_gated_on_the_wheel.py` checked `test-wheel` by
+  searching the job's concatenated shell text for phrases, filenames and
+  command names. Wrapping every `run:` step in `if false; then … fi` leaves all
+  of that text in place and executes none of it: reproduced here on the
+  untouched tree, **15 tests and 17 subtests still passed**. The checks now live
+  in `scripts/verify_wheel_gate.py`, which the workflow runs against the
+  installed wheel and which the regression file runs against deliberately bad
+  artifacts — one implementation, two callers. The file's remaining text
+  assertions are labelled WIRING and named for what they read; the new
+  EXECUTION class runs each `run:` body under bash against recorders and
+  asserts the resulting execution trace, so a body that contains every right
+  word and runs none of it records nothing and fails. Under the same `if false`
+  mutation that file now fails **8 tests and 3 subtests**.
+
+- **R5-07 — the gate did not catch a reintroduced native simulated pass.**
+  The gate ran nine hand-listed files from `tests/`, all of which reach
+  `--simulate` through the CLI facade. Replacing the installed
+  `harness_base.simulated_row` with `return dict(row)` strips the `simulated`
+  and `verdict_scope` labels from all 66 rows of the six native writers and the
+  nine files stay green (**78 tests, 69 subtests**, reproduced); break
+  `http_helpers.fold_live_verdict` as well and the same six modules write **66
+  `passed: true` rows with `serviced: 17` and `pass_rate: 1.0`** — the R4-05
+  defect — with the nine files still green. The gate now runs the six native
+  `--simulate` entry points and checks every layer of what they write: each
+  row's verdict, structural marker, two labels, details prefix and scoped
+  reference verdict, and the three-state summary underneath them. Both
+  mutations, and a revert of the closed-port fold, now fail it.
+
+- **The nine-file list is derived rather than remembered.** Every file in
+  `tests/` is classified in `scripts/verify_wheel_gate.py` as gate-eligible or
+  as needing a named checkout resource, and the gate runs all thirty from the
+  neutral directory and requires each to behave as classified — an eligible
+  file must produce at least one testcase with no failure, error or skip, and
+  an excluded file must not. An exclusion whose file starts passing fails the
+  gate, which is the review the hand-maintained list never got. **Twelve of
+  thirty are now eligible**, up from nine: installing the `mcp-server` extra
+  brings the three MCP server and SDK boundary contracts in, and the other
+  eighteen carry the resource each one actually reads.
+
+- **The pinned reference calibration is a publish dependency.** Section E
+  observed that a Release cut from a tag with no green ordinary CI still only
+  had to pass the wheel gate. `needs:` cannot cross workflows, so the
+  calibration now also runs in `publish-pypi.yml` and `publish` needs it; a
+  test holds the two copies identical, because a drifted copy still reads as
+  coverage.
+
 
 ## [4.21.2] - 2026-09-08
 

--- a/scripts/verify_wheel_gate.py
+++ b/scripts/verify_wheel_gate.py
@@ -1,0 +1,560 @@
+#!/usr/bin/env python3
+"""The release gate, as code that runs, rather than as text a test can read.
+
+The fourth external review (R4-16, 2026-09-08) found that `publish` depended on
+`build` and on nothing that had tested the artifact. A `test-wheel` job was
+added. The fifth review (R5-01, R5-07, 2026-09-09) found two things about it:
+
+  R5-01  The contract test in `testing/test_release_is_gated_on_the_wheel.py`
+         searched the concatenated shell text of the job for phrases, filenames
+         and command names. Wrapping every `run:` step in `if false; then … fi`
+         leaves all of that text in place and executes none of it: all 15 tests
+         and 17 subtests still passed. Tokens in a string do not establish
+         executable control flow.
+
+  R5-07  The gate ran nine hand-listed files from `tests/`. Replacing the
+         installed `harness_base.simulated_row` with `return dict(row)` strips
+         the row labels off all 66 rows of the six native `--simulate` writers,
+         and those nine files stay green (78 tests, 69 subtests). Break
+         `http_helpers.fold_live_verdict` as well and the same six modules write
+         66 `passed: true` rows with `serviced: 17` and `pass_rate: 1.0` -- the
+         exact R4-05 defect -- and the nine files are still green.
+
+Both findings have the same shape: the gate's strength was asserted somewhere
+other than where the gate ran. So the gate lives here now, in one module that
+CI executes against the installed wheel and that
+`testing/test_release_is_gated_on_the_wheel.py` executes against deliberately
+bad artifacts. A check that only one of the two can reach is a check nobody has
+seen fail.
+
+Run it with the interpreter of the venv the wheel was installed into, from a
+directory that is NOT the checkout::
+
+    /path/to/wheel-venv/bin/python scripts/verify_wheel_gate.py verify --tests tests
+
+Every sub-command exits non-zero, with the reason on stdout, when its check
+fails. Nothing here prints a green result it did not establish: a run that
+produced no verdicts is reported as unmeasured, never as clean.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Iterable
+
+_HERE = str(Path(__file__).resolve().parent)
+
+
+def _drop_the_checkout_from_sys_path() -> None:
+    """Running this file by path puts its own directory on `sys.path`, which
+    would let `import auroc` -- and 29 other sibling script names -- resolve to
+    the checkout while the point of the exercise is to resolve everything to
+    the installed wheel.
+
+    Called from `main`, not at import: nothing here imports the package at
+    module level, and a test that imports this module must not have the
+    checkout removed from under it.
+    """
+    sys.path[:] = [p for p in sys.path if p not in ("", ".", _HERE)]
+
+
+# ---------------------------------------------------------------------------
+# The vocabulary a simulated row must carry.
+# ---------------------------------------------------------------------------
+#
+# Stated here as literals rather than imported from `protocol_tests`, because
+# the module under test is the thing whose labels are in question. Importing
+# them would let one edit satisfy both sides. `check_scope_vocabulary` compares
+# these with the installed constants, so drift is a failure rather than a
+# silent agreement.
+
+INCONCLUSIVE_PREFIX = "INCONCLUSIVE - "
+SIMULATED_ROW_SCOPE = "reference-model self-test (no target)"
+REFERENCE_VERDICT_SCOPE = (
+    "reference model in this module; not an observation of the target")
+
+#: The six harnesses that handle ``--simulate`` in their own ``main()``, and the
+#: number of rows each writes. The CLI facade never reaches them, which is why
+#: R4-05 shipped: the tests that existed covered the facade.
+NATIVE_SIMULATE = {
+    "protocol_tests.ap2_harness": 17,
+    "protocol_tests.x402_fireblocks_harness": 17,
+    "protocol_tests.ucp_acp_harness": 12,
+    "protocol_tests.card_token_harness": 12,
+    "protocol_tests.settlement_finality_harness": 8,
+    "protocol_tests.aiuc1_compliance_harness": 12,
+}
+
+#: Files in `tests/` that must pass against nothing but the installed wheel:
+#: at least one testcase, no failure, no error, and no skip. A skip here is
+#: unmeasured, and unmeasured is not clean.
+#:
+#: This list is REVIEWED here and DERIVED by `audit_packaged_tests`, which runs
+#: every file in `tests/` from the neutral directory and requires each one to
+#: behave as classified. A file that stops needing the checkout, or starts
+#: needing it, fails the gate until someone moves it -- which is the review the
+#: hand-maintained nine-file list never got.
+WHEEL_GATE_ELIGIBLE = {
+    "test_auroc.py",
+    "test_evidence_pack_declares_its_denominator.py",
+    "test_fallback_validator_matches_schema.py",
+    "test_fb013_quorum_binds_distinct_approvers.py",
+    "test_fria_evidence.py",
+    "test_imported_risk_score_needs_a_denominator.py",
+    "test_mcp021_auth_fail_open.py",
+    "test_mcp_sdk_schema_resolution_boundary.py",
+    "test_mcp_server_runtime.py",
+    "test_mcp_server_streamable_http_boundary.py",
+    "test_registry_schema_validity_is_enforced.py",
+    "test_simulate_does_not_claim_a_pass.py",
+}
+
+#: Files that read something the wheel does not ship, with the resource named.
+#: "They all need the checkout" was too broad (R5-07); each of these was run
+#: from the neutral directory and the reason recorded is the one it gave.
+CHECKOUT_ONLY = {
+    "test_aggregate_state_is_shared.py": "opens scripts/*.py by checkout path",
+    "test_attestation_can_say_inconclusive.py": "opens REPO/schemas/attestation-report.json",
+    "test_attestation_schema_neutrality.py": "opens REPO/schemas/attestation-report.json",
+    "test_community_manifest_integrity.py": "reads community_modules/MANIFEST.yaml",
+    "test_dgb_bundle_export.py": "reads fixtures/dgb/, docs/paper-dgb/, benchmarks/",
+    "test_evidence_artifacts_are_three_state.py": "reads reports/ and runs git",
+    "test_one_predicate_both_shapes.py": "opens scripts/html_report.py by checkout path",
+    "test_owasp_agentic_mapping.py": "reads docs/coverage/ and runs git",
+    "test_owasp_asi_is_one_source.py": "reads configs/, scripts/, protocol_tests/ as files",
+    "test_owasp_titles_have_one_source.py": "opens scripts/*.py by checkout path",
+    "test_rcl_fixture_export.py": "reads fixtures/rcl/rcl-oracle-fixtures.v1.json",
+    "test_record_states_its_own_independence.py": "runs scripts/verify_attestation_record.py by path",
+    "test_registry_refuses_without_schema.py": "runs scripts/registry_reference_server.py by path",
+    "test_registry_server_contract.py": "runs scripts/verify_attestation_record.py by path",
+    "test_report_states_its_provenance.py": "reads docs/evidence/ and attestations/",
+    "test_result_semantics_predeclared.py": "reads docs/result-semantics.json",
+    "test_the_wheel_ships_what_it_reads.py": "builds a wheel from the source tree",
+    "test_verdict_taint_audit.py": "reads protocol_tests/*.py as files",
+}
+
+
+# ---------------------------------------------------------------------------
+# Pure checks. Each returns a list of problems; an empty list is a pass.
+# ---------------------------------------------------------------------------
+
+def check_dist_shape(names: Iterable[str]) -> list[str]:
+    """`dist/` must hold exactly one wheel, at least one sdist, nothing else.
+
+    v4.16.0 failed to publish on 2026-08-30 because a build-environment record
+    landed in `dist/` and twine met it as an InvalidDistribution. An sdist-only
+    build is the other direction: nothing to install, so nothing to test.
+    """
+    names = sorted(names)
+    wheels = [n for n in names if n.endswith(".whl")]
+    sdists = [n for n in names if n.endswith(".tar.gz")]
+    others = [n for n in names if not n.endswith((".whl", ".tar.gz"))]
+    problems = []
+    if len(wheels) != 1:
+        problems.append(f"expected exactly one wheel in dist/, found {len(wheels)}: {wheels}")
+    if not sdists:
+        problems.append("no sdist in dist/")
+    if others:
+        problems.append(f"dist/ contains non-distribution files: {others}")
+    return problems
+
+
+def check_payment_report(report: dict) -> list[str]:
+    """R3-01: installed 4.21.0 reported 17/17 PASS against a port nothing listens on."""
+    problems = []
+    summary = report.get("summary")
+    if not isinstance(summary, dict):
+        return ["the closed-port report has no summary"]
+    total = summary.get("total", 0)
+    if total < 1:
+        problems.append("the closed-port run produced no verdicts: unmeasured, not clean")
+    if summary.get("passed", 0) != 0:
+        problems.append(f"{summary.get('passed')} of {total} PASS against a port "
+                        f"nothing listens on (R3-01)")
+    if summary.get("serviced", 0) != 0:
+        problems.append(f"serviced={summary.get('serviced')} against a closed port: "
+                        f"a denominator was counted for requests nobody answered")
+    rows = report.get("results") or []
+    claimed = [r.get("test_id") for r in rows if r.get("passed") is True]
+    if claimed:
+        problems.append(f"rows claim a pass against a closed port: {claimed[:5]}")
+    return problems
+
+
+def check_simulated_report(report: dict, *, expected_rows: int | None = None) -> list[str]:
+    """Every layer of a native `--simulate --report` file, not just `passed`.
+
+    R5-07's first mutation leaves `passed` false and removes `simulated` and
+    `verdict_scope` from all 66 rows; its second turns them into 66 passes with
+    a Wilson interval. A check that reads one field catches one of the two.
+    """
+    problems = []
+    rows = report.get("results")
+    if not isinstance(rows, list) or not rows:
+        return ["the simulated run wrote no rows"]
+    if expected_rows is not None and len(rows) != expected_rows:
+        problems.append(f"{len(rows)} rows, expected {expected_rows}: a simulated row went missing")
+
+    reference_passes = 0
+    for row in rows:
+        tid = row.get("test_id", "?")
+        if row.get("passed") is not False:
+            problems.append(f"{tid}: a simulated row claimed passed={row.get('passed')!r}")
+        if row.get("not_evaluated") is not True:
+            problems.append(f"{tid}: no `not_evaluated` marker on a fabricated-answer row")
+        if row.get("simulated") is not True:
+            problems.append(f"{tid}: row is not labelled `simulated`")
+        if row.get("verdict_scope") != SIMULATED_ROW_SCOPE:
+            problems.append(f"{tid}: verdict_scope is {row.get('verdict_scope')!r}, "
+                            f"expected {SIMULATED_ROW_SCOPE!r}")
+        details = str(row.get("details") or "")
+        if not details.startswith(INCONCLUSIVE_PREFIX):
+            problems.append(f"{tid}: details do not agree with the field: {details[:60]!r}")
+        ref = row.get("reference_verdict")
+        if not isinstance(ref, dict):
+            problems.append(f"{tid}: the fabricated verdict was discarded, not scoped")
+            continue
+        if ref.get("scope") != REFERENCE_VERDICT_SCOPE:
+            problems.append(f"{tid}: reference_verdict.scope is {ref.get('scope')!r}")
+        if not isinstance(ref.get("passed"), bool):
+            problems.append(f"{tid}: reference_verdict.passed is not a bool")
+        if not str(ref.get("reason") or ""):
+            problems.append(f"{tid}: reference_verdict carries no reason")
+        reference_passes += bool(ref.get("passed"))
+
+    if reference_passes == 0:
+        problems.append("no reference verdict survived: the fabricated outcome was "
+                        "deleted rather than scoped, so nothing shows what the "
+                        "module answered itself")
+
+    summary = report.get("summary")
+    if not isinstance(summary, dict):
+        problems.append("the simulated run wrote no summary")
+    else:
+        n = len(rows)
+        expected = {"total": n, "passed": 0, "failed": 0, "inconclusive": n,
+                    "serviced": 0, "status": "inconclusive",
+                    "pass_rate": None, "wilson_95_ci": None}
+        actual = {k: summary.get(k) for k in expected}
+        if actual != expected:
+            problems.append(f"summary disagrees with the rows, or a rate was computed "
+                            f"over nothing: {actual} != {expected}")
+    scope = report.get("verdict_scope")
+    if not isinstance(scope, dict) or scope.get("live_requested") is not False:
+        problems.append("the report does not say that nothing live was requested")
+    return problems
+
+
+_TESTSUITE = re.compile(r"<testsuite\b([^>]*)>")
+
+
+def junit_counts(xml_text: str) -> dict:
+    """`tests/errors/failures/skipped` from a pytest JUnit file.
+
+    Read by attribute name rather than by position: pytest writes them in
+    alphabetical order and a version that reorders them must not be read as a
+    file with no failures in it. The element counts are the fallback when the
+    `<testsuite>` attributes are absent.
+    """
+    fields = ("tests", "errors", "failures", "skipped")
+    m = _TESTSUITE.search(xml_text)
+    if m:
+        attrs = dict(re.findall(r'([A-Za-z_]+)="([^"]*)"', m.group(1)))
+        if all(attrs.get(f, "").isdigit() for f in fields):
+            return {f: int(attrs[f]) for f in fields}
+    return {
+        "tests": len(re.findall(r"<testcase\b", xml_text)),
+        "errors": len(re.findall(r"<error\b", xml_text)),
+        "failures": len(re.findall(r"<failure\b", xml_text)),
+        "skipped": len(re.findall(r"<skipped\b", xml_text)),
+    }
+
+
+def is_clean(counts: dict) -> bool:
+    """At least one testcase, and no failure, error or skip in it."""
+    return (counts["tests"] >= 1 and counts["errors"] == 0
+            and counts["failures"] == 0 and counts["skipped"] == 0)
+
+
+def check_test_classification(present: Iterable[str]) -> list[str]:
+    """Every file in `tests/` is either gate-eligible or a named exclusion."""
+    present = set(present)
+    known = WHEEL_GATE_ELIGIBLE | set(CHECKOUT_ONLY)
+    problems = []
+    for name in sorted(present - known):
+        problems.append(f"{name} is new and unclassified: add it to "
+                        f"WHEEL_GATE_ELIGIBLE or to CHECKOUT_ONLY with its reason")
+    for name in sorted(known - present):
+        problems.append(f"{name} is classified but no longer exists in tests/")
+    both = WHEEL_GATE_ELIGIBLE & set(CHECKOUT_ONLY)
+    if both:
+        problems.append(f"classified twice: {sorted(both)}")
+    return problems
+
+
+# ---------------------------------------------------------------------------
+# Checks that run something.
+# ---------------------------------------------------------------------------
+
+def _run(argv: list[str], **kw) -> subprocess.CompletedProcess:
+    return subprocess.run(argv, capture_output=True, text=True, timeout=900, **kw)
+
+
+def check_imports_resolve_to_the_wheel() -> list[str]:
+    """Source shadowing is why the CI install check proves less than it looks."""
+    problems = []
+    for name in ("protocol_tests", "scripts"):
+        try:
+            module = __import__(name)
+        except ImportError as exc:  # pragma: no cover - a broken wheel
+            problems.append(f"the installed wheel does not provide {name}: {exc}")
+            continue
+        where = list(module.__path__)[0]
+        if "site-packages" not in where:
+            problems.append(f"{name} resolved to {where}, not to the installed wheel")
+        else:
+            print(f"  {name} -> {where}")
+    return problems
+
+
+def check_scope_vocabulary() -> list[str]:
+    """The gate's literals and the package's constants must be the same words."""
+    try:
+        from protocol_tests import http_helpers
+    except ImportError as exc:  # pragma: no cover
+        return [f"cannot import protocol_tests.http_helpers: {exc}"]
+    problems = []
+    for label, mine, theirs in (
+            ("INCONCLUSIVE_PREFIX", INCONCLUSIVE_PREFIX, http_helpers.INCONCLUSIVE_PREFIX),
+            ("SIMULATED_ROW_SCOPE", SIMULATED_ROW_SCOPE, http_helpers.SIMULATED_ROW_SCOPE),
+            ("REFERENCE_VERDICT_SCOPE", REFERENCE_VERDICT_SCOPE,
+             http_helpers.REFERENCE_VERDICT_SCOPE)):
+        if mine != theirs:
+            problems.append(f"{label} drifted: gate says {mine!r}, package says {theirs!r}")
+    return problems
+
+
+def check_entry_points(bindir: Path) -> list[str]:
+    """The documented entry points, run as a consumer runs them."""
+    problems = []
+    commands = [
+        [str(bindir / "agent-security"), "--version"],
+        [sys.executable, "-m", "protocol_tests.mock_mcp_server", "--help"],
+        [sys.executable, "-m", "scripts.registry_reference_server", "--help"],
+    ]
+    for argv in commands:
+        done = _run(argv)
+        if done.returncode != 0:
+            problems.append(f"{' '.join(argv)} exited {done.returncode}: "
+                            f"{(done.stderr or done.stdout)[-300:]}")
+        else:
+            print(f"  ok: {' '.join(argv)}")
+    return problems
+
+
+def check_closed_port(bindir: Path, workdir: Path) -> list[str]:
+    """R3-01, in the release path rather than in a changelog."""
+    report = workdir / "ap2-closed-port.json"
+    done = _run([str(bindir / "agent-security"), "test", "ap2",
+                 "--url", "http://127.0.0.1:9", "--report", str(report)],
+                cwd=str(workdir))
+    print(f"  closed-port harness exit code: {done.returncode}")
+    if not report.exists():
+        return [f"the closed-port run wrote no report: {(done.stderr or done.stdout)[-400:]}"]
+    problems = check_payment_report(json.loads(report.read_text()))
+    if not problems:
+        summary = json.loads(report.read_text())["summary"]
+        print(f"  closed-port summary: {summary}")
+    return problems
+
+
+def check_native_simulate(workdir: Path) -> list[str]:
+    """The six native `--simulate` entry points, which the facade never reaches.
+
+    This is the surface R5-07 named: the gate's nine files use the CLI facade,
+    so a broken shared writer -- `harness_base.simulated_row`, or the
+    `fold_live_verdict` simulate branch under it -- ships green.
+    """
+    problems = []
+    for module, expected in NATIVE_SIMULATE.items():
+        report = workdir / f"{module.rsplit('.', 1)[1]}-simulate.json"
+        done = _run([sys.executable, "-m", module, "--simulate", "--report", str(report)],
+                    cwd=str(workdir))
+        if not report.exists():
+            problems.append(f"{module}: no report written "
+                            f"(exit {done.returncode}): {(done.stderr or done.stdout)[-300:]}")
+            continue
+        found = check_simulated_report(json.loads(report.read_text()),
+                                       expected_rows=expected)
+        if found:
+            problems.extend(f"{module}: {p}" for p in found)
+        else:
+            print(f"  {module}: {expected} rows, all INCONCLUSIVE and labelled")
+    return problems
+
+
+def _pytest_one(tests_dir: Path, name: str, junit: Path) -> dict:
+    done = _run([sys.executable, "-m", "pytest", "-q", "-p", "no:cacheprovider",
+                 str(Path(tests_dir.name) / name), f"--junitxml={junit}"],
+                cwd=str(tests_dir.parent))
+    counts = junit_counts(junit.read_text()) if junit.exists() else {
+        "tests": 0, "errors": 1, "failures": 0, "skipped": 0}
+    counts["returncode"] = done.returncode
+    counts["tail"] = (done.stdout or done.stderr or "").strip().splitlines()[-1:] or [""]
+    return counts
+
+
+def audit_packaged_tests(tests_dir: Path, workdir: Path) -> list[str]:
+    """Run every file in `tests/` and require it to behave as classified.
+
+    Eligible files must be clean against nothing but the wheel. Excluded files
+    must NOT be -- an exclusion whose file now passes here is an exclusion
+    nobody has re-read, which is how nine files stayed nine while `tests/` grew
+    to thirty.
+    """
+    present = sorted(p.name for p in tests_dir.glob("test_*.py"))
+    problems = check_test_classification(present)
+    if problems:
+        return problems
+
+    for name in present:
+        junit = workdir / f"junit-{name}.xml"
+        counts = _pytest_one(tests_dir, name, junit)
+        clean = is_clean(counts)
+        expected_clean = name in WHEEL_GATE_ELIGIBLE
+        mark = "eligible" if expected_clean else "excluded"
+        print(f"  [{mark:8}] {name:52} {counts['tests']:3} tests "
+              f"{counts['failures']} failed {counts['errors']} errors "
+              f"{counts['skipped']} skipped")
+        if expected_clean and not clean:
+            problems.append(
+                f"{name} is on the wheel gate and did not pass against the "
+                f"installed wheel alone: {counts['tests']} tests, "
+                f"{counts['failures']} failures, {counts['errors']} errors, "
+                f"{counts['skipped']} skipped -- {counts['tail'][0]}")
+        if not expected_clean and clean:
+            problems.append(
+                f"{name} is excluded as \"{CHECKOUT_ONLY[name]}\" but passed "
+                f"cleanly against the installed wheel: move it to "
+                f"WHEEL_GATE_ELIGIBLE or correct the reason")
+    return problems
+
+
+# ---------------------------------------------------------------------------
+# Sub-commands
+# ---------------------------------------------------------------------------
+
+def _report(title: str, problems: list[str]) -> int:
+    if problems:
+        print(f"FAIL {title}")
+        for p in problems:
+            print(f"  - {p}")
+        return 1
+    print(f"ok   {title}")
+    return 0
+
+
+def cmd_dist_shape(args) -> int:
+    dist = Path(args.dist)
+    names = sorted(p.name for p in dist.iterdir()) if dist.is_dir() else []
+    if not dist.is_dir():
+        return _report(f"dist shape ({dist})", [f"{dist} is not a directory"])
+    print(f"  dist/ holds: {names}")
+    return _report("dist shape", check_dist_shape(names))
+
+
+def cmd_check_payment_report(args) -> int:
+    return _report(f"closed-port report {args.path}",
+                   check_payment_report(json.loads(Path(args.path).read_text())))
+
+
+def cmd_check_simulated_report(args) -> int:
+    return _report(f"simulated report {args.path}",
+                   check_simulated_report(json.loads(Path(args.path).read_text()),
+                                          expected_rows=args.expect_rows))
+
+
+def cmd_eligible_tests(args) -> int:
+    tests_dir = Path(args.tests).resolve()
+    present = sorted(p.name for p in tests_dir.glob("test_*.py"))
+    problems = check_test_classification(present)
+    for name in sorted(WHEEL_GATE_ELIGIBLE):
+        print(name)
+    print(f"# {len(WHEEL_GATE_ELIGIBLE)} of {len(present)} files in "
+          f"{tests_dir} are wheel-gate eligible", file=sys.stderr)
+    return _report("test classification", problems) if problems else 0
+
+
+def cmd_verify(args) -> int:
+    tests_dir = Path(args.tests).resolve()
+    if not tests_dir.is_dir():
+        print(f"FAIL {tests_dir} is not a directory")
+        return 1
+    if Path(tests_dir.parent / "protocol_tests").exists():
+        print(f"FAIL {tests_dir.parent} contains a protocol_tests source tree; "
+              f"run the gate from a directory that is not the checkout")
+        return 1
+
+    failures = 0
+    with tempfile.TemporaryDirectory(prefix="wheel-gate-") as tmp:
+        workdir = Path(tmp)
+        stages = [
+            ("imports resolve to the installed wheel", check_imports_resolve_to_the_wheel, ()),
+            ("the gate and the package use one vocabulary", check_scope_vocabulary, ()),
+            ("documented entry points run", check_entry_points, (Path(sys.executable).parent,)),
+            ("a payment harness against a closed port passes nothing",
+             check_closed_port, (Path(sys.executable).parent, workdir)),
+            ("native --simulate publishes no pass, anywhere a row is read",
+             check_native_simulate, (workdir,)),
+            ("packaged-behaviour tests, classified by what they need",
+             audit_packaged_tests, (tests_dir, workdir)),
+        ]
+        for title, fn, fnargs in stages:
+            print(f"\n== {title}")
+            failures += _report(title, fn(*fnargs))
+    print()
+    if failures:
+        print(f"RELEASE GATE FAILED: {failures} stage(s)")
+        return 1
+    print("RELEASE GATE PASSED")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    _drop_the_checkout_from_sys_path()
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    sub = ap.add_subparsers(dest="command", required=True)
+
+    p = sub.add_parser("dist-shape", help="exactly one wheel, an sdist, nothing else")
+    p.add_argument("--dist", required=True)
+    p.set_defaults(func=cmd_dist_shape)
+
+    p = sub.add_parser("verify", help="run the whole gate against the installed wheel")
+    p.add_argument("--tests", required=True, help="a copy of tests/ in a neutral directory")
+    p.set_defaults(func=cmd_verify)
+
+    p = sub.add_parser("eligible-tests", help="print the derived gate-eligible test files")
+    p.add_argument("--tests", required=True)
+    p.set_defaults(func=cmd_eligible_tests)
+
+    p = sub.add_parser("check-payment-report", help="apply the closed-port assertions to a report")
+    p.add_argument("path")
+    p.set_defaults(func=cmd_check_payment_report)
+
+    p = sub.add_parser("check-simulated-report", help="apply the simulated-row contract to a report")
+    p.add_argument("path")
+    p.add_argument("--expect-rows", type=int, default=None)
+    p.set_defaults(func=cmd_check_simulated_report)
+
+    args = ap.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/testing/test_release_is_gated_on_the_wheel.py
+++ b/testing/test_release_is_gated_on_the_wheel.py
@@ -1,37 +1,62 @@
-"""A release must not publish a wheel nothing tested, and calibration must run.
+"""A release must not publish a wheel nothing tested, and the gate must run.
 
 Fourth external review, 2026-09-08 (R4-16). `publish` depended on `build` and
-on nothing else. The workflow built distributions, wrote and attested a
-provenance statement, and uploaded -- so it established WHO built the artifact
-and that it corresponds to the tagged source, and nothing about whether the
-artifact works. CI is a separate push/PR workflow whose install check runs
-inside the checkout, where `import protocol_tests` can resolve to the source
-tree rather than to the installed wheel; a wheel that ships nothing at all can
-pass a check performed next to the sources.
+on nothing else, so the workflow established WHO built the artifact and that it
+corresponds to the tagged source, and nothing about whether the artifact works.
+A `test-wheel` job was added and this file was written to guard it.
 
-Actions cannot run here, so these are static assertions on the workflow text,
-in the style of `TestTheWorkflowWiring` in test_release_provenance.py. Each one
-names the property it is standing in for:
+Fifth external review, 2026-09-09 (R5-01). This file guarded it by searching
+the job's concatenated shell text for phrases, filenames and command names.
+Wrapping every `run:` step of `test-wheel` in `if false; then … fi` leaves all
+of that text in place and executes none of it, and all 15 tests and 17 subtests
+still passed. Tokens in a string do not establish executable control flow, and
+half the test names here claimed behaviour the assertions could not reach.
 
-    publish is unreachable unless the wheel was tested   `needs`
-    the test ran outside the checkout                    `cd "$RUNNER_TEMP"`
-    the R3-01 reproduction is in the release path        closed-port assertion
-    the pinned calibration cannot skip quietly           junit `<skipped` gate
-    fork PRs stay read-only                              permissions
+So the file is now three kinds of check, and each one says which it is:
 
-A workflow assertion is weaker than an execution. It is what is available for a
-job that fires on `release: published`, and the alternative -- asserting
+    WIRING      structure read out of the parsed YAML -- `needs` edges, the
+                artifact a job consumes, permissions, and whether a job or step
+                is reachable at all. A step disabled with `if: false` is not a
+                step, and `_steps` does not return it.
+
+    EXECUTION   the `run:` bodies of `test-wheel` executed under bash against a
+                sandbox, with the commands they call replaced by recorders. The
+                assertions are about the resulting execution TRACE, so a body
+                that contains every right word and runs none of it records
+                nothing and fails. This is the direct answer to R5-01.
+
+    BEHAVIOUR   `scripts/verify_wheel_gate.py`, the module CI runs, executed
+                here against deliberately bad artifacts: a dist directory with
+                no wheel, one with two, one with a stray file, a closed-port
+                report with a nonzero pass count, and a simulated report whose
+                rows claim a pass or lost their labels. Same code, both
+                callers, so neither can be green by containing the right words.
+
+A workflow assertion is still weaker than a release. It is what is available
+for a job that fires on `release: published`; the alternative -- asserting
 nothing -- is how this dependency edge went missing in the first place.
 """
 
 from __future__ import annotations
 
+import importlib.util
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
 import unittest
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
 PUBLISH = REPO / ".github" / "workflows" / "publish-pypi.yml"
 CI = REPO / ".github" / "workflows" / "ci.yml"
+GATE = REPO / "scripts" / "verify_wheel_gate.py"
+
+#: `if:` values that can never be true. A gate whose job carries one of these
+#: is a gate that never runs, and the YAML still reads exactly the same.
+NEVER_TRUE = {"false", "0", "${{ false }}", "${{false}}", "${{ 1 == 2 }}"}
 
 
 def _load(path: Path) -> dict:
@@ -42,13 +67,397 @@ def _load(path: Path) -> dict:
     return yaml.safe_load(path.read_text(encoding="utf-8"))
 
 
+def _reachable(node: dict) -> bool:
+    """A job or step with a never-true `if:` is not part of the graph."""
+    cond = node.get("if")
+    return cond is None or str(cond).strip().lower() not in NEVER_TRUE
+
+
 def _steps(job: dict) -> list[dict]:
-    return job.get("steps", [])
+    """Only the steps that can actually execute."""
+    if not _reachable(job):
+        return []
+    return [s for s in job.get("steps", []) if _reachable(s)]
 
 
 def _runs(job: dict) -> str:
+    """Concatenated shell text. Every use of this is a WIRING claim."""
     return "\n".join(s.get("run") or "" for s in _steps(job))
 
+
+def _gate_module():
+    """Import `scripts/verify_wheel_gate.py` without touching `sys.path`."""
+    spec = importlib.util.spec_from_file_location("_verify_wheel_gate", GATE)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# EXECUTION: run the job's shell for real, against recorders.
+# ---------------------------------------------------------------------------
+
+#: One shim stands in for python, pip and agent-security. It appends its own
+#: invocation to the trace file and exits 0, except for `python -m venv`, which
+#: also creates the bin/ directory the later steps address by path.
+SHIM = """#!/bin/sh
+echo "$(basename "$0") $*" >> "$WHEEL_GATE_TRACE"
+if [ "$1" = "-m" ] && [ "$2" = "venv" ] && [ -n "$3" ]; then
+  mkdir -p "$3/bin"
+  for c in python pip agent-security; do
+    cp "$WHEEL_GATE_SHIM" "$3/bin/$c"
+    chmod +x "$3/bin/$c"
+  done
+fi
+exit 0
+"""
+
+
+class _Sandbox:
+    """A GITHUB_WORKSPACE and a RUNNER_TEMP with recorders on PATH."""
+
+    def __init__(self, root: Path, *, dist: list[str]):
+        self.root = root
+        self.workspace = root / "workspace"
+        self.runner_temp = root / "runner-temp"
+        self.bin = root / "bin"
+        self.trace = root / "trace.log"
+        for d in (self.workspace, self.runner_temp, self.bin,
+                  self.workspace / "dist", self.workspace / "scripts",
+                  self.workspace / "tests"):
+            d.mkdir(parents=True, exist_ok=True)
+        for name in dist:
+            (self.workspace / "dist" / name).write_text("not really a distribution")
+        (self.workspace / "tests" / "test_placeholder.py").write_text("")
+        shutil.copy(GATE, self.workspace / "scripts" / GATE.name)
+        shim = self.bin / "_shim"
+        shim.write_text(SHIM)
+        shim.chmod(0o755)
+        for command in ("python", "python3", "pip", "npx", "agent-security"):
+            shutil.copy(shim, self.bin / command)
+            (self.bin / command).chmod(0o755)
+        self.trace.write_text("")
+
+    def env(self) -> dict:
+        env = dict(os.environ)
+        env.update({
+            "GITHUB_WORKSPACE": str(self.workspace),
+            "RUNNER_TEMP": str(self.runner_temp),
+            "WHEEL_GATE_TRACE": str(self.trace),
+            "WHEEL_GATE_SHIM": str(self.bin / "_shim"),
+            "PATH": f"{self.bin}:{os.environ.get('PATH', '')}",
+        })
+        return env
+
+    def run(self, body: str) -> subprocess.CompletedProcess:
+        script = self.root / "step.sh"
+        script.write_text(body)
+        return subprocess.run(["bash", str(script)], cwd=str(self.runner_temp),
+                              env=self.env(), capture_output=True, text=True,
+                              timeout=120)
+
+    def lines(self) -> list[str]:
+        return [l for l in self.trace.read_text().splitlines() if l.strip()]
+
+
+class TestTheGateStepsActuallyExecute(unittest.TestCase):
+    """EXECUTION. R5-01: `if false; then … fi` kept every phrase and ran none."""
+
+    WHEEL = "agent_security_harness-9.9.9-py3-none-any.whl"
+    SDIST = "agent_security_harness-9.9.9.tar.gz"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.job = _load(PUBLISH)["jobs"]["test-wheel"]
+        cls.bodies = [s["run"] for s in _steps(cls.job) if s.get("run")]
+        if any("${{" in b for b in cls.bodies):
+            raise unittest.SkipTest(
+                "a run body interpolates a GitHub expression; this harness "
+                "executes bash, not the expression evaluator")
+
+    def _trace_of_the_job(self, dist: list[str] | None = None) -> list[str]:
+        dist = [self.WHEEL, self.SDIST] if dist is None else dist
+        with tempfile.TemporaryDirectory(prefix="wheel-gate-steps-") as tmp:
+            box = _Sandbox(Path(tmp), dist=dist)
+            for body in self.bodies:
+                done = box.run(body)
+                self.assertEqual(done.returncode, 0,
+                                 f"a gate step failed in the sandbox:\n{body}\n"
+                                 f"{done.stdout}\n{done.stderr}")
+            return box.lines()
+
+    def test_the_steps_run_commands_rather_than_containing_them(self):
+        """The whole finding. An empty trace means nothing executed."""
+        trace = self._trace_of_the_job()
+        self.assertTrue(
+            trace,
+            "the test-wheel steps executed no command at all: every check in "
+            "this job is text that never runs (R5-01)")
+
+    def test_the_executed_commands_include_the_gate(self):
+        trace = "\n".join(self._trace_of_the_job())
+        for fact, why in (
+                ("verify_wheel_gate.py dist-shape",
+                 "nothing checks the shape of the artifact before installing it"),
+                ("-m venv",
+                 "no fresh interpreter is created; an import could resolve anywhere"),
+                ("verify_wheel_gate.py verify",
+                 "the release gate itself never runs"),
+        ):
+            with self.subTest(executed=fact):
+                self.assertIn(fact, trace, why)
+
+    def test_the_wheel_is_installed_by_the_venv_pip_and_not_the_runner_one(self):
+        trace = self._trace_of_the_job()
+        installs = [l for l in trace if l.startswith("pip ") and " install" in l]
+        self.assertTrue(installs, "no pip install ran")
+        self.assertTrue(any(".whl" in l for l in installs),
+                        f"pip installed something that is not the built wheel: {installs}")
+        self.assertTrue(any("mcp-server" in l for l in installs),
+                        "the mcp-server extra is not installed, so the three MCP "
+                        "boundary contracts cannot be collected in a neutral directory")
+
+    def test_the_gate_is_run_by_the_venv_interpreter(self):
+        trace = self._trace_of_the_job()
+        verify = [l for l in trace if "verify_wheel_gate.py verify" in l]
+        self.assertTrue(verify, "the gate never runs")
+        self.assertTrue(all(l.startswith("python ") for l in verify), verify)
+        # The venv's python is copied from the shim into wheel-venv/bin, so an
+        # invocation of the runner's python would not have created that file.
+        self.assertTrue(any("--tests" in l for l in verify),
+                        f"the gate runs without a tests directory: {verify}")
+
+    def test_two_wheels_in_dist_stop_the_job(self):
+        """BEHAVIOUR through the workflow's own shell, not through its text."""
+        with tempfile.TemporaryDirectory(prefix="wheel-gate-twowheels-") as tmp:
+            box = _Sandbox(Path(tmp), dist=[self.WHEEL, self.SDIST,
+                                            "agent_security_harness-9.9.10-py3-none-any.whl"])
+            codes = [box.run(body).returncode for body in self.bodies]
+            self.assertTrue(any(c != 0 for c in codes),
+                            f"two wheels in dist/ and every step exited 0: {codes}")
+
+    def test_no_wheel_in_dist_stops_the_job(self):
+        with tempfile.TemporaryDirectory(prefix="wheel-gate-nowheel-") as tmp:
+            box = _Sandbox(Path(tmp), dist=[self.SDIST])
+            codes = [box.run(body).returncode for body in self.bodies]
+            self.assertTrue(any(c != 0 for c in codes),
+                            f"an sdist-only build installed and tested nothing: {codes}")
+
+
+# ---------------------------------------------------------------------------
+# BEHAVIOUR: the gate module, against artifacts that must not ship.
+# ---------------------------------------------------------------------------
+
+class TestTheGateRejectsBadArtifacts(unittest.TestCase):
+    """BEHAVIOUR. These call the same functions the release job calls."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.gate = _gate_module()
+
+    # -- the built distribution ---------------------------------------------
+
+    def test_a_well_formed_dist_is_accepted(self):
+        """The positive control: without it, a check that rejects everything
+        would pass every test below."""
+        self.assertEqual(self.gate.check_dist_shape(["a-1.0-py3-none-any.whl", "a-1.0.tar.gz"]), [])
+
+    def test_dist_shapes_that_must_not_publish(self):
+        for label, names in (
+                ("sdist only", ["a-1.0.tar.gz"]),
+                ("two wheels", ["a-1.0-py3-none-any.whl", "a-1.1-py3-none-any.whl", "a-1.0.tar.gz"]),
+                ("no sdist", ["a-1.0-py3-none-any.whl"]),
+                ("a stray file", ["a-1.0-py3-none-any.whl", "a-1.0.tar.gz", "build-environment.txt"]),
+                ("empty", []),
+        ):
+            with self.subTest(dist=label):
+                self.assertTrue(self.gate.check_dist_shape(names),
+                                f"{label} would have been published")
+
+    # -- the closed-port reproduction (R3-01) --------------------------------
+
+    def _closed_port_report(self, rows: int = 3, **summary) -> dict:
+        base = {"total": rows, "passed": 0, "failed": 0, "inconclusive": rows,
+                "serviced": 0, "status": "inconclusive", "pass_rate": None,
+                "wilson_95_ci": None}
+        base.update(summary)
+        return {"summary": base,
+                "results": [{"test_id": f"AP2-{i:03d}", "passed": False} for i in range(1, rows + 1)]}
+
+    def test_a_clean_closed_port_report_is_accepted(self):
+        self.assertEqual(self.gate.check_payment_report(self._closed_port_report()), [])
+
+    def test_a_closed_port_report_with_passes_is_rejected(self):
+        report = self._closed_port_report(passed=3, inconclusive=0, serviced=3, pass_rate=1.0)
+        for row in report["results"]:
+            row["passed"] = True
+        problems = self.gate.check_payment_report(report)
+        self.assertTrue(any("PASS against a port nothing listens on" in p for p in problems),
+                        problems)
+
+    def test_a_closed_port_report_with_no_verdicts_is_rejected(self):
+        """Unmeasured is not clean: zero passes over zero rows is not a result."""
+        report = {"summary": {"total": 0, "passed": 0, "serviced": 0}, "results": []}
+        self.assertTrue(any("unmeasured" in p for p in self.gate.check_payment_report(report)))
+
+    # -- the native --simulate writers (R4-05, and R5-07's escape from it) ---
+
+    def _simulated_report(self, rows: int = 3) -> dict:
+        results = [{
+            "test_id": f"AP2-{i:03d}",
+            "passed": False,
+            "not_evaluated": True,
+            "simulated": True,
+            "verdict_scope": self.gate.SIMULATED_ROW_SCOPE,
+            "details": f"{self.gate.INCONCLUSIVE_PREFIX}simulated run: nothing was contacted",
+            "reference_verdict": {"passed": True, "reason": "the model said so",
+                                  "scope": self.gate.REFERENCE_VERDICT_SCOPE},
+        } for i in range(1, rows + 1)]
+        return {"results": results,
+                "verdict_scope": {"live_requested": False},
+                "summary": {"total": rows, "passed": 0, "failed": 0,
+                            "inconclusive": rows, "serviced": 0,
+                            "status": "inconclusive", "pass_rate": None,
+                            "wilson_95_ci": None}}
+
+    def test_a_correctly_scoped_simulated_report_is_accepted(self):
+        self.assertEqual(
+            self.gate.check_simulated_report(self._simulated_report(), expected_rows=3), [])
+
+    def test_the_row_shapes_a_simulated_run_must_not_publish(self):
+        """Each case is one field of the R4-05 defect, or of the R5-07 escape
+        that removed the labels while leaving `passed` alone."""
+        cases = {
+            "a row claims a pass": lambda r: r["results"][0].update(passed=True),
+            "the structural marker is gone": lambda r: r["results"][0].pop("not_evaluated"),
+            "the simulated label is gone": lambda r: r["results"][0].pop("simulated"),
+            "the row scope is gone": lambda r: r["results"][0].pop("verdict_scope"),
+            "the details disagree with the field":
+                lambda r: r["results"][0].update(details="tampered cart rejected"),
+            "the fabricated verdict was discarded":
+                lambda r: r["results"][0].pop("reference_verdict"),
+            "the fabricated verdict lost its scope":
+                lambda r: r["results"][0]["reference_verdict"].pop("scope"),
+            "no reference verdict survived at all":
+                lambda r: [row["reference_verdict"].update(passed=False) for row in r["results"]],
+            "the summary counts passes":
+                lambda r: r["summary"].update(passed=3, inconclusive=0, serviced=3, pass_rate=1.0),
+            "a rate was computed over nothing":
+                lambda r: r["summary"].update(wilson_95_ci={"lower": 0.8, "upper": 1.0}),
+            "the report does not say live was never requested":
+                lambda r: r["verdict_scope"].update(live_requested=True),
+            "a row went missing": lambda r: r["results"].pop(),
+        }
+        for label, break_it in cases.items():
+            with self.subTest(defect=label):
+                report = self._simulated_report()
+                break_it(report)
+                self.assertTrue(
+                    self.gate.check_simulated_report(report, expected_rows=3),
+                    f"a simulated report would have shipped with: {label}")
+
+    def test_the_six_native_entry_points_are_all_on_the_gate(self):
+        """R5-07: the nine files used the CLI facade, which never reaches these."""
+        for module in ("protocol_tests.ap2_harness",
+                       "protocol_tests.x402_fireblocks_harness",
+                       "protocol_tests.ucp_acp_harness",
+                       "protocol_tests.card_token_harness",
+                       "protocol_tests.settlement_finality_harness",
+                       "protocol_tests.aiuc1_compliance_harness"):
+            with self.subTest(module=module):
+                self.assertIn(module, self.gate.NATIVE_SIMULATE)
+
+    # -- how the packaged-test selection is derived --------------------------
+
+    def test_every_file_in_tests_is_classified(self):
+        """The nine-file list was hand-maintained and 21 of 30 files were
+        omitted with one sentence covering all of them. A new file now fails
+        the gate until someone says which it is."""
+        present = sorted(p.name for p in (REPO / "tests").glob("test_*.py"))
+        self.assertEqual(self.gate.check_test_classification(present), [])
+
+    def test_an_unclassified_new_file_fails_the_gate(self):
+        present = sorted(p.name for p in (REPO / "tests").glob("test_*.py"))
+        problems = self.gate.check_test_classification(present + ["test_brand_new.py"])
+        self.assertTrue(any("unclassified" in p for p in problems), problems)
+
+    def test_a_classified_file_that_disappeared_fails_the_gate(self):
+        present = sorted(p.name for p in (REPO / "tests").glob("test_*.py"))
+        problems = self.gate.check_test_classification(present[1:])
+        self.assertTrue(any("no longer exists" in p for p in problems), problems)
+
+    def test_every_exclusion_names_the_resource_it_needs(self):
+        """"They all need the checkout" was too broad (R5-07)."""
+        for name, reason in self.gate.CHECKOUT_ONLY.items():
+            with self.subTest(excluded=name):
+                self.assertTrue(len(reason) > 15 and not reason.startswith("needs the checkout"),
+                                f"{name} is excluded for {reason!r}")
+
+    def test_the_gate_runs_more_of_the_suite_than_the_hand_written_nine(self):
+        eligible = self.gate.WHEEL_GATE_ELIGIBLE
+        self.assertGreaterEqual(
+            len(eligible), 12,
+            f"the derived selection is {len(eligible)} files; the hand-maintained "
+            f"list it replaced was nine")
+        for name in eligible:
+            with self.subTest(test=name):
+                self.assertTrue((REPO / "tests" / name).is_file())
+
+    # -- unmeasured is not clean --------------------------------------------
+
+    def test_a_run_with_skips_or_no_testcases_is_not_clean(self):
+        for label, counts, clean in (
+                ("a normal green run", {"tests": 9, "errors": 0, "failures": 0, "skipped": 0}, True),
+                ("everything skipped", {"tests": 7, "errors": 0, "failures": 0, "skipped": 7}, False),
+                ("one skip among passes", {"tests": 9, "errors": 0, "failures": 0, "skipped": 1}, False),
+                ("nothing collected", {"tests": 0, "errors": 0, "failures": 0, "skipped": 0}, False),
+                ("a collection error", {"tests": 1, "errors": 1, "failures": 0, "skipped": 0}, False),
+        ):
+            with self.subTest(run=label):
+                self.assertEqual(self.gate.is_clean(counts), clean)
+
+    def test_junit_counts_are_read_from_the_file_pytest_writes(self):
+        xml = ('<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite '
+               'name="pytest" errors="1" failures="2" skipped="3" tests="9" '
+               'time="0.1"><testcase classname="t" name="a"/></testsuite></testsuites>')
+        self.assertEqual(self.gate.junit_counts(xml),
+                         {"tests": 9, "errors": 1, "failures": 2, "skipped": 3})
+
+    def test_the_gate_refuses_to_run_next_to_a_source_tree(self):
+        """Source shadowing is the reason the CI install check proves less than
+        it looks like it proves."""
+        with tempfile.TemporaryDirectory(prefix="wheel-gate-shadow-") as tmp:
+            root = Path(tmp)
+            (root / "tests").mkdir()
+            (root / "protocol_tests").mkdir()
+            done = subprocess.run([sys.executable, str(GATE), "verify",
+                                   "--tests", str(root / "tests")],
+                                  capture_output=True, text=True, timeout=120)
+            self.assertNotEqual(done.returncode, 0)
+            self.assertIn("not the checkout", done.stdout + done.stderr)
+
+    def test_the_command_line_exits_non_zero_on_a_bad_report(self):
+        """The workflow calls this through a shell, so the exit code is the
+        only thing that stops a release."""
+        with tempfile.TemporaryDirectory(prefix="wheel-gate-cli-") as tmp:
+            good = Path(tmp) / "good.json"
+            bad = Path(tmp) / "bad.json"
+            good.write_text(json.dumps(self._closed_port_report()))
+            report = self._closed_port_report(passed=3, inconclusive=0, serviced=3)
+            for row in report["results"]:
+                row["passed"] = True
+            bad.write_text(json.dumps(report))
+            for path, expected in ((good, 0), (bad, 1)):
+                with self.subTest(report=path.name):
+                    done = subprocess.run(
+                        [sys.executable, str(GATE), "check-payment-report", str(path)],
+                        capture_output=True, text=True, timeout=120)
+                    self.assertEqual(done.returncode, expected, done.stdout)
+
+
+# ---------------------------------------------------------------------------
+# WIRING: what the parsed workflow says about the graph.
+# ---------------------------------------------------------------------------
 
 class TestPublishIsGatedOnTestingTheWheel(unittest.TestCase):
     @classmethod
@@ -56,9 +465,12 @@ class TestPublishIsGatedOnTestingTheWheel(unittest.TestCase):
         cls.doc = _load(PUBLISH)
         cls.jobs = cls.doc["jobs"]
 
-    def test_a_wheel_test_job_exists(self):
+    def test_a_wheel_test_job_exists_and_is_reachable(self):
         self.assertIn("test-wheel", self.jobs,
                       "no job tests the built wheel; publish would gate on nothing")
+        self.assertTrue(_reachable(self.jobs["test-wheel"]),
+                        f"test-wheel carries if: {self.jobs['test-wheel'].get('if')!r}, "
+                        f"which is never true")
 
     def test_publish_needs_the_wheel_test(self):
         """The edge itself. Without it the job can exist and never run."""
@@ -68,6 +480,27 @@ class TestPublishIsGatedOnTestingTheWheel(unittest.TestCase):
                       f"publish needs {needs}; a failing wheel test would not stop "
                       f"the upload")
         self.assertIn("build", needs)
+
+    def test_publish_needs_the_pinned_calibration(self):
+        """Fifth review, section E: a Release cut from a tag with no green
+        ordinary CI still only had to pass the wheel gate, because `needs:`
+        cannot cross workflows and the calibration lived in ci.yml alone."""
+        needs = self.jobs["publish"]["needs"]
+        needs = [needs] if isinstance(needs, str) else list(needs)
+        self.assertIn("calibration", needs,
+                      f"publish needs {needs}; the pinned reference-server "
+                      f"calibration is not in the release graph")
+        self.assertIn("calibration", self.jobs)
+        self.assertTrue(_reachable(self.jobs["calibration"]))
+
+    def test_the_release_calibration_is_the_same_job_as_the_ci_one(self):
+        """Two copies that drift are worse than one, because the stale copy
+        still reads as coverage."""
+        ci = _load(CI)["jobs"]["mcp-reference-calibration"]
+        release = self.jobs["calibration"]
+        self.assertEqual([s.get("run") for s in _steps(ci)],
+                         [s.get("run") for s in _steps(release)],
+                         "the release calibration has drifted from the CI one")
 
     def test_the_wheel_test_consumes_the_built_artifact_not_a_fresh_build(self):
         """Testing a rebuild tests a different file than the one published."""
@@ -79,48 +512,31 @@ class TestPublishIsGatedOnTestingTheWheel(unittest.TestCase):
         self.assertNotIn("python -m build", _runs(job),
                          "test-wheel rebuilds instead of testing what publish uploads")
 
-    def test_the_wheel_is_installed_and_run_outside_the_checkout(self):
-        """Source shadowing is the reason the CI smoke check proves less than
-        it looks like it proves."""
-        runs = _runs(self.jobs["test-wheel"])
-        self.assertIn('cd "$RUNNER_TEMP"', runs,
-                      "every step must leave the checkout before importing")
-        self.assertIn("python -m venv", runs, "a fresh interpreter, not the runner's")
-        self.assertIn("site-packages", runs,
-                      "nothing asserts the import resolved to the installed wheel")
+    def test_no_step_of_the_gate_is_conditional(self):
+        """A gate step with an `if:` is a gate step that can decline to run.
+        None of them needs one, so none of them has one."""
+        for step in self.jobs["test-wheel"].get("steps", []):
+            with self.subTest(step=step.get("name") or step.get("uses")):
+                self.assertIsNone(step.get("if"))
 
-    def test_the_smoke_commands_are_the_documented_entry_points(self):
+    def test_the_workflow_mentions_leaving_the_checkout(self):
+        """WIRING, and named as such: this asserts the text says `cd
+        "$RUNNER_TEMP"`, not that anything did. `TestTheGateStepsActuallyExecute`
+        runs the steps, and the gate itself refuses to run beside a source tree."""
         runs = _runs(self.jobs["test-wheel"])
-        for command in ("agent-security --version",
-                        "protocol_tests.mock_mcp_server --help"):
-            with self.subTest(command=command):
-                self.assertIn(command, runs)
+        self.assertIn('cd "$RUNNER_TEMP', runs)
+        self.assertIn("python -m venv", runs)
 
-    def test_the_closed_port_reproduction_is_in_the_release_path(self):
-        """R3-01: installed 4.21.0 reported 17/17 PASS against a dead port. The
-        reproduction is a release gate now, not a story in a changelog."""
+    def test_the_gate_script_is_taken_from_the_checkout_not_the_wheel(self):
+        """A wheel that shipped a broken gate would otherwise certify itself."""
         runs = _runs(self.jobs["test-wheel"])
-        self.assertIn("http://127.0.0.1:9", runs, "no closed-port run")
-        self.assertIn("test ap2", runs, "the reproduction names no payment harness")
-        self.assertIn("PASS against a port nothing listens on", runs,
-                      "the closed-port run does not assert anything about passes")
-        self.assertIn("unmeasured, not clean", runs,
-                      "a run that produced no verdicts would read as zero passes")
-
-    def test_packaged_behaviour_tests_run_against_the_installed_copy(self):
-        runs = _runs(self.jobs["test-wheel"])
-        self.assertIn("pytest", runs, "no test suite runs against the wheel")
-        self.assertIn("tests/test_registry_schema_validity_is_enforced.py", runs)
-        named = [line.strip().rstrip(" \\")
-                 for line in runs.splitlines() if line.strip().startswith("tests/")]
-        self.assertGreaterEqual(len(named), 5,
-                                f"only {len(named)} packaged test file(s) run from the wheel")
-        for rel in named:
-            with self.subTest(test=rel):
-                self.assertTrue((REPO / rel).is_file(), f"{rel} does not exist")
+        self.assertIn('"$GITHUB_WORKSPACE/scripts/verify_wheel_gate.py"', runs)
+        self.assertNotIn("-m scripts.verify_wheel_gate", runs)
 
     def test_the_wheel_test_job_does_not_widen_permissions(self):
         self.assertEqual(self.jobs["test-wheel"].get("permissions"),
+                         {"contents": "read"})
+        self.assertEqual(self.jobs["calibration"].get("permissions"),
                          {"contents": "read"})
 
 
@@ -132,6 +548,7 @@ class TestTheCalibrationIsRequiredNotOptional(unittest.TestCase):
 
     def test_a_calibration_job_exists(self):
         self.assertIn("mcp-reference-calibration", self.jobs)
+        self.assertTrue(_reachable(self.jobs["mcp-reference-calibration"]))
 
     def test_it_populates_the_cache_with_the_pin_the_script_declares(self):
         """A pin typed into the workflow drifts from the pin in the script."""
@@ -141,14 +558,13 @@ class TestTheCalibrationIsRequiredNotOptional(unittest.TestCase):
         self.assertIn("npx -y -p", runs, "nothing populates the npm cache")
 
     def test_the_pin_is_still_a_fixed_version_in_the_script(self):
-        import sys
         sys.path.insert(0, str(REPO / "scripts"))
         from mcp_reference_calibration import REFERENCE_SERVER
         self.assertRegex(REFERENCE_SERVER, r"^@modelcontextprotocol/server-everything@\d{4}\.\d{1,2}\.\d{1,2}$")
 
-    def test_a_skip_fails_the_job(self):
-        """The whole finding: the calibration skips when the package is not
-        cached, and a skip reads green. Unmeasured is not clean."""
+    def test_the_workflow_text_inspects_the_run_for_skips(self):
+        """WIRING. The calibration's own file is what establishes the
+        behaviour; this only establishes that the job looks for a skip."""
         runs = _runs(self.jobs["mcp-reference-calibration"])
         self.assertIn("--junitxml", runs, "nothing records what actually ran")
         self.assertIn("<skipped", runs, "nothing inspects the run for skips")


### PR DESCRIPTION
From the fifth external review. Both findings are about the release gate we shipped last round being weaker than its own test names claim.

**R5-01.** `testing/test_release_is_gated_on_the_wheel.py` checked the workflow by searching concatenated shell text for phrases and filenames. Wrapping every `run` step of `test-wheel` in `if false; then … fi` left all that text in place, executed none of it, and **all 15 tests and 17 subtests passed**. Tokens in a string do not establish executable control flow.

**R5-07.** The nine packaged test files passed unmodified (78 / 69). Reintroducing the R4-05 defect in the installed package left the same nine files green while `python -m protocol_tests.ap2_harness --simulate --report …` emitted the bad report. The CLI simulation tests use the facade and never traverse the native writer.

Fix: the gate's checks are now a real program, `scripts/verify_wheel_gate.py`, run by the wheel venv's interpreter from a neutral directory with the script taken from the checkout — a wheel shipping a broken gate must not certify itself. Six stages: import resolution to site-packages, gate/package vocabulary agreement, entry points, the R3-01 closed-port reproduction, **the six native `--simulate` entry points checked at every layer** (per-row verdict, `not_evaluated`, `simulated`, `verdict_scope`, details prefix, scoped `reference_verdict`, and the three-state summary), and a packaged-test audit. The contract test file is rewritten into WIRING / EXECUTION / BEHAVIOUR classes so a test that only reads YAML says so in its name.

**Eligibility is derived, not remembered.** All 30 `tests/` files are classified and run from the neutral directory; eligible means ≥1 testcase with zero failures, errors **or skips**, and an excluded file that starts passing fails the gate. **12 of 30 are eligible, up from 9** — installing the `mcp-server` extra brings in the registry-server and MCP boundary contracts the review named as wrongly omitted.

**Calibration is now a real dependency.** `needs:` cannot cross workflows, so the pinned calibration job is duplicated into `publish-pypi.yml` and `publish` needs `[build, test-wheel, calibration]`; a test holds the two copies byte-identical, because a drifted copy still reads as coverage.

Independently reproduced in a clean worktree at fea381d: `publish` needs all three jobs; the contract file passes 39/75 clean, and Astra's `if false` mutation now **fails it (4 failed)**; a wheel built from this branch, installed with the `mcp-server` extra in a fresh venv and run from a neutral directory, gives `RELEASE GATE PASSED` (exit 0), and with `simulated_row → dict(row)` injected into the installed package the same command **exits 1**. (My first attempt failed on a good wheel because my venv lacked the `mcp-server` extra the workflow installs — the gate correctly refuses to certify a wheel whose eligible test skipped.)

**A correction to the review's account, worth recording:** `simulated_row → dict(row)` alone does *not* produce `passed: true`. It strips `simulated` and `verdict_scope` while `fold_live_verdict` independently keeps `passed` false. The stated 66 fabricated passes need **both** folds broken — the agent verified this and the gate catches either. The escape is real; the mechanism is two layers, not one.

Injections (diff-confirmed): `if false` → 8 failed / 3 subfailed; `simulated_row → dict(row)` → gate exit 1 ("row is not labelled simulated" ×66); the `fold_live_verdict` simulate branch reverted → gate exit 1 ("a simulated row claimed passed=True", `pass_rate 1.0`); `needs` reduced to `build` → 2 failed; the closed-port fold reverted → gate exit 1; the attestation schema deleted from the wheel → gate exit 1; console entry point exiting 3 → 3 stages fail; sdist-only / two wheels / stray file → `dist-shape` exit 1. Suite 1536 passed / 1927 subtests / 0 failed (baseline 1512 / 1865).

Of Astra's six bad-release scenarios, five are now caught by execution rather than inference: native simulation defect, reverted closed-port fold, sdist-only build, broken console entry point, and missing attestation schema. **"Calibration executes but asserts nothing" remains inference** — the junit check counts testcases and skips, which is execution, not assertion strength.

🤖 Generated with [Claude Code](https://claude.com/claude-code)