### PR TITLE
Bind the release-test-count claim to v4.21.3 (623), now that the tag exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Results: 8/10 passed (80% pass rate) - see report.json
 > servicing the request, reports **INCONCLUSIVE** — never PASS. See
 > [v4.13.1](CHANGELOG.md) for why that distinction is enforced rather than assumed.
 
-623 executable security tests across 45 test-bearing modules on `main` (verified 2026-09-07 via `scripts/count_tests.py`; the v4.21.2 release carries 623). MCP + A2A + L402 + x402 wire-protocol testing, plus UCP/ACP merchant-journey, AP2 mandate-chain, Fireblocks x402 hardening, Visa TAP / Mastercard Agentic Token funding-instrument, and denial-of-settlement finality conformance across the full agentic-payments stack. Decision-layer attack scenarios. One `pip install` away.
+623 executable security tests across 45 test-bearing modules on `main` (verified 2026-09-07 via `scripts/count_tests.py`; the v4.21.3 release carries 623). MCP + A2A + L402 + x402 wire-protocol testing, plus UCP/ACP merchant-journey, AP2 mandate-chain, Fireblocks x402 hardening, Visa TAP / Mastercard Agentic Token funding-instrument, and denial-of-settlement finality conformance across the full agentic-payments stack. Decision-layer attack scenarios. One `pip install` away.
 
 If this evidence discipline is useful in your agent-security work, **star this
 repository to follow releases**.
@@ -330,7 +330,7 @@ mapping and the human-in-the-loop harness** · v4.13.1 a correctness fix to that
 endpoint provenance · v4.16.0 three target shapes: a verdict must be able to be wrong AND to be right · v4.17.0 eight modules could not tell a refusal from a compliance · v4.18.0 INCONCLUSIVE became a field, and the read-list emptied · v4.19.0 a correctness disclosure: verdicts moved in both directions · v4.20.0 the last absence-graded verdicts got a positive control · v4.21.0 the instrument was the thing under test: 7 of 9 defects were in the measurement apparatus · v4.21.1 the published wheel reported 17/17 against a host that did not exist · v4.21.2 a fourth review asked what the repaired layer assumes: 47 rows called a control held on a reply that said nothing · **v4.21.3 a fifth review asked whether the checks can fail: the workflow contract tests passed with every step disabled, and nine of twelve register denominators could be replaced by a constant** · v4.15.0 unserviced requests are no longer recorded as passes (see
 [CHANGELOG.md](CHANGELOG.md)).
 
-The release carries **623** tests; `main` is at **623**. At v4.21.2 they agree: MCP-021, the MCP
+The release carries **623** tests; `main` is at **623**. At v4.21.3 they agree: MCP-021, the MCP
 authentication fail-open differential, and DCA-001..DCA-011, the multi-hop delegated-authority
 attenuation suite, all landed before the tag. They do not always agree: at v4.15.0 the release
 carried 603 while `main` was at 608, the difference being MAG-019, MEM-011, MEM-012, X4-056 and

--- a/docs/release-claims.json
+++ b/docs/release-claims.json
@@ -5,12 +5,12 @@
   "claims": [
     {
       "id": "release-test-count",
-      "fact": "The v4.21.2 release carries 623 unique test IDs.",
+      "fact": "The v4.21.3 release carries 623 unique test IDs.",
       "value": "623",
-      "release_tag": "v4.21.2",
+      "release_tag": "v4.21.3",
       "command": "python3 scripts/count_tests.py",
       "value_extraction": "Definitive count:\\s*(\\d+)",
-      "generated_on": "2026-09-08",
+      "generated_on": "2026-09-09",
       "coverage_report_revision": null,
       "evidence_class": "E1",
       "independence_level": "I0",
@@ -18,7 +18,7 @@
       "surfaces": [
         {
           "path": "README.md",
-          "pattern": "the v4\\.21\\.2 release carries (\\d+)"
+          "pattern": "the v4\\.21\\.3 release carries (\\d+)"
         },
         {
           "path": "README.md",


### PR DESCRIPTION
Follows the v4.21.3 release. The claim surfaces move to the new tag only after that tag is on origin, so `verify_release_claims` never points at a tag that does not resolve.

`scripts/verify_release_claims.py`: **6 passed, 0 failed, 0 not reproduced** — including `regenerate @ v4.21.3: reproduced 623` and `tag binds commit: v4.21.3 resolves to 4c5c7622fa64`.

Local suite: 1610 passed, 2 skipped, 2243 subtests, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)