### PR TITLE
Gate the release on the surfaces it is about: --preflight and a written order

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -7,7 +7,12 @@ different order produced a specific, recorded failure.
 
 ```bash
 # 1. Merge the release PR. The version bump lands on main in the SAME commit
-#    the tag will point at.
+#    the tag will point at -- so everything the tag should say must be IN it:
+#      - pyproject.toml version bump
+#      - docs/release-claims.json: rebind `release-test-count` to the NEW tag
+#        (release_tag AND the `fact` sentence AND the README surface patterns)
+#    testing/test_release_claims.py fails the PR if the bump lands without the
+#    rebind. Do not rebind in a follow-up PR: see "Why the claim is rebound in the release PR".
 
 # 2. Push the tag FIRST, before touching any public surface.
 git tag vX.Y.Z && git push origin vX.Y.Z
@@ -28,6 +33,32 @@ gh release create vX.Y.Z --verify-tag --title "..." --notes-file ...
 `--apply` (step 3, optional) rewrites the repository **description** to the
 tree's figures. It cannot touch anything in step 3's list: those live in other
 repositories.
+
+## Why the claim is rebound in the release PR
+
+`docs/release-claims.json` binds each release-facing fact to the revision, command and
+value that produced it. Until 2026-09-10 it was rebound in a PR that landed *after* the
+tag, which meant the tree every tag pointed at named the release **before** it:
+
+    v4.21.0   pyproject 4.21.0   manifest v4.20.0   (and the previous value, 611)
+    v4.21.1   pyproject 4.21.1   manifest v4.21.0
+    v4.21.2   pyproject 4.21.2   manifest v4.21.1
+    v4.21.3   pyproject 4.21.3   manifest v4.21.2
+
+Four for four. `main` reconciled minutes later, so every check that runs on `main` saw an
+agreeing pair and nothing flagged it.
+
+It is not cosmetic, and it propagates outward. An external nightly sentinel pinned at
+`v4.21.3` was sent *by this manifest* to regenerate a value at `v4.21.2` -- a tag its
+`--depth 1 --branch v4.21.3` clone could not contain -- and correctly reported the check
+as not reproduced. A manifest bound one release back turns a shallow clone from
+sufficient into insufficient.
+
+`testing/test_release_claims.py::test_a_release_claim_names_the_version_the_tree_is_at`
+asserts `release_tag == "v" + <pyproject version>`. It compares against `pyproject.toml`
+rather than `git tag` on purpose: no tag object is needed, so it holds in the depth-1
+clone CI uses, and it fires in the release commit itself -- the one moment the version
+has moved and the manifest has not. On every other commit the two agree and it is silent.
 
 ## Why the tag goes before the surfaces
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,103 @@
+# Releasing
+
+The order below is not stylistic. Each step exists because doing it in a
+different order produced a specific, recorded failure.
+
+## The order
+
+```bash
+# 1. Merge the release PR. The version bump lands on main in the SAME commit
+#    the tag will point at.
+
+# 2. Push the tag FIRST, before touching any public surface.
+git tag vX.Y.Z && git push origin vX.Y.Z
+
+# 3. Update the surfaces that name the release, and let them go live:
+#      - msaleme/start-here          README (includes a copyable Action pin)
+#      - https://pubpoint.com/facts-evidence/   (Cloudflare Pages; wait for deploy)
+#    The exact figures to write:
+python3 scripts/check_public_metadata.py --print-expected
+
+# 4. Gate. This must print OK (preflight) before you go on.
+python3 scripts/check_public_metadata.py --preflight
+
+# 5. Publish. --verify-tag refuses to invent a tag that does not exist.
+gh release create vX.Y.Z --verify-tag --title "..." --notes-file ...
+```
+
+`--apply` (step 3, optional) rewrites the repository **description** to the
+tree's figures. It cannot touch anything in step 3's list: those live in other
+repositories.
+
+## Why the tag goes before the surfaces
+
+`start-here` carries a copyable GitHub Action pin:
+
+    uses: msaleme/red-team-blue-team-agent-fabric@vX.Y.Z
+
+If the surfaces are updated before the tag is pushed, that pin names a tag that
+does not exist, and anyone who copies it during the window gets a workflow that
+cannot resolve. **A pin that 404s is worse than a pin that is one version behind
+and works.** Pushing the tag first (step 2) closes that window: the pin resolves
+from the moment it is published.
+
+## Why the release object goes last
+
+`Public metadata drift` runs on `release: published`. It compares the tree at the
+highest release tag against the surfaces **read live at that moment**. Publish
+the release before the surfaces are current and it fails — correctly, and every
+time.
+
+That is not hypothetical. It happened on four consecutive releases for the
+description (v4.18.0, v4.19.0rc1, v4.19.0, v4.20.0), was fixed for the
+description by `--apply`, and then recurred on four more (v4.21.0, v4.21.1,
+v4.21.2, v4.21.3) through the two remote surfaces `--apply` cannot reach.
+
+Publishing last means the workflow's first run is against a world that already
+agrees.
+
+## A failed release run is not permanently red
+
+Both sides of that comparison are read at run time — the tag list and the live
+surfaces — so a run that failed because a surface was stale **passes on re-run
+once the surface is fixed**:
+
+```bash
+gh run rerun <run-id> -R msaleme/red-team-blue-team-agent-fabric
+```
+
+Verified 2026-09-09: re-running turned v4.21.0 through v4.21.3 green with no
+change to those tags. Do not re-cut a tag to clear this.
+
+(This differs from a workflow-file fix, which genuinely cannot reach an existing
+tag, because the workflow file *is* read from the tag's commit.)
+
+## What `--preflight` is for, and what it refuses
+
+Between steps 2 and 4 the tag exists but the release object does not, so the
+release-date lookup 404s and an ordinary run exits `2` (UNREACHABLE) however
+correct the surfaces are. A gate that can never return `0` is not a gate.
+
+`--preflight` treats that one 404 as expected and prints what it skipped:
+
+```
+OK (preflight)  ... match the tree (... , vX.Y.Z)
+    Release date NOT checked: vX.Y.Z is not published yet.
+    Re-run without --preflight after `gh release create`.
+```
+
+It is **refused once the release exists** — exit `1`, telling you to re-run
+without it. Otherwise the flag would be a way to skip a check that could have
+run, which is the defect this checker exists to catch, wearing a flag.
+
+It excuses nothing else. A 403, a rate limit, a network error, a stale count or
+a stale version all still fail under `--preflight`. See
+`testing/test_public_metadata_check.py::TestPreflight`.
+
+## Exit codes
+
+| code | meaning |
+|------|---------|
+| `0` | every surface agrees with the tree |
+| `1` | drift — the surfaces are named individually |
+| `2` | UNREACHABLE — a surface was not read. **Not a pass.** |

--- a/scripts/check_public_metadata.py
+++ b/scripts/check_public_metadata.py
@@ -41,10 +41,17 @@ instead, which is why the date is checked and not only the numbers.
 
 ## Release sequencing, and --apply
 
-The workflow also runs on `release: published`. That run compares the description
-against the tree at the tag that was just published, and it fails whenever the
-description is edited AFTER the release is created, because at that instant the
-description still names the previous version. It failed that way on four
+The workflow also runs on `release: published`. That run compares against the
+tree at the HIGHEST release tag present when the job runs -- `git tag
+--sort=-v:refname | head -1`, not the tag that triggered it -- and it reads the
+remote surfaces live over HTTP at that same moment. Both sides are therefore
+read at run time, not frozen at the tag. One consequence is worth stating
+because it was got wrong once: a failed release run is NOT permanently red. Once
+the surfaces are corrected, re-running it passes, and on 2026-09-09 re-running
+turned v4.21.0 through v4.21.3 green without any change to those tags.
+
+It fails whenever a surface is updated AFTER the release is created, because at
+that instant the surface still names the previous version. It failed that way on four
 consecutive releases (v4.18.0, v4.19.0rc1, v4.19.0, v4.20.0), each time correctly,
 and each time the description was fixed by hand a few minutes later. A red run
 that is always right and always stale is a process defect, not a checker defect.
@@ -60,6 +67,42 @@ what the tree at HEAD implies (`rewrite_description`, pure and tested offline),
 PATCHes it with the caller's token, then runs the normal comparison so the
 output ends in OK or DRIFT rather than in "applied". It refuses to write a
 description the checker itself would still reject.
+
+## The remote surfaces, and --preflight
+
+`--apply` fixes the description and nothing else. REMOTE_READMES and
+REMOTE_PAGES live in OTHER repositories, so no token this script is given can
+rewrite them, and the description being handled is exactly why the remaining gap
+was easy to miss: the release step reported OK while two surfaces stayed stale.
+That recurred on v4.21.0, v4.21.1, v4.21.2 and v4.21.3 -- the same failure the
+section above records for v4.18.0..v4.20.0, arriving through the surfaces that
+`--apply` cannot reach.
+
+Updating those surfaces before the tag exists is NOT the answer on its own: the
+`start-here` line is a copyable GitHub Action pin, and a pin naming a tag that
+has not been pushed resolves to nothing. A pin that 404s is worse than a pin
+that is one version behind but works.
+
+The order that satisfies both -- the pin always resolves, and the release run is
+green when it fires:
+
+    1. merge the release PR            (the version bump lands on main)
+    2. git tag vX.Y.Z && git push      (the tag exists, so the pin resolves)
+    3. update REMOTE_READMES + REMOTE_PAGES, merge, let the page deploy
+    4. python3 scripts/check_public_metadata.py --preflight    -> must be OK
+    5. gh release create vX.Y.Z --verify-tag
+
+`--preflight` exists because steps 2-4 sit in a window where the tag exists but
+the release object does not, so `fetch_release_date` 404s and the normal run
+exits 2 (UNREACHABLE) no matter how correct the surfaces are. A gate that can
+never return 0 is not a gate. Under `--preflight` that one 404 is expected and
+the release-date comparison is skipped -- named in the output, never silent.
+
+The flag is refused once the release is published. Otherwise it would be a way
+to skip a check that could have run, which is the defect this file exists to
+catch, wearing a flag.
+
+See docs/RELEASING.md.
 
 ## What it compares
 
@@ -499,6 +542,9 @@ def main() -> int:
                     help="print the description fields the tree implies, then exit 0")
     ap.add_argument("--apply", action="store_true",
                     help="rewrite the live description to the tree's figures, then check")
+    ap.add_argument("--preflight", action="store_true",
+                    help="check the surfaces BEFORE `gh release create`, when the "
+                         "release object does not exist yet. Refused once it does.")
     args = ap.parse_args()
 
     want = {"count": canonical_count(),
@@ -545,13 +591,36 @@ def main() -> int:
         problems.append(f"CITATION.cff: version says {cff_version}, tree says {want_version}")
 
     unreachable = []
+    released = None
+    release_date_skipped = False
     try:
         released = fetch_release_date(args.repo, f"v{want_version}")
-        if cff_date is not None and released and cff_date != released:
-            problems.append(f"CITATION.cff: date-released says {cff_date}, "
-                            f"v{want_version} was published {released}")
+    except urllib.error.HTTPError as e:
+        if e.code == 404 and args.preflight:
+            # Expected, and ONLY under --preflight: the flag exists for the
+            # window between the release PR merging and `gh release create`, so
+            # there is no release object to date yet. Recorded and printed
+            # rather than passed over -- a check that did not run is not a check
+            # that passed, which is the same rule that makes UNREACHABLE exit 2.
+            release_date_skipped = True
+        else:
+            unreachable.append(f"release date for v{want_version} ({type(e).__name__})")
     except Exception as e:                        # noqa: BLE001
         unreachable.append(f"release date for v{want_version} ({type(e).__name__})")
+
+    # --preflight must not become a way to skip a check that could have run. If
+    # the release is already published there is a real date to compare, so the
+    # flag is refused rather than quietly honoured.
+    if args.preflight and released:
+        problems.append(
+            f"--preflight was passed, but v{want_version} is already published "
+            f"({released}). Preflight covers the window BEFORE "
+            f"`gh release create`; re-run without it so the release date is "
+            f"checked rather than skipped.")
+
+    if cff_date is not None and released and cff_date != released:
+        problems.append(f"CITATION.cff: date-released says {cff_date}, "
+                        f"v{want_version} was published {released}")
 
     for label, repo in REMOTE_READMES:
         try:
@@ -572,10 +641,14 @@ def main() -> int:
             return 2
 
     if not problems:
-        print(f"OK  {args.repo} description, CITATION.cff, "
+        label = "OK (preflight)" if args.preflight else "OK"
+        print(f"{label}  {args.repo} description, CITATION.cff, "
               f"{len(REMOTE_READMES)} remote READMEs and "
               f"{len(REMOTE_PAGES)} published pages match the tree "
               f"({want_count} tests, {want['modules']} modules, v{want_version})")
+        if release_date_skipped:
+            print(f"    Release date NOT checked: v{want_version} is not published "
+                  f"yet. Re-run without --preflight after `gh release create`.")
         return 0
 
     print(f"DRIFT in public metadata for {args.repo}\n")

--- a/testing/test_public_metadata_check.py
+++ b/testing/test_public_metadata_check.py
@@ -264,6 +264,76 @@ class TestExitCodes(unittest.TestCase):
         self.assertEqual(self._run(exc=err), 2)
 
 
+class TestPreflight(unittest.TestCase):
+    """--preflight covers the window where the tag exists but the release does not.
+
+    Without it the release-date fetch 404s and main() exits 2 no matter how
+    correct every surface is, so a release step could never gate on exit 0.
+    With it, that ONE 404 is expected -- and nothing else is.
+    """
+
+    VERSION = "4.15.0"
+
+    def _run(self, preflight, release_date_exc=None, release_date=None,
+             description=None):
+        description = description or f"{FRESH_COUNT} {_TESTS} ... v{self.VERSION}"
+        argv = ["check_public_metadata.py", "--repo", "o/r"]
+        if preflight:
+            argv.append("--preflight")
+
+        def _date(repo, tag):
+            if release_date_exc:
+                raise release_date_exc
+            return release_date
+
+        with mock.patch.object(sys, "argv", argv), \
+             mock.patch.object(cpm, "fetch_description", lambda r: description), \
+             mock.patch.object(cpm, "canonical_count", lambda: FRESH_COUNT), \
+             mock.patch.object(cpm, "canonical_version", lambda: self.VERSION), \
+             mock.patch.object(cpm, "canonical_modules", lambda: "44"), \
+             mock.patch.object(cpm, "citation_fields",
+                               lambda repo=None: (self.VERSION, "2026-08-07")), \
+             mock.patch.object(cpm, "fetch_release_date", _date), \
+             mock.patch.object(cpm, "REMOTE_READMES", ()), \
+             mock.patch.object(cpm, "REMOTE_PAGES", ()):
+            return cpm.main()
+
+    @staticmethod
+    def _missing():
+        return urllib.error.HTTPError("u", 404, "Not Found", {}, None)
+
+    def test_unreleased_version_exits_two_without_the_flag(self) -> None:
+        """The premise. This is why the flag has to exist at all."""
+        self.assertEqual(self._run(False, release_date_exc=self._missing()), 2)
+
+    def test_unreleased_version_exits_zero_with_the_flag(self) -> None:
+        self.assertEqual(self._run(True, release_date_exc=self._missing()), 0)
+
+    def test_preflight_is_refused_once_the_release_exists(self) -> None:
+        """The flag must not be usable to skip a check that could have run."""
+        self.assertEqual(self._run(True, release_date="2026-08-07"), 1)
+
+    def test_preflight_does_not_excuse_a_non_404(self) -> None:
+        """Only the missing release is expected. A rate limit is still unreachable."""
+        err = urllib.error.HTTPError("u", 403, "rate limited", {}, None)
+        self.assertEqual(self._run(True, release_date_exc=err), 2)
+
+    def test_preflight_does_not_excuse_a_network_error(self) -> None:
+        self.assertEqual(
+            self._run(True, release_date_exc=urllib.error.URLError("no route")), 2)
+
+    def test_preflight_still_fails_on_real_drift(self) -> None:
+        """The whole point of the gate: a stale surface must still block."""
+        stale = f"{FRESH_COUNT} {_TESTS} ... v4.13.1"
+        self.assertEqual(
+            self._run(True, release_date_exc=self._missing(), description=stale), 1)
+
+    def test_preflight_still_fails_on_a_stale_count(self) -> None:
+        stale = f"{STALE_COUNT} {_TESTS} ... v{self.VERSION}"
+        self.assertEqual(
+            self._run(True, release_date_exc=self._missing(), description=stale), 1)
+
+
 class TestSurfaceScoping(unittest.TestCase):
     """A check that fails on a true statement gets muted, so scope matters."""
 

--- a/testing/test_release_claims.py
+++ b/testing/test_release_claims.py
@@ -106,6 +106,61 @@ class TestReleaseClaimsManifest(unittest.TestCase):
                     commit, r"^[0-9a-f]{40}$",
                     f"claim {claim['id']!r} pins a commit, so it must be a full 40-char SHA.")
 
+    def test_a_release_claim_names_the_version_the_tree_is_at(self):
+        """The manifest inside a tag must be about THAT tag.
+
+        Four consecutive releases shipped a manifest bound to their predecessor:
+
+            v4.21.0  pyproject 4.21.0  manifest v4.20.0   (and the previous VALUE, 611)
+            v4.21.1  pyproject 4.21.1  manifest v4.21.0
+            v4.21.2  pyproject 4.21.2  manifest v4.21.1
+            v4.21.3  pyproject 4.21.3  manifest v4.21.2
+
+        The cause is ordering, not carelessness. The release PR bumps the version, the
+        tag is cut at that commit, and a SEPARATE later PR rebinds the claim -- so the
+        tree the tag points at always names the release before it. `main` reconciles a
+        few minutes later, which is why nothing noticed: every check that runs on main
+        sees an agreeing pair.
+
+        This is not cosmetic. `docs/release-claims.json` states its purpose as binding
+        each release-facing fact to "the revision, command, and value that produced it",
+        and inside every release it was bound to the wrong revision. It also propagates:
+        an external nightly sentinel pinned at v4.21.3 was sent by this manifest to
+        regenerate a value at v4.21.2, a tag its shallow clone could not contain, and
+        reported the check as not reproduced (2026-09-10).
+
+        Asserting against `pyproject.toml` rather than against `git tag` is deliberate,
+        twice over. It needs no tag object, so it holds in the depth-1 clone CI uses.
+        And it fires in the RELEASE COMMIT ITSELF -- the moment the version bumps and
+        the manifest has not followed -- which is the only place the fix belongs. On any
+        other commit the two already agree and this is silent.
+
+        Rebind the claim in the release PR. See docs/RELEASING.md.
+        """
+        from protocol_tests.version import get_harness_version
+
+        want = f"v{get_harness_version()}"
+        release_claims = [c for c in self.manifest["claims"] if c.get("release_tag")]
+        self.assertTrue(release_claims, "no claim carries a release_tag")
+
+        for claim in release_claims:
+            with self.subTest(claim=claim["id"]):
+                self.assertEqual(
+                    claim["release_tag"], want,
+                    f"claim {claim['id']!r} is bound to {claim['release_tag']!r} but this "
+                    f"tree is version {want}. If this is the release PR, rebind the claim "
+                    f"here rather than in a follow-up -- a tag cut now would carry a "
+                    f"manifest about the previous release. See docs/RELEASING.md.")
+
+                # The prose is a surface too. v4.21.0 shipped a `fact` naming both the
+                # wrong tag and the wrong value, so agreeing on release_tag alone would
+                # have let half of that through.
+                self.assertIn(
+                    want, claim.get("fact", ""),
+                    f"claim {claim['id']!r} is bound to {want} but its `fact` reads "
+                    f"{claim.get('fact', '')!r}. The sentence a reader sees must name the "
+                    f"same release the claim is bound to.")
+
     def test_every_surface_states_the_manifest_value(self):
         """The check that would have caught 603 going stale."""
         from verify_release_claims import check_surfaces


### PR DESCRIPTION
`Public metadata drift` has failed on **eight releases in two weeks**. The module docstring already records the first four — v4.18.0, v4.19.0rc1, v4.19.0, v4.20.0 — and the fix for them: run `--apply` before `gh release create`.

That fixed the **description**. It could not fix `REMOTE_READMES` or `REMOTE_PAGES`, which live in other repositories and no token this script holds can rewrite. So the same class returned on v4.21.0 → v4.21.3 through the surfaces `--apply` cannot reach, *while the release step reported OK*.

**The checker was never wrong.** It ran after the only moment it could have helped. Replaying it against the surfaces exactly as they stood when v4.21.3 was tagged:

```
main/tag tree: {'count': '623', 'modules': '45', 'version': '4.21.3'}
PREFLIGHT verdict: DRIFT -> release blocked
   - start-here: version says 4.21.2, tree says 4.21.3
   - PubPoint facts & evidence: version says 4.21.2, tree says 4.21.3
```

### The order, now written down

Updating the surfaces before the tag is **not** sufficient on its own: the `start-here` line is a copyable Action pin, and a pin naming an unpushed tag resolves to nothing. A pin that 404s is worse than one that is a version behind and works. So the tag goes first, surfaces second, release object last:

```
1. merge the release PR
2. git tag vX.Y.Z && git push origin vX.Y.Z    # the pin resolves
3. update the remote surfaces, let the page deploy
4. check_public_metadata.py --preflight        # must be OK
5. gh release create vX.Y.Z --verify-tag
```

`docs/RELEASING.md` carries this with the reason attached to each step.

### Why `--preflight` has to exist

Steps 2–4 sit in a window where the tag exists but the release object does not, so `fetch_release_date` 404s and an ordinary run exits `2` (UNREACHABLE) however correct every surface is. **A gate that can never return 0 is not a gate.**

`--preflight` treats that *one* 404 as expected and prints what it skipped rather than passing over it silently. It excuses nothing else — 403, rate limit, network error, stale count, stale version all still fail under it.

It is **refused once the release is published** (exit 1, naming the date it found). Otherwise the flag would be a way to skip a check that could have run — the exact defect this file exists to catch, wearing a flag.

### One correction to the docstring

It said the release run compares "the tree at the tag that was just published". It does not — the workflow resolves `git tag --sort=-v:refname | head -1` at run time and reads the surfaces live, so **both sides are read at run time**. I got the consequence wrong once today before reading the workflow: a failed release run is *not* permanently red. Re-running v4.21.0 → v4.21.3 after the surfaces were corrected turned all four green with no change to those tags.

### Verification

- `TestPreflight`, 7 cases, offline.
- **Positive control:** 6 of 7 fail against the pre-change checker. The 7th (`test_unreleased_version_exits_two_without_the_flag`) passes on both sides because it asserts the premise — which is what makes the other six mean anything.
- `testing/` **1151 passed**, `tests/` **473 passed**.
- **Live smoke** against the published v4.21.3: `--preflight` exits 1 with the refusal message; a normal run exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)