### PR TITLE
WT: the docstring claimed four target observations; there is one, plus a reviewable reading guide

### DIFF
--- a/HARNESS_TEST_CATALOG.md
+++ b/HARNESS_TEST_CATALOG.md
@@ -1,7 +1,7 @@
 # Agent Security Harness — Canonical Test Catalog
 
 **Source repo:** msaleme/red-team-blue-team-agent-fabric
-**Generated:** `scripts/generate_test_catalog.py` at commit `72af259`
+**Generated:** `scripts/generate_test_catalog.py` at commit `a6d27d6`
 **Test count:** 631 unique test IDs across 47 registered harness modules (46 contain test IDs; `community_runner.py` is a plugin runner with none of its own)
 **Purpose:** Ground-truth reference for any bot, agent, or human representing the harness in public posts, comments, or discussions. Cite only tests listed here. Do not invent IDs or statistics.
 
@@ -789,10 +789,10 @@ WM-005 | Multi-Language Watermark Compliance | protocol_tests/watermark_harness.
 ### workspace_trust_harness.py (`protocol_tests/workspace_trust_harness.py`) — 4 tests
 
 ```
-WT-001 | Repository-Supplied Config Executes on Ingestion | protocol_tests/workspace_trust_harness.py:185
-WT-002 | Read-Only Ingestion Still Executes the Sink | protocol_tests/workspace_trust_harness.py:225
-WT-003 | Cloned Source Does Not Carry the Sink | protocol_tests/workspace_trust_harness.py:260
-WT-004 | Named-Sink Sanitisation Suppresses Execution | protocol_tests/workspace_trust_harness.py:313
+WT-001 | Repository-Supplied Config Executes on Ingestion | protocol_tests/workspace_trust_harness.py:220
+WT-002 | Read-Only Ingestion Still Executes the Sink | protocol_tests/workspace_trust_harness.py:260
+WT-003 | Cloned Source Does Not Carry the Sink | protocol_tests/workspace_trust_harness.py:295
+WT-004 | Named-Sink Sanitisation Suppresses Execution | protocol_tests/workspace_trust_harness.py:348
 ```
 
 ### x402 Fireblocks Extension (`protocol_tests/x402_fireblocks_harness.py`) — 17 tests

--- a/docs/WORKSPACE-TRUST-REVIEW.md
+++ b/docs/WORKSPACE-TRUST-REVIEW.md
@@ -1,0 +1,124 @@
+# WT-001..004: what the code does, for someone deciding whether to run it
+
+This is a reading guide for `protocol_tests/workspace_trust_harness.py`. It exists because running
+this harness means letting it execute a command on your machine, and you should decide that from the
+source rather than from a description of it.
+
+**Every claim below cites a line range. Open them.** The point of this document is to shorten your
+search, not to replace it. Where a claim and the code disagree, the code is right and this document
+is wrong.
+
+All line numbers are at `a6d27d6` (PR #569, merged 2026-09-10).
+
+---
+
+## 1. It executes the command you give it, through a shell
+
+`_invoke`, **lines 145-163**:
+
+```python
+cmd = self.command.replace("{repo}", str(repo))
+proc = subprocess.run(cmd, shell=True, capture_output=True,
+                      text=True, timeout=120, check=False)
+```
+
+The string you pass to `--command` is run with `shell=True`, after `{repo}` is replaced with a path
+to a fixture repository the harness built. There is no allowlist, no parsing, and no sandbox. If you
+pass a command, that command runs, with your privileges, in your environment.
+
+This is the whole mechanism of the harness: it characterises *your* ingesting command, so it has to
+run it. It is also the fact worth deciding on before anything else in this document.
+
+Timeout is 120s. A non-zero exit or empty output is treated as "did not ingest" and produces
+INCONCLUSIVE rather than a verdict.
+
+## 2. Where it works
+
+**Line 116**: `self._tmp = Path(tempfile.mkdtemp(prefix="wt-harness-"))`
+
+Every fixture repository it builds lives under that one directory.
+
+## 3. What the fixture contains
+
+`_build_repo`, **lines 127-143**. For each fixture it creates a directory, writes a `README.md`,
+runs `git init` / `add` / `commit`, and then, only when a canary path is passed, appends this to the
+fixture's own `.git/config`:
+
+```python
+sink = f'/bin/sh -c "echo fired > {shlex.quote(str(canary))}"'
+...
+fh.write(f"\n[core]\n\tfsmonitor = {json.dumps(sink)}\n")
+```
+
+So the sink is a real execution sink, and what it executes is `echo fired > <path>` where `<path>`
+is a file inside the temp directory from line 116. It writes one short file and does nothing else.
+`shlex.quote` is applied to the path.
+
+This is the payload. If you are going to check one thing in this document against the source, check
+this line.
+
+## 4. Every other process it starts
+
+- `_git`, **lines 120-125**: `git` with `-c user.email` / `-c user.name` set and
+  `GIT_TERMINAL_PROMPT=0`, always with `cwd` inside the temp directory. Used for `init`, `add`,
+  `commit`, `status`, `diff`, `log`, and `config --local`.
+- **Line 256**, in WT-003: `git clone -q <fixture> <temp path>`, both inside the temp directory.
+
+Those are the only subprocess calls besides §1. There are no others in the file.
+
+## 5. What it deletes
+
+`cleanup()`, **lines 344-345**: `shutil.rmtree(self._tmp, ignore_errors=True)`, scoped to the
+directory from line 116. `main()` calls it in a `finally`.
+
+## 6. Claims of absence, and how to check them
+
+Each of these is checkable from the source; none should be taken on my word.
+
+- **No network.** There are no imports of `urllib`, `socket`, `http`, or `requests` in the file, and
+  no subprocess call reaches the network. `git clone` at line 256 clones a local path. Verify by
+  grepping the imports at the top of the file.
+- **No modification of your repositories, git config, or environment.** Every `_git` call passes
+  `cwd` inside the temp directory and sets identity via `-c` flags rather than writing config. There
+  is no `--global`, no `git config --system`, and no write to any path outside line 116's directory,
+  **with one exception in §7.**
+
+## 7. The one write outside the temp directory
+
+**Line 393**, in `main()`:
+
+```python
+Path(args.report).write_text(json.dumps(report, indent=2, default=str), ...)
+```
+
+`--report` writes to whatever path you give it. That is the intended behaviour and it is the only
+filesystem write the harness performs outside its own temp directory. It happens only if you pass
+the flag.
+
+Stating it because "writes nothing outside the temp directory" would otherwise be a convenient and
+false summary.
+
+## 8. Provenance
+
+- Introduced in **PR #569**, merged as **`a6d27d6`** on 2026-09-10.
+- Authored by Michael K. Saleme with AI assistance, in a single session on 2026-09-10.
+- CI at merge: 8 checks, including tests on Python 3.10 through 3.13.
+- Controls: `testing/test_workspace_trust_controls.py`, which pins WT-001 to FAIL against a naive
+  ingester, PASS against a sanitising one, and INCONCLUSIVE against a command that ingests nothing.
+- The mechanics it relies on were reproduced against git 2.43.0 before the module was written:
+  a directory copy carrying the sink fires on `git status`; the same repository obtained by
+  `git clone` does not; `git -c core.fsmonitor=false status` does not.
+
+It has had no external review. This document is the first thing written for an outside reader.
+
+## 9. What this document does not establish
+
+It does not establish that running the harness is safe on your system. That depends on what your
+command does, what privileges it holds, and what else is on the machine, and none of those are
+visible from here.
+
+It is written by the author of the code. It is not an audit, not independent, and not a security
+assessment. It says what the code does and points at where to confirm it.
+
+If a reading of the source contradicts anything above, the source is correct and I would like to
+know which line.

--- a/docs/WORKSPACE-TRUST-REVIEW.md
+++ b/docs/WORKSPACE-TRUST-REVIEW.md
@@ -77,20 +77,21 @@ machine running the harness. The three are still useful, and none is evidence ab
 The docstring claimed all four until `39fd4d2`. The adversarial read found it.
 
 (The line ranges in this table were wrong in a draft of this document, off by four, written from
-stale offsets rather than derived. They are generated from the AST now. Noted because a miscited
-range is exactly what this document asks you not to accept on trust.)
+stale offsets. They are correct at the pinned revision, which you can confirm by opening them. That
+they were derived rather than typed is my account of how, not a property the repository enforces.)
 
 ## 3. What the positive control actually establishes
 
 WT-001 runs your command against a clean fixture first. That run is treated as "ingested" when it
-**exits zero and writes something to stdout or stderr** (lines 189-194).
+**exits zero** (lines 193-195) **and writes something to stdout or stderr** (lines 196-198).
 
 That is weaker than "the command read the repository". A command that exits zero and prints
 anything, without opening the directory, satisfies it. The check exists to stop a non-ingesting
 command scoring as "not vulnerable"; it does not prove ingestion.
 
-The crafted invocation's return value is **not** checked. The verdict is computed from the clean
-control succeeding plus whether the canary file exists (lines 218-230).
+The crafted invocation's return value is **not** checked: `_run_against` calls `self._invoke(repo)`
+at **line 207** and discards what it returns. The verdict is computed from the clean control
+succeeding plus whether the canary file exists (lines 200-209).
 
 ## 4. Where it works, and the one path that leaves
 
@@ -98,12 +99,16 @@ control succeeding plus whether the canary file exists (lines 218-230).
 - `cleanup()`, **lines 379-380**: `shutil.rmtree(self._tmp, ignore_errors=True)`, called in a
   `finally`. `ignore_errors=True` means deletion is attempted, not verified. It says nothing about
   processes your command may have left running.
-- **`--report` leaves the temp directory twice.** Line 428 writes to the path you pass; a relative
-  path resolves against your working directory and `write_text` overwrites an existing file. And
-  line 418 calls `run_provenance()`, which runs further git subprocesses **against the harness
-  checkout, not the fixture** (`protocol_tests/run_provenance.py`, line 191): `rev-parse HEAD`,
-  `describe --tags --exact-match`, `status --porcelain`, and a version probe. Those calls carry
-  **no timeout**.
+- **`--report` adds two behaviours, neither confined to the temp directory by the harness.**
+  Line 428 writes to the path you pass. You choose it, so it may or may not sit outside the temp
+  root; a relative path resolves against your working directory and `write_text` overwrites an
+  existing file. Separately, line 418 calls `run_provenance()`, which runs git **against the harness
+  checkout rather than the fixture** (`run_provenance.py`, the repo root is selected at line 687,
+  the shared subprocess helper is line 191). The calls it *may* make, all without a timeout, are
+  `rev-parse HEAD` (line 643, skipped when `GITHUB_SHA` is set), `describe --tags --exact-match`
+  (line 654, skipped when `GITHUB_REF_NAME` is set), `status --porcelain --untracked-files=no`
+  (line 656), and a `--version` probe reached only on failure (line 645). Which of them run depends
+  on your environment.
 
 If `--report` is not passed, neither happens.
 
@@ -134,7 +139,9 @@ double-quoted shell string; treat it as the quoting that is there, not as a gene
 - **Line 291**, WT-003: `git clone -q <fixture> <temp path>`, both local.
 
 `_git` **inherits `os.environ`** (line 152) and overrides only identity and terminal prompting. It
-does not isolate your git configuration or hooks. Global and system git config apply.
+does not isolate your git configuration or hooks. What that establishes is the absence of isolation,
+not that global and system config invariably load: an inherited environment can itself alter or
+suppress normal config loading.
 
 Those are the direct subprocess calls in this file, plus §1 and the `run_provenance` path in §4.
 
@@ -153,18 +160,25 @@ What is checkable:
   that rather than accept it.
 - The `git clone` at line 291 clones a local path.
 
-Similarly, "no modification of your repositories or environment" is **not** claimed. The harness's
-own git calls are scoped to the temp directory, but your command is unrestricted and `run_provenance`
-reads the harness checkout.
+Similarly, "no modification of your repositories or environment" is **not** claimed. The `_git`
+helper's calls are scoped to the temp directory, but that is not all of this module's own logic:
+`run_provenance` reads the harness checkout (§4), and your command is unrestricted.
 
 ## 8. Controls
 
-`testing/test_workspace_trust_controls.py` pins WT-001 to FAIL against a naive ingester, PASS against
-one that sanitises, and INCONCLUSIVE against a command that ingests nothing or exits non-zero. It
-also derives from the AST which tests invoke the command and asserts the set is exactly `{WT-001}`.
+`testing/test_workspace_trust_controls.py` pins WT-001 against four target shapes defined at
+**lines 51-54**, asserted at **lines 70-117**: FAIL against a naive ingester, PASS against one that
+sanitises, and INCONCLUSIVE against `true` (silent, exits zero) and against `exit 3`.
 
-CI at merge: 8 checks, Python 3.10 through 3.13.
-PR: `https://github.com/msaleme/red-team-blue-team-agent-fabric/pull/569`
+Note the narrowness. Those are the two non-ingesting shapes tested. A command that produces output
+without reading the directory satisfies the control (§3) and is not covered by either.
+
+**Lines 151-203** derive from the AST which tests invoke the command and assert the set is exactly
+`{WT-001}`.
+
+CI: 8 checks including Python 3.10 through 3.13 on PR #569
+(`https://github.com/msaleme/red-team-blue-team-agent-fabric/pull/569`). That run predates the
+correction in `39fd4d2` and therefore does not establish that the AST guard above passed.
 
 ## 9. Statements about process, marked as unverifiable
 
@@ -193,7 +207,9 @@ know which line.
 
 ## Correction history
 
-Nine findings from the second-agent read of the first version, all incorporated:
+Nine correction-history entries from the second-agent read of the first version. Not a defect
+count: that read covered nine sections, some carrying several observations and some, like item 2,
+recording a claim that was already supported and was retained.
 
 1. INCONCLUSIVE generalised: only the clean control is checked; the crafted return is discarded (§3)
 2. Fixture confinement, correctly scoped in v1, retained

--- a/docs/WORKSPACE-TRUST-REVIEW.md
+++ b/docs/WORKSPACE-TRUST-REVIEW.md
@@ -1,20 +1,46 @@
-# WT-001..004: what the code does, for someone deciding whether to run it
+# WT-001..004: what the code does, for someone deciding whether to read it
 
-This is a reading guide for `protocol_tests/workspace_trust_harness.py`. It exists because running
-this harness means letting it execute a command on your machine, and you should decide that from the
-source rather than from a description of it.
+A reading guide for `protocol_tests/workspace_trust_harness.py`. It exists because a reviewer asked
+for source, command semantics, fixture behaviour and provenance before deciding whether to review
+this at all, and no such document existed.
 
-**Every claim below cites a line range. Open them.** The point of this document is to shorten your
-search, not to replace it. Where a claim and the code disagree, the code is right and this document
-is wrong.
+**This document authorizes nothing.** It is not a request to install or execute the harness, not a
+safety assessment, and not an audit. It shortens a search. Where it and the code disagree, the code
+is right.
 
-All line numbers are at `a6d27d6` (PR #569, merged 2026-09-10).
+## Immutable provenance
+
+| | |
+|---|---|
+| Repository | `https://github.com/msaleme/red-team-blue-team-agent-fabric` |
+| Revision all citations are pinned to | `39fd4d297eda0f7be1280ef6df7d37fc4af8b054` |
+| Introduced in | PR #569, merged `a6d27d6` 2026-09-10 |
+| Docstring correction | `39fd4d2`, same day, after the adversarial read below |
+
+SHA-256 of the files cited, at that revision:
+
+```
+fcd309b8f0773dbecdb8d630e161f2086142961274bf85d8f9b12be28d407a19  protocol_tests/workspace_trust_harness.py
+1796dd42dd349b3421a3d704286b6f573b15cee1d9a267cc93d790bdc8878c48  testing/test_workspace_trust_controls.py
+1870c10ebd481fff684a8b0635ae0b66161e1af2375d05e871b7145c3d59c38f  protocol_tests/run_provenance.py
+```
+
+Line numbers below are valid at `39fd4d2` and nowhere else. `main` moves; check out the SHA.
+
+## Evidence class
+
+Author-written. **E1/I0.**
+
+A second agent read an earlier version of this document against the source and returned it with nine
+findings, which are corrected below and listed at the end. **That does not make this I1.** A
+different reader improves error detection; it does not make the description independent, and the
+reviewer said so themselves. Nothing here should be taken from me rather than from the source.
 
 ---
 
-## 1. It executes the command you give it, through a shell
+## 1. It executes the command you give it, through a shell, as you
 
-`_invoke`, **lines 145-163**:
+`_invoke`, **lines 176-194**:
 
 ```python
 cmd = self.command.replace("{repo}", str(repo))
@@ -22,27 +48,69 @@ proc = subprocess.run(cmd, shell=True, capture_output=True,
                       text=True, timeout=120, check=False)
 ```
 
-The string you pass to `--command` is run with `shell=True`, after `{repo}` is replaced with a path
-to a fixture repository the harness built. There is no allowlist, no parsing, and no sandbox. If you
-pass a command, that command runs, with your privileges, in your environment.
+The string passed to `--command` runs with `shell=True`, in your process context, with your
+privileges, inheriting this process's working directory and environment. There is no allowlist, no
+parsing, no sandbox and no `cwd` or `env` isolation.
 
-This is the whole mechanism of the harness: it characterises *your* ingesting command, so it has to
-run it. It is also the fact worth deciding on before anything else in this document.
+**Substitution is literal.** `{repo}` is replaced by `str(repo)` with no quoting added. The path is
+a `mkdtemp` path, so it is normally well behaved, but the harness does not guarantee that and does
+not escape it.
 
-Timeout is 120s. A non-zero exit or empty output is treated as "did not ingest" and produces
-INCONCLUSIVE rather than a verdict.
+**The 120s timeout bounds this one invocation.** It does not bound processes the command spawns, and
+it is not a bound on the run. §4 names a separate code path with no timeout at all.
 
-## 2. Where it works
+This is the whole mechanism: the harness characterises *your* ingesting command, so it must run it.
+It is the fact to decide on before anything else here.
 
-**Line 116**: `self._tmp = Path(tempfile.mkdtemp(prefix="wt-harness-"))`
+## 2. Only WT-001 invokes that command
 
-Every fixture repository it builds lives under that one directory.
+| Test | Lines | What it drives |
+|---|---|---|
+| `WT-001` | 213-232 | the command under test, via `_run_against` |
+| `WT-002` | 236-270 | local `git` directly, no invocation |
+| `WT-003` | 274-323 | local `git` directly, no invocation |
+| `WT-004` | 327-363 | local `git` directly, no invocation |
 
-## 3. What the fixture contains
+A run therefore yields **one** observation about your command and three about git's behaviour on the
+machine running the harness. The three are still useful, and none is evidence about your command.
 
-`_build_repo`, **lines 127-143**. For each fixture it creates a directory, writes a `README.md`,
-runs `git init` / `add` / `commit`, and then, only when a canary path is passed, appends this to the
-fixture's own `.git/config`:
+The docstring claimed all four until `39fd4d2`. The adversarial read found it.
+
+(The line ranges in this table were wrong in a draft of this document, off by four, written from
+stale offsets rather than derived. They are generated from the AST now. Noted because a miscited
+range is exactly what this document asks you not to accept on trust.)
+
+## 3. What the positive control actually establishes
+
+WT-001 runs your command against a clean fixture first. That run is treated as "ingested" when it
+**exits zero and writes something to stdout or stderr** (lines 189-194).
+
+That is weaker than "the command read the repository". A command that exits zero and prints
+anything, without opening the directory, satisfies it. The check exists to stop a non-ingesting
+command scoring as "not vulnerable"; it does not prove ingestion.
+
+The crafted invocation's return value is **not** checked. The verdict is computed from the clean
+control succeeding plus whether the canary file exists (lines 218-230).
+
+## 4. Where it works, and the one path that leaves
+
+- `mkdtemp(prefix="wt-harness-")`, **line 147**. Fixtures live under it.
+- `cleanup()`, **lines 379-380**: `shutil.rmtree(self._tmp, ignore_errors=True)`, called in a
+  `finally`. `ignore_errors=True` means deletion is attempted, not verified. It says nothing about
+  processes your command may have left running.
+- **`--report` leaves the temp directory twice.** Line 428 writes to the path you pass; a relative
+  path resolves against your working directory and `write_text` overwrites an existing file. And
+  line 418 calls `run_provenance()`, which runs further git subprocesses **against the harness
+  checkout, not the fixture** (`protocol_tests/run_provenance.py`, line 191): `rev-parse HEAD`,
+  `describe --tags --exact-match`, `status --porcelain`, and a version probe. Those calls carry
+  **no timeout**.
+
+If `--report` is not passed, neither happens.
+
+## 5. What the fixture contains
+
+`_build_repo`, **lines 158-172**. Creates a directory, writes a `README.md`, runs `git init` / `add`
+/ `commit`, and only when a canary path is passed appends to the fixture's own `.git/config`:
 
 ```python
 sink = f'/bin/sh -c "echo fired > {shlex.quote(str(canary))}"'
@@ -50,75 +118,89 @@ sink = f'/bin/sh -c "echo fired > {shlex.quote(str(canary))}"'
 fh.write(f"\n[core]\n\tfsmonitor = {json.dumps(sink)}\n")
 ```
 
-So the sink is a real execution sink, and what it executes is `echo fired > <path>` where `<path>`
-is a file inside the temp directory from line 116. It writes one short file and does nothing else.
-`shlex.quote` is applied to the path.
+The sink is a real execution sink. What it executes is `echo fired > <path>`, writing one short file
+inside the temp directory from §4.
 
-This is the payload. If you are going to check one thing in this document against the source, check
-this line.
+**Scope of that claim:** it describes the string the harness constructs. It is not a runtime
+guarantee about what executes on your machine during a run, because your command also runs (§1) and
+git inherits your configuration (§6). `shlex.quote` is applied to the path, but it sits inside a
+double-quoted shell string; treat it as the quoting that is there, not as a general guarantee.
 
-## 4. Every other process it starts
+## 6. Other processes, and inherited state
 
-- `_git`, **lines 120-125**: `git` with `-c user.email` / `-c user.name` set and
+- `_git`, **lines 151-156**: `git` with `-c user.email` / `-c user.name` and
   `GIT_TERMINAL_PROMPT=0`, always with `cwd` inside the temp directory. Used for `init`, `add`,
-  `commit`, `status`, `diff`, `log`, and `config --local`.
-- **Line 256**, in WT-003: `git clone -q <fixture> <temp path>`, both inside the temp directory.
+  `commit`, `status`, `diff`, `log`, `config --local`.
+- **Line 291**, WT-003: `git clone -q <fixture> <temp path>`, both local.
 
-Those are the only subprocess calls besides §1. There are no others in the file.
+`_git` **inherits `os.environ`** (line 152) and overrides only identity and terminal prompting. It
+does not isolate your git configuration or hooks. Global and system git config apply.
 
-## 5. What it deletes
+Those are the direct subprocess calls in this file, plus §1 and the `run_provenance` path in §4.
 
-`cleanup()`, **lines 344-345**: `shutil.rmtree(self._tmp, ignore_errors=True)`, scoped to the
-directory from line 116. `main()` calls it in a `finally`.
+## 7. Claims of absence, scoped honestly
 
-## 6. Claims of absence, and how to check them
+The earlier version of this document said the harness makes no network calls. **That claim cannot be
+made unconditionally and has been removed.** Your command runs with a shell (§1); anything it does,
+including network access, is outside what this file constrains.
 
-Each of these is checkable from the source; none should be taken on my word.
+What is checkable:
 
-- **No network.** There are no imports of `urllib`, `socket`, `http`, or `requests` in the file, and
-  no subprocess call reaches the network. `git clone` at line 256 clones a local path. Verify by
-  grepping the imports at the top of the file.
-- **No modification of your repositories, git config, or environment.** Every `_git` call passes
-  `cwd` inside the temp directory and sets identity via `-c` flags rather than writing config. There
-  is no `--global`, no `git config --system`, and no write to any path outside line 116's directory,
-  **with one exception in §7.**
+- No direct network client is used by this module's own logic. It imports from
+  `protocol_tests.http_helpers` (**line 79**) for two symbols, `INCONCLUSIVE_PREFIX` and
+  `console_status`. **That module does import `urllib`** (`http_helpers.py` lines 21-23) and defines
+  network helpers; this harness calls neither. An import is reach, not use, and you should confirm
+  that rather than accept it.
+- The `git clone` at line 291 clones a local path.
 
-## 7. The one write outside the temp directory
+Similarly, "no modification of your repositories or environment" is **not** claimed. The harness's
+own git calls are scoped to the temp directory, but your command is unrestricted and `run_provenance`
+reads the harness checkout.
 
-**Line 393**, in `main()`:
+## 8. Controls
 
-```python
-Path(args.report).write_text(json.dumps(report, indent=2, default=str), ...)
-```
+`testing/test_workspace_trust_controls.py` pins WT-001 to FAIL against a naive ingester, PASS against
+one that sanitises, and INCONCLUSIVE against a command that ingests nothing or exits non-zero. It
+also derives from the AST which tests invoke the command and asserts the set is exactly `{WT-001}`.
 
-`--report` writes to whatever path you give it. That is the intended behaviour and it is the only
-filesystem write the harness performs outside its own temp directory. It happens only if you pass
-the flag.
+CI at merge: 8 checks, Python 3.10 through 3.13.
+PR: `https://github.com/msaleme/red-team-blue-team-agent-fabric/pull/569`
 
-Stating it because "writes nothing outside the temp directory" would otherwise be a convenient and
-false summary.
+## 9. Statements about process, marked as unverifiable
 
-## 8. Provenance
+The following are assertions by the author. Git metadata cannot establish any of them, and the
+adversarial read flagged them as uncited. They are kept because withdrawing them would be less
+informative than labelling them:
 
-- Introduced in **PR #569**, merged as **`a6d27d6`** on 2026-09-10.
-- Authored by Michael K. Saleme with AI assistance, in a single session on 2026-09-10.
-- CI at merge: 8 checks, including tests on Python 3.10 through 3.13.
-- Controls: `testing/test_workspace_trust_controls.py`, which pins WT-001 to FAIL against a naive
-  ingester, PASS against a sanitising one, and INCONCLUSIVE against a command that ingests nothing.
-- The mechanics it relies on were reproduced against git 2.43.0 before the module was written:
-  a directory copy carrying the sink fires on `git status`; the same repository obtained by
-  `git clone` does not; `git -c core.fsmonitor=false status` does not.
+- Authored by Michael K. Saleme with AI assistance, in one session on 2026-09-10.
+- The mechanics were reproduced against git 2.43.0 before the module was written: a directory copy
+  carrying the sink fires on `git status`; the same repository obtained by `git clone` does not;
+  `git -c core.fsmonitor=false status` does not. **No execution transcript was retained.**
+- No external review other than the second-agent description check described above.
 
-It has had no external review. This document is the first thing written for an outside reader.
+## 10. What this document does not establish
 
-## 9. What this document does not establish
+That running the harness is safe on your system. That depends on your command, your privileges and
+your machine, none of which are visible here.
 
-It does not establish that running the harness is safe on your system. That depends on what your
-command does, what privileges it holds, and what else is on the machine, and none of those are
-visible from here.
-
-It is written by the author of the code. It is not an audit, not independent, and not a security
-assessment. It says what the code does and points at where to confirm it.
+It is written by the author of the code, corrected after one second-agent read, and remains E1/I0.
+It is descriptive. A completed packet authorizes neither installation nor execution.
 
 If a reading of the source contradicts anything above, the source is correct and I would like to
 know which line.
+
+---
+
+## Correction history
+
+Nine findings from the second-agent read of the first version, all incorporated:
+
+1. INCONCLUSIVE generalised: only the clean control is checked; the crafted return is discarded (§3)
+2. Fixture confinement, correctly scoped in v1, retained
+3. "does nothing else" read as a runtime guarantee, and the `shlex.quote` nesting (§5)
+4. `--report`'s `run_provenance` spawns git outside the fixture root, untimed (§4)
+5. `ignore_errors=True` is attempted, not verified, deletion (§4)
+6. The network claim was wrong unconditionally, and `http_helpers` reaches `urllib` (§7)
+7. A relative `--report` path resolves from the caller's cwd and can overwrite (§4)
+8. Authorship, reproduction and "no external review" are uncited assertions (§9)
+9. Only WT-001 invokes the command, a defect in the code's own docstring, fixed in `39fd4d2` (§2)

--- a/docs/WORKSPACE-TRUST-REVIEW.md
+++ b/docs/WORKSPACE-TRUST-REVIEW.md
@@ -31,8 +31,9 @@ Line numbers below are valid at `39fd4d2` and nowhere else. `main` moves; check 
 
 Author-written. **E1/I0.**
 
-A second agent read an earlier version of this document against the source and returned it with nine
-findings, which are corrected below and listed at the end. **That does not make this I1.** A
+A second agent read earlier versions of this document against the source and returned nine
+correction-history entries, listed at the end. That is sectioned coverage rather than a defect
+count: one of the nine records a claim that was already supported and was retained. **That does not make this I1.** A
 different reader improves error detection; it does not make the description independent, and the
 reviewer said so themselves. Nothing here should be taken from me rather than from the source.
 
@@ -107,8 +108,9 @@ succeeding plus whether the canary file exists (lines 200-209).
   the shared subprocess helper is line 191). The calls it *may* make, all without a timeout, are
   `rev-parse HEAD` (line 643, skipped when `GITHUB_SHA` is set), `describe --tags --exact-match`
   (line 654, skipped when `GITHUB_REF_NAME` is set), `status --porcelain --untracked-files=no`
-  (line 656), and a `--version` probe reached only on failure (line 645). Which of them run depends
-  on your environment.
+  (line 656), and a `--version` probe reached only on failure (line 645). That last one is a
+  different kind of call: it runs with no `cwd`, so it probes whether git is executable at all
+  rather than inspecting any checkout. Which of them run depends on your environment.
 
 If `--report` is not passed, neither happens.
 

--- a/protocol_tests/workspace_trust_harness.py
+++ b/protocol_tests/workspace_trust_harness.py
@@ -94,18 +94,49 @@ class WorkspaceTrustResult(HarnessResult):
 
 
 class WorkspaceTrustTests(RecordingHarness):
-    """Characterise one command that ingests a local repository.
+    """Characterise one command that ingests a local repository, plus local git.
 
-    Every test runs the command TWICE: once against a clean control repository
-    and once against a crafted one. The control run is the positive control and
-    it is not optional. If the command cannot ingest a clean repository -- wrong
-    invocation, missing binary, a `{repo}` placeholder that was never
-    substituted -- then it also will not ingest the crafted one, no canary
-    fires, and without the control that scores as "the sink did not execute".
+    ## Which tests observe the command under test, and which do not
+
+    Until 2026-09-10 this docstring asserted that all four tests invoked the
+    command under test. That was true of one of them, and an external reader
+    checking the claim against the source is what found it. The wrong sentence
+    is described rather than quoted here, because
+    testing/test_workspace_trust_controls.py greps for it and a quoted copy
+    would keep the guard permanently red. Corrected here rather than softened, because a
+    family docstring that overstates what its members observe is the defect this
+    package spent the same day repairing in MEM-013..015.
+
+        WT-001  invokes the command under test, via _run_against      TARGET
+        WT-002  drives local git directly, no invocation              LOCAL GIT
+        WT-003  drives local git directly, no invocation              LOCAL GIT
+        WT-004  drives local git directly, no invocation              LOCAL GIT
+
+    So a run produces ONE observation about the caller's command and three about
+    git's behaviour on the machine the harness is running on. The three are
+    still worth having -- they establish that the fixture fires at all, that a
+    clone does not carry the sink, and that the published mitigation suppresses
+    it -- but none of them is evidence about the ingesting command, and a report
+    that reads as four findings about a target would be wrong.
+
+    ## The positive control, and where it applies
+
+    WT-001 runs the command twice: once against a clean control repository and
+    once against a crafted one. The control run is not optional. If the command
+    cannot ingest a clean repository -- wrong invocation, missing binary, a
+    `{repo}` placeholder that was never substituted -- then it also will not
+    ingest the crafted one, no canary fires, and without the control that scores
+    as "the sink did not execute".
 
     That is X4-057's shape: nothing accepted, nothing settled, nothing
     overdrawn, "the control held". Here it would be nothing ingested, nothing
     executed, "not vulnerable". The control run turns that into INCONCLUSIVE.
+
+    What the control establishes is narrower than "the command ingested the
+    repository": it is exit status zero with output on stdout or stderr. A
+    command that exits zero and prints something without reading the directory
+    satisfies it. That is a weaker precondition than the name suggests and it is
+    stated here so a reader does not assume otherwise.
     """
 
     def __init__(self, command: str, self_test: bool = False):
@@ -149,6 +180,10 @@ class WorkspaceTrustTests(RecordingHarness):
         produced output. It is deliberately not "the command exited 0" alone --
         a stub that does nothing exits 0 too.
         """
+        # Literal substitution, then a shell. No quoting is added around the
+        # path, and the command inherits this process's cwd and environment.
+        # The 120s timeout bounds THIS invocation only: it does not bound
+        # descendants the command spawns, and it is not a bound on the run.
         cmd = self.command.replace("{repo}", str(repo))
         try:
             proc = subprocess.run(cmd, shell=True, capture_output=True,

--- a/testing/test_workspace_trust_controls.py
+++ b/testing/test_workspace_trust_controls.py
@@ -17,11 +17,16 @@ mirror of #357, where six identity tests could not fail for any input.
     inert        exits 0, ingests nothing, prints nothing        -> WT-001 INCONCLUSIVE
     broken       exits non-zero                                   -> WT-001 INCONCLUSIVE
 
-`inert` is the one that would otherwise be missed, and it is why every test in
-the family runs the command against a clean control repository first. A command
-that never ingests anything also never triggers the sink, so without that run it
-scores as "not vulnerable" -- X4-057's shape exactly: nothing accepted, nothing
-settled, nothing overdrawn, "the control held".
+`inert` is the one that would otherwise be missed, and it is why WT-001 runs the
+command against a clean control repository first. A command that never ingests
+anything also never triggers the sink, so without that run it scores as "not
+vulnerable" -- X4-057's shape exactly: nothing accepted, nothing settled,
+nothing overdrawn, "the control held".
+
+Note which test that is. WT-001 is the only member of the family that invokes
+the command under test at all; WT-002, WT-003 and WT-004 drive local git
+directly. The cases below therefore characterise WT-001, and the two that name
+other tests say so explicitly.
 
 ## WT-003 is the family's own negative control
 
@@ -141,6 +146,61 @@ class WorkspaceTrustControlTests(unittest.TestCase):
         r = _run(NAIVE, "test_wt_002_read_only_ingestion_still_executes")
         self.assertFalse(r.passed, f"WT-002 passed against a live sink: {r.details}")
         self.assertIn("status", r.details, "the failing operation is not named")
+
+
+class WhichTestsObserveTheTargetTests(unittest.TestCase):
+    """The family docstring must match which tests invoke the command under test.
+
+    Added 2026-09-10. The class docstring said "Every test runs the command
+    TWICE"; one test in four did. An external reader checking the claim against
+    the source found it, which is the only way that class of defect surfaces:
+    every test passed, both host sweeps agreed, and the suite was consistent
+    with itself throughout.
+
+    This derives the answer from the source instead of restating it, so adding
+    target invocation to another test fails here until the docstring is updated.
+    """
+
+    TARGET_CALLS = ("_run_against", "_invoke")
+
+    def _tests_that_invoke_the_target(self) -> set[str]:
+        import ast
+        src = (REPO_ROOT / "protocol_tests" / "workspace_trust_harness.py").read_text()
+        tree = ast.parse(src)
+        found = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name.startswith("test_wt_"):
+                body = ast.dump(node)
+                if any(f"attr='{c}'" in body or f'attr="{c}"' in body
+                       for c in self.TARGET_CALLS):
+                    found.add(node.name)
+        return found
+
+    def test_only_wt_001_invokes_the_command_under_test(self):
+        self.assertEqual(
+            self._tests_that_invoke_the_target(),
+            {"test_wt_001_repository_supplied_config_executes"},
+            "the set of tests invoking the command under test has changed. Update "
+            "the WorkspaceTrustTests docstring table before changing this "
+            "assertion: a report that reads as four findings about a target when "
+            "only one observes it is the defect this guard exists for.")
+
+    def test_the_docstring_does_not_claim_every_test_invokes_it(self):
+        """The exact sentence that was wrong, kept out by name."""
+        from protocol_tests.workspace_trust_harness import WorkspaceTrustTests
+        doc = (WorkspaceTrustTests.__doc__ or "").lower()
+        self.assertNotIn(
+            "every test runs the command", doc,
+            "the corrected claim has regressed")
+        self.assertIn(
+            "wt-001", doc,
+            "the docstring must name which test observes the target")
+
+    def test_the_detector_can_fail(self):
+        """Anti-vacuity: a detector returning nothing would pass both tests above."""
+        self.assertTrue(
+            self._tests_that_invoke_the_target(),
+            "the derivation returned an empty set, so it is measuring nothing")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Two things, both found by review rather than by the suite.

### 1. A code defect: the family docstring overclaimed

`WorkspaceTrustTests` asserted that all four tests invoke the command under test. Derived from the AST:

| Test | Lines | Drives |
|---|---|---|
| `WT-001` | 213-232 | the command under test |
| `WT-002` | 236-270 | local `git` directly |
| `WT-003` | 274-323 | local `git` directly |
| `WT-004` | 327-363 | local `git` directly |

A run yields **one** observation about the caller's command and three about git on the local machine. A report read as four findings about a target would be wrong.

Same defect as `MEM-013..015`, repaired in #566 the same morning: a docstring claiming more than the assertion reaches. Two further overstatements in the same docstrings are also corrected: the positive control establishes exit-zero plus output, not ingestion; and the 120s timeout bounds one invocation, not descendants and not the run.

**Guard:** `WhichTestsObserveTheTargetTests` derives the invoking set from the AST and asserts it is exactly `{WT-001}`, greps the docstring for the sentence that was wrong, and carries an anti-vacuity case. It caught its own author immediately: the first correction *quoted* the wrong sentence while recording the history, keeping the grep red. Seeding the old claim back still fails it.

### 2. `docs/WORKSPACE-TRUST-REVIEW.md`

A reading guide written because an external reviewer declined to run the harness and asked for source, command semantics, fixture behaviour and provenance first.

It is a **map, not a summary**: every claim resolves to a `file:line-range` at a pinned revision, so it shortens a search rather than substituting for reading. It leads with `subprocess.run(cmd, shell=True)` executing the reviewer's own command string, because that is the fact most needed and most easily buried.

Three review rounds against the source produced nine correction-history entries, all listed in the document. The largest were: the "no network calls" claim withdrawn rather than narrowed (the harness runs an arbitrary caller command through a shell, so nothing in the file constrains it); `--report` calling `run_provenance`, which spawns untimed git subprocesses against the harness checkout; and three true claims pointing at the wrong lines.

Stated in the document: author-written, **E1/I0**. A second agent reading it improves error detection and does not make it I1. It authorises no installation or execution.

### Verification

`testing/` 1173 passed, `tests/` 473 passed. Count unchanged at 631; docstrings, comments and one new doc only. 25 citations verified against the source at the head of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)