### PR TITLE
docs: 58 cited test IDs did not exist; guard the class

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ explicitly *not* goals. Full detail and the anti-goals in [ROADMAP.md](ROADMAP.m
 
 | Who | Use Case |
 |-----|----------|
-| [FransDevelopment / Open Agent Trust Registry](https://github.com/FransDevelopment/open-agent-trust-registry) | OATR SDK v1.2.0 test fixtures (X4-021 through X4-030) -- Ed25519 attestation verification |
+| [FransDevelopment / Open Agent Trust Registry](https://github.com/FransDevelopment/open-agent-trust-registry) | OATR SDK v1.2.0 test fixtures (X4-021 through X4-027) -- Ed25519 attestation verification |
 
 ### Independent reproduction
 

--- a/docs/AIUC1-CROSSWALK.md
+++ b/docs/AIUC1-CROSSWALK.md
@@ -14,7 +14,7 @@ material no matter how many requirements it covers. Executed evidence requires a
 stated target and a pinned revision; independent review requires a qualified
 outside party.
 
-> **Standard currency:** this mapping was built against **v2026-Q1** (reviewed March 2026). AIUC-1 now revises quarterly — **Q2 (April 2026)** added MCP/A2A protocol-security and agent-identity controls; **Q3 (released 2026-07-15)** modified 8 requirements / 41 controls. Requirement-level rows below remain valid (renumbering happened at sub-control level), but see the **Q3-2026 Currency Note** near the end of this document before citing this crosswalk against the current standard. Last currency review: 2026-07-16. **Requirement titles verified verbatim against the published pillar pages on 2026-09-05** (`/security`, `/safety`, `/reliability`, `/data-and-privacy`, `/accountability`, `/society`); four had drifted from the standard's wording and were corrected, most consequentially A003, which this document called *data collection* where the standard says *data access*. **Next review due on the Q4-2026 release, 2026-10-15**; AIUC-1 ships on a fixed quarterly cadence (Jan/Apr/Jul/Oct 15), so the review date is knowable in advance rather than event-driven.
+> **Standard currency:** this mapping was built against **v2026-Q1** (reviewed March 2026). AIUC-1 now revises quarterly — **Q2 (April 2026)** added MCP/A2A protocol-security and agent-identity controls; **Q3 (released 2026-07-15)** modified 8 requirements / 41 controls. Requirement-level rows below remain valid (renumbering happened at sub-control level), but see the **Q3-2026 Currency Note** near the end of this document before citing this crosswalk against the current standard. Last currency review: 2026-07-16. **The author compared requirement titles against the published pillar pages on 2026-09-05** (`/security`, `/safety`, `/reliability`, `/data-and-privacy`, `/accountability`, `/society`); four had drifted from the standard's wording and were corrected, most consequentially A003, which this document called *data collection* where the standard says *data access*. **Next review due on the Q4-2026 release, 2026-10-15**; AIUC-1 ships on a fixed quarterly cadence (Jan/Apr/Jul/Oct 15), so the review date is knowable in advance rather than event-driven.
 
 ---
 
@@ -25,8 +25,8 @@ outside party.
 | AIUC-1 Req | Requirement | Our Coverage |
 |---|---|---|
 | **B001** | Third-party testing of adversarial robustness | Harness test vectors may support evidence collection for prompt injection, jailbreaks, polymorphic attacks, multi-step chains, and CVE reproduction. See the [test inventory](TEST-INVENTORY.md) and run the count script for the current test-ID total. |
-| **B002** | Detect adversarial input | MCP tool injection (MCP-001-010), A2A message spoofing (A2A-001-012), prompt injection via operational data (APP-001-030) |
-| **B005** | Implement real-time input filtering | Filter bypass via encoding tricks, nested injection, polymorphic payloads, context displacement (ADV-001-010) |
+| **B002** | Detect adversarial input | MCP tool injection (MCP-001-010), A2A message spoofing (A2A-001-012), prompt injection via operational data (ADI-001, ADI-002, ADI-003) |
+| **B005** | Implement real-time input filtering | Payload-variation probes mapped as potentially relevant: per-attempt payload mutation and encoding variation (POLY-001, POLY-002), nested schema injection (CVE-001), tool-description context displacement (MCP-011, graded as denial-of-service rather than filtering). These observe a target's *responses*; they do not measure a filtering implementation or its latency. |
 | **B009** | Limit output over-exposure | Information leakage detection, output exfiltration tests, API key regex scanning |
 
 ### D. Reliability (all listed requirements mapped)
@@ -34,15 +34,15 @@ outside party.
 | AIUC-1 Req | Requirement | Our Coverage |
 |---|---|---|
 | **D003** | Restrict unsafe tool calls | MCP capability escalation, unauthorized tool registration, A2A task hijacking, L402/x402 unauthorized payment execution |
-| **D004** | Third-party testing of tool calls | 62 wire-protocol tests (MCP + A2A + L402 + x402) + 83 platform adapter tests across 25 cloud + 20 enterprise platforms |
+| **D004** | Third-party testing of tool calls | 133 wire-protocol tests (MCP 33 + A2A 13 + L402 33 + x402 54) + 83 platform adapter tests (cloud 25 + enterprise core 31 + enterprise extended 27) across 5 cloud + 20 enterprise platform adapters |
 
 ### C. Safety (mapped subset)
 
 | AIUC-1 Req | Requirement | Our Coverage |
 |---|---|---|
-| **C001** | Define AI risk taxonomy | Framework provides STRIDE + OWASP Agentic + NIST AI 800-2 risk taxonomy with all 631 tests categorized |
+| **C001** | Define AI risk taxonomy | Framework provides STRIDE, OWASP Agentic and NIST AI 800-2 risk categorisation across the repository's 631 tests. Not every test carries a mapping in every taxonomy: for the OWASP Agentic mapped population see the generated `docs/coverage/owasp-agentic-v1.1.json`, which is validated in CI. |
 | **C002** | Conduct pre-deployment testing | Entire framework designed for pre-deployment. `pip install agent-security-harness` and run before shipping. |
-| **C010** | Third-party testing for harmful outputs | Adversarial test suite validates whether safety controls hold under attack |
+| **C010** | Third-party testing for harmful outputs | Adversarial test vectors are mapped as potentially relevant to evidence collection about harmful outputs. An authorized, pinned run with retained results would be needed to characterise whether a target's control held. |
 | **C011** | Third-party testing for out-of-scope outputs | Protocol-level scope violation tests (MCP-003 capability escalation, A2A unauthorized access) |
 
 ### A. Data & Privacy (mapped subset)
@@ -56,9 +56,9 @@ outside party.
 
 | AIUC-1 Req | Requirement | Our Coverage |
 |---|---|---|
-| **E004** | Assign accountability | [CSG paper](https://doi.org/10.5281/zenodo.19162104) defines 3-tier governance with explicit accountability. 12 mechanisms, 77 days production evidence. |
+| **E004** | Assign accountability | [CSG paper](https://doi.org/10.5281/zenodo.19162104) defines 3-tier governance with explicit accountability. The paper reports 12 mechanisms and 77 days of production operation; that is the cited authors' statement, not a retained operational record held here. |
 | **E006** | Conduct vendor due diligence | A bounded, authorized harness run may contribute technical evidence to a vendor-due-diligence review. It does not replace the review or establish a vendor conclusion on its own. |
-| **E015** | Log AI system activity | JSON reports with full request/response transcripts serve as audit evidence |
+| **E015** | Log AI system activity | JSON reports retain request and response records and may serve as audit evidence. Completeness varies by path and is not guaranteed: some harnesses retain summaries or excerpt response bodies (for example `l402_harness.py` truncates a retained body to 2000 characters), so the reports are not full transcripts. |
 
 ### F. Society (mapped subset)
 

--- a/docs/aiuc1-prep.md
+++ b/docs/aiuc1-prep.md
@@ -88,7 +88,7 @@ The tool generates:
 
 The full mapping is in `configs/aiuc1_mapping.yaml`. Key mappings:
 
-- **Security (B001-B005)**: MCP harness (MCP-001 to MCP-010) + Identity harness (ID-001 to ID-018)
+- **Security (B001-B005)**: MCP harness (MCP-001 to MCP-010) + Identity harness (ID-001 to ID-003)
 - **Reliability (C001-C010)**: A2A harness (A2A-001 to A2A-012) + AIUC-1 compliance tests + L402 tests
 - **Transparency (D001-D004)**: Attestation module + Provenance harness + Identity audit tests
 - **Safety (E001-E003)**: AIUC-1 compliance harness (simulation only - gap)

--- a/testing/test_documented_test_ids_resolve.py
+++ b/testing/test_documented_test_ids_resolve.py
@@ -1,0 +1,157 @@
+"""A test ID cited in a document must be a test ID that exists.
+
+## Why
+
+Three documents cited 58 test IDs that did not exist:
+
+- `docs/AIUC1-CROSSWALK.md` offered `APP-001-030` for prompt injection via
+  operational data (3 exist, as `ADI-001..003`) and `ADV-001-010` for filter
+  bypass (that prefix has never been used; the ten real tests in that module are
+  `POLY-`, `CHAIN-`, `JAIL-`, `RECON-`, `STATE-`).
+- `README.md` credited a third party's fixtures as `X4-021 through X4-030`;
+  `X4-028..030` do not exist.
+- `docs/aiuc1-prep.md` claimed `ID-001 to ID-018`; three exist.
+
+Every one is a round number where a derived one belonged. The crosswalk maps this
+repository onto an external certification and is publicly readable, so that is
+the fabricated-citation class this repository exists to argue against.
+
+Found 2026-09-11 by an outside reader tracing claims to code. Not by the suite.
+
+## What it checks, and the shape of the rule
+
+Three forms, because the first version caught only one of the three defects:
+
+1. A **range**, `ABC-001-030`. Every ID in it must exist. A range is a structural
+   claim about a block of tests and nothing innocent forms one, so this applies
+   whatever the prefix. It is the only rule that catches a wholly invented
+   prefix like `APP`.
+2. A **prose range**, `ABC-001 through ABC-030` / `to ABC-030`. Same rule. The
+   README defect used this form and rule 1 did not see it.
+3. A **bare ID whose prefix the repository actually uses**, e.g. `X4-030` when
+   `X4-001..057` exist. A known prefix with an unknown number is a typo or an
+   invention, and this is what caught the README and `aiuc1-prep` cases.
+
+## What it deliberately does NOT check
+
+A bare ID under an **unknown** prefix. `SHA-256` matches the shape of a test ID
+and is not one; `docs/proposals/` names tests that are proposed rather than
+built; some documents cite IDs belonging to other repositories. Flagging those
+would make this a check that fails on true statements, and such a check gets
+muted rather than obeyed. The cost is real and is stated: a document could invent
+`ZZZ-001` as a single bare ID and pass. Ranges cannot hide that way, and ranges
+are how all 58 were written.
+
+It also cannot decide whether a cited test is *apposite* to the claim beside it.
+`POLY-002` exists, and a row citing it for audit logging would pass here and
+still be wrong. That stays a reading task; the register in
+`test_review_findings_are_ratcheted.py` records it as UNGUARDABLE.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+import count_tests  # noqa: E402
+
+_RANGE = re.compile(r"\b([A-Z][A-Z0-9]*)-(\d{3})-(\d{3})\b")
+_PROSE_RANGE = re.compile(
+    r"\b([A-Z][A-Z0-9]*)-(\d{3})\s+(?:through|to)\s+(?:[A-Z][A-Z0-9]*-)?(\d{3})\b")
+_BARE = re.compile(r"\b([A-Z][A-Z0-9]*-\d{3})\b(?!-\d)")
+_ID_LITERAL = re.compile(r'"([A-Z][A-Z0-9]*-[0-9]{3}[a-z]?)"')
+
+
+def _real_ids() -> set[str]:
+    """Every test ID the shipped code defines.
+
+    `count_tests.module_ids()` scans `protocol_tests/` only. `red_team_automation.py`
+    sits at the repository root and defines 81 `RT-` IDs; keying on the counter
+    alone made this guard fail against every document that cited them correctly.
+    Widened after that, which is why the union below is not redundant.
+    """
+    ids: set[str] = set()
+    for module_ids in count_tests.module_ids().values():
+        ids |= set(module_ids)
+    for path in list(REPO_ROOT.glob("*.py")) + list((REPO_ROOT / "protocol_tests").rglob("*.py")):
+        ids |= set(_ID_LITERAL.findall(path.read_text(encoding="utf-8", errors="replace")))
+    return ids
+
+
+def _documents():
+    for path in sorted((REPO_ROOT / "docs").rglob("*.md")):
+        yield path, path.read_text(encoding="utf-8", errors="replace")
+    readme = REPO_ROOT / "README.md"
+    if readme.is_file():
+        yield readme, readme.read_text(encoding="utf-8", errors="replace")
+
+
+class DocumentedTestIdsResolve(unittest.TestCase):
+
+    def setUp(self):
+        self.real = _real_ids()
+        self.known_prefixes = {i.split("-")[0] for i in self.real}
+
+    def _check_range(self, rel, prefix, lo, hi, form):
+        want = [f"{prefix}-{i:03d}" for i in range(int(lo), int(hi) + 1)]
+        missing = [w for w in want if w not in self.real]
+        if not missing:
+            return
+        with self.subTest(doc=str(rel), rng=f"{prefix}-{lo}-{hi}"):
+            self.fail(
+                f"{rel} cites {prefix}-{lo} {form} {prefix}-{hi}, and "
+                f"{len(missing)} of {len(want)} do not exist "
+                f"({missing[0]}..{missing[-1]}). Cite the IDs the repository "
+                "defines, or describe the capability without an ID range. A "
+                "round number here is how all 58 earlier phantoms were written.")
+
+    def test_every_cited_id_range_expands_to_tests_that_exist(self):
+        for path, text in _documents():
+            rel = path.relative_to(REPO_ROOT)
+            for prefix, lo, hi in sorted(set(_RANGE.findall(text))):
+                self._check_range(rel, prefix, lo, hi, "-")
+
+    def test_every_prose_id_range_expands_to_tests_that_exist(self):
+        """`X4-021 through X4-030`. Rule 1 cannot see this form."""
+        for path, text in _documents():
+            rel = path.relative_to(REPO_ROOT)
+            for prefix, lo, hi in sorted(set(_PROSE_RANGE.findall(text))):
+                self._check_range(rel, prefix, lo, hi, "through")
+
+    def test_a_known_prefix_with_an_unknown_number_does_not_exist(self):
+        for path, text in _documents():
+            rel = path.relative_to(REPO_ROOT)
+            for tid in sorted(set(_BARE.findall(text))):
+                if tid.split("-")[0] not in self.known_prefixes:
+                    continue
+                with self.subTest(doc=str(rel), id=tid):
+                    self.assertIn(
+                        tid, self.real,
+                        f"{rel} cites {tid}. That prefix is one this repository "
+                        "uses, so the number is a typo or an invention.")
+
+    def test_the_id_population_is_real(self):
+        """Anti-vacuity. An empty or tiny `real` set changes what every rule means."""
+        self.assertGreater(len(self.real), 600)
+        self.assertGreater(len(self.known_prefixes), 50)
+        for expected in ("MCP-001", "X4-057", "ADI-001", "RT-001"):
+            self.assertIn(expected, self.real,
+                          f"{expected} missing: _real_ids() stopped seeing a module")
+
+    def test_the_scanner_reads_documents_that_cite_ids(self):
+        """A glob matching nothing satisfies every rule above."""
+        docs = list(_documents())
+        self.assertGreater(len(docs), 20)
+        citing = [p for p, t in docs if _BARE.search(t) or _RANGE.search(t)]
+        self.assertGreater(
+            len(citing), 5,
+            "almost no document cites a test ID, so the regexes stopped matching "
+            "rather than the docs stopping citing tests")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/testing/test_review_findings_are_ratcheted.py
+++ b/testing/test_review_findings_are_ratcheted.py
@@ -161,6 +161,46 @@ REVIEW_FINDINGS: list[tuple[str, str, str, str]] = [
      "author 2026-09-11, caught by the examined-subtest count dropping 28 to 24",
      GUARDED,
      "testing/test_review_findings_are_ratcheted.py: test_the_reachability_check_examines_a_non_empty_set"),
+    # --- 2026-09-11, first outside review round against the register -------
+    ("AIUC1-CROSSWALK.md cited APP-001-030 and ADV-001-010: forty test IDs, none "
+     "of which existed. README cited X4-021 through X4-030 (three absent) and "
+     "aiuc1-prep.md ID-001 to ID-018 (fifteen absent). 58 phantom IDs, every one "
+     "a round number where a derived one belonged",
+     "Ledger claim-tracing review 2026-09-11 (crosswalk); author, deriving the "
+     "class across all documents (README, aiuc1-prep)", GUARDED,
+     "testing/test_documented_test_ids_resolve.py"),
+    ("whether a cited test is apposite to the requirement beside it",
+     "Ledger claim-tracing review 2026-09-11", UNGUARDABLE,
+     "existence is decidable and relevance is not. POLY-002 exists, and a row "
+     "citing it for audit logging would pass every rule in the ID guard and still "
+     "be wrong. Semantic fit between a requirement and a test is the reading task "
+     "the review itself performed."),
+    ("crosswalk D004 claimed 62 wire-protocol tests where the four named modules "
+     "define 133, and '25 cloud platforms' where 5 adapters exist producing 25 "
+     "tests: a test count printed as a platform count",
+     "Ledger claim-tracing review 2026-09-11", UNGUARDABLE,
+     "a derived-count guard is written and correct in principle, but the three "
+     "derivations available here disagreed on the adjacent 'all 631 categorised' "
+     "claim (96 CI-validated mapped, 488 by source kwarg, 579 by the reviewer's "
+     "artifact) because they measure different populations. Until the document "
+     "states which population each number is, a guard would pin the wrong one."),
+    ("crosswalk C010 said the suite 'validates whether safety controls hold under "
+     "attack', and E004 rendered a cited paper's claim as '77 days production "
+     "evidence': runtime and enforcement language inside rows the document itself "
+     "declares mapped/E1",
+     "Hermes evidence-grading F1/F2 and Ledger CW-06/CW-09, independently, "
+     "2026-09-11", UNGUARDABLE,
+     "a forbidden-verb list over mapped rows is writable and would be brittle and "
+     "easily evaded by paraphrase. The durable form needs each row to carry a "
+     "structured evidence class, which the document does not yet have. Recorded "
+     "as the next structural change rather than guarded weakly now."),
+    ("crosswalk E015 claimed JSON reports carry full request/response transcripts "
+     "while l402_harness.py truncates a retained body to 2000 characters",
+     "Ledger claim-tracing review 2026-09-11", UNGUARDABLE,
+     "Ledger proposed a real design: a fake transport emitting a unique marker per "
+     "call with a body past the excerpt boundary, asserting every call is retained "
+     "or explicitly labelled partial. That is a test worth building and is not "
+     "built, so it is recorded here rather than claimed."),
 ]
 
 #: Documents that pin themselves to a revision and publish source hashes.

--- a/testing/test_static_detectors_can_fire.py
+++ b/testing/test_static_detectors_can_fire.py
@@ -497,6 +497,20 @@ UNCONTROLLED = {
     # Globs for `def _record` to derive the prose-graded class as a
     # DENOMINATOR for its ratchet.
     "test_refusal_establishes_a_pass.py",
+    # Scans `docs/**/*.md` and README for cited test IDs that do not resolve, so
+    # it DOES forbid a construction and a seeded violation is entirely meaningful
+    # for it. It is here for a narrower reason: `_seed()` builds a throwaway
+    # package containing one `.py` module, and this detector's input is markdown.
+    # A seeded Python file would demonstrate nothing about it, and widening the
+    # shared harness to emit documents for one detector would make the harness
+    # less legible than the exemption.
+    #
+    # Its controls are real and recorded in its own docstring: the two invented
+    # ranges, the prose `through` form, a known-prefix typo, and three cases that
+    # must be ACCEPTED (SHA-256, a proposals-directory ID, a valid range). If the
+    # shared harness ever grows a document seed, move this into DETECTORS.
+    "test_documented_test_ids_resolve.py",
+
     # test_serviced_guard.py left this queue 2026-09-07. It globbed for
     # `_record` + `response_received` to enumerate harnesses; that rule could
     # not see a harness inheriting `_record`, and was replaced by a registry


### PR DESCRIPTION
## What was wrong

`docs/AIUC1-CROSSWALK.md` cited **`APP-001-030`** for prompt injection via operational data and **`ADV-001-010`** for filter bypass. Neither prefix has ever existed in this repository. Three tests cover the first (`ADI-001..003`); the ten real tests in the second module are `POLY-`, `CHAIN-`, `JAIL-`, `RECON-`, `STATE-`.

Deriving the class across every document instead of fixing the two flagged rows found two more:

| Document | Claimed | Exists |
|---|---|---|
| `AIUC1-CROSSWALK.md` | `APP-001-030`, `ADV-001-010` | none of the 40 |
| `README.md` | `X4-021 through X4-030` | `X4-021..027` |
| `docs/aiuc1-prep.md` | `ID-001 to ID-018` | `ID-001..003` |

**58 phantom IDs**, every one a round number where a derived one belonged. The crosswalk maps this repository onto an external certification and is publicly readable.

Found by an outside reader tracing claims to code. Not by the suite.

## Other corrections, each verified against source

- **D004** claimed 62 wire-protocol tests; the four named modules define **133** (MCP 33, A2A 13, L402 33, x402 54). It also said "25 cloud platforms" — that is the cloud *test* count; **5** adapters produce those 25.
- **C001** claimed "all 631 tests categorized." Three available derivations disagree — 96 CI-validated mapped, 488 by source kwarg, 579 by the reviewer's artifact — because they count different populations. The row now states the canonical 631 total and points at the generated, CI-validated coverage JSON rather than asserting a number that cannot be derived twice.
- **C010** ("validates whether safety controls hold under attack") and **E004** ("77 days production evidence") used runtime and enforcement language in rows the document itself declares mapped/E1. Two reviewers reached these independently.
- **E015** claimed full request/response transcripts while `l402_harness.py` truncates a retained body to 2000 characters.
- The dated "titles verified verbatim" line is now stated as an author comparison, since no retrieval artifact was retained.

## The guard

`testing/test_documented_test_ids_resolve.py`, three rules — because the first version caught one of the three defects:

1. A `NNN-NNN` **range** must fully resolve, whatever the prefix. The only rule that catches a wholly invented prefix like `APP`.
2. A **prose range** (`X through Y`, `to Y`). The README defect used this form and rule 1 could not see it.
3. A **bare ID under a prefix the repository does use** (`X4-030`, `ID-018`). A known prefix with an unknown number is a typo or an invention.

**Deliberately out of scope, and the docstring says so:** a bare ID under an unknown prefix. `SHA-256` has the shape of a test ID; `docs/proposals/` names tests that are proposed rather than built; some docs cite other repositories' IDs. Flagging those makes a check that fails on true statements, and such a check gets muted rather than obeyed. The cost is stated: a single invented bare ID under a novel prefix would pass. Ranges cannot hide that way, and all 58 were written as ranges.

## A defect in the guard itself

The first version keyed the real ID set on `count_tests.module_ids()`, which scans `protocol_tests/` only. `red_team_automation.py` sits at the repository root and defines 81 `RT-` IDs, so the guard failed against every document citing them **correctly** — 129 failures, almost all mine. Widened before shipping.

## Controls

Seeded and confirmed to fire: both invented ranges, the prose form, a known-prefix typo, an emptied ID population. Seeded and confirmed to be **accepted**: `SHA-256`, a proposals-directory ID, a valid range.

Queued in `test_static_detectors_can_fire.py`'s `UNCONTROLLED` list with the actual reason rather than the boilerplate — it *does* forbid a construction and is seedable, but `_seed()` builds a Python module and this detector reads markdown.

## Register

Five rows added: one GUARDED, four UNGUARDABLE with reasons — including the D004 count, which is guardable in principle but not until the document says which population each number describes.

## Verification

- `testing/` 1189 passed
- `tests/` 466 passed, 2 skipped (`mcp-server` extra not installed locally; pre-existing)
- `scripts/count_tests.py` unchanged at 631

🤖 Generated with [Claude Code](https://claude.com/claude-code)