### PR TITLE
evidence: retain the outputs behind release claims, and stop asserting independence

### DIFF
--- a/docs/AUDIT-R33-INDEPENDENT-REVIEW.md
+++ b/docs/AUDIT-R33-INDEPENDENT-REVIEW.md
@@ -1,7 +1,15 @@
-# Independent Review R33 — Agent Security Harness v4.1
+# Automated Review R33 — Agent Security Harness v4.1
+
+> **This is not an independent review, despite the file name.** The reviewer below
+> is a language model run by the repository author, so this is E1/I0 the same as
+> any other author-run artifact. The heading was corrected on 2026-09-11; the file
+> name is kept so existing links continue to resolve, and it should not be read as
+> a claim. A separate agent producing a different reading improves error detection
+> and confers no independence. README records that the harness as a whole has had
+> no independent review.
 
 **Date:** April 10, 2026
-**Reviewer:** Claude Opus 4.6 (automated)
+**Reviewer:** Claude Opus 4.6, run by the author (automated; not an independent party)
 **Scope:** Full codebase review of `msaleme/red-team-blue-team-agent-fabric` at commit 4c02e94 (post-v4.1 merge)
 **Focus:** New v4.1/v4.2 modules + overall codebase health
 

--- a/docs/EVIDENCE-INTEGRITY-OPERATING-RULES.md
+++ b/docs/EVIDENCE-INTEGRITY-OPERATING-RULES.md
@@ -1,8 +1,15 @@
 # Evidence-integrity operating rules
 
-Three rules, agreed with the independent reviewer on 2026-09-01 after a review
-cycle in which each of them was learned from a specific failure rather than
-proposed as principle.
+Three rules, adopted on 2026-09-01 after a review cycle in which each of them was
+learned from a specific failure rather than proposed as principle. The findings
+that produced them are retained in PRs #457 and #486.
+
+An earlier version of this line said the rules were "agreed with the independent
+reviewer". That was withdrawn on 2026-09-11: this repository does not record who
+the reviewer was, their relationship to the project, or whether they were an agent
+under common control, and README states plainly that the harness has had no
+independent review as a whole. A second reader improves error detection; it does
+not make the reading independent.
 
 > Every evidence-integrity register must report its derived numerator and
 > surveyed denominator; every new detector must prove it can catch a seeded
@@ -68,8 +75,9 @@ Any test ID that passes under **both** shape D (`BLAND_COMPLIANCE`) and shape E
 (`NEGATED_REFUSAL_PLUS_HARM`) is **unverified until read**. It is a read
 trigger — never a finding, a debt count, or a repair queue.
 
-The instrument has survived external use once: an independent review classified
+The instrument has survived use by a second reader once: that review classified
 **45** such IDs and **no guessed-vocabulary defect survived source inspection**.
+Second reader, not independent assessor: see the note at the top of this file.
 An earlier application to two modules narrowed seven passes to four candidates,
 of which exactly one was a defect. Reported as a count it would have claimed four.
 

--- a/docs/evidence/release-claims/release-test-count-v4.21.3.txt
+++ b/docs/evidence/release-claims/release-test-count-v4.21.3.txt
@@ -1,0 +1,61 @@
+# Retained output for release-claims.json claim: release-test-count
+# Command   : python3 scripts/count_tests.py
+# Revision  : 4c5c7622fa641bdbe43a79314edd506ddb95cd5e (tag v4.21.3)
+# Captured  : 2026-09-11T17:24:38Z by the repository author (E1/I0)
+# Method    : git archive v4.21.3 | tar -x, then run the command in that tree.
+#             The working tree was NOT used, so this output cannot borrow main's count.
+# ---------------------------------------------------------------------------
+============================================================
+Test Count Report
+============================================================
+
+  A2A Protocol                                    13
+  Advanced Attacks                                10
+  agent_data_injection.py                          3
+  AIUC-1 Compliance                               12
+  AP2 Mandate Chain                               17
+  autogen_harness.py                              10
+  benchmark_integrity_harness.py                   7
+  Capability Profile                              10
+  Card-Network Agentic Tokens                     12
+  CBRN Prevention                                  8
+  Cloud Agent Platforms                           25
+  CrewAI CVE Reproduction                         10
+  Delegated-Authority Attenuation                 11
+  Enterprise Platforms (core)                     31
+  Enterprise Platforms (extended)                 27
+  Extended Thinking                                6
+  Framework Adapters                              15
+  governance_modification_harness.py               6
+  GTG-1002 APT Simulation                         17
+  Harmful Output                                  10
+  hitl_harness.py                                  8
+  Identity & Authorization                        18
+  Incident Response                                8
+  intent_contract_harness.py                       8
+  Jailbreak                                       25
+  kill_switch_harness.py                           4
+  L402 Payment                                    33
+  MCP Protocol                                    33
+  MCP Supply-Chain                                 4
+  MCP Tool Poisoning Reproduction                 10
+  memory_harness.py                               12
+  Multi-Agent Interaction                         19
+  Over-Refusal                                    25
+  Prompt Caching                                   6
+  Provenance & Attestation                        15
+  Programmatic Tool Calling                        6
+  receipt_claim_harness.py                        11
+  Return Channel                                   8
+  Denial-of-Settlement / Finality                  8
+  skill_security_harness.py                        8
+  Tool Search (Embeddings)                         6
+  UCP/ACP Merchant Journey                        12
+  watermark_harness.py                             5
+  x402 Fireblocks Extension                       17
+  x402 Payment                                    54
+
+  TOTAL UNIQUE TEST IDS                          623
+  SUM OF PER-MODULE COUNTS                       623
+
+Definitive count: 623

--- a/docs/release-claims.json
+++ b/docs/release-claims.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": "1.0.0",
-  "purpose": "Bind each release-facing fact to the revision, command, and value that produced it, so a reader can reproduce or reject it without relying on narrative text. See scripts/verify_release_claims.py and GitHub issue #369.",
+  "purpose": "Bind each release-facing fact to the revision, command, and value that produced it, so a reader can reproduce or reject it without relying on narrative text. A pinned claim also carries the retained output of the command that produced it: a command plus an expected value is a recipe for reproduction, not the result that was observed. See scripts/verify_release_claims.py and GitHub issue #369.",
   "not_established": "This manifest records provenance. It does not create independent evidence, change the E-class or I-level of any result, or support a claim that the harness improves the security of any target. A test count is an inventory fact, not a security-efficacy claim.",
   "claims": [
     {
@@ -24,27 +24,40 @@
           "path": "README.md",
           "pattern": "The release carries \\*\\*(\\d+)\\*\\* tests"
         }
-      ]
+      ],
+      "resolution": "pinned",
+      "resolved_revision": "4c5c7622fa641bdbe43a79314edd506ddb95cd5e",
+      "evidence_artifact": {
+        "path": "docs/evidence/release-claims/release-test-count-v4.21.3.txt",
+        "sha256": "5280ca570b86fe02f69db2880d28ded609037c221520c3e874b0ee13a95fb84e",
+        "revision": "4c5c7622fa641bdbe43a79314edd506ddb95cd5e",
+        "command": "python3 scripts/count_tests.py",
+        "captured_by": "repository author",
+        "evidence_class": "E1",
+        "independence_level": "I0",
+        "limitation": "A retained transcript of the author running the command at the pinned revision. It establishes that the value was observed, not that it was observed by anyone independent."
+      }
     },
     {
       "id": "main-test-count",
-      "fact": "main carries 631 unique test IDs.",
+      "fact": "At the HEAD a reader resolves, main carries the number of unique test IDs that `scripts/count_tests.py` reports; 631 at the time of writing.",
       "value": "631",
       "release_tag": null,
       "commit": "HEAD",
       "command": "python3 scripts/count_tests.py",
       "value_extraction": "Definitive count:\\s*(\\d+)",
-      "generated_on": "2026-09-10",
+      "generated_on": null,
       "coverage_report_revision": null,
       "evidence_class": "E1",
       "independence_level": "I0",
-      "limitation": "Same inventory limitation as release-test-count. This value moves with main by design; testing/test_code_quality.py::TestRegTestCount already pins it into pyproject.toml, README, SKILL.md and cli.py, so it is listed here for completeness rather than because it was unguarded.",
+      "limitation": "Same inventory limitation as release-test-count. This claim is LIVE: it is resolved against whatever HEAD the reader has, so it carries no generated_on date. It previously paired commit:HEAD with a fixed date, which cannot be substantiated as a result generated on that date without an immutable revision and retained output. testing/test_code_quality.py::TestRegTestCount pins the current value into pyproject.toml, README, SKILL.md and cli.py.",
       "surfaces": [
         {
           "path": "README.md",
           "pattern": "`main` is at \\*\\*(\\d+)\\*\\*"
         }
-      ]
+      ],
+      "resolution": "live"
     }
   ]
 }

--- a/testing/test_code_quality.py
+++ b/testing/test_code_quality.py
@@ -218,7 +218,7 @@ class TestRegTestCount(unittest.TestCase):
         "testing/CRITICAL_EVALUATION",
         "docs/v3.8-roadmap.md",
         "docs/v3.9-roadmap.md",
-        "docs/AUDIT-R33-INDEPENDENT-REVIEW.md",   # dated external audit
+        "docs/AUDIT-R33-INDEPENDENT-REVIEW.md",   # dated author-run review, not external
         "docs/engagement/WEEKLY_HOOKS",           # dated engagement snapshots
         "docs/blog/",                             # dated posts, counts as-published
     )

--- a/testing/test_independence_claims_are_disclosed.py
+++ b/testing/test_independence_claims_are_disclosed.py
@@ -1,0 +1,145 @@
+"""A claim of independent review must carry a disclosure or a citation.
+
+## Why
+
+`docs/EVIDENCE-INTEGRITY-OPERATING-RULES.md` opened with "Three rules, agreed
+with the independent reviewer", naming no reviewer, no organisation, no
+relationship, and no retained artifact. `docs/AUDIT-R33-INDEPENDENT-REVIEW.md`
+was titled "Independent Review" and named its reviewer four lines down as
+"Claude Opus 4.6 (automated)": a language model run by the author.
+
+Meanwhile README says the harness as a whole has had no independent review. The
+repository was asserting and denying the same thing in different files.
+
+Raised 2026-09-11 as F5 by a second reader grading evidence classes, who also
+supplied the rule this file encodes:
+
+> Do not call a separate agent "independent" merely because it produced a
+> different reading.
+
+## What this can and cannot decide
+
+It **cannot** establish independence. Reviewer identity, absence of common
+control, and economic interest are relational facts about the world, and no test
+reading this repository can reach them. That half is recorded as UNGUARDABLE in
+`test_review_findings_are_ratcheted.py`.
+
+What it **can** do is refuse the bare assertion. Wherever a document claims
+independent review, a reader must find one of three things nearby: a denial (the
+overwhelmingly common case here, and the honest one), a named party or retained
+artifact, or an explicit disclosure that the reviewer was not independent. A
+sentence that claims independence and supplies none of those is the defect.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+#: An assertion that independent review happened.
+_ASSERTS = re.compile(
+    r"\b(?:the|an|our|a)\s+independent\s+(?:review|reviewer|assessor|audit|assessment)\b"
+    r"|\bindependently\s+(?:reviewed|assessed|audited|verified)\b",
+    re.I)
+
+#: Nearby text that makes the assertion legitimate. Any one is enough.
+_DISCHARGES = (
+    # a denial, which is what most of this repository correctly does
+    re.compile(r"\b(?:not|no|never|without|lacks?|absent|nobody|none)\b[^.]{0,120}?"
+               r"independent|independent[^.]{0,120}?\b(?:not|no|never)\b", re.I),
+    re.compile(r"does not (?:have|constitute|establish|amount to|confer)", re.I),
+    re.compile(r"\bNOT independent\b", re.I),
+    # a definition rather than a claim about this project
+    re.compile(r"\b(?:means|defined as|distinguish|requires a qualified|"
+               r"a qualified (?:party|outside))\b", re.I),
+    # a citation: a retained artifact, issue, PR, or named party
+    re.compile(r"#\d{2,}|https?://|\bissue\b|\bPR\b|\bretained\b|\bsee\b\s+[`\w/.-]+\.(?:md|json)", re.I),
+    # an explicit disclosure that the reviewer was not independent
+    re.compile(r"run by the (?:author|repository author)|under common control|"
+               r"second reader|author-run|E1/I0", re.I),
+)
+
+_SKIP_DIRS = {"paper-dgb", "drafts", "proposals", "research"}
+
+
+def _documents():
+    for path in sorted((REPO_ROOT / "docs").rglob("*.md")):
+        if _SKIP_DIRS & set(path.relative_to(REPO_ROOT).parts):
+            continue
+        yield path, path.read_text(encoding="utf-8", errors="replace")
+    readme = REPO_ROOT / "README.md"
+    if readme.is_file():
+        yield readme, readme.read_text(encoding="utf-8", errors="replace")
+
+
+def _paragraphs(text: str):
+    for para in re.split(r"\n\s*\n", text):
+        yield para
+
+
+class IndependenceClaimsAreDisclosed(unittest.TestCase):
+
+    def test_no_document_asserts_independent_review_without_support(self):
+        for path, text in _documents():
+            rel = path.relative_to(REPO_ROOT)
+            for para in _paragraphs(text):
+                if not _ASSERTS.search(para):
+                    continue
+                if any(d.search(para) for d in _DISCHARGES):
+                    continue
+                with self.subTest(doc=str(rel)):
+                    snippet = " ".join(para.split())[:150]
+                    self.fail(
+                        f"{rel} asserts independent review with nothing beside it: "
+                        f"\"{snippet}\". Name the party or the retained artifact, "
+                        f"disclose that the reviewer was not independent, or say "
+                        f"plainly that the project does not have it. A separate "
+                        f"agent producing a different reading is not independence.")
+
+    def test_the_title_of_a_review_document_does_not_outrun_its_reviewer(self):
+        """AUDIT-R33 was titled 'Independent Review' and reviewed by a model.
+
+        A file whose own `Reviewer:` line names a language model must not carry an
+        unqualified independence claim in its heading.
+        """
+        model = re.compile(r"^\*\*Reviewer:\*\*\s*(.+)$", re.M)
+        looks_automated = re.compile(r"claude|gpt|gemini|llama|automated|agent|model", re.I)
+        for path, text in _documents():
+            m = model.search(text)
+            if not m or not looks_automated.search(m.group(1)):
+                continue
+            head = text[:text.index("\n\n")] if "\n\n" in text else text[:400]
+            rel = path.relative_to(REPO_ROOT)
+            with self.subTest(doc=str(rel)):
+                if not re.search(r"\bindependent\b", head, re.I):
+                    continue
+                self.assertTrue(
+                    any(d.search(text[:1200]) for d in _DISCHARGES),
+                    f"{rel} has an automated reviewer ({m.group(1).strip()!r}) and the word "
+                    f"'independent' in its heading, with no disclaimer near the top.")
+
+    def test_the_scanner_sees_the_claims_it_should(self):
+        """Anti-vacuity: a regex matching nothing passes both rules above."""
+        docs = list(_documents())
+        self.assertGreater(len(docs), 15)
+        hits = [p for p, t in docs if _ASSERTS.search(t)]
+        self.assertGreater(
+            len(hits), 2,
+            "almost no document mentions independent review, so the assertion "
+            "pattern stopped matching rather than the claims disappearing")
+
+    def test_a_bare_assertion_is_actually_rejected(self):
+        """The positive control: prove the rule fires on the original sentence."""
+        bare = "Three rules, agreed with the independent reviewer on 2026-09-01."
+        self.assertTrue(_ASSERTS.search(bare))
+        self.assertFalse(
+            any(d.search(bare) for d in _DISCHARGES),
+            "the withdrawn sentence would pass this guard, so the guard is not "
+            "checking what it claims to check")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/testing/test_release_claims.py
+++ b/testing/test_release_claims.py
@@ -29,7 +29,9 @@ not be read as having reproduced any value.
 
 from __future__ import annotations
 
+import hashlib
 import json
+import re
 import sys
 import unittest
 from pathlib import Path
@@ -44,7 +46,14 @@ MANIFEST_PATH = REPO_ROOT / "docs" / "release-claims.json"
 REQUIRED_FIELDS = {
     "id", "fact", "value", "release_tag",  "command", "value_extraction",
     "generated_on", "evidence_class", "independence_level", "limitation", "surfaces",
+    "resolution",
 }
+
+#: A claim is resolved against a fixed revision, or against whatever HEAD the
+#: reader has. The distinction was implicit and the two were mixed: the main
+#: count paired `commit: "HEAD"` with `generated_on: "2026-09-10"`, which reads
+#: as a result generated on that date and cannot be substantiated as one.
+PINNED, LIVE = "pinned", "live"
 
 
 class TestReleaseClaimsManifest(unittest.TestCase):
@@ -245,3 +254,107 @@ class TestAnUnresolvableTagIsNotSilentlyHead(unittest.TestCase):
         self.assertIn("HEAD", label)
         self.assertNotEqual(status, verify_release_claims.SKIP)
 
+
+class TestClaimResolutionIsHonest(unittest.TestCase):
+    """A dated result must not be bound to a floating ref, and a pinned claim
+    must carry the output that produced it.
+
+    Both findings came from an outside reader grading evidence classes on
+    2026-09-11 (F3 and F4). Neither was an E1-to-E2 inflation: the labels were
+    right. They were provenance-boundary defects, which is a quieter failure and
+    the reason they survived several careful readings.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+    def test_every_claim_declares_how_it_resolves(self):
+        for claim in self.manifest["claims"]:
+            with self.subTest(claim=claim.get("id")):
+                self.assertIn(
+                    claim.get("resolution"), (PINNED, LIVE),
+                    f"claim {claim.get('id')!r} does not say whether it resolves against a "
+                    f"fixed revision or against the reader's HEAD. That is the distinction "
+                    f"the two rules below depend on.")
+
+    def test_a_live_claim_carries_no_generation_date(self):
+        """F3. `commit: HEAD` plus a fixed date asserts a dated observation.
+
+        HEAD is deliberately dynamic and the surface check regenerates tagless
+        claims at current HEAD, which is right for a current-inventory statement.
+        It cannot substantiate the claim as a result produced on a past date
+        without an immutable resolved revision and retained output. So a live
+        claim states no date; if a dated observation is wanted, pin it.
+        """
+        live = [c for c in self.manifest["claims"] if c.get("resolution") == LIVE]
+        self.assertTrue(live, "no live claim: this rule is guarding nothing")
+        for claim in live:
+            with self.subTest(claim=claim["id"]):
+                self.assertIsNone(
+                    claim.get("generated_on"),
+                    f"claim {claim['id']!r} resolves live but carries "
+                    f"generated_on={claim.get('generated_on')!r}. Either drop the date, or "
+                    f"make it pinned with a resolved_revision and a retained artifact.")
+
+    def test_a_pinned_claim_retains_the_output_that_produced_it(self):
+        """F4. A command plus an expected value is a recipe, not a result."""
+        pinned = [c for c in self.manifest["claims"] if c.get("resolution") == PINNED]
+        self.assertTrue(pinned, "no pinned claim: this rule is guarding nothing")
+        for claim in pinned:
+            cid = claim["id"]
+            with self.subTest(claim=cid):
+                rev = claim.get("resolved_revision") or ""
+                self.assertRegex(
+                    rev, r"^[0-9a-f]{40}$",
+                    f"claim {cid!r} is pinned but names no immutable 40-character revision")
+
+                art = claim.get("evidence_artifact")
+                self.assertIsInstance(
+                    art, dict,
+                    f"claim {cid!r} is pinned and retains no evidence_artifact. The manifest's "
+                    f"stated purpose is to bind a fact to the value that produced it; a command "
+                    f"and an expected value are instructions for reproducing it, not the "
+                    f"observation itself.")
+
+                path = REPO_ROOT / art["path"]
+                self.assertTrue(path.is_file(), f"{cid}: artifact {art['path']} is missing")
+
+                actual = hashlib.sha256(path.read_bytes()).hexdigest()
+                self.assertEqual(
+                    actual, art["sha256"],
+                    f"{cid}: {art['path']} hashes to {actual[:12]}, manifest says "
+                    f"{art['sha256'][:12]}. The retained output changed after it was recorded.")
+
+                self.assertEqual(
+                    art.get("revision"), rev,
+                    f"{cid}: the artifact records revision {art.get('revision')!r} but the "
+                    f"claim is pinned to {rev!r}. An artifact from a different revision is "
+                    f"not evidence for this claim.")
+                self.assertEqual(
+                    art.get("command"), claim["command"],
+                    f"{cid}: the artifact records a different command than the claim declares")
+
+                text = path.read_text(encoding="utf-8", errors="replace")
+                found = re.search(claim["value_extraction"], text)
+                self.assertIsNotNone(
+                    found,
+                    f"{cid}: the claim's own value_extraction pattern does not match anything "
+                    f"in the retained output. The artifact does not record this claim's value.")
+                self.assertEqual(
+                    found.group(1), claim["value"],
+                    f"{cid}: the retained output says {found.group(1)!r} where the claim says "
+                    f"{claim['value']!r}.")
+
+    def test_the_artifact_is_not_a_stub(self):
+        """Anti-vacuity: a one-line file satisfies every hash and regex check above."""
+        for claim in self.manifest["claims"]:
+            art = claim.get("evidence_artifact")
+            if not art:
+                continue
+            with self.subTest(claim=claim["id"]):
+                body = (REPO_ROOT / art["path"]).read_text(encoding="utf-8", errors="replace")
+                self.assertGreater(
+                    len(body.splitlines()), 10,
+                    f"{claim['id']}: the retained artifact is a handful of lines. A transcript "
+                    f"trimmed to just the answer is the recipe problem again, one layer down.")

--- a/testing/test_review_findings_are_ratcheted.py
+++ b/testing/test_review_findings_are_ratcheted.py
@@ -201,6 +201,31 @@ REVIEW_FINDINGS: list[tuple[str, str, str, str]] = [
      "call with a body past the excerpt boundary, asserting every call is retained "
      "or explicitly labelled partial. That is a test worth building and is not "
      "built, so it is recorded here rather than claimed."),
+    # --- 2026-09-11, Hermes evidence-class grading F3/F4/F5 -----------------
+    ("release-claims.json paired `commit: \"HEAD\"` with a fixed generated_on "
+     "date, asserting a dated observation against a ref that resolves differently "
+     "for every reader",
+     "Hermes evidence-grading F3, 2026-09-11", GUARDED,
+     "testing/test_release_claims.py: test_a_live_claim_carries_no_generation_date"),
+    ("both release claims supplied a command, a regex and an expected value but no "
+     "retained output. A command plus an expected value is a recipe for "
+     "reproduction, not the result that was observed",
+     "Hermes evidence-grading F4, 2026-09-11", GUARDED,
+     "testing/test_release_claims.py: test_a_pinned_claim_retains_the_output_that_produced_it"),
+    ("three documents asserted independent review with nothing behind it: the "
+     "operating rules named 'the independent reviewer' with no party or artifact, "
+     "and AUDIT-R33 was titled 'Independent Review' four lines above a Reviewer "
+     "line naming a language model run by the author, while README states the "
+     "harness has had no independent review",
+     "Hermes evidence-grading F5, 2026-09-11, extended by the author to the R33 "
+     "title", GUARDED,
+     "testing/test_independence_claims_are_disclosed.py"),
+    ("whether a named reviewer was actually independent",
+     "Hermes evidence-grading F5, 2026-09-11", UNGUARDABLE,
+     "reviewer identity, absence of common control, and economic interest are "
+     "relational facts about the world. No test reading this repository can reach "
+     "them. The guard above refuses the bare assertion and requires a party, an "
+     "artifact, or a disclosure; it cannot verify the party is what it says."),
 ]
 
 #: Documents that pin themselves to a revision and publish source hashes.


### PR DESCRIPTION
Three findings from a second reader grading evidence classes at `67674a5e`. **None was an E1-to-E2 inflation** — the labels were right. All three were provenance-boundary defects, which is a quieter failure and why they survived several readings.

## F3 — a dated result bound to a floating ref

`main-test-count` paired `"commit": "HEAD"` with `"generated_on": "2026-09-10"`. HEAD is deliberately dynamic, so that asserts a dated observation against a ref that resolves differently for every reader.

The claim is now explicitly `live`, carries no date, and states its fact in live terms.

## F4 — recipes, not retained results

Both claims supplied a command, an extraction regex, and an expected value — and no retained output. The manifest's own stated purpose is to bind a fact to *the value that produced it*, and a command plus an expected value is a recipe for reproduction rather than the result observed.

`release-test-count` now carries an `evidence_artifact`: the transcript of `count_tests.py` run against a `git archive v4.21.3` extraction, hashed, with the resolved 40-character revision. **Reproduced 623 at `4c5c7622`**, matching both the claim and the SHA the reviewer resolved independently. The working tree was not used, so the output cannot borrow main's count.

Claims now declare `resolution`:

| | requirement |
|---|---|
| `live` | must carry **no** generation date |
| `pinned` | must name an immutable 40-char revision **and** retain the output — whose hash, revision, command and extracted value all agree with the claim |

Seeded four ways: both original defects, a tampered artifact, and an artifact recording a different value. All four fire.

## F5 — asserting independence with nothing behind it

The operating rules said *"agreed with the independent reviewer"* — no party, no relationship, no artifact.

Worse, and **not in the original finding**: `AUDIT-R33-INDEPENDENT-REVIEW.md` is titled "Independent Review" four lines above a `Reviewer:` line reading *"Claude Opus 4.6 (automated)"* — a model run by the author. Meanwhile README states the harness as a whole has had no independent review. The repository was asserting and denying the same thing in different files.

All three withdrawn. R33 keeps its filename so existing links resolve, and now opens by disclaiming the name — renaming a public path would 404 inbound links, so that's flagged rather than done.

The rule encoded is the reviewer's own: **do not call a separate agent "independent" merely because it produced a different reading.**

`test_independence_claims_are_disclosed.py` refuses the bare assertion — a claim of independent review must sit near a denial, a named party or retained artifact, or a disclosure that the reviewer was not independent.

It **cannot establish independence** and says so. Identity, absence of common control, and economic interest are relational facts no test here can reach; that half is recorded UNGUARDABLE. Its positive control asserts the exact withdrawn sentence would be rejected, and the repository's many honest denials are accepted unchanged.

## Register

22 rows: 14 GUARDED, 8 UNGUARDABLE, 0 OPEN.

## Verification

- `testing/` 1197 passed
- `tests/` 466 passed, 2 skipped (`mcp-server` extra, pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)