### PR TITLE
fix: drift detection collapsed the third state, and four comparison claims

### DIFF
--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -10,8 +10,13 @@ which is which is the whole point of the split below.
   a date on it.
 - **This suite's own numbers are derived, regenerated 2026-09-08** from
   `scripts/count_tests.py` and `protocol_tests/asi_inventory.py`.
-  `testing/test_comparison_doc_is_current.py` recomputes every one of them and
-  fails if the document drifts from the catalog.
+  `testing/test_comparison_doc_is_current.py` recomputes the counts in the
+  three-column tables below and fails if the document drifts from the catalog. It
+  does **not** recompute every number in this file: it selects three-column rows
+  with a digit in the second column, so a two-column row is invisible to it. That
+  is how the AIUC-1 requirement row below carried a wrong figure through several
+  readings. A green run on that guard is not evidence that every numeric claim
+  here was checked.
 
 The fifth external review (R5-09, 2026-09-09) found the two mixed together: an
 April feature table claiming "MCP: 18 tests" and behavioural profiling "Planned
@@ -30,6 +35,16 @@ adversarial pressure.
 Not re-examined since 2026-04. No competitor system was executed or inspected
 for the 2026-09 revision of this document.
 
+**No cell below names the release it describes, and none carries a row-level
+source.** The links identify products, not the version examined, so a reader
+cannot tell which build any statement was true of, and a dash means "not found
+when we looked in April 2026" rather than "absent from the product". Read every
+competitor cell as unsourced as to version. `testing/test_comparison_doc_is_current.py`
+expressly excludes these cells from its checks and asserts only that the date
+wording is present, so nothing here is machine-verified. Treat this table as an
+archived snapshot of our reading, not as a current assessment of anyone's
+product.
+
 | Capability | [Cisco MCP Scanner](https://github.com/cisco-ai-defense/mcp-scanner) | [Snyk Agent Scan](https://github.com/snyk/agent-scan) | [NVIDIA Garak](https://github.com/NVIDIA/garak) |
 |---|---|---|---|
 | **Approach** | Static + LLM-as-judge | Config scanning + toxic flow | Model-layer probing |
@@ -45,9 +60,11 @@ for the 2026-09 revision of this document.
 
 ## This suite -- DERIVED, regenerated 2026-09-08
 
-Every count in this section is recomputed from source by
-`testing/test_comparison_doc_is_current.py`. The third column names the modules
-it is summed from, so the derivation is checkable without rerunning anything.
+Every count **in this section** is recomputed from source by
+`testing/test_comparison_doc_is_current.py`; the scope limit stated at the top
+applies to the document as a whole, not to these rows. The third column names the
+modules it is summed from, so the derivation is checkable without rerunning
+anything.
 
 | Surface | Tests | Derived from |
 |---|---|---|
@@ -64,9 +81,9 @@ governance and incident-response modules that `count_tests.py` lists in full.
 | Capability | Status |
 |---|---|
 | Approach | Wire-protocol adversarial testing |
-| Behavioural profiling / drift | Shipped: `scripts/behavioral_profile.py` |
+| Behavioural profiling / drift | Shipped: `scripts/behavioral_profile.py`. Compares verdict states across two runs and reports PASS/FAIL transitions as regression or improvement. Transitions into or out of INCONCLUSIVE are reported as changed *evidence*, never as behavioural drift, and pairs with an INCONCLUSIVE on either side are excluded from the stability score rather than counted. Until 2026-09-11 it compared the pass flag alone, which scored an unevaluated result as a failure. |
 | Compliance evidence packs | AIUC-1, OWASP, NIST |
-| AIUC-1 requirement mapping | 19 of 20 requirements |
+| AIUC-1 requirement mapping | `configs/aiuc1_mapping.yaml` declares 24 requirement keys: 23 COVERED, 1 GAP |
 | Statistical multi-trial | Wilson intervals over serviced trials (NIST AI 800-2) |
 | CI/CD integration | GitHub Action + CLI |
 | License | Apache 2.0 |
@@ -97,10 +114,18 @@ counting them as coverage was the overclaim an external review corrected on
 | ASI10 | Rogue Agents | 13 |
 | — | No ASI primary (positive controls, content safety, robustness) | 52 |
 
-The table's rows sum to 621, not to the 631 unique test IDs above: 10 tests
-carry no ASI tag site at all and so are not in the corpus this table is a
-denominator for. Untagged is a third state, and folding it into "no primary"
-would report an unmade decision as a made one.
+The table's rows sum to 621, not to the 631 unique test IDs above. The 10
+missing IDs are `RCL-001`..`RCL-007` and `RCL-009`..`RCL-011`, and they **do**
+carry a tag: `receipt_claim_harness.py` constructs their results with
+`owasp_asi="ASI09"`. The extractor attributes a tag only when the test ID and the
+tag resolve at the same call site, and these IDs are passed into a shared helper,
+so the tag is real and not attributable by this instrument.
+
+That is an attribution limit of the extractor, not an absence in the tests, and
+an earlier version of this passage stated it as the latter. It understates ASI09
+rather than overstating anything. Do not relabel these ten as a deliberate "no
+primary": that would report an unmade decision as a made one, in the opposite
+direction.
 
 **ASI10 Rogue Agents (13) and ASI08 Cascading Failures (19) are thin.**
 That is a true statement about this suite, not a rendering gap. Before the remap

--- a/scripts/behavioral_profile.py
+++ b/scripts/behavioral_profile.py
@@ -84,6 +84,48 @@ def _index_by_test_id(results: list[dict[str, Any]]) -> dict[str, dict[str, Any]
 
 
 # ---------------------------------------------------------------------------
+# Verdict state
+# ---------------------------------------------------------------------------
+
+#: The canonical INCONCLUSIVE markers, imported rather than restated so this
+#: script cannot drift from the harnesses it reads. `row_field` handles a row
+#: arriving as a dataclass in-process or a dict from a written report.
+try:
+    from protocol_tests.http_helpers import INCONCLUSIVE_FIELDS, row_field
+except ImportError:  # running from a checkout without the package importable
+    INCONCLUSIVE_FIELDS = ("not_evaluated", "informational")
+
+    def row_field(row, name, default=None):
+        if isinstance(row, dict):
+            return row.get(name, default)
+        return getattr(row, name, default)
+
+PASS, FAIL, INCONCLUSIVE = "PASS", "FAIL", "INCONCLUSIVE"
+
+
+def verdict_state(row) -> str:
+    """PASS, FAIL, or INCONCLUSIVE for one result row.
+
+    This script read `.get("passed", False)` alone until 2026-09-11, which makes
+    INCONCLUSIVE indistinguishable from FAIL, because an unevaluated result
+    carries `passed=False`. Two consequences, both wrong in the direction that
+    hides a problem:
+
+    * `FAIL -> INCONCLUSIVE` scored as stable with no drift, so a target that
+      stopped answering looked like a target behaving consistently.
+    * `PASS -> INCONCLUSIVE` was reported as `PASS -> FAIL`, a regression alarm
+      naming a cause that did not happen.
+
+    Found by a second reader tracing a comparison-table row to its source. The
+    row advertised behavioural drift detection without disclosing that the
+    observation boundary was two-state.
+    """
+    if any(row_field(row, f, False) for f in INCONCLUSIVE_FIELDS):
+        return INCONCLUSIVE
+    return PASS if row_field(row, "passed", False) else FAIL
+
+
+# ---------------------------------------------------------------------------
 # Stability score
 # ---------------------------------------------------------------------------
 
@@ -93,16 +135,29 @@ def compute_stability(
 ) -> dict[str, Any]:
     """Compute stability score between two runs.
 
-    stability = matching_results / total_results * 100
+    stability = matching_results / comparable_results * 100
 
-    A result "matches" if the passed boolean is the same in both runs.
-    Tests present in only one run count as mismatches.
+    A result "matches" if its verdict state is the same in both runs. The state
+    is three-valued; comparing the `passed` boolean alone scored an unevaluated
+    result as a failure. See `verdict_state`.
+
+    **An INCONCLUSIVE on either side is not comparable.** It is excluded from
+    both numerator and denominator and reported separately, because a run that
+    could not establish a verdict is evidence of nothing about stability. Scoring
+    it as stable would let a target that stopped answering read as consistent;
+    scoring it as drift would raise an alarm naming a cause that did not happen.
     """
     all_ids = sorted(set(baseline_idx) | set(current_idx))
     if not all_ids:
-        return {"score": 100.0, "matching": 0, "total": 0, "details": []}
+        # Not 100.0. A stability score over zero observations asserts perfect
+        # stability from no evidence, which is the same defect one level up.
+        return {"score": None, "matching": 0, "comparable": 0,
+                "inconclusive": 0, "total": 0,
+                "score_basis": "no results compared", "details": []}
 
     matching = 0
+    comparable = 0
+    inconclusive = 0
     details: list[dict[str, Any]] = []
 
     for tid in all_ids:
@@ -118,28 +173,47 @@ def compute_stability(
             })
             continue
 
-        b_passed = b.get("passed", False)
-        c_passed = c.get("passed", False)
+        b_state = verdict_state(b)
+        c_state = verdict_state(c)
 
-        if b_passed == c_passed:
+        if INCONCLUSIVE in (b_state, c_state):
+            inconclusive += 1
+            details.append({
+                "test_id": tid,
+                "stable": None,
+                "reason": "inconclusive",
+                "baseline": b_state,
+                "current": c_state,
+            })
+            continue
+
+        comparable += 1
+        if b_state == c_state:
             matching += 1
-            details.append({"test_id": tid, "stable": True})
+            details.append({"test_id": tid, "stable": True, "baseline": b_state,
+                            "current": c_state})
         else:
             details.append({
                 "test_id": tid,
                 "stable": False,
                 "reason": "result_changed",
-                "baseline": b_passed,
-                "current": c_passed,
+                "baseline": b_state,
+                "current": c_state,
             })
 
     total = len(all_ids)
-    score = (matching / total * 100) if total else 100.0
+    score = (matching / comparable * 100) if comparable else None
 
     return {
-        "score": round(score, 2),
+        "score": round(score, 2) if score is not None else None,
         "matching": matching,
+        "comparable": comparable,
+        "inconclusive": inconclusive,
         "total": total,
+        "score_basis": (
+            "matching / comparable, where comparable excludes pairs with an "
+            "INCONCLUSIVE on either side. score is null when nothing was "
+            "comparable: 100%% over zero tests is not stability."),
         "details": details,
     }
 
@@ -156,9 +230,16 @@ def detect_drift(
 
     Each drift event includes:
       - test_id, test_name
-      - old_result, new_result (PASS / FAIL)
+      - old_result, new_result (PASS / FAIL / INCONCLUSIVE)
       - severity of the test
-      - category: regression (PASS->FAIL), improvement (FAIL->PASS), flaky
+      - category: regression, improvement, evidence_lost, evidence_gained
+
+    A transition into or out of INCONCLUSIVE is reported as a change of
+    *evidence*, never as a regression or an improvement. `PASS -> INCONCLUSIVE`
+    is not a target that started failing; it is a target that stopped being
+    measurable, and calling it a regression names a cause that did not happen.
+    `FAIL -> INCONCLUSIVE` is not stability either, which is what the previous
+    two-state comparison recorded, because both sides carried `passed=False`.
     """
     drifts: list[dict[str, Any]] = []
     common_ids = sorted(set(baseline_idx) & set(current_idx))
@@ -166,21 +247,22 @@ def detect_drift(
     for tid in common_ids:
         b = baseline_idx[tid]
         c = current_idx[tid]
-        b_passed = b.get("passed", False)
-        c_passed = c.get("passed", False)
+        old_result = verdict_state(b)
+        new_result = verdict_state(c)
 
-        if b_passed == c_passed:
+        if old_result == new_result:
             continue
 
-        old_result = "PASS" if b_passed else "FAIL"
-        new_result = "PASS" if c_passed else "FAIL"
-
-        if b_passed and not c_passed:
+        if new_result == INCONCLUSIVE:
+            # The verdict became unavailable. That is a change in what can be
+            # established, not a change in the target's behaviour.
+            category = "evidence_lost"
+        elif old_result == INCONCLUSIVE:
+            category = "evidence_gained"
+        elif old_result == PASS and new_result == FAIL:
             category = "regression"
-        elif not b_passed and c_passed:
-            category = "improvement"
         else:
-            category = "flaky"
+            category = "improvement"
 
         drifts.append({
             "test_id": tid,

--- a/testing/test_behavioral_profile.py
+++ b/testing/test_behavioral_profile.py
@@ -109,9 +109,23 @@ class TestStability:
         assert stab["matching"] == 1
 
     def test_empty_runs(self):
+        """No observations is not perfect stability.
+
+        This asserted `score == 100.0` until 2026-09-11. Comparing two empty runs
+        produced a claim of flawless behavioural stability from zero evidence,
+        which is the repository's oldest defect class wearing a percentage sign:
+        an absence of observed failure reported as an observed pass.
+
+        Raised as CP-04 by a second reader, alongside the two-state comparison in
+        the same script. The score is now `None` when nothing was comparable, and
+        `score_basis` says why.
+        """
         stab = compute_stability({}, {})
-        assert stab["score"] == 100.0
+        assert stab["score"] is None, (
+            "an empty comparison must not report a stability percentage; "
+            "100% over zero tests is a claim with no observation behind it")
         assert stab["total"] == 0
+        assert stab["comparable"] == 0
 
 
 # ---------------------------------------------------------------------------

--- a/testing/test_behavioral_profile_three_state.py
+++ b/testing/test_behavioral_profile_three_state.py
@@ -1,0 +1,181 @@
+"""Behavioural drift must not score an unevaluated result as a failure.
+
+## Why
+
+`scripts/behavioral_profile.py` compared runs on `.get("passed", False)` alone.
+An INCONCLUSIVE result carries `passed=False`, so it was indistinguishable from
+a FAIL, and both consequences ran in the direction that hides a problem:
+
+* `FAIL -> INCONCLUSIVE` compared equal, so a target that stopped answering
+  scored as **stable, no drift**.
+* `PASS -> INCONCLUSIVE` was reported as `PASS -> FAIL`, a regression alarm
+  naming a cause that did not happen.
+
+A third: an empty comparison returned `score: 100.0`, asserting perfect
+stability from zero observations.
+
+Found 2026-09-11 by a second reader tracing a comparison-table row to its source
+(CP-04). The row advertised behavioural drift detection and did not disclose that
+the observation boundary was two-state. The script is the shipped artifact behind
+that row, so the defect was live, not documentary.
+
+This is the same class the harnesses fought through `INCONCLUSIVE_FIELDS`,
+`console_status` and the serviced guard. It reached a `scripts/` tool because
+nothing shared was imported there.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+sys.path.insert(0, str(REPO_ROOT))
+
+import behavioral_profile as bp  # noqa: E402
+
+
+def row(tid, passed, **kw):
+    return {"test_id": tid, "name": tid, "passed": passed, **kw}
+
+
+def idx(*rows):
+    return {r["test_id"]: r for r in rows}
+
+
+class VerdictState(unittest.TestCase):
+
+    def test_the_three_states_are_distinguishable(self):
+        self.assertEqual(bp.verdict_state(row("T", True)), bp.PASS)
+        self.assertEqual(bp.verdict_state(row("T", False)), bp.FAIL)
+        self.assertEqual(
+            bp.verdict_state(row("T", False, not_evaluated=True)), bp.INCONCLUSIVE)
+
+    def test_both_canonical_markers_are_read(self):
+        """`not_evaluated` and `informational` are not synonyms and both count.
+
+        `identity_harness` uses the second. Reading only the first made a whole
+        module's results look like failures elsewhere in this repository.
+        """
+        for field in ("not_evaluated", "informational"):
+            with self.subTest(field=field):
+                self.assertEqual(
+                    bp.verdict_state(row("T", False, **{field: True})),
+                    bp.INCONCLUSIVE)
+
+    def test_an_inconclusive_result_outranks_its_passed_flag(self):
+        """A result carrying both must not be scored on `passed`."""
+        self.assertEqual(
+            bp.verdict_state(row("T", True, not_evaluated=True)), bp.INCONCLUSIVE)
+
+
+class StabilityDoesNotScoreTheUnevaluated(unittest.TestCase):
+
+    def test_fail_to_inconclusive_is_not_recorded_as_stable(self):
+        """The defect, stated as a test. Both sides carry passed=False."""
+        out = bp.compute_stability(
+            idx(row("T-1", False)),
+            idx(row("T-1", False, not_evaluated=True)))
+        detail = out["details"][0]
+        self.assertIsNot(
+            detail["stable"], True,
+            "a target that stopped producing a verdict scored as stable, which "
+            "is the two-state comparison this file exists to prevent")
+        self.assertEqual(detail["reason"], "inconclusive")
+        self.assertEqual(out["inconclusive"], 1)
+        self.assertEqual(out["comparable"], 0)
+
+    def test_an_inconclusive_pair_is_excluded_from_the_score(self):
+        out = bp.compute_stability(
+            idx(row("T-1", True), row("T-2", True)),
+            idx(row("T-1", True), row("T-2", False, not_evaluated=True)))
+        self.assertEqual(out["comparable"], 1)
+        self.assertEqual(out["matching"], 1)
+        self.assertEqual(out["inconclusive"], 1)
+        self.assertEqual(out["score"], 100.0,
+                         "the one comparable pair matched, so the score is 100 "
+                         "over that pair and the inconclusive one is reported "
+                         "separately rather than silently scored")
+
+    def test_a_real_regression_is_still_detected(self):
+        """The opposing direction. Excluding INCONCLUSIVE must not excuse FAIL."""
+        out = bp.compute_stability(idx(row("T-1", True)), idx(row("T-1", False)))
+        self.assertEqual(out["details"][0]["stable"], False)
+        self.assertEqual(out["details"][0]["reason"], "result_changed")
+        self.assertEqual(out["score"], 0.0)
+
+    def test_nothing_comparable_is_not_perfect_stability(self):
+        """`score: 100.0` over zero observations asserted stability from nothing."""
+        self.assertIsNone(bp.compute_stability({}, {})["score"])
+        both_out = bp.compute_stability(
+            idx(row("T-1", False, not_evaluated=True)),
+            idx(row("T-1", False, not_evaluated=True)))
+        self.assertIsNone(
+            both_out["score"],
+            "every pair was inconclusive, so there is no stability figure to "
+            "report; 100% over zero comparable tests is the same defect")
+
+
+class DriftNamesTheRightCause(unittest.TestCase):
+
+    def _one(self, b, c):
+        d = bp.detect_drift(idx(b), idx(c))
+        return d[0] if d else None
+
+    def test_pass_to_inconclusive_is_not_a_regression(self):
+        ev = self._one(row("T-1", True), row("T-1", False, not_evaluated=True))
+        self.assertIsNotNone(ev, "the transition must still be reported")
+        self.assertEqual(
+            ev["category"], "evidence_lost",
+            "reporting this as a regression names a cause that did not happen: "
+            "the target did not start failing, it stopped being measurable")
+        self.assertEqual(ev["new_result"], bp.INCONCLUSIVE)
+
+    def test_fail_to_inconclusive_is_reported_at_all(self):
+        """Previously invisible: both sides were `passed=False`, so it was skipped."""
+        ev = self._one(row("T-1", False), row("T-1", False, not_evaluated=True))
+        self.assertIsNotNone(ev, "a verdict that became unavailable was silently dropped")
+        self.assertEqual(ev["category"], "evidence_lost")
+
+    def test_inconclusive_to_pass_is_not_an_improvement(self):
+        ev = self._one(row("T-1", False, not_evaluated=True), row("T-1", True))
+        self.assertEqual(
+            ev["category"], "evidence_gained",
+            "the target may always have passed; what changed is that a verdict "
+            "could be established")
+
+    def test_genuine_regression_and_improvement_still_classify(self):
+        self.assertEqual(self._one(row("T-1", True), row("T-1", False))["category"],
+                         "regression")
+        self.assertEqual(self._one(row("T-1", False), row("T-1", True))["category"],
+                         "improvement")
+
+    def test_an_unchanged_state_produces_no_event(self):
+        for r in (row("T-1", True), row("T-1", False),
+                  row("T-1", False, not_evaluated=True)):
+            with self.subTest(state=bp.verdict_state(r)):
+                self.assertIsNone(self._one(r, dict(r)))
+
+
+class TheSourceCannotSilentlyRevert(unittest.TestCase):
+
+    def test_no_two_state_comparison_remains_in_the_script(self):
+        """The repair was to two call sites; a third would reintroduce it."""
+        src = (REPO_ROOT / "scripts" / "behavioral_profile.py").read_text(encoding="utf-8")
+        for bad in ('b.get("passed"', 'c.get("passed"'):
+            self.assertNotIn(
+                bad, src,
+                f"{bad!r} reads the pass flag directly and cannot see the third "
+                "state. Use verdict_state().")
+
+    def test_the_canonical_markers_are_imported_not_restated(self):
+        """A local copy of the marker list drifts from the harnesses it reads."""
+        src = (REPO_ROOT / "scripts" / "behavioral_profile.py").read_text(encoding="utf-8")
+        self.assertIn("from protocol_tests.http_helpers import", src)
+        self.assertIn("INCONCLUSIVE_FIELDS", src)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/testing/test_comparison_doc_is_current.py
+++ b/testing/test_comparison_doc_is_current.py
@@ -139,6 +139,57 @@ class TestEverySelfProductCountMatchesTheCatalog(unittest.TestCase):
                     f"{surface} claims {stated} tests; the modules it names hold "
                     f"{sum(self.counts[m] for m in modules)}")
 
+    def test_the_aiuc1_requirement_row_matches_its_config(self) -> None:
+        """The two-column row the numeric guard above cannot see.
+
+        `test_each_surface_row_sums_to_the_modules_it_names` selects rows with
+        `len(r) == 3`. The AIUC-1 requirement row has two columns, so it was
+        excluded, and it carried "19 of 20 requirements" while
+        `configs/aiuc1_mapping.yaml` declared 24 keys with 23 COVERED and 1 GAP.
+        Wrong in both numbers, through several readings of a document that told
+        the reader every count was recomputed.
+
+        Raised 2026-09-11 as CP-05 by a second reader. Recomputing the row is the
+        repair; describing the guard's limit in prose was the first half of it.
+        """
+        import yaml
+
+        cfg = yaml.safe_load((REPO / "configs" / "aiuc1_mapping.yaml").read_text(encoding="utf-8"))
+
+        def requirement_statuses(node, acc):
+            if isinstance(node, dict):
+                for key, value in node.items():
+                    if (isinstance(key, str) and len(key) == 4
+                            and key[0] in "BCDEF" and key[1:].isdigit()):
+                        acc[key] = (value or {}).get("status") if isinstance(value, dict) else None
+                    else:
+                        requirement_statuses(value, acc)
+            elif isinstance(node, list):
+                for item in node:
+                    requirement_statuses(item, acc)
+            return acc
+
+        statuses = requirement_statuses(cfg, {})
+        self.assertGreater(
+            len(statuses), 10,
+            "no requirement keys were derived from the config, so this rule is "
+            "comparing the document against nothing")
+        covered = sum(1 for s in statuses.values() if s == "COVERED")
+
+        row = re.search(r"\|\s*AIUC-1 requirement mapping\s*\|([^|]+)\|", self.text)
+        self.assertIsNotNone(row, "the AIUC-1 requirement row is missing from the document")
+        claimed = row.group(1)
+
+        numbers = [int(n) for n in re.findall(r"\b(\d+)\b", claimed)]
+        self.assertIn(
+            len(statuses), numbers,
+            f"the AIUC-1 row does not state the config's requirement-key count "
+            f"({len(statuses)}); it says {claimed.strip()!r}")
+        self.assertIn(
+            covered, numbers,
+            f"the AIUC-1 row does not state the config's COVERED count "
+            f"({covered}); it says {claimed.strip()!r}")
+
     def test_the_asi_table_matches_the_inventory(self) -> None:
         from protocol_tests.asi_inventory import by_category
 

--- a/testing/test_review_findings_are_ratcheted.py
+++ b/testing/test_review_findings_are_ratcheted.py
@@ -155,6 +155,54 @@ REVIEW_FINDINGS: list[tuple[str, str, str, str]] = [
      "was guarded on a sample and would have been reported as covered",
      "author 2026-09-11", GUARDED,
      "testing/test_review_findings_are_ratcheted.py: CitedCommitsResolve"),
+    ("the edit adding this batch's rows matched an anchor that exists only on a "
+     "sibling branch and used str.replace with no assertion, so it changed "
+     "nothing and reported success. Caught only because the register count "
+     "printed 18 where 23 was expected",
+     "author 2026-09-11", UNGUARDABLE,
+     "this is a property of how a file was edited, not of the repository, so "
+     "there is nothing in the tree for a test to hold. Recorded because the "
+     "failure mode is the one this whole register exists to answer: a change "
+     "that reports success and does nothing. The practical defence is to assert "
+     "the anchor before writing and to print the resulting count, which is what "
+     "surfaced it."),
+
+    # --- 2026-09-11, Ledger claim-tracing on COMPARISON.md (CP-01..CP-05) ---
+    ("behavioral_profile.py compared runs on the passed flag alone, so "
+     "INCONCLUSIVE was indistinguishable from FAIL: FAIL->INCONCLUSIVE scored as "
+     "stable with no drift, PASS->INCONCLUSIVE was reported as a regression, and "
+     "an empty comparison returned score 100.0. Its own unit test asserted that "
+     "100.0",
+     "Ledger COMPARISON review CP-04, 2026-09-11", GUARDED,
+     "testing/test_behavioral_profile_three_state.py"),
+    ("COMPARISON.md claimed '19 of 20 requirements' where the linked config "
+     "declares 24 requirement keys, 23 COVERED and 1 GAP",
+     "Ledger COMPARISON review CP-05, 2026-09-11", GUARDED,
+     "testing/test_comparison_doc_is_current.py: test_the_aiuc1_requirement_row_matches_its_config"),
+    ("COMPARISON.md told the reader its guard 'recomputes every one' of its "
+     "counts, while the guard selects only three-column rows with a digit in the "
+     "second column. The two-column AIUC-1 row was invisible to it, which is how "
+     "CP-05 survived several readings of a document promising the opposite",
+     "Ledger COMPARISON review CP-02, 2026-09-11", GUARDED,
+     "testing/test_comparison_doc_is_current.py: test_the_aiuc1_requirement_row_matches_its_config"),
+    ("COMPARISON.md said 10 tests 'carry no ASI tag site at all'. They carry "
+     "owasp_asi=ASI09; the extractor cannot attribute a tag when the test ID "
+     "reaches a shared helper as a parameter. An instrument limit stated as an "
+     "absence in the tests, understating our own coverage",
+     "Ledger COMPARISON review CP-03, 2026-09-11", UNGUARDABLE,
+     "the sum-to-621 arithmetic is already guarded and was correct. What went "
+     "wrong was the prose explanation attached to a correct number, and no test "
+     "can decide whether an English sentence names the right cause for a gap. "
+     "The passage now states the attribution limit and names the ten IDs."),
+    ("all 30 competitor cells assert product behaviour with no row-level source "
+     "and no version of the product examined",
+     "Ledger COMPARISON review CP-01, 2026-09-11", UNGUARDABLE,
+     "a citation-presence rule is writable, but the repair that matters is "
+     "retrieving and dating each competitor claim, which requires examining "
+     "other people's products and cannot be done from this repository. The table "
+     "now says plainly that no cell names a version and that a dash means 'not "
+     "found when we looked', so the limit is disclosed rather than guarded."),
+
     ("widening the accepted link forms briefly made a permalink into THIS "
      "repository count as a foreign citation, exempting from the reachability "
      "check the exact links that 404 when a commit is unreachable",


### PR DESCRIPTION
Five findings from tracing `docs/COMPARISON.md` to code (CP-01..CP-05). **One is a live code defect**; the rest are claims the source does not support.

## CP-04 — the code defect

`scripts/behavioral_profile.py` compared runs on `.get("passed", False)` alone. An INCONCLUSIVE result carries `passed=False`, so it was indistinguishable from a FAIL. Both consequences ran in the direction that hides a problem:

| Transition | Was reported as | Actually |
|---|---|---|
| `FAIL → INCONCLUSIVE` | **stable, no drift** | a target that stopped answering |
| `PASS → INCONCLUSIVE` | **PASS → FAIL** regression | a verdict became unavailable |
| two empty runs | **score 100.0** | zero observations |

The script's own unit test asserted that `100.0`.

Both comparison sites now read `verdict_state()`, which **imports** `INCONCLUSIVE_FIELDS` and `row_field` from `http_helpers` rather than restating the markers, so this script cannot drift from the harnesses it reads. Pairs with an INCONCLUSIVE on either side are excluded from the stability score and reported separately; the score is `None` when nothing was comparable. Transitions into or out of INCONCLUSIVE are categorised `evidence_lost` / `evidence_gained`, never regression or improvement.

This is the class the harnesses closed through `INCONCLUSIVE_FIELDS`, `console_status` and the serviced guard. It reached a `scripts/` tool because nothing shared was imported there.

`test_behavioral_profile_three_state.py` holds it: **13 of its 14 tests fail against the pre-fix script**, including the opposing direction — a real `PASS → FAIL` regression is still detected, and excluding INCONCLUSIVE must not excuse FAIL.

## CP-05 and CP-02 — a wrong number, and why nothing caught it

The AIUC-1 row claimed **"19 of 20 requirements"**. `configs/aiuc1_mapping.yaml` declares **24** requirement keys, 23 COVERED and 1 GAP. Wrong in both numbers.

CP-02 explains how it survived: the document told the reader its guard *"recomputes every one"* of its counts. The guard selects rows with `len(r) == 3`, and the AIUC-1 row has **two** columns, so it was never checked. **A false claim about guard coverage concealed a false number.**

Both repaired: the scope limit is now stated, and the row is recomputed from the config by a new rule rather than merely described. Seeding `19 of 20` back fails.

## CP-03 — this one ran the other way

The document said 10 tests *"carry no ASI tag site at all"*. They carry `owasp_asi="ASI09"` — `receipt_claim_harness.py` sets it in shared helpers, and the extractor attributes a tag only when the ID and tag resolve at the same call site. An instrument limit stated as an absence in the tests, **understating our own coverage**.

The arithmetic (621 vs 631) was correct. The explanation attached to it was not.

## CP-01 — disclosed, not guarded

No competitor cell names the release it describes or carries a row-level source, and the guard expressly excludes those cells. Dating thirty claims means examining other people's products, which cannot be done from this repository, so the table now says plainly that no cell names a version and that a dash means "not found when we looked".

## Register

24 rows: 14 GUARDED, 10 UNGUARDABLE, 0 OPEN.

One row records that **this batch's own register edit first failed silently** — it matched an anchor that exists only on a sibling branch and used `str.replace` with no assertion, so it changed nothing and reported success. Caught only because the printed row count read 18 where 23 was expected. That is the exact failure mode the register exists to answer.

## Verification

- `testing/` 1204 passed
- `tests/` 466 passed, 2 skipped (pre-existing `mcp-server` extra)
- `ruff` F821 clean, count unchanged at 631

🤖 Generated with [Claude Code](https://claude.com/claude-code)